### PR TITLE
Update UI tweaks from Claude Design

### DIFF
--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo, ShellState } from "../main";
+import type { ModelInfo, Status, ShellState } from "../main";
 import { esc } from "../lib/html";
 import type { AgentTaskView, TaskMode, ToolCommand } from "./tasks";
 
@@ -14,6 +14,9 @@ export interface NewTaskPageProps {
   submitError: string;
   tasks: AgentTaskView[];
   selectedModel: ModelInfo | undefined;
+  overlayKeyDraft: string;
+  overlayKeySaving: boolean;
+  overlayKeyError: string;
 }
 
 export function renderNewTaskPage(props: NewTaskPageProps): string {
@@ -22,21 +25,28 @@ export function renderNewTaskPage(props: NewTaskPageProps): string {
   const agentMode = props.mode === "agent";
   const running = agentMode ? props.submittingTask : props.toolInFlight;
   const runDisabled = running || !props.draft.trim() || !connected || (agentMode && !modelReady);
-  const guard = renderTaskGuard(props.mode, connected, props.selectedModel);
+  const needsKey = connected && agentMode && !!props.selectedModel && !props.selectedModel.has_key;
+  const gated = !connected || needsKey;
 
   return `
     <div class="new-task-page">
       <div class="new-task-compose">
         <div class="new-task-copy">
-          <p class="t-eyebrow">new task</p>
           <h2 class="t-h2">what should socai research?</h2>
           <p class="t-small subtle">start a one-shot browser task. socai opens a temporary chrome tab, runs the agent, saves the result, then closes the tab.</p>
         </div>
-        ${renderTaskForm(props, agentMode, running, runDisabled)}
-        ${guard}
-        ${props.submitError ? `<pre class="result-pre result-error">${esc(props.submitError)}</pre>` : ""}
-        ${agentMode ? "" : renderToolResult(props)}
+        <div class="compose-form-stack ${gated ? "is-masked" : ""}">
+          <div class="compose-form-inner" aria-hidden="${gated ? "true" : "false"}">
+            ${renderTaskForm(props, agentMode, running, runDisabled)}
+            ${renderInlineGuard(props.mode, props.toolCommand, props.selectedModel)}
+            ${props.submitError ? `<pre class="result-pre result-error">${esc(props.submitError)}</pre>` : ""}
+            ${agentMode ? "" : renderToolResult(props)}
+          </div>
+          ${!connected ? renderConnectOverlay(props.shell.status) : ""}
+          ${connected && needsKey ? renderApiKeyOverlay(props.selectedModel!, props) : ""}
+        </div>
       </div>
+      ${renderRunningChip(props.tasks)}
       ${renderTaskGlance(props.tasks)}
     </div>
   `;
@@ -72,12 +82,10 @@ function renderTaskForm(
   `;
 }
 
-function renderTaskGuard(mode: TaskMode, connected: boolean, selected: ModelInfo | undefined): string {
-  if (!connected) return `<p class="t-small subtle">connect chrome first.</p>`;
-  if (mode !== "agent") return renderToolHint(mode);
+function renderInlineGuard(mode: TaskMode, toolCommand: ToolCommand, selected: ModelInfo | undefined): string {
+  if (mode !== "agent") return renderToolHint(toolCommand);
   if (!selected) return `<p class="t-small subtle">loading agent models…</p>`;
-  if (!selected.has_key) return `<p class="t-small subtle">configure the agent in the header first.</p>`;
-  return `<p class="t-small subtle">each task gets its own temporary chrome tab and closes it when finished.</p>`;
+  return "";
 }
 
 function renderAgentSummary(selected: ModelInfo | undefined): string {
@@ -104,12 +112,17 @@ function renderToolPicker(toolCommand: ToolCommand): string {
   `;
 }
 
-function renderToolHint(_mode: TaskMode): string {
-  return `<p class="t-small subtle">test tools on a fresh temporary xiaohongshu tab.</p>`;
+function renderToolHint(toolCommand: ToolCommand): string {
+  const hint = {
+    search_notes: "test search_notes on a fresh temporary xiaohongshu tab.",
+    topic_scan: "test topic_scan on a fresh temporary xiaohongshu tab.",
+    extract_note: "paste a note id or url; socai opens a fresh temporary page and extracts it.",
+  }[toolCommand];
+  return `<p class="t-small subtle">${hint}</p>`;
 }
 
 function taskPlaceholder(mode: TaskMode, toolCommand: ToolCommand): string {
-  if (mode === "agent") return "tell socai what you want researched…";
+  if (mode === "agent") return "tell socai what you want researched…\neach task opens its own temporary chrome tab.";
   switch (toolCommand) {
     case "search_notes": return "search query…";
     case "topic_scan": return "topic to scan…";
@@ -117,11 +130,101 @@ function taskPlaceholder(mode: TaskMode, toolCommand: ToolCommand): string {
   }
 }
 
-function renderTaskGlance(tasks: AgentTaskView[]): string {
+function renderConnectOverlay(status: Status): string {
+  const connecting = status.state === "connecting";
+  const label = connecting
+    ? `chrome · connecting · ${(status as Extract<Status, { state: "connecting" }>).attempt}/3`
+    : "chrome · disconnected";
+  const heading = connecting ? "looking for chrome…" : "connect chrome to start";
+  const cta = connecting ? "connecting…" : "connect chrome →";
+  const dotClass = connecting ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow";
+  return `
+    <div class="connect-overlay" role="dialog" aria-label="chrome required">
+      <span class="connect-overlay-pill">
+        <i class="badge-dot ${dotClass}" aria-hidden="true"></i>${label}
+      </span>
+      <h3 class="connect-overlay-head">${heading}</h3>
+      <button
+        id="overlay-chrome-connect"
+        type="button"
+        class="btn-primary connect-overlay-cta"
+        ${connecting ? "disabled" : ""}
+      >${cta}</button>
+      <a
+        class="connect-overlay-link t-small"
+        href="https://developer.chrome.com/docs/devtools/remote-debugging"
+        target="_blank"
+        rel="noopener noreferrer"
+      >how do i enable remote debugging? ↗</a>
+    </div>
+  `;
+}
+
+function renderApiKeyOverlay(selected: ModelInfo, props: NewTaskPageProps): string {
+  const placeholder = {
+    anthropic: "sk-ant-...",
+    openai: "sk-...",
+  }[selected.provider] ?? "paste api key";
+  const saving = props.overlayKeySaving;
+  const cta = saving ? "saving…" : "save & continue →";
+  const disableSubmit = saving || !props.overlayKeyDraft.trim();
+  return `
+    <form
+      id="overlay-key-form"
+      class="connect-overlay"
+      role="dialog"
+      aria-label="api key required"
+      data-provider="${esc(selected.provider)}"
+    >
+      <span class="connect-overlay-pill">
+        <i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>
+        agent · ${esc(selected.display_name)} · key needed
+      </span>
+      <h3 class="connect-overlay-head">
+        add your ${esc(selected.display_name.toLowerCase())} api key
+      </h3>
+      <input
+        id="overlay-key-input"
+        type="password"
+        class="input-field connect-overlay-input"
+        placeholder="${esc(placeholder)}"
+        autocomplete="off"
+        value="${esc(props.overlayKeyDraft)}"
+        ${saving ? "disabled" : ""}
+      />
+      <button
+        id="overlay-key-save"
+        type="submit"
+        class="btn-primary connect-overlay-cta"
+        ${disableSubmit ? "disabled" : ""}
+      >${cta}</button>
+      ${props.overlayKeyError ? `<p class="t-small result-error connect-overlay-error">${esc(props.overlayKeyError)}</p>` : ""}
+    </form>
+  `;
+}
+
+function renderRunningChip(tasks: AgentTaskView[]): string {
   const running = [...tasks]
-    .filter((task) => task.status === "running" || task.status === "queued")
-    .sort((a, b) => b.created_at - a.created_at)
-    .slice(0, 4);
+    .filter((t) => t.status === "running" || t.status === "queued")
+    .sort((a, b) => b.created_at - a.created_at);
+  if (running.length === 0) return "";
+  const first = running[0];
+  const isOne = running.length === 1;
+  const count = isOne ? "1 task running" : `${running.length} tasks running`;
+  const taskLabel = isOne
+    ? `<span class="running-chip-dot" aria-hidden="true">·</span><span class="running-chip-task">${esc(first.task)}</span>`
+    : "";
+  return `
+    <button type="button" class="running-chip" data-task-id="${esc(first.task_id)}">
+      <i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>
+      <span class="running-chip-count">${count}</span>
+      ${taskLabel}
+      <span class="running-chip-arrow" aria-hidden="true">→</span>
+    </button>
+  `;
+}
+
+function renderTaskGlance(tasks: AgentTaskView[]): string {
   const recent = [...tasks]
     .filter((task) => task.status !== "running" && task.status !== "queued")
     .sort((a, b) => b.created_at - a.created_at)
@@ -129,13 +232,6 @@ function renderTaskGlance(tasks: AgentTaskView[]): string {
 
   return `
     <div class="task-glance">
-      <section class="task-glance-card">
-        <div class="task-glance-head">
-          <p class="t-eyebrow result-label">running</p>
-          <span class="t-small subtle">${running.length}</span>
-        </div>
-        ${renderTaskSummaryRows(running, "no running tasks.")}
-      </section>
       <section class="task-glance-card">
         <div class="task-glance-head">
           <p class="t-eyebrow result-label">recent</p>

--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -199,6 +199,11 @@ function renderApiKeyOverlay(selected: ModelInfo, props: NewTaskPageProps): stri
         ${disableSubmit ? "disabled" : ""}
       >${cta}</button>
       ${props.overlayKeyError ? `<p class="t-small result-error connect-overlay-error">${esc(props.overlayKeyError)}</p>` : ""}
+      <button
+        id="overlay-switch-tools"
+        type="button"
+        class="connect-overlay-link t-small"
+      >use tool tests (no key needed) →</button>
     </form>
   `;
 }

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -314,6 +314,14 @@ export namespace agentPanel {
       invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
     });
 
+    document.getElementById("overlay-switch-tools")?.addEventListener("click", () => {
+      mode = "tools";
+      submitError = "";
+      overlayKey = "";
+      overlayError = "";
+      shell.rerender();
+    });
+
     const overlayKeyInput = document.getElementById("overlay-key-input") as HTMLInputElement | null;
     overlayKeyInput?.addEventListener("input", () => {
       overlayKey = overlayKeyInput.value;

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -42,6 +42,12 @@ export namespace agentPanel {
   let keyError = "";
   let configOpen = false;
 
+  // Overlay key-entry sub-state — used by the inline new-task gate when
+  // chrome is connected but the selected agent has no key.
+  let overlayKey = "";
+  let overlaySaving = false;
+  let overlayError = "";
+
   export function setModels(models: ModelInfo[]): void {
     modelsCache = models;
     if (!model || !models.some((m) => m.default_model === model)) {
@@ -215,6 +221,9 @@ export namespace agentPanel {
               submitError,
               tasks,
               selectedModel: selectedModel(),
+              overlayKeyDraft: overlayKey,
+              overlayKeySaving: overlaySaving,
+              overlayKeyError: overlayError,
             })
           : renderHistoryPage({ tasks, selectedTask: selectedTask(), selectedTaskId })}
       </div>
@@ -300,6 +309,45 @@ export namespace agentPanel {
       if (mode === "agent") await startAgentTask(shell);
       else await runDedicatedTool(shell);
     });
+
+    document.getElementById("overlay-chrome-connect")?.addEventListener("click", () => {
+      invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
+    });
+
+    const overlayKeyInput = document.getElementById("overlay-key-input") as HTMLInputElement | null;
+    overlayKeyInput?.addEventListener("input", () => {
+      overlayKey = overlayKeyInput.value;
+      const submit = document.getElementById("overlay-key-save") as HTMLButtonElement | null;
+      if (submit) submit.disabled = overlaySaving || !overlayKey.trim();
+    });
+    if (overlayKeyInput && document.activeElement === document.body) {
+      overlayKeyInput.focus();
+    }
+
+    document.getElementById("overlay-key-form")?.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      await saveOverlayKey(shell);
+    });
+  }
+
+  async function saveOverlayKey(shell: ShellState): Promise<void> {
+    const form = document.getElementById("overlay-key-form") as HTMLFormElement | null;
+    const provider = form?.dataset.provider;
+    const key = overlayKey.trim();
+    if (!provider || !key || overlaySaving) return;
+    overlaySaving = true;
+    overlayError = "";
+    shell.rerender();
+    try {
+      await invoke("agent_save_api_key", { provider, apiKey: key });
+      setModels(await invoke<ModelInfo[]>("agent_list_models"));
+      overlayKey = "";
+    } catch (err) {
+      overlayError = `${err}`;
+    } finally {
+      overlaySaving = false;
+      shell.rerender();
+    }
   }
 
   function updateSubmitButton(shell: ShellState): void {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -410,7 +410,7 @@ body.has-paper > * { position: relative; z-index: 1; }
   width: min(100%, 840px);
   align-self: center;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--sp-5);
   padding-top: var(--sp-1);
 }
@@ -523,7 +523,10 @@ body.has-paper > * { position: relative; z-index: 1; }
   line-height: 1.5;
   color: var(--fg-soft);
 }
-.task-row-glyph-running { color: var(--ink-0); }
+.task-row-glyph-running {
+  color: var(--ink-0);
+  animation: pulse 1.4s ease-in-out infinite;
+}
 .task-row-glyph-failed { color: var(--status-error-fg); }
 .task-row-main {
   display: flex;
@@ -789,3 +792,123 @@ code {
   color: var(--fg-soft);
   cursor: not-allowed;
 }
+
+/* ── Running-tasks chip (appears on new-task page when any task runs) ── */
+.running-chip {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  max-width: min(100%, 720px);
+  padding: 7px var(--sp-3);
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-1);
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
+}
+.running-chip:hover { border-color: var(--line-strong); }
+.running-chip:active { transform: scale(0.98); }
+.running-chip-count {
+  font-weight: 500;
+  white-space: nowrap;
+}
+.running-chip-dot { color: var(--fg-soft); }
+.running-chip-task {
+  color: var(--fg-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.running-chip-arrow {
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+}
+.running-chip:hover .running-chip-arrow { color: var(--ink-0); }
+
+/* ── Connect overlay (shown on disconnected/connecting new-task) ──── */
+.compose-form-stack {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.compose-form-inner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  transition: filter var(--t-base) var(--ease), opacity var(--t-base) var(--ease);
+}
+.compose-form-stack.is-masked .compose-form-inner {
+  pointer-events: none;
+  filter: saturate(0) blur(1.5px);
+  opacity: 0.55;
+  user-select: none;
+}
+.connect-overlay {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 5;
+  width: min(360px, calc(100% - var(--sp-6)));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  padding: var(--sp-5);
+  background: var(--surface);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  box-shadow: var(--shadow-pop);
+}
+.connect-overlay-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: var(--hairline);
+  background: var(--canvas);
+  padding: 4px 10px;
+  border-radius: var(--r-pill);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-1);
+  white-space: nowrap;
+}
+.connect-overlay-head {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: var(--ink-0);
+}
+.connect-overlay-cta {
+  align-self: stretch;
+  margin-top: var(--sp-1);
+  padding: 9px var(--sp-4);
+  font-size: 13px;
+  text-align: center;
+}
+.connect-overlay-input {
+  align-self: stretch;
+  font-family: var(--font-mono);
+}
+.connect-overlay-error {
+  margin: 0;
+  align-self: stretch;
+}
+.connect-overlay-link {
+  margin: 0;
+  color: var(--fg-soft);
+  text-decoration: none;
+  transition: color var(--t-fast) var(--ease);
+}
+.connect-overlay-link:hover { color: var(--ink-0); }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -907,6 +907,12 @@ code {
 }
 .connect-overlay-link {
   margin: 0;
+  padding: 0;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
   color: var(--fg-soft);
   text-decoration: none;
   transition: color var(--t-fast) var(--ease);


### PR DESCRIPTION
## Summary

Implements the **Socai Today** design handoff from `claude.ai/design`. The new-task flow now gracefully handles the two dead-end states that the user identified — chrome not connected, and selected agent missing an API key — by masking the compose form behind a centered popover instead of leaving it inert with no recourse.

- **Form-mask + overlay pattern.** When chrome is disconnected/connecting, or the selected agent has no key, the compose form stays visible but inert (`filter: saturate(0) blur(1.5px)`, 55% opacity, `pointer-events: none`) and a popover floats over it. Disconnected → connect CTA + Chrome remote-debugging help link; missing-key → inline password input that submits to `agent_save_api_key` and closes itself on success.
- **Running chip replaces the running glance section.** The always-on "running" half of the 2-up glance is gone — most of the time it was an empty placeholder. A pulsing chip now appears between the compose card and the recent section *only when* a task is actively running, jumping to history on click.
- **Smaller copy/animation tweaks** to land the design intent: temp-tab hint moves into the agent-mode placeholder so the standalone guard subtitle can go away; running glyph in task rows pulses with the same `1.4s ease-in-out` keyframe as the topbar dots; recent section is now full-width single-column.

## Test plan

- [ ] `pnpm exec tauri dev` and walk the four overlay paths: launch with chrome closed (disconnected), click connect, watch it transition through connecting → connected. Then revoke the key in settings (or use an account without one) and confirm the api-key overlay appears with provider-specific placeholder.
- [ ] In missing-key state: type a key, press Enter or click "save & continue", confirm the overlay closes and the form unmasks without reloading.
- [ ] Start a task; verify the running chip appears between compose and recent with the pulsing dot and task name. Click it → jumps to history with that task selected.
- [ ] Verify the chip hides cleanly when no tasks are running (no reserved space).
- [ ] In history view, confirm the running task row's `●` glyph pulses.
- [ ] Switch to tool-tests mode while disconnected — confirm only the connect overlay appears (no api-key overlay, since tool tests don't need a key).

## Screenshots
<img width="2812" height="2172" alt="CleanShot 2026-05-18 at 21 53 15@2x" src="https://github.com/user-attachments/assets/26b6fcd4-93fc-4a0f-9f26-c5d5bc2ddbda" />

<img width="2812" height="2172" alt="CleanShot 2026-05-18 at 21 53 48@2x" src="https://github.com/user-attachments/assets/778b1ff0-23cd-4ac8-b69e-42bb90eba6c1" />

<img width="2812" height="2172" alt="CleanShot 2026-05-18 at 21 54 50@2x" src="https://github.com/user-attachments/assets/fba91f6d-834c-48df-a2e3-aea71f156e51" />
 


🤖 Generated with [Claude Code](https://claude.com/claude-code)