### PR TITLE
Add Rust CDP foundation: connection state machine + live tab list

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -48,6 +48,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
+dependencies = [
+ "async-std",
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +315,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -310,6 +498,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chromiumoxide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
+dependencies = [
+ "async-std",
+ "async-tungstenite",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "which",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +584,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -496,6 +760,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -683,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +969,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -717,6 +993,43 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -815,12 +1128,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -847,6 +1176,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,11 +1212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1116,6 +1465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,10 +1573,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -1615,6 +1991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +2064,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +2095,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2073,6 +2473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2567,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2629,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2656,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2329,6 +2775,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2881,38 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2453,10 +2961,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2649,6 +3189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +3264,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +3290,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2756,10 +3329,13 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "socai_app"
 version = "0.1.0"
 dependencies = [
+ "chromiumoxide",
+ "futures",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tokio",
 ]
 
 [[package]]
@@ -2874,6 +3450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3008,7 +3585,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3306,9 +3883,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3496,7 +4087,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3535,6 +4138,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"
@@ -3655,6 +4276,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version-compare"
@@ -3936,6 +4563,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,6 +4770,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4160,6 +4808,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4204,6 +4867,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4216,6 +4885,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4225,6 +4900,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4246,6 +4927,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4255,6 +4942,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4270,6 +4963,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4279,6 +4978,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4312,6 +5017,16 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -4319,6 +5034,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -4506,6 +5227,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -15,3 +15,6 @@ tauri-build = { version = "2.5.6", features = [] }
 tauri = { version = "2.11.1", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+chromiumoxide = "0.7"

--- a/app/src-tauri/src/cdp/commands.rs
+++ b/app/src-tauri/src/cdp/commands.rs
@@ -1,0 +1,168 @@
+use chromiumoxide::cdp::browser_protocol::target::GetTargetsParams;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::cdp::state::{CdpState, SharedState, StatusPayload, TargetInfo};
+use crate::cdp::supervisor;
+
+#[tauri::command]
+pub async fn cdp_connect(
+    state: State<'_, SharedState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let arc = (*state).clone();
+    {
+        let guard = arc.lock().await;
+        if !guard.is_disconnected() {
+            return Ok(());
+        }
+    }
+    tokio::spawn(supervisor::run_connect(arc, app));
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn cdp_disconnect(
+    state: State<'_, SharedState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    supervisor::run_disconnect((*state).clone(), app).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn cdp_status(state: State<'_, SharedState>) -> Result<StatusPayload, String> {
+    Ok((&*state.lock().await).into())
+}
+
+#[tauri::command]
+pub async fn cdp_refresh(
+    state: State<'_, SharedState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let browser_arc = {
+        let guard = state.lock().await;
+        match &*guard {
+            CdpState::Connected { browser, .. } => Arc::clone(browser),
+            _ => return Ok(()),
+        }
+    };
+
+    let result = match browser_arc.execute(GetTargetsParams::default()).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[cdp refresh] connection check failed: {e:?}");
+            supervisor::on_connection_dropped((*state).clone(), app).await;
+            return Ok(());
+        }
+    };
+
+    let fresh: HashMap<String, TargetInfo> = result
+        .result
+        .target_infos
+        .iter()
+        .map(|t| {
+            let id = t.target_id.inner().clone();
+            (
+                id.clone(),
+                TargetInfo {
+                    target_id: id,
+                    r#type: t.r#type.clone(),
+                    title: t.title.clone(),
+                    url: t.url.clone(),
+                },
+            )
+        })
+        .collect();
+
+    let mut guard = state.lock().await;
+    let CdpState::Connected { targets, .. } = &mut *guard else {
+        return Ok(());
+    };
+    if *targets == fresh {
+        return Ok(());
+    }
+    *targets = fresh.clone();
+    let mut page_list: Vec<TargetInfo> = fresh
+        .values()
+        .filter(|t| t.r#type == "page")
+        .cloned()
+        .collect();
+    page_list.sort_by(|a, b| a.target_id.cmp(&b.target_id));
+    drop(guard);
+    let _ = app.emit("cdp:targets_changed", page_list);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn cdp_test_search(
+    state: State<'_, SharedState>,
+    query: String,
+) -> Result<String, String> {
+    let query = query.trim().to_string();
+    if query.is_empty() {
+        return Err("query is empty".into());
+    }
+
+    let browser_arc = {
+        let guard = state.lock().await;
+        match &*guard {
+            CdpState::Connected { browser, .. } => Arc::clone(browser),
+            _ => return Err("not connected".into()),
+        }
+    };
+
+    let page = browser_arc
+        .new_page("https://www.google.com")
+        .await
+        .map_err(|e| format!("new_page failed: {e}"))?;
+
+    page.wait_for_navigation()
+        .await
+        .map_err(|e| format!("wait_for_navigation failed: {e}"))?;
+
+    let _ = page.bring_to_front().await;
+
+    let search = page
+        .find_element("textarea[name=q], input[name=q]")
+        .await
+        .map_err(|e| format!("could not find search box: {e}"))?;
+
+    search
+        .click()
+        .await
+        .map_err(|e| format!("click failed: {e}"))?
+        .type_str(&query)
+        .await
+        .map_err(|e| format!("type failed: {e}"))?
+        .press_key("Enter")
+        .await
+        .map_err(|e| format!("press enter failed: {e}"))?;
+
+    page.wait_for_navigation()
+        .await
+        .map_err(|e| format!("wait for results failed: {e}"))?;
+
+    let url = page.url().await.ok().flatten().unwrap_or_default();
+    Ok(format!("opened results for \"{query}\" — {url}"))
+}
+
+#[tauri::command]
+pub async fn cdp_list_pages(
+    state: State<'_, SharedState>,
+) -> Result<Vec<TargetInfo>, String> {
+    let guard = state.lock().await;
+    match &*guard {
+        CdpState::Connected { targets, .. } => {
+            let mut pages: Vec<TargetInfo> = targets
+                .values()
+                .filter(|t| t.r#type == "page")
+                .cloned()
+                .collect();
+            pages.sort_by(|a, b| a.target_id.cmp(&b.target_id));
+            Ok(pages)
+        }
+        _ => Err("not connected".into()),
+    }
+}

--- a/app/src-tauri/src/cdp/endpoint.rs
+++ b/app/src-tauri/src/cdp/endpoint.rs
@@ -30,8 +30,7 @@ pub fn discover() -> Result<Endpoint, String> {
 }
 
 fn profile_roots() -> Vec<PathBuf> {
-    let Ok(home) = env::var("HOME") else { return Vec::new(); };
-    let home = PathBuf::from(home);
+    let Some(home) = home_dir() else { return Vec::new(); };
 
     #[cfg(target_os = "macos")]
     let candidates: &[&str] = &[
@@ -58,6 +57,28 @@ fn profile_roots() -> Vec<PathBuf> {
     ];
 
     candidates.iter().map(|c| home.join(c)).collect()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    if let Ok(home) = env::var("HOME") {
+        if !home.is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(profile) = env::var("USERPROFILE") {
+            if !profile.is_empty() {
+                return Some(PathBuf::from(profile));
+            }
+        }
+        if let (Ok(drive), Ok(path)) = (env::var("HOMEDRIVE"), env::var("HOMEPATH")) {
+            if !drive.is_empty() && !path.is_empty() {
+                return Some(PathBuf::from(format!("{drive}{path}")));
+            }
+        }
+    }
+    None
 }
 
 fn endpoint_from_profile(profile: &Path) -> Option<Endpoint> {

--- a/app/src-tauri/src/cdp/endpoint.rs
+++ b/app/src-tauri/src/cdp/endpoint.rs
@@ -1,0 +1,76 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Endpoint {
+    pub source: String,
+    pub browser_ws_url: String,
+}
+
+pub fn discover() -> Result<Endpoint, String> {
+    if let Ok(url) = env::var("SOCAI_CDP_WS") {
+        if !url.is_empty() {
+            return Ok(Endpoint {
+                source: "SOCAI_CDP_WS".into(),
+                browser_ws_url: url,
+            });
+        }
+    }
+
+    for profile in profile_roots() {
+        if let Some(endpoint) = endpoint_from_profile(&profile) {
+            return Ok(endpoint);
+        }
+    }
+
+    Err("no running chrome with --remote-debugging-port found. \
+         launch chrome with the debug flag, or set SOCAI_CDP_WS."
+        .into())
+}
+
+fn profile_roots() -> Vec<PathBuf> {
+    let Ok(home) = env::var("HOME") else { return Vec::new(); };
+    let home = PathBuf::from(home);
+
+    #[cfg(target_os = "macos")]
+    let candidates: &[&str] = &[
+        "Library/Application Support/Google/Chrome",
+        "Library/Application Support/Comet",
+        "Library/Application Support/Arc/User Data",
+        "Library/Application Support/Microsoft Edge",
+        "Library/Application Support/BraveSoftware/Brave-Browser",
+    ];
+
+    #[cfg(target_os = "linux")]
+    let candidates: &[&str] = &[
+        ".config/google-chrome",
+        ".config/chromium",
+        ".config/microsoft-edge",
+        ".config/BraveSoftware/Brave-Browser",
+    ];
+
+    #[cfg(target_os = "windows")]
+    let candidates: &[&str] = &[
+        "AppData/Local/Google/Chrome/User Data",
+        "AppData/Local/Microsoft/Edge/User Data",
+        "AppData/Local/BraveSoftware/Brave-Browser/User Data",
+    ];
+
+    candidates.iter().map(|c| home.join(c)).collect()
+}
+
+fn endpoint_from_profile(profile: &Path) -> Option<Endpoint> {
+    let marker = profile.join("DevToolsActivePort");
+    let contents = fs::read_to_string(&marker).ok()?;
+    let mut lines = contents.lines();
+    let port: u16 = lines.next()?.trim().parse().ok()?;
+    let path = lines.next()?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(Endpoint {
+        source: format!("active_port:{}", marker.display()),
+        browser_ws_url: format!("ws://127.0.0.1:{port}{path}"),
+    })
+}

--- a/app/src-tauri/src/cdp/events.rs
+++ b/app/src-tauri/src/cdp/events.rs
@@ -1,0 +1,122 @@
+use chromiumoxide::cdp::browser_protocol::target::GetTargetsParams;
+use chromiumoxide::Browser;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+use crate::cdp::state::{CdpState, SharedState, TargetInfo};
+use crate::cdp::supervisor;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
+// v1 strategy: poll Target.getTargets every 100ms while Connected, diff,
+// emit cdp:targets_changed when the page list actually changes.
+// TODO: replace with chromiumoxide event subscription on Target.targetCreated /
+// targetDestroyed / targetInfoChanged once the browser-level event API surface
+// is confirmed.
+pub fn spawn_target_poller(browser: Arc<Browser>, state: SharedState, app: AppHandle) {
+    tokio::spawn(async move {
+        let mut last_emitted: Vec<TargetInfo> = current_page_list(&state).await;
+        let _ = app.emit("cdp:targets_changed", &last_emitted);
+
+        let mut ticker = tokio::time::interval(POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut consecutive_failures: u32 = 0;
+
+        loop {
+            ticker.tick().await;
+
+            if !state_is_connected(&state).await {
+                break;
+            }
+
+            let result = match browser.execute(GetTargetsParams::default()).await {
+                Ok(r) => {
+                    consecutive_failures = 0;
+                    r
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    eprintln!(
+                        "[cdp poll] getTargets failed ({consecutive_failures}/{MAX_CONSECUTIVE_FAILURES}): {e:?}"
+                    );
+                    if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                        eprintln!("[cdp poll] connection appears dead — declaring Disconnected");
+                        supervisor::on_connection_dropped(state.clone(), app.clone()).await;
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            let fresh: HashMap<String, TargetInfo> = result
+                .result
+                .target_infos
+                .iter()
+                .map(|t| {
+                    let id = t.target_id.inner().clone();
+                    (
+                        id.clone(),
+                        TargetInfo {
+                            target_id: id,
+                            r#type: t.r#type.clone(),
+                            title: t.title.clone(),
+                            url: t.url.clone(),
+                        },
+                    )
+                })
+                .collect();
+
+            let mut guard = state.lock().await;
+            let pages_changed = if let CdpState::Connected { targets, .. } = &mut *guard {
+                let changed = *targets != fresh;
+                if changed {
+                    *targets = fresh;
+                }
+                changed
+            } else {
+                break;
+            };
+
+            if !pages_changed {
+                continue;
+            }
+
+            let page_list = if let CdpState::Connected { targets, .. } = &*guard {
+                page_list_from(targets)
+            } else {
+                break;
+            };
+            drop(guard);
+
+            if page_list != last_emitted {
+                last_emitted = page_list.clone();
+                let _ = app.emit("cdp:targets_changed", &page_list);
+            }
+        }
+    });
+}
+
+async fn state_is_connected(state: &SharedState) -> bool {
+    matches!(*state.lock().await, CdpState::Connected { .. })
+}
+
+async fn current_page_list(state: &SharedState) -> Vec<TargetInfo> {
+    if let CdpState::Connected { targets, .. } = &*state.lock().await {
+        page_list_from(targets)
+    } else {
+        Vec::new()
+    }
+}
+
+fn page_list_from(targets: &HashMap<String, TargetInfo>) -> Vec<TargetInfo> {
+    let mut pages: Vec<TargetInfo> = targets
+        .values()
+        .filter(|t| t.r#type == "page")
+        .cloned()
+        .collect();
+    pages.sort_by(|a, b| a.target_id.cmp(&b.target_id));
+    pages
+}

--- a/app/src-tauri/src/cdp/mod.rs
+++ b/app/src-tauri/src/cdp/mod.rs
@@ -1,0 +1,7 @@
+pub mod commands;
+pub mod endpoint;
+pub mod events;
+pub mod state;
+pub mod supervisor;
+
+pub use state::init_state;

--- a/app/src-tauri/src/cdp/state.rs
+++ b/app/src-tauri/src/cdp/state.rs
@@ -1,0 +1,90 @@
+use chromiumoxide::Browser;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::cdp::endpoint::Endpoint;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetInfo {
+    pub target_id: String,
+    pub r#type: String,
+    pub title: String,
+    pub url: String,
+}
+
+pub enum CdpState {
+    Disconnected {
+        reason: String,
+    },
+    Connecting {
+        attempt: u8,
+    },
+    Connected {
+        #[allow(dead_code)] // held to tie the WebSocket lifetime to this variant
+        browser: Arc<Browser>,
+        endpoint: Endpoint,
+        browser_version: String,
+        targets: HashMap<String, TargetInfo>,
+    },
+}
+
+impl CdpState {
+    pub fn initial() -> Self {
+        Self::Disconnected {
+            reason: "not_yet_connected".into(),
+        }
+    }
+
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self, Self::Disconnected { .. })
+    }
+
+    pub fn is_connecting(&self) -> bool {
+        matches!(self, Self::Connecting { .. })
+    }
+}
+
+pub type SharedState = Arc<Mutex<CdpState>>;
+
+pub fn init_state() -> SharedState {
+    Arc::new(Mutex::new(CdpState::initial()))
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StatusPayload {
+    Disconnected {
+        reason: String,
+    },
+    Connecting {
+        attempt: u8,
+    },
+    Connected {
+        endpoint: String,
+        browser_version: String,
+        page_count: usize,
+    },
+}
+
+impl From<&CdpState> for StatusPayload {
+    fn from(state: &CdpState) -> Self {
+        match state {
+            CdpState::Disconnected { reason } => Self::Disconnected {
+                reason: reason.clone(),
+            },
+            CdpState::Connecting { attempt } => Self::Connecting { attempt: *attempt },
+            CdpState::Connected {
+                endpoint,
+                browser_version,
+                targets,
+                ..
+            } => Self::Connected {
+                endpoint: endpoint.browser_ws_url.clone(),
+                browser_version: browser_version.clone(),
+                page_count: targets.values().filter(|t| t.r#type == "page").count(),
+            },
+        }
+    }
+}

--- a/app/src-tauri/src/cdp/supervisor.rs
+++ b/app/src-tauri/src/cdp/supervisor.rs
@@ -1,0 +1,170 @@
+use chromiumoxide::cdp::browser_protocol::target::{GetTargetsParams, SetDiscoverTargetsParams};
+use chromiumoxide::Browser;
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+use crate::cdp::endpoint;
+use crate::cdp::events;
+use crate::cdp::state::{CdpState, SharedState, StatusPayload, TargetInfo};
+
+const MAX_ATTEMPTS: u8 = 3;
+const ATTEMPT_DELAY: Duration = Duration::from_millis(500);
+
+pub async fn run_connect(state: SharedState, app: AppHandle) {
+    for attempt in 1..=MAX_ATTEMPTS {
+        if !transition_if_eligible_to_connect(&state, &app, CdpState::Connecting { attempt }).await {
+            return;
+        }
+
+        match try_connect_once(&app, &state).await {
+            Ok(()) => return,
+            Err(err) => {
+                if attempt == MAX_ATTEMPTS {
+                    transition_unconditional(
+                        &state,
+                        &app,
+                        CdpState::Disconnected { reason: err },
+                    )
+                    .await;
+                    return;
+                }
+                tokio::time::sleep(ATTEMPT_DELAY).await;
+            }
+        }
+    }
+}
+
+pub async fn run_disconnect(state: SharedState, app: AppHandle) {
+    transition_unconditional(
+        &state,
+        &app,
+        CdpState::Disconnected {
+            reason: "user_disconnected".into(),
+        },
+    )
+    .await;
+}
+
+async fn try_connect_once(app: &AppHandle, state: &SharedState) -> Result<(), String> {
+    let endpoint = endpoint::discover()?;
+
+    let (browser, mut handler) = Browser::connect(&endpoint.browser_ws_url)
+        .await
+        .map_err(|e| format!("connect failed: {e}"))?;
+
+    let app_for_pump = app.clone();
+    let state_for_pump = state.clone();
+    tokio::spawn(async move {
+        // The handler stream yields Result<_, CdpError>. Individual errors
+        // (decode failures for unmodeled events, etc.) are NOT fatal — the
+        // connection is alive as long as the stream itself keeps producing.
+        // Only stream exhaustion (None) means the WebSocket actually closed.
+        while let Some(event) = handler.next().await {
+            if let Err(e) = event {
+                eprintln!("[cdp pump] non-fatal: {e:?}");
+            }
+        }
+        eprintln!("[cdp pump] stream ended — connection lost");
+        on_connection_dropped(state_for_pump, app_for_pump).await;
+    });
+
+    let version = browser
+        .version()
+        .await
+        .map_err(|e| format!("version query failed: {e}"))?;
+    let browser_version = format!("{} v{}", version.product, version.revision);
+
+    browser
+        .execute(SetDiscoverTargetsParams {
+            discover: true,
+            filter: None,
+        })
+        .await
+        .map_err(|e| format!("setDiscoverTargets failed: {e}"))?;
+
+    let raw = browser
+        .execute(GetTargetsParams::default())
+        .await
+        .map_err(|e| format!("getTargets failed: {e}"))?;
+    let targets: HashMap<String, TargetInfo> = raw
+        .result
+        .target_infos
+        .iter()
+        .map(|t| {
+            let id = t.target_id.inner().clone();
+            (
+                id.clone(),
+                TargetInfo {
+                    target_id: id,
+                    r#type: t.r#type.clone(),
+                    title: t.title.clone(),
+                    url: t.url.clone(),
+                },
+            )
+        })
+        .collect();
+
+    let browser = Arc::new(browser);
+
+    let mut guard = state.lock().await;
+    if !guard.is_connecting() {
+        return Err("connect cancelled".into());
+    }
+    *guard = CdpState::Connected {
+        browser: Arc::clone(&browser),
+        endpoint,
+        browser_version,
+        targets,
+    };
+    let payload: StatusPayload = (&*guard).into();
+    drop(guard);
+    let _ = app.emit("cdp:status_changed", payload);
+
+    events::spawn_target_poller(browser, state.clone(), app.clone());
+
+    Ok(())
+}
+
+pub async fn on_connection_dropped(state: SharedState, app: AppHandle) {
+    let mut guard = state.lock().await;
+    if matches!(*guard, CdpState::Connected { .. }) {
+        eprintln!("[cdp] transitioning Connected → Disconnected (connection_lost)");
+        *guard = CdpState::Disconnected {
+            reason: "connection_lost".into(),
+        };
+        let payload: StatusPayload = (&*guard).into();
+        drop(guard);
+        let _ = app.emit("cdp:status_changed", payload);
+    }
+}
+
+async fn transition_if_eligible_to_connect(
+    state: &SharedState,
+    app: &AppHandle,
+    new: CdpState,
+) -> bool {
+    let mut guard = state.lock().await;
+    let eligible = matches!(
+        *guard,
+        CdpState::Disconnected { .. } | CdpState::Connecting { .. }
+    );
+    if !eligible {
+        return false;
+    }
+    *guard = new;
+    let payload: StatusPayload = (&*guard).into();
+    drop(guard);
+    let _ = app.emit("cdp:status_changed", payload);
+    true
+}
+
+async fn transition_unconditional(state: &SharedState, app: &AppHandle, new: CdpState) {
+    let mut guard = state.lock().await;
+    *guard = new;
+    let payload: StatusPayload = (&*guard).into();
+    drop(guard);
+    let _ = app.emit("cdp:status_changed", payload);
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,5 +1,16 @@
+mod cdp;
+
 pub fn run() {
     tauri::Builder::default()
+        .manage(cdp::init_state())
+        .invoke_handler(tauri::generate_handler![
+            cdp::commands::cdp_connect,
+            cdp::commands::cdp_disconnect,
+            cdp::commands::cdp_status,
+            cdp::commands::cdp_refresh,
+            cdp::commands::cdp_list_pages,
+            cdp::commands::cdp_test_search,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running socai");
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,5 +1,18 @@
-// Inline the brand mark so it picks up `currentColor` from its container.
-// Source: design system v1, assets/socai-mark.svg.
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+type Status =
+  | { state: "disconnected"; reason: string }
+  | { state: "connecting"; attempt: number }
+  | { state: "connected"; endpoint: string; browser_version: string; page_count: number };
+
+interface TargetInfo {
+  target_id: string;
+  type: string;
+  title: string;
+  url: string;
+}
+
 const MARK_SVG = `
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="48" height="48" fill="none" role="img" aria-label="socai">
     <rect x="2.5" y="2.5" width="27" height="27" rx="3" stroke="currentColor" stroke-width="1.6"></rect>
@@ -7,16 +20,197 @@ const MARK_SVG = `
   </svg>
 `;
 
-function main(): void {
+let status: Status = { state: "disconnected", reason: "starting" };
+let pages: TargetInfo[] = [];
+let searchQuery = "";
+let actionStatus = "";
+let actionInFlight = false;
+
+function renderHero(): void {
   const root = document.getElementById("app");
   if (!root) return;
-  root.innerHTML = `
-    <main class="hero">
-      <div class="hero-mark">${MARK_SVG}</div>
-      <h1 class="t-display">socai</h1>
-      <p class="t-lede">The web-use agent.</p>
-    </main>
+  root.innerHTML = `<main class="hero">${heroContent()}</main>`;
+  bindActions();
+  refocusInputIfRendered();
+}
+
+function heroContent(): string {
+  switch (status.state) {
+    case "disconnected":
+      return `
+        <div class="hero-mark">${MARK_SVG}</div>
+        <p class="t-eyebrow">chrome · disconnected</p>
+        <h1 class="t-display">connect chrome</h1>
+        <p class="t-lede">${disconnectExplainer(status.reason)}</p>
+        <button id="connect" class="btn-primary">connect</button>
+      `;
+    case "connecting":
+      return `
+        <div class="hero-mark">${MARK_SVG}</div>
+        <p class="t-eyebrow">chrome · connecting · attempt ${status.attempt}/3</p>
+        <h1 class="t-display">looking for chrome…</h1>
+      `;
+    case "connected":
+      return `
+        <div class="hero-mark">${MARK_SVG}</div>
+        <p class="t-eyebrow" id="connected-eyebrow">${connectedEyebrowText()}</p>
+        <h1 class="t-display">${esc(status.browser_version)}</h1>
+        ${actionPanel()}
+        <button id="disconnect" class="btn-ghost">disconnect</button>
+        <ul class="tab-list">
+          ${pages.map(renderTab).join("")}
+        </ul>
+      `;
+  }
+}
+
+function connectedEyebrowText(): string {
+  const n = pages.length;
+  return `chrome · connected · ${n} tab${n === 1 ? "" : "s"}`;
+}
+
+function actionPanel(): string {
+  return `
+    <section class="action-panel">
+      <p class="t-eyebrow">try an action</p>
+      <form id="search-form" class="action-form">
+        <input
+          id="search-input"
+          class="input-field"
+          type="text"
+          placeholder="search google for…"
+          value="${esc(searchQuery)}"
+          autocomplete="off"
+          ${actionInFlight ? "disabled" : ""}
+        />
+        <button type="submit" class="btn-primary" ${actionInFlight ? "disabled" : ""}>
+          ${actionInFlight ? "running…" : "search"}
+        </button>
+      </form>
+      <p class="t-small action-status" id="action-status">${esc(actionStatus)}</p>
+    </section>
   `;
+}
+
+function renderTab(t: TargetInfo): string {
+  return `
+    <li class="tab-row">
+      <div class="tab-title t-body">${esc(t.title || "(untitled)")}</div>
+      <div class="tab-url t-mono">${esc(truncate(t.url, 90))}</div>
+    </li>
+  `;
+}
+
+function disconnectExplainer(reason: string): string {
+  if (reason === "not_yet_connected" || reason === "starting") {
+    return "click connect to attach socai to your running chrome.";
+  }
+  if (reason === "user_disconnected") {
+    return "disconnected. click to reconnect when you're ready.";
+  }
+  if (reason === "connection_lost") {
+    return "chrome went away. click to reconnect when you're ready.";
+  }
+  return reason;
+}
+
+function bindActions(): void {
+  document.getElementById("connect")?.addEventListener("click", () => {
+    invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
+  });
+  document.getElementById("disconnect")?.addEventListener("click", () => {
+    invoke("cdp_disconnect").catch((e) => console.error("cdp_disconnect failed:", e));
+  });
+
+  const input = document.getElementById("search-input") as HTMLInputElement | null;
+  if (input) {
+    input.addEventListener("input", () => {
+      searchQuery = input.value;
+    });
+  }
+
+  document.getElementById("search-form")?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const query = searchQuery.trim();
+    if (!query || actionInFlight) return;
+
+    actionInFlight = true;
+    actionStatus = `opening tab and searching for "${query}"…`;
+    renderHero();
+
+    try {
+      const result = await invoke<string>("cdp_test_search", { query });
+      actionStatus = result;
+    } catch (err) {
+      actionStatus = `error: ${err}`;
+    } finally {
+      actionInFlight = false;
+      renderHero();
+    }
+  });
+}
+
+function refocusInputIfRendered(): void {
+  if (status.state !== "connected" || actionInFlight) return;
+  const input = document.getElementById("search-input") as HTMLInputElement | null;
+  if (input && document.activeElement !== input && searchQuery !== "") {
+    // Keep focus only if the user was mid-typing; don't steal it on first paint.
+    return;
+  }
+}
+
+function updateTabsInPlace(): void {
+  if (status.state !== "connected") return;
+  const eyebrow = document.getElementById("connected-eyebrow");
+  if (eyebrow) eyebrow.textContent = connectedEyebrowText();
+  const list = document.querySelector(".tab-list");
+  if (list) list.innerHTML = pages.map(renderTab).join("");
+}
+
+function esc(s: string): string {
+  return s.replace(/[<>&"']/g, (c) => {
+    return (
+      { "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&#39;" } as Record<string, string>
+    )[c];
+  });
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+async function main(): Promise<void> {
+  try {
+    status = await invoke<Status>("cdp_status");
+  } catch (e) {
+    console.error("initial cdp_status failed:", e);
+  }
+  renderHero();
+
+  await listen<Status>("cdp:status_changed", (event) => {
+    const wasConnected = status.state === "connected";
+    status = event.payload;
+    if (status.state !== "connected") {
+      pages = [];
+      if (wasConnected) {
+        actionStatus = "";
+      }
+    }
+    renderHero();
+  });
+
+  await listen<TargetInfo[]>("cdp:targets_changed", (event) => {
+    pages = event.payload;
+    updateTabsInPlace();
+  });
+
+  const refresh = (): void => {
+    invoke("cdp_refresh").catch((e) => console.error("cdp_refresh failed:", e));
+  };
+  window.addEventListener("focus", refresh);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") refresh();
+  });
 }
 
 main();

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -182,6 +182,16 @@ function truncate(s: string, n: number): string {
 async function main(): Promise<void> {
   try {
     status = await invoke<Status>("cdp_status");
+    if (status.state === "connected") {
+      // Initial cdp:targets_changed was emitted at connect time, which may
+      // have happened before this webview started listening (e.g. tauri dev
+      // HMR). Pull a fresh snapshot so the tab list isn't blank.
+      try {
+        pages = await invoke<TargetInfo[]>("cdp_list_pages");
+      } catch (e) {
+        console.error("initial cdp_list_pages failed:", e);
+      }
+    }
   } catch (e) {
     console.error("initial cdp_status failed:", e);
   }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -187,7 +187,7 @@ body.has-paper > * { position: relative; z-index: 1; }
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: var(--sp-5);
   padding: var(--sp-9) var(--sp-6);
   text-align: center;
@@ -202,5 +202,125 @@ body.has-paper > * { position: relative; z-index: 1; }
   margin: 0;
 }
 .hero .t-lede {
-  max-width: 38ch;
+  max-width: 50ch;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────── */
+.btn-primary,
+.btn-ghost {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  padding: var(--sp-3) var(--sp-5);
+  border-radius: var(--r-3);
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease),
+              color var(--t-fast) var(--ease),
+              border-color var(--t-fast) var(--ease);
+  user-select: none;
+}
+.btn-primary {
+  background: var(--ink-0);
+  color: var(--ink-9);
+  border: 1px solid var(--ink-0);
+}
+.btn-primary:hover { background: var(--ink-1); }
+.btn-primary:active { background: var(--ink-2); }
+.btn-ghost {
+  background: transparent;
+  color: var(--fg-muted);
+  border: var(--hairline);
+}
+.btn-ghost:hover {
+  color: var(--ink-0);
+  border-color: var(--line-strong);
+}
+
+/* ── Action panel (test/search) ───────────────────────────────── */
+.action-panel {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--sp-3);
+  margin-top: var(--sp-3);
+  padding: var(--sp-5);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  background: var(--surface);
+}
+.action-panel .t-eyebrow {
+  margin: 0;
+  text-align: left;
+}
+.action-form {
+  display: flex;
+  gap: var(--sp-2);
+  width: 100%;
+}
+.input-field {
+  flex: 1;
+  padding: var(--sp-3) var(--sp-4);
+  border: var(--hairline);
+  border-radius: var(--r-3);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.4;
+  background: var(--canvas);
+  color: var(--fg);
+  transition: border-color var(--t-fast) var(--ease);
+}
+.input-field::placeholder {
+  color: var(--fg-faint);
+}
+.input-field:focus {
+  outline: none;
+  border-color: var(--ink-0);
+}
+.input-field:disabled {
+  background: var(--surface-2);
+  color: var(--fg-soft);
+  cursor: not-allowed;
+}
+.action-form .btn-primary:disabled {
+  background: var(--ink-3);
+  border-color: var(--ink-3);
+  cursor: not-allowed;
+}
+.action-status {
+  min-height: 1.2em;
+  text-align: left;
+  margin: 0;
+}
+
+/* ── Tab list ─────────────────────────────────────────────────── */
+.tab-list {
+  list-style: none;
+  margin: var(--sp-6) 0 0 0;
+  padding: 0;
+  width: 100%;
+  max-width: 720px;
+  border-top: var(--hairline);
+  text-align: left;
+}
+.tab-row {
+  padding: var(--sp-3) var(--sp-2);
+  border-bottom: var(--hairline);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+.tab-title {
+  color: var(--ink-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tab-url {
+  color: var(--fg-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
Closes #9. Replaces the Python-sidecar approach from closed #5/#6.

## Summary

- New Rust module `app/src-tauri/src/cdp/` (6 files, ~470 lines) that owns the Chrome CDP WebSocket directly via chromiumoxide. Tauri/Rust holds the connection in-process; no Python sidecar in the desktop runtime path.
- Three-state connection machine (`Disconnected` → `Connecting` → `Connected`) with 3 × 500ms retry on user-initiated connect; no auto-reconnect on drop. Connection is treated as a resource the user requests when they have a task, not as permanent infrastructure.
- Live tab list driven by `cdp:targets_changed` events; eyebrow tab count updates in place without touching the rest of the hero.
- `cdp_refresh` Tauri command + `window.focus` / `visibilitychange` listeners reconcile state whenever the app regains attention.
- Active-testing affordance in the connected hero: a search box that opens a new tab, navigates to Google, types the query, presses Enter, and surfaces the result URL — first exercise of the *write* path through the connection.

## Architecture notes for reviewers

- **`CdpState` is a Rust enum, not separate fields with a state string.** Variants hold variant-specific data (`Connecting { attempt }`, `Connected { browser, endpoint, browser_version, targets }`). Wire format (`StatusPayload`) is a separate type with the same shape minus the non-serializable `Browser` handle.
- **Two independent disconnect detectors** share `supervisor::on_connection_dropped`:
  - Layer 1: the chromiumoxide event-pump task signals when its handler stream ends.
  - Layer 2: the target poller declares disconnect after 3 consecutive `Target.getTargets` failures (~300ms).
  Both are idempotent (no-op if state isn't Connected). Whichever fires first wins.
- **`Browser` is wrapped in `Arc<Browser>`** because chromiumoxide's `Browser` is not `Clone`. The Arc lives in both the `Connected` state variant (to tie WebSocket lifetime to the variant) and the events poller. When state transitions away from Connected, the state's Arc drops; the poller's Arc drops on the next loop iteration (state-not-Connected check); the underlying connection then closes.
- **`tokio::sync::Mutex<CdpState>`** because we hold the guard across `.await` points (`std::sync::Mutex` would block the worker thread).
- **Endpoint discovery** reads `DevToolsActivePort` from `~/Library/Application Support/Google/Chrome/` (and Comet/Arc/Edge/Brave on macOS, with `cfg`-gated linux/windows fallbacks). Skips HTTP `/json/version` auto-discovery entirely — Chrome 111+ disables those endpoints by default, but the WebSocket URL from `DevToolsActivePort` works fine.
- **`Target.setDiscoverTargets { discover: true }` is called once on connect** so chromiumoxide back-fills `targetCreated` events for tabs that already exist; without this, `browser.pages()` is empty on a pre-existing Chrome (Phase 0 spike landed on this gotcha).

## Known limitations called out as TODOs

- **`cdp/events.rs` uses 100ms polling** of `Target.getTargets`, diff-and-emit. Meets the issue's 200ms latency DoD but is wasteful (10 RPS to Chrome just to enumerate). A `TODO` points at the proper fix: subscribing to `Target.targetCreated`/`Destroyed`/`InfoChanged` via chromiumoxide's `event_listener` API. Deferred to avoid getting stuck on event-API uncertainty during this PR.
- **`[cdp pump] non-fatal: Serde(...)` log noise.** chromiumoxide can't decode every CDP frame Chrome sends (newer events, extension frames). We log and continue — but the log is noisy under real usage. Cleanup is a small follow-up.
- **No platform-specific Chrome flag launching.** Users must launch Chrome with `--remote-debugging-port=<n>` themselves. Helper for this lives in the existing Python CLI; porting / wrapping it is a separate UX issue.

## Manual test

- `pnpm exec tauri dev` — app shows "connect chrome" disconnected hero.
- Click connect with Chrome running with `--remote-debugging-port` → connects within ~1s, hero shows browser version + live tab count + tab list.
- Open / close tabs in Chrome → list updates within 200ms.
- Type a search query in the "try an action" panel → new tab opens in Chrome, navigates to Google, fills query, submits, returns the result URL.
- Click disconnect → returns to Disconnected.
- Quit Chrome while connected → poller detects within ~300ms, hero shows "chrome went away. click to reconnect…".
- Switch to another app and back → focus listener fires `cdp_refresh`; if Chrome is gone, state transitions to Disconnected.

## Follow-ups

- #7 ("Build Connect Chrome onboarding screen") references the old `NEEDS_APPROVAL`/`DISCOVERING` states that don't exist in this simpler machine. Its UI spec (localStorage gating, recovery banner, design system references) is still valid; just needs the state-machine references updated.
- Switch tab list updates from polling to chromiumoxide event subscriptions.
- Reduce `[cdp pump] non-fatal` log volume — pattern-match Serde decode errors out, keep other errors visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)