### PR TITLE
Refine desktop task interface

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use socai_core::agent::{configured_default_model_for, load_api_key, AgentEvent, Provider};
 use socai_core::runtime::{
     create_llm_provider, ensure_llm_provider_configured, run_agent_task as run_agent_with_tools,
-    AgentRunConfig, BrowserStatus, BrowserTargetInfo, RuntimePageSession, SocaiRuntime,
+    AgentRunConfig, BrowserStatus, RuntimePageSession, SocaiRuntime,
 };
 use socai_core::sites::xhs::{
     extract_note_command, search_notes_command, topic_scan_command, xhs_agent_instructions,
@@ -11,7 +11,7 @@ use socai_core::sites::xhs::{
 };
 use tauri::{AppHandle, Emitter, State};
 
-const TAURI_AGENT_PREAMBLE: &str = "You are running inside the Socai desktop app.";
+const TAURI_AGENT_PREAMBLE: &str = "You are running inside the socai desktop app.";
 
 // ── CDP connect tests (existing) ───────────────────────────────────────────
 
@@ -37,42 +37,8 @@ pub async fn cdp_status(runtime: State<'_, SocaiRuntime>) -> Result<BrowserStatu
 }
 
 #[tauri::command]
-pub async fn cdp_list_pages(
-    runtime: State<'_, SocaiRuntime>,
-) -> Result<Vec<BrowserTargetInfo>, String> {
-    Ok(runtime.browser_pages().await)
-}
-
-#[tauri::command]
 pub async fn cdp_refresh(_runtime: State<'_, SocaiRuntime>) -> Result<(), String> {
     Ok(())
-}
-
-#[tauri::command]
-pub async fn cdp_test_search(
-    runtime: State<'_, SocaiRuntime>,
-    query: String,
-) -> Result<String, String> {
-    let query = query.trim();
-    if query.is_empty() {
-        return Err("query is empty".into());
-    }
-    let encoded = url_encode_query(query);
-    let url = format!("https://www.google.com/search?q={encoded}");
-    let page = runtime
-        .create_page(&url)
-        .await
-        .map_err(|e| format!("create_page failed: {e}"))?;
-    let info = page
-        .page_info()
-        .await
-        .map_err(|e| format!("page_info failed: {e}"))?;
-    let final_url = info
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default()
-        .to_string();
-    Ok(format!("opened results for \"{query}\" — {final_url}"))
 }
 
 // ── Tool-call tests ─────────────────────────────────────────────────────────
@@ -304,18 +270,4 @@ fn event_to_payload(event: &AgentEvent) -> AgentEventPayload {
             text: format!("done in {turns} turns"),
         },
     }
-}
-
-fn url_encode_query(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char);
-            }
-            b' ' => out.push('+'),
-            _ => out.push_str(&format!("%{b:02X}")),
-        }
-    }
-    out
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -19,9 +19,7 @@ pub fn run() {
                         RuntimeBrowserEvent::StatusChanged(payload) => {
                             let _ = handle.emit("cdp:status_changed", payload);
                         }
-                        RuntimeBrowserEvent::TargetsChanged(pages) => {
-                            let _ = handle.emit("cdp:targets_changed", pages);
-                        }
+                        RuntimeBrowserEvent::TargetsChanged(_) => {}
                     }
                 }
             });
@@ -32,8 +30,6 @@ pub fn run() {
             commands::cdp_disconnect,
             commands::cdp_status,
             commands::cdp_refresh,
-            commands::cdp_list_pages,
-            commands::cdp_test_search,
             commands::tool_search_notes,
             commands::tool_topic_scan,
             commands::tool_extract_note,

--- a/app/src/capability_tests.ts
+++ b/app/src/capability_tests.ts
@@ -1,14 +1,9 @@
-//! Three capability tests shipped with the desktop app — CDP connect,
-//! XHS tool calls, agent task. All three live in this one file because
-//! they're closely related and small enough that splitting them per panel
-//! would add more navigation cost than it saves.
-//!
-//! The shell in `main.ts` calls into the `cdpPanel` / `toolsPanel` /
-//! `agentPanel` namespaces below; each owns its own local state and
-//! exposes `render(shell)` + `bind(shell)`.
+//! Capability panels shipped with the desktop app. The shell in `main.ts`
+//! renders one universal task entrance; this file keeps the task state,
+//! agent configuration, and low-level tool runners together.
 
 import { invoke } from "@tauri-apps/api/core";
-import type { AgentEventPayload, ModelInfo, ShellState, TargetInfo } from "./main";
+import type { AgentEventPayload, ModelInfo, ShellState } from "./main";
 
 interface AgentOutcome {
   run_id: string;
@@ -27,248 +22,158 @@ export function esc(s: string): string {
   });
 }
 
-function truncate(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n - 1) + "…" : s;
-}
-
-// ── CDP connect smoke test ────────────────────────────────────────────────
-
-export namespace cdpPanel {
-  let cdpQuery = "";
-  let cdpStatusText = "";
-  let cdpInFlight = false;
-
-  export function reset(): void {
-    cdpStatusText = "";
-  }
-
-  export function render(shell: ShellState): string {
-    const tabList = shell.status.state === "connected" && shell.pages.length > 0
-      ? `<ul class="tab-list">${shell.pages.map(renderTab).join("")}</ul>`
-      : "";
-
-    if (shell.status.state === "connected") {
-      return `
-        <form id="cdp-form" class="row-form">
-          <input
-            id="cdp-input"
-            class="input-field"
-            type="text"
-            placeholder="google search…"
-            value="${esc(cdpQuery)}"
-            autocomplete="off"
-            ${cdpInFlight ? "disabled" : ""}
-          />
-          <button type="submit" class="btn-primary" ${cdpInFlight ? "disabled" : ""}>
-            ${cdpInFlight ? "running…" : "search"}
-          </button>
-          <button id="cdp-disconnect" type="button" class="btn-ghost">disconnect</button>
-        </form>
-        ${cdpStatusText ? `<p class="t-small status-line">${esc(cdpStatusText)}</p>` : ""}
-        ${tabList}
-      `;
-    }
-
-    return `
-      <div class="row-form">
-        <button id="cdp-connect" class="btn-primary" ${shell.status.state === "connecting" ? "disabled" : ""}>
-          ${shell.status.state === "connecting" ? "connecting…" : "connect"}
-        </button>
-      </div>
-    `;
-  }
-
-  export function bind(shell: ShellState): void {
-    document.getElementById("cdp-connect")?.addEventListener("click", () => {
-      invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
-    });
-    document.getElementById("cdp-disconnect")?.addEventListener("click", () => {
-      invoke("cdp_disconnect").catch((e) => console.error("cdp_disconnect failed:", e));
-    });
-    const input = document.getElementById("cdp-input") as HTMLInputElement | null;
-    input?.addEventListener("input", () => { cdpQuery = input.value; });
-    document.getElementById("cdp-form")?.addEventListener("submit", async (e) => {
-      e.preventDefault();
-      const q = cdpQuery.trim();
-      if (!q || cdpInFlight) return;
-      cdpInFlight = true;
-      cdpStatusText = `opening tab and searching for "${q}"…`;
-      shell.rerender();
-      try {
-        cdpStatusText = await invoke<string>("cdp_test_search", { query: q });
-      } catch (err) {
-        cdpStatusText = `error: ${err}`;
-      } finally {
-        cdpInFlight = false;
-        shell.rerender();
-      }
-    });
-  }
-
-  function renderTab(t: TargetInfo): string {
-    return `
-      <li class="tab-row">
-        <div class="tab-title t-body">${esc(t.title || "(untitled)")}</div>
-        <div class="tab-url t-mono">${esc(truncate(t.url, 90))}</div>
-      </li>
-    `;
-  }
-}
-
-// ── XHS tool calls (search_notes / topic_scan / extract_note) ─────────────
-
-export namespace toolsPanel {
-  type ToolCommand = "search_notes" | "topic_scan" | "extract_note";
-
-  interface RunningState {
-    cmd: ToolCommand;
-    preview: string;
-  }
-
-  let searchQuery = "";
-  let topicQuery = "";
-  let extractNoteId = "";
-  let active: RunningState | null = null;
-  let result: unknown = null;
-  let errorText = "";
-
-  export function render(shell: ShellState): string {
-    const connected = shell.status.state === "connected";
-    const disabled = (cmd: ToolCommand): string => {
-      if (!connected) return "disabled";
-      return active && active.cmd !== cmd ? "disabled" : "";
-    };
-    const running = (cmd: ToolCommand): boolean => active?.cmd === cmd;
-    const guard = connected ? "" : `<p class="t-small subtle">connect chrome first.</p>`;
-
-    return `
-      ${guard}
-      <div class="tool-grid">
-        <form id="tool-search-form" class="row-form">
-          <span class="tool-name t-mono">search_notes</span>
-          <input id="tool-search-input" class="input-field" placeholder="query" value="${esc(searchQuery)}" ${disabled("search_notes")} />
-          <button type="submit" class="btn-primary" ${disabled("search_notes")}>
-            ${running("search_notes") ? "running…" : "run"}
-          </button>
-        </form>
-
-        <form id="tool-topic-form" class="row-form">
-          <span class="tool-name t-mono">topic_scan</span>
-          <input id="tool-topic-input" class="input-field" placeholder="query" value="${esc(topicQuery)}" ${disabled("topic_scan")} />
-          <button type="submit" class="btn-primary" ${disabled("topic_scan")}>
-            ${running("topic_scan") ? "running…" : "run"}
-          </button>
-        </form>
-
-        <form id="tool-extract-form" class="row-form">
-          <span class="tool-name t-mono">extract_note</span>
-          <input id="tool-extract-input" class="input-field" placeholder="note_id" value="${esc(extractNoteId)}" ${disabled("extract_note")} />
-          <button type="submit" class="btn-primary" ${disabled("extract_note")}>
-            ${running("extract_note") ? "running…" : "run"}
-          </button>
-        </form>
-      </div>
-
-      <div class="result-block">
-        ${renderResult()}
-      </div>
-    `;
-  }
-
-  function renderResult(): string {
-    if (active) {
-      return `<pre class="result-pre result-running">running: ${esc(active.preview)}</pre>`;
-    }
-    if (errorText) {
-      return `<pre class="result-pre result-error">${esc(errorText)}</pre>`;
-    }
-    if (result) {
-      return `<pre class="result-pre">${esc(JSON.stringify(result, null, 2))}</pre>`;
-    }
-    return `<p class="t-small placeholder">no result yet.</p>`;
-  }
-
-  export function bind(shell: ShellState): void {
-    const sInput = document.getElementById("tool-search-input") as HTMLInputElement | null;
-    sInput?.addEventListener("input", () => { searchQuery = sInput.value; });
-    document.getElementById("tool-search-form")?.addEventListener("submit", async (e) => {
-      e.preventDefault();
-      const q = searchQuery.trim();
-      if (!q) return;
-      await runTool(shell, {
-        cmd: "search_notes",
-        preview: `search_notes(query=${JSON.stringify(q)})`,
-      }, () => invoke("tool_search_notes", { query: q }));
-    });
-
-    const tInput = document.getElementById("tool-topic-input") as HTMLInputElement | null;
-    tInput?.addEventListener("input", () => { topicQuery = tInput.value; });
-    document.getElementById("tool-topic-form")?.addEventListener("submit", async (e) => {
-      e.preventDefault();
-      const q = topicQuery.trim();
-      if (!q) return;
-      await runTool(shell, {
-        cmd: "topic_scan",
-        preview: `topic_scan(query=${JSON.stringify(q)})`,
-      }, () => invoke("tool_topic_scan", { query: q }));
-    });
-
-    const eInput = document.getElementById("tool-extract-input") as HTMLInputElement | null;
-    eInput?.addEventListener("input", () => { extractNoteId = eInput.value; });
-    document.getElementById("tool-extract-form")?.addEventListener("submit", async (e) => {
-      e.preventDefault();
-      const id = extractNoteId.trim();
-      if (!id) return;
-      await runTool(shell, {
-        cmd: "extract_note",
-        preview: `extract_note(note_id=${JSON.stringify(id)})`,
-      }, () => invoke("tool_extract_note", { noteId: id }));
-    });
-  }
-
-  async function runTool(
-    shell: ShellState,
-    state: RunningState,
-    action: () => Promise<unknown>,
-  ): Promise<void> {
-    if (active) return;
-    active = state;
-    errorText = "";
-    result = null;
-    shell.rerender();
-    try {
-      result = await action();
-    } catch (err) {
-      errorText = `${err}`;
-    } finally {
-      active = null;
-      shell.rerender();
-    }
-  }
-}
-
 // ── Agent task ─────────────────────────────────────────────────────────────
 
 export namespace agentPanel {
+  type TaskMode = "agent" | "tools";
+  type ToolCommand = "search_notes" | "topic_scan" | "extract_note";
+
   let task = "";
+  let mode: TaskMode = "agent";
+  let toolCommand: ToolCommand = "search_notes";
   let model = "";
   let inFlight = false;
+  let toolInFlight = false;
+  let toolResult: unknown = null;
+  let toolError = "";
   let events: AgentEventPayload[] = [];
   let outcome: AgentOutcome | null = null;
   let errorText = "";
   let modelsCache: ModelInfo[] = [];
 
-  // Key-entry sub-state — only visible when the active model lacks a key.
+  // Key-entry sub-state — used by the header configuration popover.
   let pendingKey = "";
   let savingKey = false;
   let keyError = "";
+  let configOpen = false;
 
   export function setModels(models: ModelInfo[]): void {
     modelsCache = models;
-    if (!model) {
+    if (!model || !models.some((m) => m.default_model === model)) {
       const withKey = models.find((m) => m.has_key);
       model = (withKey ?? models[0])?.default_model ?? "";
     }
+  }
+
+  export function renderHeader(): string {
+    return `
+      <div class="agent-status">
+        ${renderAgentBadge()}
+        ${configOpen ? renderConfigPopover() : ""}
+      </div>
+    `;
+  }
+
+  export function bindHeader(shell: ShellState): void {
+    document.getElementById("agent-config-toggle")?.addEventListener("click", () => {
+      configOpen = !configOpen;
+      shell.rerender();
+    });
+
+    const modelEl = document.getElementById("agent-header-model") as HTMLSelectElement | null;
+    modelEl?.addEventListener("change", () => {
+      model = modelEl.value;
+      keyError = "";
+      pendingKey = "";
+      shell.rerender();
+    });
+
+    const keyInput = document.getElementById("agent-header-key-input") as HTMLInputElement | null;
+    keyInput?.addEventListener("input", () => { pendingKey = keyInput.value; });
+
+    const saveBtn = document.getElementById("agent-header-key-save") as HTMLButtonElement | null;
+    saveBtn?.addEventListener("click", async () => {
+      const provider = saveBtn.dataset.provider;
+      const key = pendingKey.trim();
+      if (!provider || !key || savingKey) return;
+      savingKey = true;
+      keyError = "";
+      shell.rerender();
+      try {
+        await invoke("agent_save_api_key", { provider, apiKey: key });
+        setModels(await invoke<ModelInfo[]>("agent_list_models"));
+        pendingKey = "";
+      } catch (err) {
+        keyError = `${err}`;
+      } finally {
+        savingKey = false;
+        shell.rerender();
+      }
+    });
+  }
+
+  export function closeHeaderConfig(): boolean {
+    if (!configOpen) return false;
+    configOpen = false;
+    return true;
+  }
+
+  function renderAgentBadge(): string {
+    const selected = selectedModel();
+    const expanded = configOpen ? "true" : "false";
+    if (!selected) {
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>agent · loading</button>`;
+    }
+    if (!selected.has_key) {
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>agent · ${esc(selected.display_name)} · key needed</button>`;
+    }
+    return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>agent · ${esc(selected.display_name)}</button>`;
+  }
+
+  function renderConfigPopover(): string {
+    const selected = selectedModel();
+    const modelOpts = modelsCache
+      .map((m) => {
+        const sel = model === m.default_model ? "selected" : "";
+        const flag = m.has_key ? "" : " · no key";
+        return `<option value="${esc(m.default_model)}" ${sel}>${esc(m.display_name)} — ${esc(m.default_model)}${flag}</option>`;
+      })
+      .join("");
+
+    return `
+      <div class="topbar-popover agent-config-popover" role="dialog" aria-label="agent configuration">
+        <p class="t-eyebrow agent-config-title">agent</p>
+        <label class="agent-config-field">
+          <span class="t-small">model</span>
+          <select id="agent-header-model" class="input-field" ${savingKey || inFlight ? "disabled" : ""}>
+            ${modelOpts || `<option value="">loading…</option>`}
+          </select>
+        </label>
+        ${
+          selected
+            ? `<p class="t-small subtle">${esc(selected.display_name)} · <span class="t-mono">${esc(selected.default_model)}</span></p>`
+            : `<p class="t-small subtle">loading available models…</p>`
+        }
+        ${selected ? selected.has_key ? `<p class="t-small subtle">api key configured.</p>` : renderHeaderKeyEntry(selected) : ""}
+      </div>
+    `;
+  }
+
+  function renderHeaderKeyEntry(selected: ModelInfo): string {
+    return `
+      <div class="agent-config-key">
+        <p class="t-small subtle">${esc(selected.display_name)} needs an API key.</p>
+        <input
+          id="agent-header-key-input"
+          class="input-field"
+          type="password"
+          placeholder="paste api key"
+          value="${esc(pendingKey)}"
+          autocomplete="off"
+          ${savingKey ? "disabled" : ""}
+        />
+        <div class="agent-config-actions">
+          <button id="agent-header-key-save" type="button" data-provider="${esc(selected.provider)}" class="btn-primary btn-compact" ${savingKey ? "disabled" : ""}>
+            ${savingKey ? "saving…" : "save"}
+          </button>
+          ${keyError ? `<span class="t-small result-error">${esc(keyError)}</span>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  function selectedModel(): ModelInfo | undefined {
+    return modelsCache.find((m) => m.default_model === model);
   }
 
   /// Append a streamed event AND incrementally update the DOM so we don't
@@ -288,44 +193,96 @@ export namespace agentPanel {
 
   export function render(shell: ShellState): string {
     const connected = shell.status.state === "connected";
-    const selected = modelsCache.find((m) => m.default_model === model);
-    const keylessSelected = !!selected && !selected.has_key;
-    const formDisabled = inFlight || !connected;
-    const runDisabled = formDisabled || keylessSelected;
-
-    const modelOpts = modelsCache
-      .map((m) => {
-        const sel = model === m.default_model ? "selected" : "";
-        const flag = m.has_key ? "" : " · no key";
-        return `<option value="${esc(m.default_model)}" ${sel}>${esc(m.display_name)} — ${esc(m.default_model)}${flag}</option>`;
-      })
-      .join("");
-
-    const guard = connected ? "" : `<p class="t-small subtle">connect chrome first.</p>`;
+    const selected = selectedModel();
+    const modelReady = !!selected && selected.has_key;
+    const agentMode = mode === "agent";
+    const running = agentMode ? inFlight : toolInFlight;
+    const runDisabled = running || !connected || (agentMode && !modelReady);
+    const guard = renderTaskGuard(connected, selected);
 
     return `
-      ${guard}
-      <form id="agent-form" class="agent-form">
-        <textarea
-          id="agent-task"
-          class="input-field input-textarea"
-          rows="3"
-          placeholder="task"
-          ${formDisabled ? "disabled" : ""}
-        >${esc(task)}</textarea>
+      <div class="task-interface">
+        <form id="task-form" class="task-form">
+          <textarea
+            id="task-input"
+            class="task-input"
+            rows="5"
+            placeholder="${esc(taskPlaceholder())}"
+            ${running ? "disabled" : ""}
+          >${esc(task)}</textarea>
 
-        <div class="row-form agent-row">
-          <select id="agent-model" class="input-field" ${inFlight ? "disabled" : ""}>
-            ${modelOpts || `<option value="">(loading…)</option>`}
-          </select>
-          <button type="submit" class="btn-primary" ${runDisabled ? "disabled" : ""}>
-            ${inFlight ? "running…" : "run"}
+          <div class="task-controls">
+            <div class="mode-switch" aria-label="task mode">
+              <button id="mode-agent" type="button" class="mode-button ${agentMode ? "mode-button-active" : ""}">agent mode</button>
+              <button id="mode-tools" type="button" class="mode-button ${!agentMode ? "mode-button-active" : ""}">dedicated tools</button>
+            </div>
+            ${agentMode ? renderAgentSummary(selected) : renderToolPicker()}
+            <button type="submit" class="btn-primary" ${runDisabled ? "disabled" : ""}>
+              ${running ? "running…" : agentMode ? "run task" : "run tool"}
+            </button>
+          </div>
+        </form>
+
+        ${guard}
+        ${agentMode ? renderAgentResult() : renderToolResult()}
+      </div>
+    `;
+  }
+
+  function renderTaskGuard(connected: boolean, selected: ModelInfo | undefined): string {
+    if (!connected) return `<p class="t-small subtle">connect chrome first.</p>`;
+    if (mode !== "agent") return renderToolHint();
+    if (!selected) return `<p class="t-small subtle">loading agent models…</p>`;
+    if (!selected.has_key) return `<p class="t-small subtle">configure the agent in the header first.</p>`;
+    return `<p class="t-small subtle">socai will decide which browser steps and tools to use.</p>`;
+  }
+
+  function renderAgentSummary(selected: ModelInfo | undefined): string {
+    const summary = selected
+      ? `agent · ${esc(selected.display_name)} · <span class="t-mono">${esc(selected.default_model)}</span>`
+      : "agent · loading";
+    return `<p class="t-small subtle task-context">${summary}</p>`;
+  }
+
+  function renderToolPicker(): string {
+    const tools: Array<[ToolCommand, string]> = [
+      ["search_notes", "search notes"],
+      ["topic_scan", "topic scan"],
+      ["extract_note", "extract note"],
+    ];
+    return `
+      <div class="tool-picker" aria-label="tool">
+        ${tools.map(([cmd, label]) => `
+          <button type="button" data-tool="${cmd}" class="tool-choice ${toolCommand === cmd ? "tool-choice-active" : ""}">
+            ${label}
           </button>
-        </div>
+        `).join("")}
+      </div>
+    `;
+  }
 
-        ${keylessSelected ? renderKeyEntry(selected!.provider, selected!.display_name) : ""}
-      </form>
+  function renderToolHint(): string {
+    switch (toolCommand) {
+      case "search_notes":
+        return `<p class="t-small subtle">search xiaohongshu notes for the query above.</p>`;
+      case "topic_scan":
+        return `<p class="t-small subtle">run a structured topic scan for the query above.</p>`;
+      case "extract_note":
+        return `<p class="t-small subtle">paste a note id above to extract the note.</p>`;
+    }
+  }
 
+  function taskPlaceholder(): string {
+    if (mode === "agent") return "tell socai what you want researched…";
+    switch (toolCommand) {
+      case "search_notes": return "search query…";
+      case "topic_scan": return "topic to scan…";
+      case "extract_note": return "note_id…";
+    }
+  }
+
+  function renderAgentResult(): string {
+    return `
       <p class="t-eyebrow result-label">result</p>
       <div class="result-block">
         ${
@@ -353,82 +310,89 @@ export namespace agentPanel {
     `;
   }
 
-  function renderKeyEntry(provider: string, displayName: string): string {
-    return `
-      <div class="key-entry">
-        <span class="t-small">${esc(displayName)} needs an API key:</span>
-        <input
-          id="agent-key-input"
-          class="input-field"
-          type="password"
-          placeholder="paste api key"
-          value="${esc(pendingKey)}"
-          autocomplete="off"
-          ${savingKey ? "disabled" : ""}
-        />
-        <button id="agent-key-save" type="button" data-provider="${esc(provider)}" class="btn-primary" ${savingKey ? "disabled" : ""}>
-          ${savingKey ? "saving…" : "save"}
-        </button>
-        ${keyError ? `<span class="t-small result-error">${esc(keyError)}</span>` : ""}
-      </div>
-    `;
+  function renderToolResult(): string {
+    if (toolInFlight) {
+      return `<pre class="result-pre result-running">running: ${esc(toolCommand)}(${esc(JSON.stringify(task.trim()))})</pre>`;
+    }
+    if (toolError) {
+      return `<pre class="result-pre result-error">${esc(toolError)}</pre>`;
+    }
+    if (toolResult) {
+      return `<pre class="result-pre">${esc(JSON.stringify(toolResult, null, 2))}</pre>`;
+    }
+    return `<p class="t-small placeholder">no tool result yet.</p>`;
   }
 
   export function bind(shell: ShellState): void {
-    const taskEl = document.getElementById("agent-task") as HTMLTextAreaElement | null;
+    const taskEl = document.getElementById("task-input") as HTMLTextAreaElement | null;
     taskEl?.addEventListener("input", () => { task = taskEl.value; });
-    const modelEl = document.getElementById("agent-model") as HTMLSelectElement | null;
-    modelEl?.addEventListener("change", () => {
-      model = modelEl.value;
-      keyError = "";
-      pendingKey = "";
+
+    document.getElementById("mode-agent")?.addEventListener("click", () => {
+      mode = "agent";
       shell.rerender();
     });
+    document.getElementById("mode-tools")?.addEventListener("click", () => {
+      mode = "tools";
+      shell.rerender();
+    });
+    document.querySelectorAll<HTMLButtonElement>("[data-tool]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        toolCommand = btn.dataset.tool as ToolCommand;
+        toolError = "";
+        toolResult = null;
+        shell.rerender();
+      });
+    });
 
-    document.getElementById("agent-form")?.addEventListener("submit", async (e) => {
+    document.getElementById("task-form")?.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const t = task.trim();
-      if (!t || inFlight) return;
-      inFlight = true;
-      events = [];
-      outcome = null;
-      errorText = "";
-      shell.rerender();
-      try {
-        outcome = await invoke<AgentOutcome>("agent_run", {
-          task: t,
-          model: model || null,
-        });
-      } catch (err) {
-        errorText = `${err}`;
-      } finally {
-        inFlight = false;
-        shell.rerender();
-      }
+      if (mode === "agent") await runAgentTask(shell);
+      else await runDedicatedTool(shell);
     });
+  }
 
-    const keyInput = document.getElementById("agent-key-input") as HTMLInputElement | null;
-    keyInput?.addEventListener("input", () => { pendingKey = keyInput.value; });
-    const saveBtn = document.getElementById("agent-key-save") as HTMLButtonElement | null;
-    saveBtn?.addEventListener("click", async () => {
-      const provider = saveBtn.dataset.provider;
-      const key = pendingKey.trim();
-      if (!provider || !key || savingKey) return;
-      savingKey = true;
-      keyError = "";
+  async function runAgentTask(shell: ShellState): Promise<void> {
+    const t = task.trim();
+    if (!t || inFlight) return;
+    inFlight = true;
+    events = [];
+    outcome = null;
+    errorText = "";
+    shell.rerender();
+    try {
+      outcome = await invoke<AgentOutcome>("agent_run", {
+        task: t,
+        model: model || null,
+      });
+    } catch (err) {
+      errorText = `${err}`;
+    } finally {
+      inFlight = false;
       shell.rerender();
-      try {
-        await invoke("agent_save_api_key", { provider, apiKey: key });
-        const models = await invoke<ModelInfo[]>("agent_list_models");
-        modelsCache = models;
-        pendingKey = "";
-      } catch (err) {
-        keyError = `${err}`;
-      } finally {
-        savingKey = false;
-        shell.rerender();
+    }
+  }
+
+  async function runDedicatedTool(shell: ShellState): Promise<void> {
+    const value = task.trim();
+    if (!value || toolInFlight) return;
+    toolInFlight = true;
+    toolError = "";
+    toolResult = null;
+    shell.rerender();
+    try {
+      if (toolCommand === "extract_note") {
+        toolResult = await invoke("tool_extract_note", { noteId: value });
+      } else if (toolCommand === "topic_scan") {
+        toolResult = await invoke("tool_topic_scan", { query: value });
+      } else {
+        toolResult = await invoke("tool_search_notes", { query: value });
       }
-    });
+    } catch (err) {
+      toolError = `${err}`;
+    } finally {
+      toolInFlight = false;
+      shell.rerender();
+    }
   }
 
   function renderAgentEvent(ev: AgentEventPayload): string {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,22 +1,14 @@
-//! Tauri desktop entry — single scrolling page with three stacked
-//! capability tests (cdp / tools / agent).
+//! Tauri desktop entry — header status/configuration plus tools / agent panels.
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
-import { agentPanel, cdpPanel, toolsPanel } from "./capability_tests";
+import { agentPanel } from "./capability_tests";
 
 export type Status =
   | { state: "disconnected"; reason: string }
   | { state: "connecting"; attempt: number }
   | { state: "connected"; endpoint: string; browser_version: string; page_count: number };
-
-export interface TargetInfo {
-  target_id: string;
-  type: string;
-  title: string;
-  url: string;
-}
 
 export interface ModelInfo {
   provider: string;
@@ -41,7 +33,6 @@ export interface AgentEventPayload {
 
 export interface ShellState {
   status: Status;
-  pages: TargetInfo[];
   rerender: () => void;
 }
 
@@ -59,16 +50,14 @@ interface PanelModule {
 }
 
 const PANELS: PanelModule[] = [
-  { label: "cdp", render: cdpPanel.render, bind: cdpPanel.bind },
-  { label: "tools", render: toolsPanel.render, bind: toolsPanel.bind },
-  { label: "agent", render: agentPanel.render, bind: agentPanel.bind },
+  { label: "task", render: agentPanel.render, bind: agentPanel.bind },
 ];
 
 let status: Status = { state: "disconnected", reason: "starting" };
-let pages: TargetInfo[] = [];
+let connectionDetailsOpen = false;
 
 function shell(): ShellState {
-  return { status, pages, rerender: render };
+  return { status, rerender: render };
 }
 
 function render(): void {
@@ -88,37 +77,120 @@ function render(): void {
     <div class="shell">
       <header class="topbar">
         <div class="brand">${MARK_SVG}<span class="brand-name">socai</span></div>
-        <span class="t-eyebrow connection-pill">${connectionEyebrow()}</span>
+        <div class="topbar-controls">
+          ${connectionStatusBar()}
+          ${agentPanel.renderHeader()}
+        </div>
       </header>
       <main class="stack">${sections}</main>
     </div>
   `;
+  bindConnectionStatusBar();
+  agentPanel.bindHeader(state);
   for (const p of PANELS) p.bind(state);
 }
 
-function connectionEyebrow(): string {
+function connectionStatusBar(): string {
+  return `
+    <div class="connection-status" aria-live="polite">
+      ${connectionBadge()}
+      ${status.state === "connected" && connectionDetailsOpen ? renderConnectionDialog(status) : ""}
+    </div>
+  `;
+}
+
+function connectionBadge(): string {
   switch (status.state) {
     case "disconnected":
-      return "chrome · disconnected";
+      return `<button id="chrome-connect" type="button" class="badge badge-button" aria-label="connect chrome"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>chrome · disconnected</button>`;
     case "connecting":
-      return `chrome · connecting · ${status.attempt}/3`;
-    case "connected": {
-      const n = pages.length;
-      return `chrome · connected · ${n} tab${n === 1 ? "" : "s"}`;
-    }
+      return `<button type="button" class="badge badge-button" disabled><i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>chrome · connecting · ${status.attempt}/3</button>`;
+    case "connected":
+      return `<button id="chrome-status-toggle" type="button" class="badge badge-button" aria-expanded="${connectionDetailsOpen ? "true" : "false"}" aria-label="show chrome connection status"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>chrome · connected</button>`;
   }
+}
+
+function renderConnectionDialog(connected: Extract<Status, { state: "connected" }>): string {
+  const tabs = `${connected.page_count} tab${connected.page_count === 1 ? "" : "s"}`;
+  return `
+    <div class="topbar-popover connection-dialog" role="dialog" aria-label="chrome connection status">
+      <div class="connection-dialog-head">
+        <p class="t-eyebrow connection-dialog-title">chrome</p>
+        <span class="badge"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>connected</span>
+      </div>
+      <div class="connection-meta">
+        <div>
+          <p class="t-eyebrow">tabs</p>
+          <p class="t-mono">${tabs}</p>
+        </div>
+        <div>
+          <p class="t-eyebrow">browser</p>
+          <p class="t-mono">${htmlEsc(connected.browser_version)}</p>
+        </div>
+        <div class="connection-meta-wide">
+          <p class="t-eyebrow">endpoint</p>
+          <p class="t-mono connection-endpoint">${htmlEsc(connected.endpoint)}</p>
+        </div>
+      </div>
+      <button id="chrome-disconnect" type="button" class="btn-ghost">disconnect</button>
+    </div>
+  `;
+}
+
+function bindConnectionStatusBar(): void {
+  document.getElementById("chrome-connect")?.addEventListener("click", () => {
+    connectionDetailsOpen = false;
+    invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
+  });
+  document.getElementById("chrome-status-toggle")?.addEventListener("click", async () => {
+    const opening = !connectionDetailsOpen;
+    if (opening) {
+      try {
+        status = await invoke<Status>("cdp_status");
+      } catch (e) {
+        console.error("cdp_status failed:", e);
+      }
+    }
+    connectionDetailsOpen = opening;
+    render();
+  });
+  document.getElementById("chrome-disconnect")?.addEventListener("click", () => {
+    connectionDetailsOpen = false;
+    invoke("cdp_disconnect").catch((e) => console.error("cdp_disconnect failed:", e));
+  });
+}
+
+function htmlEsc(s: string): string {
+  return s.replace(/[<>&"']/g, (c) => {
+    return (
+      { "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&#39;" } as Record<string, string>
+    )[c];
+  });
+}
+
+function bindGlobalDismiss(): void {
+  document.addEventListener("click", (event) => {
+    let changed = false;
+
+    if (connectionDetailsOpen && !eventPathHasClass(event, "connection-status")) {
+      connectionDetailsOpen = false;
+      changed = true;
+    }
+    if (!eventPathHasClass(event, "agent-status") && agentPanel.closeHeaderConfig()) {
+      changed = true;
+    }
+
+    if (changed) render();
+  });
+}
+
+function eventPathHasClass(event: Event, className: string): boolean {
+  return event.composedPath().some((item) => item instanceof Element && item.classList.contains(className));
 }
 
 async function main(): Promise<void> {
   try {
     status = await invoke<Status>("cdp_status");
-    if (status.state === "connected") {
-      try {
-        pages = await invoke<TargetInfo[]>("cdp_list_pages");
-      } catch (e) {
-        console.error("initial cdp_list_pages failed:", e);
-      }
-    }
   } catch (e) {
     console.error("initial cdp_status failed:", e);
   }
@@ -129,19 +201,11 @@ async function main(): Promise<void> {
     console.error("agent_list_models failed:", e);
   }
   render();
+  bindGlobalDismiss();
 
   await listen<Status>("cdp:status_changed", (event) => {
-    const wasConnected = status.state === "connected";
     status = event.payload;
-    if (status.state !== "connected") {
-      pages = [];
-      if (wasConnected) cdpPanel.reset();
-    }
-    render();
-  });
-
-  await listen<TargetInfo[]>("cdp:targets_changed", (event) => {
-    pages = event.payload;
+    if (status.state !== "connected") connectionDetailsOpen = false;
     render();
   });
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -138,11 +138,117 @@ body.has-paper > * { position: relative; z-index: 1; }
   font-size: 14px;
   color: var(--ink-0);
 }
-.connection-pill {
+.topbar-controls {
   margin-left: auto;
-  padding: 2px var(--sp-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.connection-status,
+.agent-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  position: relative;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border: var(--hairline);
+  background: var(--surface);
+  padding: 4px 10px;
   border-radius: var(--r-pill);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--ink-1);
+  white-space: nowrap;
+}
+.badge-button {
+  appearance: none;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease);
+}
+.badge-button:hover { border-color: var(--line-strong); }
+.badge-button:disabled {
+  color: var(--fg-soft);
+  cursor: wait;
+}
+.badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--r-pill);
+  flex: 0 0 auto;
+}
+.badge-dot-muted { background: var(--ink-4); }
+.badge-dot-ink { background: var(--ink-0); }
+.badge-dot-hollow {
+  width: 7px;
+  height: 7px;
+  background: var(--surface);
+  border: 1px solid var(--ink-0);
+}
+.badge-dot-pulse { animation: pulse 1.4s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+.topbar-popover {
+  position: absolute;
+  top: calc(100% + var(--sp-2));
+  right: 0;
+  z-index: 10;
+  width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  background: var(--surface);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  box-shadow: var(--shadow-pop);
+}
+.connection-dialog-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+.connection-dialog-title { margin: 0; }
+.connection-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: var(--hairline);
+  border-radius: var(--r-3);
+  overflow: hidden;
+}
+.connection-meta > div {
+  padding: var(--sp-3);
+  background: var(--canvas);
+}
+.connection-meta > div:nth-child(1) { border-right: var(--hairline); }
+.connection-meta > div:nth-child(-n + 2) { border-bottom: var(--hairline); }
+.connection-meta p { margin: 0; }
+.connection-meta .t-mono { margin-top: var(--sp-2); }
+.connection-meta-wide { grid-column: 1 / -1; }
+.connection-endpoint { word-break: break-all; }
+.agent-config-title { margin: 0; }
+.agent-config-field,
+.agent-config-key {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.agent-config-key {
+  padding: var(--sp-3);
+  background: var(--canvas);
+  border: var(--hairline);
+  border-radius: var(--r-3);
+}
+.agent-config-key p { margin: 0; }
+.agent-config-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
 }
 
 /* ── Stacked sections ──────────────────────────────────────────── */
@@ -177,40 +283,81 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .row-form .input-field { flex: 1; }
 
-/* Tools section — fixed-width tool name column keeps rows aligned. */
-.tool-grid {
+/* Universal task entrance. */
+.task-interface {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: var(--sp-3);
 }
-.tool-name {
-  flex: 0 0 110px;
-  color: var(--fg-soft);
-}
-.tool-spacer { flex: 1; }
-
-/* Agent task: textarea + select-row + (optional) key-entry row. */
-.agent-form {
+.task-form {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  overflow: hidden;
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  background: var(--surface);
 }
-.input-textarea {
-  font-family: var(--font-sans);
+.task-input {
+  width: 100%;
+  min-height: 132px;
+  padding: var(--sp-4);
+  border: 0;
   resize: vertical;
-  min-height: 60px;
+  background: transparent;
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
 }
-.agent-row .input-field { flex: 1; }
-
-.key-entry {
+.task-input::placeholder { color: var(--fg-faint); }
+.task-input:focus { outline: none; }
+.task-input:disabled {
+  background: var(--surface-2);
+  color: var(--fg-soft);
+  cursor: not-allowed;
+}
+.task-controls {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  padding: var(--sp-2) var(--sp-3);
-  background: var(--surface-2);
-  border-radius: var(--r-3);
+  padding: var(--sp-2);
+  border-top: var(--hairline);
+  background: var(--canvas);
 }
-.key-entry .input-field { flex: 1; }
+.mode-switch,
+.tool-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.mode-switch {
+  padding: 2px;
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+}
+.mode-button,
+.tool-choice {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  border-radius: var(--r-pill);
+  color: var(--fg-soft);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  padding: 6px 10px;
+  white-space: nowrap;
+}
+.mode-button-active,
+.tool-choice-active {
+  background: var(--ink-0);
+  color: var(--ink-9);
+}
+.task-context { flex: 1; }
+.tool-picker { flex: 1; }
 
 /* ── Result + event stream ─────────────────────────────────────── */
 .result-block {
@@ -240,8 +387,6 @@ body.has-paper > * { position: relative; z-index: 1; }
 .result-running { color: var(--fg-soft); }
 .placeholder { color: var(--fg-faint); margin: 0; }
 .subtle { margin: 0; color: var(--fg-soft); }
-.status-line { margin: 0; }
-
 .event-stream {
   display: flex;
   flex-direction: column;
@@ -397,6 +542,11 @@ code {
   color: var(--fg-faint);
   cursor: not-allowed;
 }
+.btn-compact {
+  padding: 3px var(--sp-2);
+  border-radius: var(--r-pill);
+  font-size: 12px;
+}
 
 /* ── Inputs ───────────────────────────────────────────────────── */
 .input-field {
@@ -416,31 +566,4 @@ code {
   background: var(--surface-2);
   color: var(--fg-soft);
   cursor: not-allowed;
-}
-
-/* ── Tab list (cdp section) ───────────────────────────────────── */
-.tab-list {
-  list-style: none;
-  margin: var(--sp-2) 0 0 0;
-  padding: 0;
-  border-top: var(--hairline);
-}
-.tab-row {
-  padding: var(--sp-2) 0;
-  border-bottom: var(--hairline);
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-1);
-}
-.tab-title {
-  color: var(--ink-1);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.tab-url {
-  color: var(--fg-soft);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary
- Replace separate center CDP/tools/agent panels with one universal task entrypoint.
- Move Chrome and agent setup into clickable header status pills with shared popover styling and outside-click dismissal.
- Add agent-mode and dedicated-tool modes, with dedicated tools reusing the universal input for search/topic/note extraction.
- Remove open-tab listing and obsolete CDP smoke-search commands from the desktop app.

## Validation
- cd app && pnpm build
- cargo check -p socai_app
- git diff --check

## Screenshots

<img width="2812" height="2172" alt="CleanShot 2026-05-16 at 15 56 15@2x" src="https://github.com/user-attachments/assets/6967f282-fe94-4c7b-ae72-91748558748a" />
