### PR TITLE
Ignore .claude/ worktree state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .venv/
 .socai/
+.claude/
 
 # macOS
 .DS_Store


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` so the harness's per-project state (notably `.claude/worktrees/`) stops appearing as untracked content in every checkout of the repo.

## Why

Claude Code creates branch worktrees under `.claude/worktrees/<name>/`. Because that path lives inside the main working tree but wasn't ignored, every parallel checkout saw `.claude/` in `git status` — easy to accidentally stage, and noisy day-to-day.

`.claude/` is per-user/per-machine tool state, not source, so the standard treatment is to ignore the whole directory rather than try to track a subset.

## Test plan

- [ ] On a fresh checkout, create a worktree via the harness and confirm `git status` no longer reports `.claude/` as untracked.
- [ ] Confirm existing worktrees keep functioning — nothing in `.claude/` is tracked, so ignoring it can't break a checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)