### PR TITLE
Add daemon-backed CLI for external agents + lock TUI to XHS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,14 @@ desktop app (`app/`). The desktop app surfaces the agent to users.
   page primitives, task tabs.
 - `socai/browser/tools/`: generic browser tools built on CDP page sessions.
 - `socai/sites/xhs/`: Xiaohongshu entities, JS extractors, runtime, site tools.
-- `socai/cli/`: interactive CLI (`socai.cli.repl`). Entry point: `uv run socai`.
+- `socai/cli/`: entry point `uv run socai`. Submodules:
+  - `commands`: argparse dispatcher (`socai search_notes` / `topic_scan` /
+    `extract_note` / `stop`). No-args path falls through to the REPL.
+  - `repl`: interactive prompt-toolkit UI.
+  - `runner`: headless task runner (reused by REPL and the future Tauri host).
+  - `daemon` + `daemon_client`: long-lived process owning one browser "tool
+    tab" reused across CLI calls, exposed over `~/.socai/daemon.sock`.
+    Auto-spawns on first tool call, auto-shuts after 3h idle.
 
 Rules:
 
@@ -18,6 +25,9 @@ Rules:
   task tab per user task.
 - Keep JS extractors in a small JSON-returning contract; Python injects, calls,
   and validates results.
+- Tool subcommands wrap existing `XhsRuntime` / site tools — don't duplicate
+  XHS logic in the daemon. Any cleanups to the public data shape go in
+  `sites/xhs/entities.py` and `sites/xhs/tools.py`, not in the daemon layer.
 
 ## Desktop app — `app/`
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,29 @@ The web-use agent.
 uv sync
 ```
 
-## CLI
+## Desktop App
+
+```bash
+cd app
+pnpm install
+pnpm exec tauri dev
+```
+
+## TUI
 
 ```bash
 uv run socai
 ```
+
+## CLI (for Claude Code, Codex, etc)
+
+```bash
+socai search_notes "成都咖啡"                         # search + return note cards
+socai topic_scan "成都咖啡" --depth standard          # search + read top notes (one bundle)
+socai extract_note --note-id <id> --level lite        # open a note from the current page
+socai stop                                            # stop the daemon (closes the tool tab)
+```
+
+Add `--pretty` to any tool command for indented JSON. `extract_note` is a
+continuation command: a prior `search_notes` / `topic_scan` must have left the
+tool tab on a waterfall containing the target card.

--- a/socai/browser/cdp/browser.py
+++ b/socai/browser/cdp/browser.py
@@ -119,14 +119,39 @@ class BrowserSession:
             return await self.attach_page(pages[0].target_id)
         return await self.new_page()
 
-    async def new_page(self, url: str = "about:blank", *, activate: bool = True) -> PageSession:
-        # Create blank first, then navigate after attach. This avoids the
-        # createTarget(url) race where load polling can see about:blank.
-        created = await self.send("Target.createTarget", {"url": "about:blank"})
-        page = await self.attach_page(str(created["targetId"]), activate=activate)
-        if url != "about:blank":
-            await page.navigate(url)
-        return page
+    async def new_page(
+        self,
+        url: str = "about:blank",
+        *,
+        activate: bool = True,
+        wait_for_load: bool = True,
+    ) -> PageSession:
+        """Open a new tab and return its attached ``PageSession``.
+
+        Two strategies:
+
+        - ``wait_for_load=True`` (default, safe): create the tab as
+          about:blank, attach + enable domains, then call ``page.navigate(url)``
+          which waits for ``loadEventFired``. Returns when the page is loaded.
+          A few seconds of visible about:blank flicker is the cost — the
+          alternative (createTarget(url) + load polling) races: the load event
+          can fire before we finish attaching, leaving polling stuck.
+
+        - ``wait_for_load=False`` (fast): pass ``url`` directly to
+          ``Target.createTarget`` so Chrome starts navigating the moment the
+          tab appears (no about:blank flicker). Returns as soon as the tab is
+          attached and CDP domains are enabled — load may still be in flight.
+          Callers must do their own readiness polling.
+        """
+        if wait_for_load:
+            created = await self.send("Target.createTarget", {"url": "about:blank"})
+            page = await self.attach_page(str(created["targetId"]), activate=activate)
+            if url != "about:blank":
+                await page.navigate(url)
+            return page
+
+        created = await self.send("Target.createTarget", {"url": url})
+        return await self.attach_page(str(created["targetId"]), activate=activate)
 
     async def switch_page(self, target_id: str) -> PageSession:
         return await self.attach_page(target_id, activate=True)

--- a/socai/browser/cdp/task_session.py
+++ b/socai/browser/cdp/task_session.py
@@ -114,9 +114,10 @@ class BrowserTaskSessionManager:
         label: str = "",
         site: str = "",
         metadata: dict[str, Any] | None = None,
+        wait_for_load: bool = True,
     ) -> BrowserTaskSession:
         browser = await self.ensure_browser()
-        page = await browser.new_page(start_url)
+        page = await browser.new_page(start_url, wait_for_load=wait_for_load)
         task = BrowserTaskSession(
             task_id=uuid.uuid4().hex,
             page=page,

--- a/socai/cli/__init__.py
+++ b/socai/cli/__init__.py
@@ -1,12 +1,13 @@
 """Socai CLI package.
 
-Splits the CLI into:
-- ``runner``: headless task execution (browser session + agent loop).
-  Reusable from non-CLI hosts (e.g. a future Tauri app).
-- ``repl``: interactive UI — prompt, slash commands, model picker, event
-  rendering. CLI-only.
+Module map:
+- ``commands``: argparse dispatcher and tool subcommands (``socai search_notes`` …).
+- ``daemon``: long-lived process owning a browser tool tab.
+- ``daemon_client``: client helpers for talking to the daemon.
+- ``repl``: interactive prompt-toolkit UI (no-args entry point).
+- ``runner``: headless task runner reused by both the REPL and a future Tauri host.
 """
 
-from socai.cli.repl import main
+from socai.cli.commands import main
 
 __all__ = ["main"]

--- a/socai/cli/commands.py
+++ b/socai/cli/commands.py
@@ -1,0 +1,162 @@
+"""Argparse-based dispatcher for the ``socai`` command.
+
+No subcommand → interactive REPL (existing behaviour, backwards compatible).
+Subcommands → daemon-backed tool calls for external agents (Claude Code,
+Codex, MCP clients, scripts). The daemon is auto-started on the first tool
+call and auto-shuts-down after 3 hours idle; ``socai stop`` stops it early.
+
+Tool subcommands:
+- ``socai search_notes <query>``
+- ``socai topic_scan <query> [--depth quick|standard|deep] [--tab 全部|图文|视频|用户]``
+- ``socai extract_note --note-id <id> [--level card|lite|deep] [--include-media]``
+  (continuation — requires the daemon to already be on a waterfall page)
+
+Lifecycle:
+- ``socai stop`` — shut the daemon down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _print_json(payload: object, *, pretty: bool) -> None:
+    if pretty:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _emit_meta(result: dict) -> None:
+    """Print non-data daemon info (run_dir, etc.) to stderr."""
+    run_dir = result.get("run_dir")
+    if run_dir:
+        sys.stderr.write(f"[socai] run_dir={run_dir}\n")
+
+
+def _cmd_search_notes(args: argparse.Namespace) -> int:
+    from socai.cli.daemon_client import DaemonError, send
+
+    try:
+        result = send("search_notes", {"query": args.query})
+    except DaemonError as exc:
+        sys.stderr.write(f"[socai] error: {exc}\n")
+        return 1
+    _emit_meta(result)
+    _print_json(result.get("data") or {}, pretty=args.pretty)
+    return 0
+
+
+def _cmd_topic_scan(args: argparse.Namespace) -> int:
+    from socai.cli.daemon_client import DaemonError, send
+
+    payload = {"query": args.query, "depth": args.depth}
+    if args.tab:
+        payload["tab_label"] = args.tab
+    try:
+        result = send("topic_scan", payload, request_timeout=900.0)
+    except DaemonError as exc:
+        sys.stderr.write(f"[socai] error: {exc}\n")
+        return 1
+    _emit_meta(result)
+    _print_json(result.get("data") or {}, pretty=args.pretty)
+    return 0
+
+
+def _cmd_extract_note(args: argparse.Namespace) -> int:
+    from socai.cli.daemon_client import DaemonError, send
+
+    payload = {
+        "note_id": args.note_id,
+        "level": args.level,
+        "include_media": args.include_media,
+    }
+    try:
+        result = send("extract_note", payload, request_timeout=600.0)
+    except DaemonError as exc:
+        sys.stderr.write(f"[socai] error: {exc}\n")
+        return 1
+    _emit_meta(result)
+    _print_json(result.get("data") or {}, pretty=args.pretty)
+    return 0
+
+
+def _cmd_stop(_args: argparse.Namespace) -> int:
+    from socai.cli.daemon_client import stop_daemon
+
+    stopped = stop_daemon()
+    sys.stderr.write("[socai] daemon stopped\n" if stopped else "[socai] daemon was not running\n")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="socai",
+        description=(
+            "socai — XHS-savvy browser agent. Run with no arguments for the "
+            "interactive REPL, or use a subcommand to call a single tool "
+            "(useful from Claude Code / Codex / scripts)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    common_pretty = argparse.ArgumentParser(add_help=False)
+    common_pretty.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the JSON result with indentation.",
+    )
+
+    p = sub.add_parser("search_notes", parents=[common_pretty], help="Search XHS and return note card previews.")
+    p.add_argument("query", help="Search keyword.")
+    p.set_defaults(func=_cmd_search_notes)
+
+    p = sub.add_parser("topic_scan", parents=[common_pretty], help="Search + sample top notes + return one bundle.")
+    p.add_argument("query", help="Topic keyword.")
+    p.add_argument("--depth", choices=["quick", "standard", "deep"], default="standard")
+    p.add_argument("--tab", choices=["全部", "图文", "视频", "用户"], default="", help="Optional search-result tab filter.")
+    p.set_defaults(func=_cmd_topic_scan)
+
+    p = sub.add_parser(
+        "extract_note",
+        parents=[common_pretty],
+        help=(
+            "Open a single note from the current waterfall and extract its content. "
+            "Continuation command — the daemon must already be on a search/topic_scan "
+            "result page (or any waterfall containing the target card)."
+        ),
+    )
+    p.add_argument("--note-id", required=True, help="Stable XHS note id (from a prior search_notes / topic_scan result).")
+    p.add_argument("--level", choices=["card", "lite", "deep"], default="lite")
+    p.add_argument("--include-media", action="store_true", help="Include OCR/vision/video media (requires backend; deep only).")
+    p.set_defaults(func=_cmd_extract_note)
+
+    p = sub.add_parser("stop", help="Stop the running tool daemon (no-op if it isn't running).")
+    p.set_defaults(func=_cmd_stop)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args_list = list(sys.argv[1:] if argv is None else argv)
+    # No arguments → fall through to the interactive REPL (legacy entry point).
+    if not args_list:
+        from socai.cli.repl import main as repl_main
+
+        return repl_main()
+
+    parser = build_parser()
+    args = parser.parse_args(args_list)
+    if not getattr(args, "func", None):
+        parser.print_help(sys.stderr)
+        return 2
+    try:
+        return int(args.func(args) or 0)
+    except KeyboardInterrupt:
+        sys.stderr.write("\n[socai] interrupted\n")
+        return 130
+
+
+__all__ = ["build_parser", "main"]

--- a/socai/cli/daemon.py
+++ b/socai/cli/daemon.py
@@ -1,0 +1,404 @@
+"""Socai tool daemon — long-lived process owning one browser tool tab.
+
+Architecture:
+- Single ``BrowserTaskSessionManager`` (reuses the user's logged-in Chrome via
+  CDP, same path as the REPL).
+- One persistent "tool tab" (``BrowserTaskSession``) created lazily on first
+  tool call; recreated if the user closed it.
+- One cached ``XhsRuntime`` paired with the tool tab; rebuilt only when the
+  tab is rebuilt.
+- Unix-domain socket at ``~/.socai/daemon.sock``; JSON-per-line protocol.
+- All tool calls serialized by a single asyncio.Lock — the browser tab can't
+  drive two things at once.
+- Auto-shuts down after ``IDLE_TIMEOUT_S`` of no activity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any
+
+from socai.agent.run_logging import make_run_dir
+from socai.agent.tool import ToolContext
+from socai.browser.cdp import BrowserTaskSessionManager
+from socai.browser.cdp.task_session import BrowserTaskSession
+from socai.media import MediaProcessor
+from socai.sites.xhs import XhsRuntime
+from socai.sites.xhs.tools import (
+    XhsReadNoteTool,
+    XhsSearchNotesTool,
+    XhsTopicScanTool,
+)
+
+
+SOCAI_HOME = Path(os.environ.get("SOCAI_HOME", str(Path.home() / ".socai")))
+SOCKET_PATH = SOCAI_HOME / "daemon.sock"
+PID_PATH = SOCAI_HOME / "daemon.pid"
+LOG_PATH = SOCAI_HOME / "daemon.log"
+
+TOOL_TAB_LABEL = "socai-tools"
+# Chrome navigates the new tab to this URL the moment it appears (fast path
+# in BrowserSession.new_page). search_notes / topic_scan do their own state
+# polling, so we don't need the slow two-phase create-then-navigate dance.
+TOOL_TAB_START_URL = "https://www.xiaohongshu.com"
+
+IDLE_TIMEOUT_S = 3 * 60 * 60  # 3 hours of no requests → auto-shutdown
+IDLE_CHECK_INTERVAL_S = 60
+
+
+def _log(msg: str) -> None:
+    """Append a timestamped line to the daemon log."""
+    try:
+        SOCAI_HOME.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(msg.rstrip() + "\n")
+    except Exception:
+        pass
+
+
+class DaemonState:
+    """Mutable runtime state held by the daemon process."""
+
+    def __init__(self) -> None:
+        self.manager = BrowserTaskSessionManager(on_event=lambda m: _log(f"[browser] {m}"))
+        self.tool_tab: BrowserTaskSession | None = None
+        self.runtime: XhsRuntime | None = None
+        self.lock = asyncio.Lock()  # serialize all tool calls
+        self.started_at = time.monotonic()
+        self.last_activity = time.monotonic()
+
+    def touch(self) -> None:
+        """Mark activity so the idle-shutdown watchdog resets."""
+        self.last_activity = time.monotonic()
+
+    async def ensure_tool_tab(self) -> tuple[BrowserTaskSession, XhsRuntime]:
+        """Return (tab, runtime) for the persistent tool tab.
+
+        Recreates either if the user closed the tab in Chrome.
+        """
+        browser = await self.manager.ensure_browser()
+        existing = self.tool_tab
+        if existing is not None:
+            try:
+                targets = await browser.list_pages()
+                if any(t.target_id == existing.target_id for t in targets):
+                    assert self.runtime is not None  # paired with tool_tab
+                    return existing, self.runtime
+            except Exception as exc:  # noqa: BLE001 - fall through to recreate
+                _log(f"[tab] list_pages failed, recreating: {exc}")
+            _log("[tab] previous tool tab is gone, recreating")
+            self.tool_tab = None
+            self.runtime = None
+
+        task = await self.manager.create_task(
+            start_url=TOOL_TAB_START_URL,
+            label=TOOL_TAB_LABEL,
+            site="xiaohongshu",
+            wait_for_load=False,
+        )
+        runtime = XhsRuntime(task.page)
+        self.tool_tab = task
+        self.runtime = runtime
+        _log(f"[tab] created tool tab task_id={task.task_id} target={task.target_id}")
+        return task, runtime
+
+    async def shutdown(self) -> None:
+        # Close the tool tab in the user's Chrome first; manager.shutdown()
+        # only stops the CDP connection and would otherwise leave the tab
+        # hanging in the browser.
+        tab = self.tool_tab
+        if tab is not None:
+            try:
+                await self.manager.close_task(tab.task_id)
+                _log(f"[shutdown] closed tool tab {tab.task_id}")
+            except Exception as exc:  # noqa: BLE001
+                _log(f"[shutdown] close_task error: {exc}")
+        try:
+            await self.manager.shutdown()
+        except Exception as exc:  # noqa: BLE001
+            _log(f"[shutdown] manager shutdown error: {exc}")
+        self.tool_tab = None
+        self.runtime = None
+
+
+def _build_tool_context(run_dir: Path) -> ToolContext:
+    """Build a lightweight ToolContext suitable for a single CLI invocation."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    ctx = ToolContext(run_dir=run_dir)
+    ctx.enabled_sites = {"xiaohongshu"}
+    return ctx
+
+
+def _resolve_artifact_payload(run_dir: Path, reply: str) -> dict[str, Any]:
+    """Read the full artifact JSON the tool persisted. Falls back to reply."""
+    try:
+        envelope = json.loads(reply)
+    except Exception:
+        return {"raw_reply": reply}
+    if not isinstance(envelope, dict):
+        return {"raw_reply": reply}
+    artifact_rel = str(envelope.get("artifact") or "")
+    if artifact_rel:
+        artifact_path = run_dir / artifact_rel
+        try:
+            return json.loads(artifact_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001 - degrade gracefully
+            _log(f"[artifact] failed to read {artifact_path}: {exc}")
+    return envelope
+
+
+async def _run_search_notes(state: DaemonState, args: dict) -> dict:
+    query = str(args.get("query") or "").strip()
+    if not query:
+        raise ValueError("'query' is required")
+    _, runtime = await state.ensure_tool_tab()
+    run_dir = make_run_dir(f"cli_search_{query}")
+    ctx = _build_tool_context(run_dir)
+    runtime.media = None  # search doesn't need media
+    tool = XhsSearchNotesTool(runtime)
+    reply = await tool.execute({"query": query}, ctx)
+    payload = _resolve_artifact_payload(run_dir, reply)
+    return {"command": "search_notes", "run_dir": str(run_dir), "data": payload}
+
+
+async def _run_topic_scan(state: DaemonState, args: dict) -> dict:
+    query = str(args.get("query") or "").strip()
+    if not query:
+        raise ValueError("'query' is required")
+    depth = str(args.get("depth") or "standard").strip().lower()
+    tab_label = str(args.get("tab_label") or "").strip()
+
+    _, runtime = await state.ensure_tool_tab()
+    run_dir = make_run_dir(f"cli_topic_scan_{query}")
+    ctx = _build_tool_context(run_dir)
+    # Swap in a fresh per-run MediaProcessor. ``deep`` depth uses vision/audio
+    # which requires a backend; v1 CLI passes backend=None — that work no-ops
+    # gracefully, but agents that need deep media should call the REPL.
+    runtime.media = MediaProcessor.for_run_dir(run_dir, backend=None)
+    tool = XhsTopicScanTool(runtime)
+    params: dict[str, Any] = {"query": query, "depth": depth}
+    if tab_label:
+        params["tab_label"] = tab_label
+    reply = await tool.execute(params, ctx)
+    payload = _resolve_artifact_payload(run_dir, reply)
+    return {"command": "topic_scan", "run_dir": str(run_dir), "data": payload}
+
+
+async def _run_extract_note(state: DaemonState, args: dict) -> dict:
+    """Open a note by id from the **current** tool-tab page.
+
+    extract_note is a continuation command: the tool tab must already be on a
+    waterfall (search/topic_scan result, profile page, etc.) where the target
+    note's card is reachable. Without that prior context the underlying
+    ``read_note`` will not find the card and will return an error.
+    """
+    note_id = str(args.get("note_id") or "").strip()
+    if not note_id:
+        raise ValueError("'note_id' is required")
+    level = str(args.get("level") or "lite").strip().lower()
+    include_media = bool(args.get("include_media", False))
+
+    _, runtime = await state.ensure_tool_tab()
+    run_dir = make_run_dir(f"cli_extract_note_{note_id}")
+    ctx = _build_tool_context(run_dir)
+    runtime.media = MediaProcessor.for_run_dir(run_dir, backend=None) if include_media else None
+
+    # If a previous extract_note left a note modal open, close it first so the
+    # tab is back on the waterfall and the target card is clickable again.
+    try:
+        page_state = await runtime.detect_state()
+    except Exception as exc:  # noqa: BLE001 - tolerate detect failures
+        _log(f"[extract_note] detect_state failed, skipping pre-close: {exc}")
+        page_state = {}
+    # NB: pageState() JS returns the page-kind under the key ``state``
+    # (homepage / search_results / note_detail / profile_page).
+    if str(page_state.get("state") or "") == "note_detail":
+        _log("[extract_note] closing previously-open modal before next extract")
+        try:
+            await runtime.close_note()
+        except Exception as exc:  # noqa: BLE001 - close best-effort
+            _log(f"[extract_note] close_note failed: {exc}")
+
+    read_tool = XhsReadNoteTool(runtime)
+    reply = await read_tool.execute(
+        {"note_id": note_id, "level": level, "include_media": include_media},
+        ctx,
+    )
+    payload = _resolve_artifact_payload(run_dir, reply)
+    return {"command": "extract_note", "run_dir": str(run_dir), "data": payload}
+
+
+COMMAND_HANDLERS = {
+    "search_notes": _run_search_notes,
+    "topic_scan": _run_topic_scan,
+    "extract_note": _run_extract_note,
+}
+
+
+async def _handle_request(state: DaemonState, request: dict) -> dict:
+    cmd = str(request.get("cmd") or "")
+    req_id = request.get("id")
+    args = request.get("args") or {}
+
+    state.touch()
+
+    if cmd == "ping":
+        return {"id": req_id, "ok": True, "result": {"pong": True}}
+    if cmd == "status":
+        tab = state.tool_tab
+        now = time.monotonic()
+        return {
+            "id": req_id,
+            "ok": True,
+            "result": {
+                "pid": os.getpid(),
+                "socket": str(SOCKET_PATH),
+                "tool_tab": tab.to_dict() if tab else None,
+                "uptime_s": round(now - state.started_at, 1),
+                "idle_s": round(now - state.last_activity, 1),
+                "idle_timeout_s": IDLE_TIMEOUT_S,
+            },
+        }
+    if cmd == "shutdown":
+        return {"id": req_id, "ok": True, "result": {"shutting_down": True}, "_shutdown": True}
+    if cmd == "reset_tab":
+        async with state.lock:
+            if state.tool_tab is not None:
+                try:
+                    await state.manager.close_task(state.tool_tab.task_id)
+                except Exception as exc:  # noqa: BLE001
+                    _log(f"[reset_tab] close error: {exc}")
+                state.tool_tab = None
+        return {"id": req_id, "ok": True, "result": {"reset": True}}
+
+    handler = COMMAND_HANDLERS.get(cmd)
+    if handler is None:
+        return {"id": req_id, "ok": False, "error": f"unknown command: {cmd}"}
+
+    try:
+        async with state.lock:
+            result = await handler(state, args)
+        return {"id": req_id, "ok": True, "result": result}
+    except Exception as exc:  # noqa: BLE001 - return error to client
+        tb = traceback.format_exc()
+        _log(f"[error] {cmd}: {exc}\n{tb}")
+        return {"id": req_id, "ok": False, "error": str(exc), "traceback": tb}
+
+
+async def _serve_client(
+    state: DaemonState,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    stop_event: asyncio.Event,
+) -> None:
+    try:
+        while True:
+            line = await reader.readline()
+            if not line:
+                return
+            try:
+                request = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                err = {"ok": False, "error": f"bad json: {exc}"}
+                writer.write((json.dumps(err) + "\n").encode("utf-8"))
+                await writer.drain()
+                continue
+
+            response = await _handle_request(state, request)
+            shutdown_after = response.pop("_shutdown", False)
+            writer.write((json.dumps(response, ensure_ascii=False) + "\n").encode("utf-8"))
+            await writer.drain()
+            if shutdown_after:
+                stop_event.set()
+                return
+    except (asyncio.CancelledError, ConnectionResetError):
+        pass
+    except Exception as exc:  # noqa: BLE001
+        _log(f"[client] handler error: {exc}\n{traceback.format_exc()}")
+    finally:
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def _run_daemon() -> int:
+    SOCAI_HOME.mkdir(parents=True, exist_ok=True)
+    if SOCKET_PATH.exists():
+        try:
+            SOCKET_PATH.unlink()
+        except Exception as exc:  # noqa: BLE001
+            _log(f"[startup] cannot remove stale socket: {exc}")
+            return 1
+
+    state = DaemonState()
+    stop_event = asyncio.Event()
+
+    async def client_cb(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        await _serve_client(state, r, w, stop_event)
+
+    server = await asyncio.start_unix_server(client_cb, path=str(SOCKET_PATH))
+    os.chmod(SOCKET_PATH, 0o600)
+    PID_PATH.write_text(str(os.getpid()), encoding="utf-8")
+    _log(f"[startup] listening on {SOCKET_PATH} pid={os.getpid()}")
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:
+            pass
+
+    async def idle_watchdog() -> None:
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=IDLE_CHECK_INTERVAL_S)
+                return
+            except asyncio.TimeoutError:
+                pass
+            idle = time.monotonic() - state.last_activity
+            if idle >= IDLE_TIMEOUT_S:
+                _log(f"[idle] no activity for {idle:.0f}s (>= {IDLE_TIMEOUT_S}s), shutting down")
+                stop_event.set()
+                return
+
+    try:
+        async with server:
+            watchdog = asyncio.create_task(idle_watchdog())
+            try:
+                await stop_event.wait()
+            finally:
+                watchdog.cancel()
+    finally:
+        _log("[shutdown] stopping")
+        await state.shutdown()
+        try:
+            if SOCKET_PATH.exists():
+                SOCKET_PATH.unlink()
+        except Exception:
+            pass
+        try:
+            if PID_PATH.exists():
+                PID_PATH.unlink()
+        except Exception:
+            pass
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return asyncio.run(_run_daemon())
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/socai/cli/daemon_client.py
+++ b/socai/cli/daemon_client.py
@@ -1,0 +1,169 @@
+"""Client helpers for talking to the socai tool daemon."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from socai.cli.daemon import PID_PATH, SOCAI_HOME, SOCKET_PATH
+
+
+class DaemonError(RuntimeError):
+    """Raised when the daemon returns ok=false or the transport fails."""
+
+
+def _connect(timeout: float = 2.0) -> socket.socket | None:
+    if not SOCKET_PATH.exists():
+        return None
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect(str(SOCKET_PATH))
+    except (FileNotFoundError, ConnectionRefusedError, OSError):
+        try:
+            sock.close()
+        except Exception:
+            pass
+        return None
+    return sock
+
+
+def is_running() -> bool:
+    sock = _connect(timeout=0.5)
+    if sock is None:
+        return False
+    try:
+        return _send_on_socket(sock, "ping", {}, request_timeout=2.0).get("ok", False)
+    except Exception:
+        return False
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def spawn_daemon(*, wait_seconds: float = 30.0) -> None:
+    """Spawn the daemon as a detached background process and wait for it."""
+    SOCAI_HOME.mkdir(parents=True, exist_ok=True)
+    if is_running():
+        return
+
+    # Detach: new session, redirect stdio to log file. The daemon writes its
+    # own structured log via ``_log``, so plain stdio goes to the same file
+    # for any stray prints.
+    log_fh = open(SOCAI_HOME / "daemon.log", "a", encoding="utf-8")
+    log_fh.write(f"\n--- daemon spawn @ {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
+    log_fh.flush()
+    subprocess.Popen(
+        [sys.executable, "-m", "socai.cli.daemon"],
+        stdin=subprocess.DEVNULL,
+        stdout=log_fh,
+        stderr=log_fh,
+        start_new_session=True,
+        close_fds=True,
+    )
+
+    deadline = time.time() + wait_seconds
+    while time.time() < deadline:
+        if is_running():
+            return
+        time.sleep(0.2)
+    raise DaemonError(
+        f"daemon failed to start within {wait_seconds:.0f}s. Check {SOCAI_HOME / 'daemon.log'}"
+    )
+
+
+def _send_on_socket(
+    sock: socket.socket,
+    cmd: str,
+    args: dict[str, Any],
+    *,
+    request_timeout: float,
+) -> dict[str, Any]:
+    req_id = uuid.uuid4().hex
+    payload = json.dumps({"id": req_id, "cmd": cmd, "args": args}) + "\n"
+    sock.settimeout(request_timeout)
+    sock.sendall(payload.encode("utf-8"))
+
+    buf = bytearray()
+    while True:
+        chunk = sock.recv(65536)
+        if not chunk:
+            raise DaemonError("daemon closed connection before responding")
+        buf.extend(chunk)
+        if b"\n" in chunk:
+            break
+    line = bytes(buf).split(b"\n", 1)[0]
+    try:
+        return json.loads(line.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DaemonError(f"daemon returned malformed JSON: {exc}") from exc
+
+
+def send(
+    cmd: str,
+    args: dict[str, Any] | None = None,
+    *,
+    request_timeout: float = 600.0,
+    auto_spawn: bool = True,
+) -> dict[str, Any]:
+    """Send one command to the daemon and return its parsed response.
+
+    Auto-spawns the daemon if it isn't running. ``request_timeout`` covers the
+    whole request including in-browser work — topic_scan can take a while.
+    """
+    sock = _connect(timeout=2.0)
+    if sock is None:
+        if not auto_spawn:
+            raise DaemonError("daemon is not running")
+        spawn_daemon()
+        sock = _connect(timeout=2.0)
+        if sock is None:
+            raise DaemonError("failed to connect to daemon after spawn")
+    try:
+        response = _send_on_socket(sock, cmd, args or {}, request_timeout=request_timeout)
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+    if not response.get("ok", False):
+        err = response.get("error") or "unknown daemon error"
+        tb = response.get("traceback")
+        if tb:
+            sys.stderr.write(tb + "\n")
+        raise DaemonError(err)
+    return response.get("result") or {}
+
+
+def stop_daemon(*, timeout: float = 5.0) -> bool:
+    """Ask the daemon to shut down. Returns True if it was running."""
+    if not is_running():
+        return False
+    try:
+        send("shutdown", {}, request_timeout=timeout, auto_spawn=False)
+    except DaemonError:
+        pass
+    # Wait for socket cleanup as a liveness signal.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not SOCKET_PATH.exists():
+            return True
+        time.sleep(0.1)
+    return not is_running()
+
+
+def pid_from_file() -> int | None:
+    try:
+        return int(Path(PID_PATH).read_text(encoding="utf-8").strip())
+    except Exception:
+        return None

--- a/socai/cli/runner.py
+++ b/socai/cli/runner.py
@@ -7,7 +7,6 @@ returns a structured result dict.
 
 from __future__ import annotations
 
-import re
 from typing import Callable
 
 from socai.agent.backends import create_backend
@@ -16,55 +15,41 @@ from socai.agent.run_logging import JsonlEventLogger, current_traceback, make_ru
 from socai.browser.cdp import BrowserTaskSessionManager
 from socai.browser.tools.browser import build_browser_tools
 from socai.media import MediaProcessor
-from socai.sites.toolbox import SiteToolboxTool, site_catalog_prompt
+from socai.sites.toolbox import SiteToolboxTool
 from socai.sites.xhs import XhsRuntime
 from socai.sites.xhs.tools import build_xhs_tools
 
 
-DEFAULT_START_URL = "about:blank"
+XHS_SITE = "xiaohongshu"
+DEFAULT_START_URL = "https://www.xiaohongshu.com"
 DEFAULT_MAX_TURNS = 30
 
 AGENT_INSTRUCTIONS = """\
-You are running inside the Socai CLI. A fresh browser tab has been opened over a
-reused CDP connection — use the browser tools to drive it.
+You are running inside the Socai CLI. The browser is locked to Xiaohongshu
+(xiaohongshu.com / 小红书) — every task is an XHS task. Do NOT navigate to or
+search on any other website. If the user's task cannot be answered from XHS,
+say so plainly and stop.
 
-Web-use rules:
-- You may use any website. Start from the user's URL when one is provided;
-  otherwise navigate or use a site toolkit when the task implies one.
-- Use `browser_screenshot` early when visual state matters. Verify meaningful
-  clicks, modal changes, and navigation with a fresh screenshot or page state.
-- Prefer generic `browser_*` tools for unknown sites. Prefer a site toolkit only
-  after calling `site_toolbox` for that site; the next turn will expose the
-  site-specific tools and knowledge.
-- When selectors are stable, use selector tools. When a site crosses iframes,
-  shadow DOM, or has visible controls but weak DOM structure, coordinate clicks
-  from screenshots are acceptable.
+A fresh tab has been opened on xiaohongshu.com over a reused CDP connection.
 
-Reply in the same language as the task. Ground every claim in tool output, and
-mention the saved artifact path only when it adds value.
+How to work:
+- On your first turn, call `site_toolbox` with `site="xiaohongshu"` to unlock
+  the `xhs_*` site tools.
+- After unlocking, prefer the `xhs_*` site tools (search_notes, topic_scan,
+  read_note, …) over generic `browser_*` tools — they encapsulate the site's
+  quirks.
+- Use generic `browser_*` tools only when no `xhs_*` tool fits (e.g. clicking
+  a non-standard UI control on an XHS page).
+- Use `browser_screenshot` early when visual state matters; verify modal
+  changes and navigation with a fresh screenshot or `xhs_page_state`.
+
+Reply in the same language as the task. Ground every claim in tool output,
+and mention the saved artifact path only when it adds value.
 """
 
 
 AgentEventCallback = Callable[[str, str], None]
 BrowserEventCallback = Callable[[str], None]
-
-
-def _task_url(task_text: str) -> str:
-    match = re.search(r"https?://[^\s)>\]]+", str(task_text or ""))
-    return match.group(0).rstrip(".,，。") if match else ""
-
-
-def _start_url_for_task(task_text: str = "") -> str:
-    url = _task_url(task_text)
-    return url or DEFAULT_START_URL
-
-
-def _instructions() -> str:
-    parts = [
-        AGENT_INSTRUCTIONS,
-        site_catalog_prompt(),
-    ]
-    return "\n\n".join(part.strip() for part in parts if part.strip())
 
 
 async def run_agent_task(
@@ -91,7 +76,7 @@ async def run_agent_task(
     cli_log_path = run_dir / "cli_events.jsonl"
     cli_log = JsonlEventLogger(cli_log_path)
     backend = None
-    start_url = DEFAULT_START_URL
+    start_url = DEFAULT_START_URL  # always xhs — TUI is locked to xiaohongshu
 
     reused = manager.browser is not None
     previous_on_event = manager.on_event
@@ -112,7 +97,6 @@ async def run_agent_task(
     task = None
     try:
         backend = create_backend(model)
-        start_url = _start_url_for_task(task_text)
         cli_log.write(
             "cli_task_start",
             task=task_text,
@@ -120,7 +104,12 @@ async def run_agent_task(
             start_url=start_url,
             connection="reused" if reused else "new",
         )
-        task = await manager.create_task(start_url=start_url, label=task_text[:80], site="")
+        task = await manager.create_task(
+            start_url=start_url,
+            label=task_text[:80],
+            site=XHS_SITE,
+            wait_for_load=False,
+        )
         cli_log.write("browser_task_created", task=task.to_dict())
         browser = await manager.ensure_browser()
 
@@ -136,7 +125,7 @@ async def run_agent_task(
             run_dir=run_dir,
             max_turns=max_turns,
             model=model,
-            extra_instructions=_instructions(),
+            extra_instructions=AGENT_INSTRUCTIONS,
             log_callback=emit_agent_event,
         )
         result.update(

--- a/socai/sites/xhs/entities.py
+++ b/socai/sites/xhs/entities.py
@@ -50,6 +50,9 @@ class XhsNoteCard:
         return parse_count_text(self.likes)
 
     def to_dict(self) -> dict:
+        # likes_value and xsec_token are intentionally omitted from the public
+        # shape: likes_value is derivable from `likes`, and xsec_token is
+        # already embedded inside `link`.
         return {
             "note_id": self.note_id,
             "title": self.title,
@@ -57,12 +60,10 @@ class XhsNoteCard:
             "author_id": self.author_id,
             "author_url": normalize_url(self.author_url),
             "likes": self.likes,
-            "likes_value": self.likes_value,
             "link": self.link,
             "cover_url": self.cover_url,
             "type": self.type,
             "position": self.position,
-            "xsec_token": self.xsec_token,
         }
 
 
@@ -93,6 +94,10 @@ class XhsNote:
     wait_meta: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
+        # Omitted intentionally:
+        # - content_summary: redundant with full `content`
+        # - *_value fields: derivable from their string counterparts
+        # - shares / shares_value: not rendered in the XHS modal
         payload: dict = {
             "note_id": self.note_id,
             "url": normalize_url(self.url),
@@ -102,20 +107,14 @@ class XhsNote:
             "author_id": self.author_id,
             "author_url": normalize_url(self.author_url),
             "content": self.content,
-            "content_summary": self.content[:500],
             "content_source": self.content_source,
             "hashtags": self.hashtags[:12],
             "date": self.date,
             "location": self.location,
             "ip_location": self.ip_location,
             "likes": self.likes,
-            "likes_value": parse_count_text(self.likes),
             "favorites": self.favorites,
-            "favorites_value": parse_count_text(self.favorites),
             "comments_count": self.comments_count,
-            "comments_count_value": parse_count_text(self.comments_count),
-            "shares": self.shares,
-            "shares_value": parse_count_text(self.shares),
             "image_count": self.image_count or len(self.images),
             "images": self.images,
             "video": self.video,

--- a/socai/sites/xhs/page_scripts.js
+++ b/socai/sites/xhs/page_scripts.js
@@ -372,9 +372,20 @@ const SocaiXhsPageScripts = (() => {
     return m ? m[1] : '';
   }
 
+  // URLs that match the fallback selectors but aren't real note carousel
+  // images: author/commenter avatars, sponsor icons, sticker assets, etc.
+  // Note carousel images come from sns-webpic-* / ci.xiaohongshu.com.
+  const NON_NOTE_IMAGE_PATTERNS = [
+    /\/avatar\//i,                            // sns-avatar-qc.xhscdn.com/avatar/...
+    /\/comment\//i,                           // comment-area image attachments
+    /picasso-static\.xiaohongshu\.com/i,      // UI / fe-platform assets
+    /fe-static\.xhscdn\.com/i,                // misc static assets
+  ];
+
   function cleanImageUrl(url) {
     const value = absUrl(url || '');
     if (!value || value.startsWith('data:') || value.startsWith('blob:')) return '';
+    if (NON_NOTE_IMAGE_PATTERNS.some((re) => re.test(value))) return '';
     return value.replace(/imageView2\/\d\/w\/\d+\/format\/[^/?#]+/i, '');
   }
 
@@ -390,6 +401,10 @@ const SocaiXhsPageScripts = (() => {
     for (const sel of NOTE_IMAGE_SELECTORS) {
       for (const img of $$(sel, root)) {
         if (!isVisible(img)) continue;
+        // Broad fallback selectors (#noteContainer img, .note-detail img)
+        // also match imgs inside the comment area. Skip them — note carousel
+        // imgs live above the comments DOM.
+        if (inCommentArea(img)) continue;
         const candidates = [
           img.currentSrc, img.src, img.getAttribute('src'),
           img.getAttribute('data-src'), img.getAttribute('data-original'),

--- a/socai/sites/xhs/runtime.py
+++ b/socai/sites/xhs/runtime.py
@@ -12,7 +12,7 @@ from typing import Any
 from socai.browser.cdp.page import PageSession
 from socai.media import MediaProcessor
 
-from .entities import XhsAuthorProfile, XhsNote, XhsNoteCard
+from .entities import XhsAuthorProfile, XhsNote, XhsNoteCard, parse_count_text
 
 
 XHS_HOME_URL = "https://www.xiaohongshu.com/explore"
@@ -127,6 +127,11 @@ class XhsRuntime:
         submit = await self.submit_search(keyword, wait_seconds=wait_seconds)
         ok = bool(submit.get("ok"))
         cards = await self.extract_search_cards() if ok else []
+        # `url_keyword` is internal — used by `_search_transition_ok` to detect
+        # bad redirects — and redundant with the `url` field at the boundary.
+        state = submit.get("state") if isinstance(submit, dict) else None
+        if isinstance(state, dict):
+            state.pop("url_keyword", None)
         return {
             "ok": ok,
             "query": keyword,
@@ -435,8 +440,10 @@ class XhsRuntime:
             body = {}
         hashtags = body.get("hashtags") if isinstance(body.get("hashtags"), list) else []
         image_urls = body.get("image_urls") if isinstance(body.get("image_urls"), list) else []
+        # Cover is always at index 0; we keep that ordering invariant and no
+        # longer surface a redundant is_cover flag.
         images = [
-            {"url": str(url), "index": index, "is_cover": index == 0}
+            {"url": str(url), "index": index}
             for index, url in enumerate(image_urls[: max(0, int(max_images or 0)) or len(image_urls)])
             if str(url).strip()
         ]
@@ -502,7 +509,7 @@ class XhsRuntime:
         if not note.images:
             urls = await self.collect_carousel_images(max_images=max_images)
             note.images = [
-                {"url": url, "index": index, "is_cover": index == 0}
+                {"url": url, "index": index}
                 for index, url in enumerate(urls[:max_images])
             ]
             note.image_count = len(note.images)
@@ -590,12 +597,35 @@ class XhsRuntime:
             }
         payload: dict[str, Any] = {"ok": True, "entity": note.to_dict()}
         if with_comments:
-            try:
-                payload["comments"] = await self.extract_comments(max_comments=max_comments)
-            except Exception as exc:  # noqa: BLE001 - comments are best-effort
-                payload["comments"] = []
-                payload["comments_error"] = str(exc)
+            payload["comments"] = await self._extract_comments_with_retry(
+                expected=parse_count_text(note.comments_count),
+                max_comments=max_comments,
+                payload=payload,
+            )
         return payload
+
+    async def _extract_comments_with_retry(
+        self,
+        *,
+        expected: int,
+        max_comments: int,
+        payload: dict,
+        attempts: int = 4,
+        wait_s: float = 0.4,
+    ) -> list[dict]:
+        """Comments load lazily after the note shell renders — retry briefly
+        if the note advertises comments but our first read returns empty."""
+        result: list[dict] = []
+        for attempt in range(attempts):
+            try:
+                result = await self.extract_comments(max_comments=max_comments)
+            except Exception as exc:  # noqa: BLE001 - comments are best-effort
+                payload["comments_error"] = str(exc)
+                result = []
+            if result or expected <= 0:
+                return result
+            await asyncio.sleep(wait_s)
+        return result
 
     async def extract_profile(self, *, max_notes: int = 20, scroll_rounds: int = 6) -> XhsAuthorProfile:
         await self.ensure_xhs(navigate_if_needed=False)

--- a/socai/sites/xhs/tools.py
+++ b/socai/sites/xhs/tools.py
@@ -24,6 +24,19 @@ def _json(payload: dict) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
+_TOP_COMMENT_KEEP = ("text", "username", "likes", "time")
+
+
+def _slim_top_comments(items: list, *, limit: int = 5) -> list[dict]:
+    """Project a raw comment list to the public top_comments shape."""
+    out: list[dict] = []
+    for item in (items or [])[:limit]:
+        if not isinstance(item, dict):
+            continue
+        out.append({key: item.get(key) for key in _TOP_COMMENT_KEEP})
+    return out
+
+
 _LEVEL_ORDER = {"card": 0, "lite": 1, "deep": 2}
 _SCAN_PROFILES = {
     "quick": {"deep": 0, "lite": 3, "deep_comments": 0, "lite_comments": 4, "media": False},
@@ -276,13 +289,16 @@ class XhsReadNoteTool(XhsToolBase):
         entity = payload.get("entity") or {}
         comments = payload.get("comments") or []
         if isinstance(entity, dict):
-            entity["top_comments"] = comments[:5]
+            entity["top_comments"] = _slim_top_comments(comments)
+        # The full ``comments`` list is collapsed into ``entity.top_comments``;
+        # the top-level field is intentionally not surfaced.
+        payload.pop("comments", None)
         label = f"xhs_note_{entity.get('note_id') or 'note'}"
         reply = await self._emit(
             ctx,
             label=label,
             payload=payload,
-            preview={"ok": payload.get("ok", False), "entity": entity, "comments": comments[:8]},
+            preview={"ok": payload.get("ok", False), "entity": entity},
         )
         artifact = _artifact_from_reply(reply)
         if payload.get("ok") and isinstance(entity, dict):
@@ -484,7 +500,7 @@ class XhsTopicScanTool(XhsToolBase):
                 scan_timing.record(f"read_note_{level}", time.perf_counter() - read_t0)
                 entity = payload.get("entity") or {}
                 if isinstance(entity, dict):
-                    entity["top_comments"] = (payload.get("comments") or [])[:5]
+                    entity["top_comments"] = _slim_top_comments(payload.get("comments") or [])
                     try:
                         screenshot_path = ctx.next_screenshot_path(f"xhs_topic_{index + 1}_{level}")
                         with scan_timing.measure("note_screenshot"):
@@ -512,7 +528,6 @@ class XhsTopicScanTool(XhsToolBase):
                     "source_position": card.position,
                     "ok": bool(payload.get("ok")),
                     "entity": entity,
-                    "comments": (payload.get("comments") or [])[:comment_count],
                     "error": payload.get("error", ""),
                 })
             except Exception as exc:  # noqa: BLE001 - continue sampling


### PR DESCRIPTION
## Summary
- New ``socai search_notes`` / ``topic_scan`` / ``extract_note`` / ``stop`` subcommands. Backed by a Unix-socket daemon that owns one persistent Chrome tool tab, auto-spawns on first use, auto-shuts after 3h idle.
- Cleanup of the XHS data shape (drops ``*_value`` / ``content_summary`` / ``shares`` / ``xsec_token`` / ``is_cover`` / ``url_keyword``; slims ``top_comments``; filters avatar / comment / UI-asset images from the carousel). Applies to the internal agent too.
- ``BrowserSession.new_page`` gains ``wait_for_load=False`` fast path; daemon and TUI use it to skip the about:blank flicker.
- TUI (``uv run socai``) is now locked to Xiaohongshu via the system prompt and always lands on xhs.com.
- README + AGENTS updated.

## Test plan
- [ ] ``uv run socai search_notes "成都咖啡" --pretty`` returns cards with no ``xsec_token`` / ``likes_value``
- [ ] ``uv run socai extract_note --note-id <id>`` after the search opens the right note; second call closes the prior modal first
- [ ] ``uv run socai stop`` closes the tool tab in Chrome
- [ ] ``uv run socai topic_scan "..." --depth quick`` returns a bundle
- [ ] ``uv run socai`` (no args) stays on xhs and refuses off-site tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)