### PR TITLE
Add canonical typed task timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ pnpm install
 pnpm exec tauri dev
 ```
 
+For local development with app state and run artifacts written under the repo
+instead of `~/.socai`, use:
+
+```bash
+cd app
+pnpm run dev:desktop:local
+```
+
+This writes to:
+
+```text
+.socai/app/tasks.json
+.socai/runs/<run-dir>/
+```
+
 ## TUI
 
 ```bash

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "dev:desktop": "tauri dev --config src-tauri/tauri.dev.conf.json",
+    "dev:desktop:local": "SOCAI_HOME=\"$(cd .. && pwd)/.socai\" SOCAI_RUNS_DIR=\"$(cd .. && pwd)/.socai/runs\" tauri dev --config src-tauri/tauri.dev.conf.json",
     "build": "tsc && vite build",
     "build:mac": "tauri build --ci --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"macOS\":{\"signingIdentity\":\"-\"}}}'",
     "build:mac:universal": "tauri build --ci --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"macOS\":{\"signingIdentity\":\"-\"}}}'",

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
-use crate::tasks::{now_ms, AgentTaskEventPayload, AgentTaskRegistry, AgentTaskSnapshot};
+use crate::tasks::{now_ms, AgentTaskRegistry, AgentTaskSnapshot};
+use crate::timeline::{agent_event_to_timeline, AgentTaskEventKind, AgentTaskEventPayload};
 use anyhow::Result;
 use serde_json::{json, Value};
 use socai_core::agent::{
@@ -267,11 +268,13 @@ pub async fn agent_task_start(
     } else {
         emit_task_event(
             &app,
+            tasks.inner(),
             &task_id,
             "queued",
             "task queued".into(),
             Some(snapshot.clone()),
-        );
+        )
+        .await;
         let _ = start_tx.send(());
     }
     Ok(snapshot)
@@ -326,11 +329,13 @@ pub async fn agent_task_cancel(
     if changed {
         emit_task_event(
             &app,
+            tasks.inner(),
             &task_id,
             "cancelled",
             "task cancelled".into(),
             Some(snapshot.clone()),
-        );
+        )
+        .await;
     }
     Ok(snapshot)
 }
@@ -378,7 +383,7 @@ async fn run_agent_task_background(
             })
             .await
         {
-            emit_task_event(&app, &task_id, "failed", error, Some(snapshot));
+            emit_task_event(&app, &registry, &task_id, "failed", error, Some(snapshot)).await;
         }
         return;
     };
@@ -392,11 +397,13 @@ async fn run_agent_task_background(
     {
         emit_task_event(
             &app,
+            &registry,
             &task_id,
             "running",
             "task started".into(),
             Some(snapshot),
-        );
+        )
+        .await;
     }
 
     let result = run_agent_task_on_fresh_page(
@@ -432,11 +439,13 @@ async fn run_agent_task_background(
             {
                 emit_task_event(
                     &app,
+                    &registry,
                     &task_id,
                     "completed",
                     "task completed".into(),
                     Some(snapshot),
-                );
+                )
+                .await;
             }
         }
         Err(err) => {
@@ -449,7 +458,7 @@ async fn run_agent_task_background(
                 })
                 .await
             {
-                emit_task_event(&app, &task_id, "failed", error, Some(snapshot));
+                emit_task_event(&app, &registry, &task_id, "failed", error, Some(snapshot)).await;
             }
         }
     }
@@ -485,17 +494,19 @@ async fn run_agent_task_on_fresh_page(
         {
             emit_task_event(
                 &app,
+                registry,
                 &task_id,
                 "tab",
                 "chrome tab marked as controlled by socai".into(),
                 Some(snapshot),
-            );
+            )
+            .await;
         }
     }
     let outcome = async {
         let tools = xhs_agent_tools(page.clone(), llm_provider.clone()).await?;
         let (tx, rx) = tokio::sync::broadcast::channel::<AgentEvent>(256);
-        let pump = pump_agent_task_events(app, task_id.clone(), rx);
+        let pump = pump_agent_task_events(app, registry.clone(), task_id.clone(), rx);
 
         let config = AgentRunConfig {
             extra_instructions: xhs_agent_instructions(TAURI_AGENT_PREAMBLE),
@@ -530,93 +541,51 @@ async fn run_agent_task_on_fresh_page(
 
 fn pump_agent_task_events(
     app: AppHandle,
+    registry: Option<AgentTaskRegistry>,
     task_id: String,
     mut rx: tokio::sync::broadcast::Receiver<AgentEvent>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Ok(event) = rx.recv().await {
-            let payload = event_to_payload(&task_id, &event);
-            let _ = app.emit("agent_task:event", payload);
+            let payload = agent_event_to_timeline(&event);
+            emit_timeline_payload(&app, registry.as_ref(), &task_id, payload, None).await;
         }
     })
 }
 
-pub(crate) fn emit_task_event(
+pub(crate) async fn emit_task_event(
     app: &AppHandle,
+    registry: &AgentTaskRegistry,
     task_id: &str,
     kind: &str,
     text: String,
     snapshot: Option<AgentTaskSnapshot>,
 ) {
-    let payload = AgentTaskEventPayload {
-        task_id: task_id.to_string(),
-        kind: kind.to_string(),
-        text,
-        snapshot,
-        sequence: 0,
-        created_at: now_ms(),
-    };
-    let _ = app.emit("agent_task:event", payload);
+    let payload = AgentTaskEventKind::from_kind_text(kind, text);
+    emit_timeline_payload(app, Some(registry), task_id, payload, snapshot).await;
 }
 
-fn event_to_payload(task_id: &str, event: &AgentEvent) -> AgentTaskEventPayload {
-    let (kind, text) = match event {
-        AgentEvent::Started {
-            run_id,
-            task,
-            model,
-        } => (
-            "started",
-            format!("task: {task}\nrun {run_id} · model {model}"),
-        ),
-        AgentEvent::Turn { turn } => ("turn", format!("turn {turn}")),
-        AgentEvent::AssistantText { text, .. } => ("assistant", text.clone()),
-        AgentEvent::Reasoning { text, .. } => ("reasoning", text.clone()),
-        AgentEvent::ToolCall {
-            name,
-            input,
-            repeat_count,
-            ..
-        } => {
-            let preview = serde_json::to_string(input).unwrap_or_else(|_| input.to_string());
-            let text = if *repeat_count > 1 {
-                format!("{name}({preview}) repeat={repeat_count}")
-            } else {
-                format!("{name}({preview})")
-            };
-            ("tool_call", text)
+async fn emit_timeline_payload(
+    app: &AppHandle,
+    registry: Option<&AgentTaskRegistry>,
+    task_id: &str,
+    payload: AgentTaskEventKind,
+    snapshot: Option<AgentTaskSnapshot>,
+) {
+    let event = if let Some(registry) = registry {
+        match registry
+            .append_timeline_event(task_id, payload.clone(), snapshot.clone())
+            .await
+        {
+            Some(Ok(event)) => event,
+            Some(Err(err)) => {
+                eprintln!("failed to persist timeline event for {task_id}: {err:#}");
+                return;
+            }
+            None => AgentTaskEventPayload::ephemeral(task_id, payload, snapshot),
         }
-        AgentEvent::ToolResult {
-            name,
-            summary,
-            duration_ms,
-            error,
-            ..
-        } => {
-            let first = summary.lines().next().unwrap_or("");
-            let text = match error {
-                Some(err) => format!("{name} ({duration_ms}ms): {err}"),
-                None => format!("{name} ({duration_ms}ms): {first}"),
-            };
-            (
-                if error.is_some() {
-                    "tool_error"
-                } else {
-                    "tool_result"
-                },
-                text,
-            )
-        }
-        AgentEvent::ApiError { turn, message } => ("api_error", format!("turn {turn}: {message}")),
-        AgentEvent::Done { turns, .. } => ("done", format!("done in {turns} turns")),
+    } else {
+        AgentTaskEventPayload::ephemeral(task_id, payload, snapshot)
     };
-
-    AgentTaskEventPayload {
-        task_id: task_id.to_string(),
-        kind: kind.to_string(),
-        text,
-        snapshot: None,
-        sequence: 0,
-        created_at: now_ms(),
-    }
+    let _ = app.emit("agent_task:event", event);
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod tasks;
+mod timeline;
 
 use std::collections::HashSet;
 
@@ -37,11 +38,13 @@ pub fn run() {
                                 let task_id = snapshot.task_id.clone();
                                 commands::emit_task_event(
                                     &handle,
+                                    &tasks,
                                     &task_id,
                                     "interrupted",
                                     "chrome tab was closed".into(),
                                     Some(snapshot),
-                                );
+                                )
+                                .await;
                             }
                         }
                     }

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -22,6 +22,8 @@ struct AgentTaskRegistryInner {
     next_seq: u64,
     tasks: Vec<AgentTaskSnapshot>,
     abort_handles: HashMap<String, AbortHandle>,
+    timeline_next_seq: HashMap<String, u64>,
+    timeline_locks: HashMap<String, Arc<Mutex<()>>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -65,6 +67,8 @@ impl Default for AgentTaskRegistry {
                 next_seq,
                 tasks,
                 abort_handles: HashMap::new(),
+                timeline_next_seq: HashMap::new(),
+                timeline_locks: HashMap::new(),
             })),
             runner_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_AGENT_TASKS)),
         }
@@ -229,17 +233,51 @@ impl AgentTaskRegistry {
         payload: AgentTaskEventKind,
         snapshot_for_emit: Option<AgentTaskSnapshot>,
     ) -> Option<anyhow::Result<AgentTaskEventPayload>> {
-        let guard = self.inner.lock().await;
-        let snapshot = guard
-            .tasks
-            .iter()
-            .find(|task| task.task_id == task_id)?
-            .clone();
+        let (snapshot, timeline_lock) = {
+            let mut guard = self.inner.lock().await;
+            let snapshot = guard
+                .tasks
+                .iter()
+                .find(|task| task.task_id == task_id)?
+                .clone();
+            let timeline_lock = guard
+                .timeline_locks
+                .entry(task_id.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone();
+            (snapshot, timeline_lock)
+        };
+
+        let _timeline_guard = timeline_lock.lock().await;
+        let sequence = self.next_timeline_sequence(task_id, &snapshot).await;
         Some(timeline::append_timeline_event(
             &snapshot,
             payload,
             snapshot_for_emit,
+            sequence,
         ))
+    }
+
+    async fn next_timeline_sequence(&self, task_id: &str, snapshot: &AgentTaskSnapshot) -> u64 {
+        {
+            let mut guard = self.inner.lock().await;
+            if let Some(next) = guard.timeline_next_seq.get_mut(task_id) {
+                let sequence = *next;
+                *next = sequence.saturating_add(1);
+                return sequence;
+            }
+        }
+
+        // First append for this task in the current process: scan once to pick
+        // up any existing rows, then cache the next sequence in memory. This
+        // avoids re-reading timeline.jsonl on every streamed event while still
+        // preserving append-after-replay correctness.
+        let sequence = timeline::next_timeline_sequence(snapshot);
+        let mut guard = self.inner.lock().await;
+        guard
+            .timeline_next_seq
+            .insert(task_id.to_string(), sequence.saturating_add(1));
+        sequence
     }
 
     pub(crate) async fn update<F>(&self, task_id: &str, f: F) -> Option<AgentTaskSnapshot>

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -7,8 +7,9 @@ use serde_json::Value;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::AbortHandle;
 
+use crate::timeline::{self, AgentTaskEventKind, AgentTaskEventPayload};
+
 const MAX_CONCURRENT_AGENT_TASKS: usize = 1;
-const MAX_EVENT_TEXT_CHARS: usize = 8_000;
 
 #[derive(Clone)]
 pub struct AgentTaskRegistry {
@@ -41,19 +42,6 @@ pub struct AgentTaskSnapshot {
     pub(crate) turns: Option<u32>,
     pub(crate) input_tokens: Option<u64>,
     pub(crate) output_tokens: Option<u64>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
-pub struct AgentTaskEventPayload {
-    pub(crate) task_id: String,
-    pub(crate) kind: String,
-    pub(crate) text: String,
-    #[serde(default)]
-    pub(crate) snapshot: Option<AgentTaskSnapshot>,
-    #[serde(default)]
-    pub(crate) sequence: u64,
-    #[serde(default)]
-    pub(crate) created_at: u64,
 }
 
 impl Default for AgentTaskRegistry {
@@ -232,7 +220,26 @@ impl AgentTaskRegistry {
 
     pub(crate) async fn events(&self, task_id: &str) -> Option<Vec<AgentTaskEventPayload>> {
         let snapshot = self.get(task_id).await?;
-        Some(load_task_events(&snapshot))
+        Some(timeline::load_task_events(&snapshot))
+    }
+
+    pub(crate) async fn append_timeline_event(
+        &self,
+        task_id: &str,
+        payload: AgentTaskEventKind,
+        snapshot_for_emit: Option<AgentTaskSnapshot>,
+    ) -> Option<anyhow::Result<AgentTaskEventPayload>> {
+        let guard = self.inner.lock().await;
+        let snapshot = guard
+            .tasks
+            .iter()
+            .find(|task| task.task_id == task_id)?
+            .clone();
+        Some(timeline::append_timeline_event(
+            &snapshot,
+            payload,
+            snapshot_for_emit,
+        ))
     }
 
     pub(crate) async fn update<F>(&self, task_id: &str, f: F) -> Option<AgentTaskSnapshot>
@@ -333,354 +340,4 @@ fn persist_task_index(tasks: &[AgentTaskSnapshot]) {
     if let Ok(text) = serde_json::to_string_pretty(&records) {
         let _ = std::fs::write(path, text);
     }
-}
-
-fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
-    let mut events = replay_task_events(snapshot);
-    append_terminal_snapshot_events(snapshot, &mut events);
-    events
-}
-
-fn replay_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
-    let Some(run_dir) = snapshot
-        .run_dir
-        .as_ref()
-        .filter(|dir| !dir.trim().is_empty())
-    else {
-        return Vec::new();
-    };
-    let run_dir = PathBuf::from(run_dir);
-    let mut events = replay_reasoning_log(snapshot, &run_dir.join("reasoning_log.jsonl"));
-    if events.is_empty() {
-        events = replay_run_state_events(snapshot, &run_dir.join("run_state/events.jsonl"));
-    }
-    if !events.is_empty() {
-        ensure_started_event(snapshot, &mut events);
-        reindex_replay_events(snapshot, &mut events);
-    }
-    events
-}
-
-fn replay_reasoning_log(snapshot: &AgentTaskSnapshot, path: &Path) -> Vec<AgentTaskEventPayload> {
-    let mut events = Vec::new();
-    let mut last_turn = None;
-    for value in read_jsonl_values(path) {
-        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
-        match event_type {
-            "task_start" => {
-                let task = value.get("task").and_then(Value::as_str);
-                let model = value.get("model").and_then(Value::as_str);
-                events.push(replay_event(
-                    snapshot,
-                    "started",
-                    started_event_text(snapshot, task, model),
-                ));
-            }
-            "llm_response" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let text = value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if !text.is_empty() {
-                    events.push(replay_event(snapshot, "assistant", text.to_string()));
-                }
-            }
-            "tool_call_start" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                let repeat_count = number_field(&value, "repeat_count");
-                events.push(replay_event(
-                    snapshot,
-                    "tool_call",
-                    format_tool_call_text(tool, input, repeat_count),
-                ));
-            }
-            "tool_result" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let summary = value
-                    .get("result_summary")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let error = value.get("error").and_then(Value::as_str).unwrap_or("");
-                let duration_ms = duration_ms(&value);
-                let (kind, text) = format_tool_result_text(tool, summary, duration_ms, error);
-                events.push(replay_event(snapshot, kind, text));
-            }
-            "api_error" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let message = value
-                    .get("error")
-                    .or_else(|| value.get("message"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("api error");
-                events.push(replay_event(
-                    snapshot,
-                    "api_error",
-                    format!("turn {turn}: {message}"),
-                ));
-            }
-            "task_end" => {
-                let turn = number_field(&value, "turn");
-                if turn > 0 {
-                    events.push(replay_event(
-                        snapshot,
-                        "done",
-                        format!("done in {turn} turns"),
-                    ));
-                } else {
-                    events.push(replay_event(snapshot, "done", "done".into()));
-                }
-            }
-            _ => {}
-        }
-    }
-    events
-}
-
-fn replay_run_state_events(
-    snapshot: &AgentTaskSnapshot,
-    path: &Path,
-) -> Vec<AgentTaskEventPayload> {
-    let mut events = Vec::new();
-    let mut last_turn = None;
-    for value in read_jsonl_values(path) {
-        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
-        match event_type {
-            "assistant_turn" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let text = value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if !text.is_empty() {
-                    events.push(replay_event(snapshot, "assistant", text.to_string()));
-                }
-            }
-            "tool_call" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                events.push(replay_event(
-                    snapshot,
-                    "tool_call",
-                    format_tool_call_text(tool, input, 0),
-                ));
-            }
-            "tool_result" => {
-                let turn = number_field(&value, "turn");
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let summary = value
-                    .get("result_summary")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let duration_ms = duration_ms(&value);
-                let (kind, text) = format_tool_result_text(tool, summary, duration_ms, "");
-                events.push(replay_event(snapshot, kind, text));
-            }
-            _ => {}
-        }
-    }
-    events
-}
-
-fn append_terminal_snapshot_events(
-    snapshot: &AgentTaskSnapshot,
-    events: &mut Vec<AgentTaskEventPayload>,
-) {
-    match snapshot.status.as_str() {
-        "completed" => {
-            if !events.iter().any(|event| event.kind == "done") {
-                let text = snapshot
-                    .turns
-                    .map(|turns| format!("done in {turns} turns"))
-                    .unwrap_or_else(|| "done".into());
-                push_snapshot_event(snapshot, events, "done", text);
-            }
-            if !events.iter().any(|event| event.kind == "completed") {
-                push_snapshot_event(snapshot, events, "completed", "task completed".into());
-            }
-        }
-        "failed" => {
-            if !events.iter().any(|event| event.kind == "failed") {
-                let text = snapshot
-                    .error
-                    .as_deref()
-                    .filter(|error| !error.trim().is_empty())
-                    .unwrap_or("task failed")
-                    .to_string();
-                push_snapshot_event(snapshot, events, "failed", text);
-            }
-        }
-        "cancelled" => {
-            if !events.iter().any(|event| event.kind == "cancelled") {
-                push_snapshot_event(snapshot, events, "cancelled", "task cancelled".into());
-            }
-        }
-        "interrupted" => {
-            if !events.iter().any(|event| event.kind == "interrupted") {
-                let text = snapshot
-                    .error
-                    .as_deref()
-                    .filter(|error| !error.trim().is_empty())
-                    .unwrap_or("task interrupted")
-                    .to_string();
-                push_snapshot_event(snapshot, events, "interrupted", text);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn push_snapshot_event(
-    snapshot: &AgentTaskSnapshot,
-    events: &mut Vec<AgentTaskEventPayload>,
-    kind: &str,
-    text: String,
-) {
-    let sequence = events.iter().map(|event| event.sequence).max().unwrap_or(0) + 1;
-    events.push(AgentTaskEventPayload {
-        task_id: snapshot.task_id.clone(),
-        kind: kind.into(),
-        text: truncate_event_text(&text),
-        snapshot: None,
-        sequence,
-        created_at: snapshot.finished_at.unwrap_or_else(now_ms),
-    });
-}
-
-fn ensure_started_event(snapshot: &AgentTaskSnapshot, events: &mut Vec<AgentTaskEventPayload>) {
-    if events.iter().any(|event| event.kind == "started") {
-        return;
-    }
-    events.insert(
-        0,
-        replay_event(
-            snapshot,
-            "started",
-            started_event_text(snapshot, None, None),
-        ),
-    );
-}
-
-fn reindex_replay_events(snapshot: &AgentTaskSnapshot, events: &mut [AgentTaskEventPayload]) {
-    let base = snapshot.started_at.unwrap_or(snapshot.created_at);
-    for (idx, event) in events.iter_mut().enumerate() {
-        event.sequence = idx as u64 + 1;
-        event.created_at = base.saturating_add(idx as u64 + 1);
-    }
-}
-
-fn replay_event(snapshot: &AgentTaskSnapshot, kind: &str, text: String) -> AgentTaskEventPayload {
-    AgentTaskEventPayload {
-        task_id: snapshot.task_id.clone(),
-        kind: kind.into(),
-        text: truncate_event_text(&text),
-        snapshot: None,
-        sequence: 0,
-        created_at: 0,
-    }
-}
-
-fn push_turn_event(
-    snapshot: &AgentTaskSnapshot,
-    events: &mut Vec<AgentTaskEventPayload>,
-    last_turn: &mut Option<u64>,
-    turn: u64,
-) {
-    if turn == 0 || *last_turn == Some(turn) {
-        return;
-    }
-    *last_turn = Some(turn);
-    events.push(replay_event(snapshot, "turn", format!("turn {turn}")));
-}
-
-fn started_event_text(
-    snapshot: &AgentTaskSnapshot,
-    task: Option<&str>,
-    model: Option<&str>,
-) -> String {
-    let task = task.unwrap_or(&snapshot.task);
-    let model = model
-        .or(snapshot.model.as_deref())
-        .unwrap_or("unknown model");
-    let run = snapshot
-        .run_id
-        .as_deref()
-        .map(|run_id| format!("run {run_id} · "))
-        .unwrap_or_default();
-    format!("task: {task}\n{run}model {model}")
-}
-
-fn format_tool_call_text(tool: &str, input: &Value, repeat_count: u64) -> String {
-    let preview = serde_json::to_string(input).unwrap_or_else(|_| input.to_string());
-    if repeat_count > 1 {
-        format!("{tool}({preview}) repeat={repeat_count}")
-    } else {
-        format!("{tool}({preview})")
-    }
-}
-
-fn format_tool_result_text(
-    tool: &str,
-    summary: &str,
-    duration_ms: u64,
-    error: &str,
-) -> (&'static str, String) {
-    if !error.trim().is_empty() {
-        return ("tool_error", format!("{tool} ({duration_ms}ms): {error}"));
-    }
-    let first = summary.lines().next().unwrap_or("");
-    ("tool_result", format!("{tool} ({duration_ms}ms): {first}"))
-}
-
-fn duration_ms(value: &Value) -> u64 {
-    if let Some(ms) = value.get("duration_ms").and_then(Value::as_u64) {
-        return ms;
-    }
-    value
-        .get("duration_s")
-        .and_then(Value::as_f64)
-        .map(|seconds| (seconds * 1000.0).round().max(0.0) as u64)
-        .unwrap_or_default()
-}
-
-fn number_field(value: &Value, field: &str) -> u64 {
-    value
-        .get(field)
-        .and_then(|number| {
-            number
-                .as_u64()
-                .or_else(|| number.as_f64().map(|n| n as u64))
-        })
-        .unwrap_or_default()
-}
-
-fn read_jsonl_values(path: &Path) -> Vec<Value> {
-    let Ok(text) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    text.lines()
-        .filter(|line| !line.trim().is_empty())
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .collect()
-}
-
-fn truncate_event_text(text: &str) -> String {
-    if text.chars().count() <= MAX_EVENT_TEXT_CHARS {
-        return text.to_string();
-    }
-    let kept: String = text.chars().take(MAX_EVENT_TEXT_CHARS).collect();
-    format!("{kept}\n... [truncated]")
 }

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -260,9 +260,9 @@ pub(crate) fn append_timeline_event(
     snapshot: &AgentTaskSnapshot,
     payload: AgentTaskEventKind,
     snapshot_for_emit: Option<AgentTaskSnapshot>,
+    sequence: u64,
 ) -> anyhow::Result<AgentTaskEventPayload> {
     let path = timeline_path(snapshot).context("task has no run_dir for timeline")?;
-    let sequence = next_sequence(&path);
     let mut event = AgentTaskEventPayload {
         task_id: snapshot.task_id.clone(),
         payload,
@@ -391,10 +391,10 @@ fn append_jsonl(path: &Path, event: &AgentTaskEventPayload) -> std::io::Result<(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let line = serde_json::to_string(event).map_err(std::io::Error::other)?;
+    let mut line = serde_json::to_string(event).map_err(std::io::Error::other)?;
+    line.push('\n');
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-    file.write_all(line.as_bytes())?;
-    file.write_all(b"\n")
+    file.write_all(line.as_bytes())
 }
 
 fn read_timeline_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
@@ -414,6 +414,12 @@ fn read_timeline_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPaylo
         .collect();
     events.sort_by(compare_events);
     events
+}
+
+pub(crate) fn next_timeline_sequence(snapshot: &AgentTaskSnapshot) -> u64 {
+    timeline_path(snapshot)
+        .map(|path| next_sequence(&path))
+        .unwrap_or(1)
 }
 
 fn next_sequence(path: &Path) -> u64 {

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -1,0 +1,1092 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use socai_core::agent::AgentEvent;
+
+use crate::tasks::{now_ms, AgentTaskSnapshot};
+
+const TIMELINE_FILE: &str = "timeline.jsonl";
+const MAX_EVENT_TEXT_CHARS: usize = 8_000;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct AgentTaskEventPayload {
+    pub(crate) task_id: String,
+    #[serde(flatten)]
+    pub(crate) payload: AgentTaskEventKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) snapshot: Option<AgentTaskSnapshot>,
+    #[serde(default)]
+    pub(crate) sequence: u64,
+    #[serde(default)]
+    pub(crate) created_at: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum AgentTaskEventKind {
+    Queued {
+        text: String,
+    },
+    Running {
+        text: String,
+    },
+    Started {
+        run_id: String,
+        task: String,
+        model: String,
+        text: String,
+    },
+    Tab {
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_id: Option<String>,
+    },
+    Turn {
+        turn: u32,
+        text: String,
+    },
+    Assistant {
+        turn: u32,
+        text: String,
+    },
+    Reasoning {
+        turn: u32,
+        text: String,
+    },
+    ToolCall {
+        id: String,
+        turn: u32,
+        sequence_in_turn: u32,
+        name: String,
+        label: String,
+        args: Value,
+        repeat_count: u32,
+        text: String,
+    },
+    ToolResult {
+        id: String,
+        turn: u32,
+        sequence_in_turn: u32,
+        name: String,
+        label: String,
+        args: Value,
+        ok: bool,
+        summary: String,
+        duration_ms: u64,
+        #[serde(default)]
+        entities: Vec<TimelineEntity>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result_file: Option<String>,
+        text: String,
+    },
+    ToolError {
+        id: String,
+        turn: u32,
+        sequence_in_turn: u32,
+        name: String,
+        label: String,
+        args: Value,
+        ok: bool,
+        summary: String,
+        duration_ms: u64,
+        #[serde(default)]
+        entities: Vec<TimelineEntity>,
+        error: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result_file: Option<String>,
+        text: String,
+    },
+    ApiError {
+        turn: u32,
+        message: String,
+        text: String,
+    },
+    Done {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        run_id: Option<String>,
+        turns: u32,
+        text: String,
+    },
+    Completed {
+        text: String,
+    },
+    Failed {
+        text: String,
+    },
+    Cancelled {
+        text: String,
+    },
+    Interrupted {
+        text: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct TimelineEntity {
+    #[serde(rename = "type")]
+    pub(crate) entity_type: String,
+    pub(crate) data: Value,
+}
+
+impl AgentTaskEventPayload {
+    pub(crate) fn ephemeral(
+        task_id: &str,
+        payload: AgentTaskEventKind,
+        snapshot: Option<AgentTaskSnapshot>,
+    ) -> Self {
+        Self {
+            task_id: task_id.to_string(),
+            payload,
+            snapshot,
+            sequence: 0,
+            created_at: now_ms(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> &'static str {
+        self.payload.kind()
+    }
+}
+
+impl AgentTaskEventKind {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::Queued { .. } => "queued",
+            Self::Running { .. } => "running",
+            Self::Started { .. } => "started",
+            Self::Tab { .. } => "tab",
+            Self::Turn { .. } => "turn",
+            Self::Assistant { .. } => "assistant",
+            Self::Reasoning { .. } => "reasoning",
+            Self::ToolCall { .. } => "tool_call",
+            Self::ToolResult { .. } => "tool_result",
+            Self::ToolError { .. } => "tool_error",
+            Self::ApiError { .. } => "api_error",
+            Self::Done { .. } => "done",
+            Self::Completed { .. } => "completed",
+            Self::Failed { .. } => "failed",
+            Self::Cancelled { .. } => "cancelled",
+            Self::Interrupted { .. } => "interrupted",
+        }
+    }
+
+    pub(crate) fn from_kind_text(kind: &str, text: String) -> Self {
+        let text = truncate_event_text(&text);
+        match kind {
+            "queued" => Self::Queued { text },
+            "running" => Self::Running { text },
+            "tab" => Self::Tab {
+                text,
+                target_id: None,
+            },
+            "turn" => Self::Turn {
+                turn: first_number(&text).unwrap_or_default(),
+                text,
+            },
+            "assistant" => Self::Assistant { turn: 0, text },
+            "reasoning" => Self::Reasoning { turn: 0, text },
+            "tool_call" => Self::ToolCall {
+                id: String::new(),
+                turn: 0,
+                sequence_in_turn: 0,
+                name: "tool".into(),
+                label: "tool".into(),
+                args: Value::Null,
+                repeat_count: 0,
+                text,
+            },
+            "tool_result" => Self::ToolResult {
+                id: String::new(),
+                turn: 0,
+                sequence_in_turn: 0,
+                name: "tool".into(),
+                label: "tool".into(),
+                args: Value::Null,
+                ok: true,
+                summary: text.clone(),
+                duration_ms: 0,
+                entities: Vec::new(),
+                error: None,
+                result_file: None,
+                text,
+            },
+            "tool_error" => Self::ToolError {
+                id: String::new(),
+                turn: 0,
+                sequence_in_turn: 0,
+                name: "tool".into(),
+                label: "tool".into(),
+                args: Value::Null,
+                ok: false,
+                summary: String::new(),
+                duration_ms: 0,
+                entities: Vec::new(),
+                error: text.clone(),
+                result_file: None,
+                text,
+            },
+            "api_error" => Self::ApiError {
+                turn: 0,
+                message: text.clone(),
+                text,
+            },
+            "done" => Self::Done {
+                run_id: None,
+                turns: first_number(&text).unwrap_or_default(),
+                text,
+            },
+            "completed" => Self::Completed { text },
+            "failed" => Self::Failed { text },
+            "cancelled" => Self::Cancelled { text },
+            "interrupted" => Self::Interrupted { text },
+            "started" => Self::Started {
+                run_id: String::new(),
+                task: String::new(),
+                model: String::new(),
+                text,
+            },
+            _ => Self::Assistant { turn: 0, text },
+        }
+    }
+}
+
+pub(crate) fn append_timeline_event(
+    snapshot: &AgentTaskSnapshot,
+    payload: AgentTaskEventKind,
+    snapshot_for_emit: Option<AgentTaskSnapshot>,
+) -> anyhow::Result<AgentTaskEventPayload> {
+    let path = timeline_path(snapshot).context("task has no run_dir for timeline")?;
+    let sequence = next_sequence(&path);
+    let mut event = AgentTaskEventPayload {
+        task_id: snapshot.task_id.clone(),
+        payload,
+        snapshot: None,
+        sequence,
+        created_at: now_ms(),
+    };
+    append_jsonl(&path, &event).with_context(|| format!("write timeline {}", path.display()))?;
+    event.snapshot = snapshot_for_emit;
+    Ok(event)
+}
+
+pub(crate) fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
+    let mut events = read_timeline_events(snapshot);
+    if events.is_empty() {
+        events = replay_task_events(snapshot);
+        if !events.is_empty() {
+            ensure_started_event(snapshot, &mut events);
+            reindex_replay_events(snapshot, &mut events);
+        }
+    }
+    append_terminal_snapshot_events(snapshot, &mut events);
+    events.sort_by(compare_events);
+    events
+}
+
+pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind {
+    match event {
+        AgentEvent::Started {
+            run_id,
+            task,
+            model,
+        } => AgentTaskEventKind::Started {
+            run_id: run_id.clone(),
+            task: task.clone(),
+            model: model.clone(),
+            text: started_event_text_fields(task, Some(run_id), model),
+        },
+        AgentEvent::Turn { turn } => AgentTaskEventKind::Turn {
+            turn: *turn,
+            text: format!("turn {turn}"),
+        },
+        AgentEvent::AssistantText { turn, text } => AgentTaskEventKind::Assistant {
+            turn: *turn,
+            text: truncate_event_text(text),
+        },
+        AgentEvent::Reasoning { turn, text } => AgentTaskEventKind::Reasoning {
+            turn: *turn,
+            text: truncate_event_text(text),
+        },
+        AgentEvent::ToolCall {
+            id,
+            turn,
+            sequence,
+            name,
+            input,
+            repeat_count,
+        } => tool_call_event(id, *turn, *sequence, name, input, *repeat_count),
+        AgentEvent::ToolResult {
+            id,
+            turn,
+            sequence,
+            name,
+            input,
+            content,
+            summary,
+            duration_ms,
+            error,
+        } => tool_result_event(
+            id,
+            *turn,
+            *sequence,
+            name,
+            input,
+            summary,
+            *duration_ms,
+            error.as_deref(),
+            content,
+            None,
+        ),
+        AgentEvent::ApiError { turn, message } => AgentTaskEventKind::ApiError {
+            turn: *turn,
+            message: message.clone(),
+            text: format!("turn {turn}: {message}"),
+        },
+        AgentEvent::Done { run_id, turns, .. } => AgentTaskEventKind::Done {
+            run_id: Some(run_id.clone()),
+            turns: *turns,
+            text: format!("done in {turns} turns"),
+        },
+    }
+}
+
+pub(crate) fn user_label(name: &str) -> String {
+    match name {
+        "search_notes" => "searched xiaohongshu",
+        "extract_search_cards" => "read search cards",
+        "list_search_tabs" => "listed search tabs",
+        "click_search_tab" => "switched search tab",
+        "open_note" => "opened note",
+        "close_note" => "closed note",
+        "read_note" => "reading note",
+        "extract_note" => "read current note",
+        "extract_comments" => "read comments",
+        "scroll_in_note" => "scrolled note",
+        "collect_carousel_images" => "collected carousel images",
+        "extract_profile" => "read author profile",
+        "topic_scan" => "scanned topic",
+        "page_state" => "checked page state",
+        _ => return name.replace('_', " "),
+    }
+    .into()
+}
+
+fn timeline_path(snapshot: &AgentTaskSnapshot) -> Option<PathBuf> {
+    let run_dir = snapshot
+        .run_dir
+        .as_ref()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|dir| !dir.is_empty())?;
+    Some(PathBuf::from(run_dir).join(TIMELINE_FILE))
+}
+
+fn append_jsonl(path: &Path, event: &AgentTaskEventPayload) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let line = serde_json::to_string(event).map_err(std::io::Error::other)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")
+}
+
+fn read_timeline_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
+    let Some(path) = timeline_path(snapshot) else {
+        return Vec::new();
+    };
+    let mut events: Vec<AgentTaskEventPayload> = read_jsonl_values(&path)
+        .into_iter()
+        .filter_map(|value| serde_json::from_value::<AgentTaskEventPayload>(value).ok())
+        .map(|mut event| {
+            if event.task_id.is_empty() {
+                event.task_id = snapshot.task_id.clone();
+            }
+            event.snapshot = None;
+            event
+        })
+        .collect();
+    events.sort_by(compare_events);
+    events
+}
+
+fn next_sequence(path: &Path) -> u64 {
+    read_jsonl_values(path)
+        .into_iter()
+        .filter_map(|value| value.get("sequence").and_then(Value::as_u64))
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn replay_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
+    let Some(run_dir) = snapshot
+        .run_dir
+        .as_ref()
+        .filter(|dir| !dir.trim().is_empty())
+    else {
+        return Vec::new();
+    };
+    let run_dir = PathBuf::from(run_dir);
+    let mut events = replay_reasoning_log(snapshot, &run_dir, &run_dir.join("reasoning_log.jsonl"));
+    if events.is_empty() {
+        events = replay_run_state_events(snapshot, &run_dir.join("run_state/events.jsonl"));
+    }
+    events
+}
+
+fn replay_reasoning_log(
+    snapshot: &AgentTaskSnapshot,
+    run_dir: &Path,
+    path: &Path,
+) -> Vec<AgentTaskEventPayload> {
+    let mut events = Vec::new();
+    let mut last_turn = None;
+    for value in read_jsonl_values(path) {
+        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        match event_type {
+            "task_start" => {
+                let task = value.get("task").and_then(Value::as_str);
+                let model = value.get("model").and_then(Value::as_str);
+                events.push(replay_event(
+                    snapshot,
+                    AgentTaskEventKind::Started {
+                        run_id: snapshot.run_id.clone().unwrap_or_default(),
+                        task: task.unwrap_or(&snapshot.task).to_string(),
+                        model: model
+                            .or(snapshot.model.as_deref())
+                            .unwrap_or("unknown model")
+                            .to_string(),
+                        text: started_event_text(snapshot, task, model),
+                    },
+                ));
+            }
+            "llm_response" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let text = value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if !text.is_empty() {
+                    events.push(replay_event(
+                        snapshot,
+                        AgentTaskEventKind::Assistant {
+                            turn,
+                            text: truncate_event_text(text),
+                        },
+                    ));
+                }
+            }
+            "reasoning" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let text = value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if !text.is_empty() {
+                    events.push(replay_event(
+                        snapshot,
+                        AgentTaskEventKind::Reasoning {
+                            turn,
+                            text: truncate_event_text(text),
+                        },
+                    ));
+                }
+            }
+            "tool_call_start" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let sequence = number_field(&value, "sequence") as u32;
+                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
+                let input = value.get("input").unwrap_or(&Value::Null);
+                let repeat_count = number_field(&value, "repeat_count") as u32;
+                let id = tool_use_id(&value, turn, sequence, tool);
+                events.push(replay_event(
+                    snapshot,
+                    tool_call_event(&id, turn, sequence, tool, input, repeat_count),
+                ));
+            }
+            "tool_result" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let sequence = number_field(&value, "sequence") as u32;
+                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
+                let input = value.get("input").unwrap_or(&Value::Null);
+                let summary = value
+                    .get("result_summary")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let error = value.get("error").and_then(Value::as_str).unwrap_or("");
+                let duration_ms = duration_ms(&value);
+                let result_file = value
+                    .get("result_file")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let content = value
+                    .get("content")
+                    .cloned()
+                    .or_else(|| {
+                        result_file
+                            .as_deref()
+                            .and_then(|file| load_result_content(run_dir, file))
+                    })
+                    .unwrap_or(Value::Null);
+                let id = tool_use_id(&value, turn, sequence, tool);
+                events.push(replay_event(
+                    snapshot,
+                    tool_result_event(
+                        &id,
+                        turn,
+                        sequence,
+                        tool,
+                        input,
+                        summary,
+                        duration_ms,
+                        if error.trim().is_empty() {
+                            None
+                        } else {
+                            Some(error)
+                        },
+                        &content,
+                        result_file,
+                    ),
+                ));
+            }
+            "api_error" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let message = value
+                    .get("error")
+                    .or_else(|| value.get("message"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("api error");
+                events.push(replay_event(
+                    snapshot,
+                    AgentTaskEventKind::ApiError {
+                        turn,
+                        message: message.to_string(),
+                        text: format!("turn {turn}: {message}"),
+                    },
+                ));
+            }
+            "task_end" => {
+                let turn = number_field(&value, "turn") as u32;
+                events.push(replay_event(
+                    snapshot,
+                    AgentTaskEventKind::Done {
+                        run_id: snapshot.run_id.clone(),
+                        turns: turn,
+                        text: if turn > 0 {
+                            format!("done in {turn} turns")
+                        } else {
+                            "done".into()
+                        },
+                    },
+                ));
+            }
+            _ => {}
+        }
+    }
+    events
+}
+
+fn replay_run_state_events(
+    snapshot: &AgentTaskSnapshot,
+    path: &Path,
+) -> Vec<AgentTaskEventPayload> {
+    let mut events = Vec::new();
+    let mut last_turn = None;
+    for value in read_jsonl_values(path) {
+        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        match event_type {
+            "assistant_turn" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let text = value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if !text.is_empty() {
+                    events.push(replay_event(
+                        snapshot,
+                        AgentTaskEventKind::Assistant {
+                            turn,
+                            text: truncate_event_text(text),
+                        },
+                    ));
+                }
+            }
+            "tool_call" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
+                let input = value.get("input").unwrap_or(&Value::Null);
+                let id = tool_use_id(&value, turn, 0, tool);
+                events.push(replay_event(
+                    snapshot,
+                    tool_call_event(&id, turn, 0, tool, input, 0),
+                ));
+            }
+            "tool_result" => {
+                let turn = number_field(&value, "turn") as u32;
+                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
+                let input = value.get("input").unwrap_or(&Value::Null);
+                let summary = value
+                    .get("result_summary")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let duration_ms = duration_ms(&value);
+                let id = tool_use_id(&value, turn, 0, tool);
+                events.push(replay_event(
+                    snapshot,
+                    tool_result_event(
+                        &id,
+                        turn,
+                        0,
+                        tool,
+                        input,
+                        summary,
+                        duration_ms,
+                        None,
+                        &Value::Null,
+                        None,
+                    ),
+                ));
+            }
+            _ => {}
+        }
+    }
+    events
+}
+
+fn append_terminal_snapshot_events(
+    snapshot: &AgentTaskSnapshot,
+    events: &mut Vec<AgentTaskEventPayload>,
+) {
+    match snapshot.status.as_str() {
+        "completed" => {
+            if !events.iter().any(|event| event.kind() == "done") {
+                let text = snapshot
+                    .turns
+                    .map(|turns| format!("done in {turns} turns"))
+                    .unwrap_or_else(|| "done".into());
+                push_snapshot_event(
+                    snapshot,
+                    events,
+                    AgentTaskEventKind::Done {
+                        run_id: snapshot.run_id.clone(),
+                        turns: snapshot.turns.unwrap_or_default(),
+                        text,
+                    },
+                );
+            }
+            if !events.iter().any(|event| event.kind() == "completed") {
+                push_snapshot_event(
+                    snapshot,
+                    events,
+                    AgentTaskEventKind::Completed {
+                        text: "task completed".into(),
+                    },
+                );
+            }
+        }
+        "failed" => {
+            if !events.iter().any(|event| event.kind() == "failed") {
+                let text = snapshot
+                    .error
+                    .as_deref()
+                    .filter(|error| !error.trim().is_empty())
+                    .unwrap_or("task failed")
+                    .to_string();
+                push_snapshot_event(snapshot, events, AgentTaskEventKind::Failed { text });
+            }
+        }
+        "cancelled" => {
+            if !events.iter().any(|event| event.kind() == "cancelled") {
+                push_snapshot_event(
+                    snapshot,
+                    events,
+                    AgentTaskEventKind::Cancelled {
+                        text: "task cancelled".into(),
+                    },
+                );
+            }
+        }
+        "interrupted" => {
+            if !events.iter().any(|event| event.kind() == "interrupted") {
+                let text = snapshot
+                    .error
+                    .as_deref()
+                    .filter(|error| !error.trim().is_empty())
+                    .unwrap_or("task interrupted")
+                    .to_string();
+                push_snapshot_event(snapshot, events, AgentTaskEventKind::Interrupted { text });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_snapshot_event(
+    snapshot: &AgentTaskSnapshot,
+    events: &mut Vec<AgentTaskEventPayload>,
+    payload: AgentTaskEventKind,
+) {
+    let sequence = events.iter().map(|event| event.sequence).max().unwrap_or(0) + 1;
+    events.push(AgentTaskEventPayload {
+        task_id: snapshot.task_id.clone(),
+        payload,
+        snapshot: None,
+        sequence,
+        created_at: snapshot.finished_at.unwrap_or_else(now_ms),
+    });
+}
+
+fn ensure_started_event(snapshot: &AgentTaskSnapshot, events: &mut Vec<AgentTaskEventPayload>) {
+    if events.iter().any(|event| event.kind() == "started") {
+        return;
+    }
+    events.insert(
+        0,
+        replay_event(
+            snapshot,
+            AgentTaskEventKind::Started {
+                run_id: snapshot.run_id.clone().unwrap_or_default(),
+                task: snapshot.task.clone(),
+                model: snapshot
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "unknown model".into()),
+                text: started_event_text(snapshot, None, None),
+            },
+        ),
+    );
+}
+
+fn reindex_replay_events(snapshot: &AgentTaskSnapshot, events: &mut [AgentTaskEventPayload]) {
+    let base = snapshot.started_at.unwrap_or(snapshot.created_at);
+    for (idx, event) in events.iter_mut().enumerate() {
+        event.sequence = idx as u64 + 1;
+        event.created_at = base.saturating_add(idx as u64 + 1);
+    }
+}
+
+fn replay_event(
+    snapshot: &AgentTaskSnapshot,
+    payload: AgentTaskEventKind,
+) -> AgentTaskEventPayload {
+    AgentTaskEventPayload {
+        task_id: snapshot.task_id.clone(),
+        payload,
+        snapshot: None,
+        sequence: 0,
+        created_at: 0,
+    }
+}
+
+fn push_turn_event(
+    snapshot: &AgentTaskSnapshot,
+    events: &mut Vec<AgentTaskEventPayload>,
+    last_turn: &mut Option<u32>,
+    turn: u32,
+) {
+    if turn == 0 || *last_turn == Some(turn) {
+        return;
+    }
+    *last_turn = Some(turn);
+    events.push(replay_event(
+        snapshot,
+        AgentTaskEventKind::Turn {
+            turn,
+            text: format!("turn {turn}"),
+        },
+    ));
+}
+
+fn started_event_text(
+    snapshot: &AgentTaskSnapshot,
+    task: Option<&str>,
+    model: Option<&str>,
+) -> String {
+    let task = task.unwrap_or(&snapshot.task);
+    let model = model
+        .or(snapshot.model.as_deref())
+        .unwrap_or("unknown model");
+    started_event_text_fields(task, snapshot.run_id.as_deref(), model)
+}
+
+fn started_event_text_fields(task: &str, run_id: Option<&str>, model: &str) -> String {
+    let run = run_id
+        .filter(|run_id| !run_id.trim().is_empty())
+        .map(|run_id| format!("run {run_id} · "))
+        .unwrap_or_default();
+    format!("task: {task}\n{run}model {model}")
+}
+
+fn tool_call_event(
+    id: &str,
+    turn: u32,
+    sequence: u32,
+    name: &str,
+    input: &Value,
+    repeat_count: u32,
+) -> AgentTaskEventKind {
+    AgentTaskEventKind::ToolCall {
+        id: id.to_string(),
+        turn,
+        sequence_in_turn: sequence,
+        name: name.to_string(),
+        label: user_label(name),
+        args: input.clone(),
+        repeat_count,
+        text: format_tool_call_text(name, input, repeat_count.into()),
+    }
+}
+
+fn tool_result_event(
+    id: &str,
+    turn: u32,
+    sequence: u32,
+    name: &str,
+    input: &Value,
+    summary: &str,
+    duration_ms: u64,
+    error: Option<&str>,
+    content: &Value,
+    result_file: Option<String>,
+) -> AgentTaskEventKind {
+    let raw = raw_tool_result_value(content);
+    let ok = error.map(|err| err.trim().is_empty()).unwrap_or(true)
+        && raw
+            .as_ref()
+            .and_then(|value| value.get("ok"))
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+    let entities = raw
+        .as_ref()
+        .map(|value| normalize_entities(name, value))
+        .unwrap_or_default();
+    let error = error.map(str::trim).filter(|err| !err.is_empty());
+    let (_kind, text) = format_tool_result_text(name, summary, duration_ms, error.unwrap_or(""));
+    if let Some(error) = error {
+        AgentTaskEventKind::ToolError {
+            id: id.to_string(),
+            turn,
+            sequence_in_turn: sequence,
+            name: name.to_string(),
+            label: user_label(name),
+            args: input.clone(),
+            ok: false,
+            summary: truncate_event_text(summary),
+            duration_ms,
+            entities,
+            error: error.to_string(),
+            result_file,
+            text,
+        }
+    } else {
+        AgentTaskEventKind::ToolResult {
+            id: id.to_string(),
+            turn,
+            sequence_in_turn: sequence,
+            name: name.to_string(),
+            label: user_label(name),
+            args: input.clone(),
+            ok,
+            summary: truncate_event_text(summary),
+            duration_ms,
+            entities,
+            error: None,
+            result_file,
+            text,
+        }
+    }
+}
+
+fn format_tool_call_text(tool: &str, input: &Value, repeat_count: u64) -> String {
+    let preview = serde_json::to_string(input).unwrap_or_else(|_| input.to_string());
+    if repeat_count > 1 {
+        format!("{tool}({preview}) repeat={repeat_count}")
+    } else {
+        format!("{tool}({preview})")
+    }
+}
+
+fn format_tool_result_text(
+    tool: &str,
+    summary: &str,
+    duration_ms: u64,
+    error: &str,
+) -> (&'static str, String) {
+    if !error.trim().is_empty() {
+        return ("tool_error", format!("{tool} ({duration_ms}ms): {error}"));
+    }
+    let first = summary.lines().next().unwrap_or("");
+    ("tool_result", format!("{tool} ({duration_ms}ms): {first}"))
+}
+
+fn raw_tool_result_value(content: &Value) -> Option<Value> {
+    match content {
+        Value::Array(items) => items.iter().find_map(|item| {
+            if item.get("type").and_then(Value::as_str) != Some("text") {
+                return None;
+            }
+            let text = item.get("text").and_then(Value::as_str)?;
+            serde_json::from_str::<Value>(text)
+                .ok()
+                .or_else(|| Some(Value::String(text.to_string())))
+        }),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .or_else(|| Some(Value::String(text.clone()))),
+        Value::Null => None,
+        other => Some(other.clone()),
+    }
+}
+
+fn normalize_entities(tool: &str, value: &Value) -> Vec<TimelineEntity> {
+    match tool {
+        "search_notes" => value
+            .get("cards")
+            .and_then(Value::as_array)
+            .filter(|cards| !cards.is_empty())
+            .map(|cards| vec![entity("xhs_note_card_grid", Value::Array(cards.clone()))])
+            .unwrap_or_default(),
+        "extract_search_cards" => value
+            .as_array()
+            .filter(|cards| !cards.is_empty())
+            .map(|cards| vec![entity("xhs_note_card_grid", Value::Array(cards.clone()))])
+            .unwrap_or_default(),
+        "read_note" => value
+            .get("entity")
+            .filter(|entity| entity.is_object())
+            .map(|entity_value| vec![entity("xhs_note", entity_value.clone())])
+            .unwrap_or_default(),
+        "extract_note" => {
+            if value.is_object() {
+                vec![entity("xhs_note", value.clone())]
+            } else {
+                Vec::new()
+            }
+        }
+        "extract_comments" => value
+            .as_array()
+            .filter(|comments| !comments.is_empty())
+            .map(|comments| vec![entity("xhs_comments", Value::Array(comments.clone()))])
+            .unwrap_or_default(),
+        "collect_carousel_images" => value
+            .as_array()
+            .filter(|images| !images.is_empty())
+            .map(|images| vec![entity("xhs_image_strip", Value::Array(images.clone()))])
+            .unwrap_or_default(),
+        "extract_profile" => {
+            if value.is_object() {
+                vec![entity("xhs_author_profile", value.clone())]
+            } else {
+                Vec::new()
+            }
+        }
+        "topic_scan" => {
+            if value.is_object() {
+                vec![entity("xhs_topic_scan", value.clone())]
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn entity(entity_type: &str, data: Value) -> TimelineEntity {
+    TimelineEntity {
+        entity_type: entity_type.to_string(),
+        data,
+    }
+}
+
+fn load_result_content(run_dir: &Path, result_file: &str) -> Option<Value> {
+    let path = run_dir.join(result_file);
+    let text = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<Value>(&text).ok()?;
+    value.get("content").cloned()
+}
+
+fn tool_use_id(value: &Value, turn: u32, sequence: u32, tool: &str) -> String {
+    value
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("turn:{turn}:sequence:{sequence}:tool:{tool}"))
+}
+
+fn duration_ms(value: &Value) -> u64 {
+    if let Some(ms) = value.get("duration_ms").and_then(Value::as_u64) {
+        return ms;
+    }
+    value
+        .get("duration_s")
+        .and_then(Value::as_f64)
+        .map(|seconds| (seconds * 1000.0).round().max(0.0) as u64)
+        .unwrap_or_default()
+}
+
+fn number_field(value: &Value, field: &str) -> u64 {
+    value
+        .get(field)
+        .and_then(|number| {
+            number
+                .as_u64()
+                .or_else(|| number.as_f64().map(|n| n as u64))
+        })
+        .unwrap_or_default()
+}
+
+fn read_jsonl_values(path: &Path) -> Vec<Value> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .collect()
+}
+
+fn truncate_event_text(text: &str) -> String {
+    if text.chars().count() <= MAX_EVENT_TEXT_CHARS {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(MAX_EVENT_TEXT_CHARS).collect();
+    format!("{kept}\n... [truncated]")
+}
+
+fn first_number(text: &str) -> Option<u32> {
+    let digits: String = text
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+fn compare_events(a: &AgentTaskEventPayload, b: &AgentTaskEventPayload) -> std::cmp::Ordering {
+    if a.sequence > 0 && b.sequence > 0 && a.sequence != b.sequence {
+        return a.sequence.cmp(&b.sequence);
+    }
+    if a.created_at != b.created_at {
+        return a.created_at.cmp(&b.created_at);
+    }
+    std::cmp::Ordering::Equal
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -37,6 +37,11 @@ export interface AgentTaskSnapshot {
   output_tokens: number | null;
 }
 
+export interface TimelineEntity {
+  type: string;
+  data: unknown;
+}
+
 export interface AgentTaskEventPayload {
   task_id: string;
   kind:
@@ -57,9 +62,26 @@ export interface AgentTaskEventPayload {
     | "cancelled"
     | "interrupted";
   text: string;
-  snapshot: AgentTaskSnapshot | null;
+  snapshot?: AgentTaskSnapshot | null;
   sequence: number;
   created_at: number;
+  turn?: number;
+  id?: string;
+  sequence_in_turn?: number;
+  name?: string;
+  label?: string;
+  args?: unknown;
+  repeat_count?: number;
+  ok?: boolean;
+  summary?: string;
+  duration_ms?: number;
+  entities?: TimelineEntity[];
+  error?: string | null;
+  result_file?: string | null;
+  run_id?: string | null;
+  model?: string;
+  task?: string;
+  target_id?: string | null;
 }
 
 export interface ShellState {

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -58,14 +58,20 @@ pub enum AgentEvent {
         text: String,
     },
     ToolCall {
+        id: String,
         turn: u32,
+        sequence: u32,
         name: String,
         input: Value,
         repeat_count: u32,
     },
     ToolResult {
+        id: String,
         turn: u32,
+        sequence: u32,
         name: String,
+        input: Value,
+        content: Value,
         summary: String,
         duration_ms: u64,
         error: Option<String>,
@@ -234,15 +240,21 @@ pub async fn run_agent_with_events(
                     text: response.reasoning_content.clone(),
                 },
             );
+            debug_log.event(
+                "reasoning",
+                json!({"turn": turn, "text": response.reasoning_content.clone()}),
+            );
         }
         if !thinking_texts.is_empty() {
+            let thinking_text = thinking_texts.join("\n");
             emit(
                 &events,
                 AgentEvent::Reasoning {
                     turn,
-                    text: thinking_texts.join("\n"),
+                    text: thinking_text.clone(),
                 },
             );
+            debug_log.event("reasoning", json!({"turn": turn, "text": thinking_text}));
         }
 
         // Build the assistant block list manually instead of using
@@ -299,10 +311,13 @@ pub async fn run_agent_with_events(
             history.push(turn);
             let repeat_count = history.len() as u32;
 
+            let sequence = (idx + 1) as u32;
             emit(
                 &events,
                 AgentEvent::ToolCall {
+                    id: id.clone(),
                     turn,
+                    sequence,
                     name: name.clone(),
                     input: input.clone(),
                     repeat_count,
@@ -313,7 +328,8 @@ pub async fn run_agent_with_events(
                 "tool_call_start",
                 json!({
                     "turn": turn,
-                    "sequence": idx + 1,
+                    "sequence": sequence,
+                    "tool_use_id": id,
                     "tool": name,
                     "input": input,
                     "repeat_count": repeat_count,
@@ -326,13 +342,18 @@ pub async fn run_agent_with_events(
             let duration_s = (duration_ms as f64) / 1000.0;
 
             let result_content = tool_result_to_content(&result);
+            let content = content_for_log(&result_content);
             let flat = result.flat_text();
             let summary = truncate_summary(&flat, 240);
             emit(
                 &events,
                 AgentEvent::ToolResult {
+                    id: id.clone(),
                     turn,
+                    sequence,
                     name: name.clone(),
+                    input: input.clone(),
+                    content: content.clone(),
                     summary: summary.clone(),
                     duration_ms,
                     error: error.clone(),
@@ -341,10 +362,11 @@ pub async fn run_agent_with_events(
             run_state.note_tool_result(turn, name, input, &summary, duration_s);
             debug_log.tool_result(
                 turn,
-                (idx + 1) as u32,
+                sequence,
+                id,
                 name,
                 input,
-                &content_for_log(&result_content),
+                &content,
                 duration_s,
                 &summary,
                 repeat_count,

--- a/core/src/agent/run_logging.rs
+++ b/core/src/agent/run_logging.rs
@@ -7,9 +7,9 @@
 //! - `agent_log.json`            — run summary (turns, run_dir, durations, …)
 //! - `tool_results/<turn>_<seq>_<tool>.json` — full tool result body per call
 
-// tool_result takes 9 fields (turn, sequence, tool, input, content,
-// duration_s, result_summary, repeat_count, error). Plain function args
-// match the Python signature 1:1.
+// tool_result takes many fields (turn, sequence, tool_use_id, tool, input,
+// content, duration_s, result_summary, repeat_count, error). Plain function
+// args match the Python-style debug payload directly.
 #![allow(clippy::too_many_arguments)]
 
 use std::path::{Path, PathBuf};
@@ -189,6 +189,7 @@ impl RunDebugLogger {
         &self,
         turn: u32,
         sequence: u32,
+        tool_use_id: &str,
         tool_name: &str,
         tool_input: &Value,
         content: &Value,
@@ -209,6 +210,7 @@ impl RunDebugLogger {
             "timestamp": timestamp(),
             "turn": turn,
             "sequence": sequence,
+            "tool_use_id": tool_use_id,
             "tool": tool_name,
             "input": tool_input,
             "duration_s": duration_s,
@@ -226,6 +228,7 @@ impl RunDebugLogger {
             json!({
                 "turn": turn,
                 "sequence": sequence,
+                "tool_use_id": tool_use_id,
                 "tool": tool_name,
                 "input": tool_input,
                 "duration_s": duration_s,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -72,7 +72,8 @@ Each agent run writes files under `run_dir`.
 | Path | Purpose | Notes |
 | --- | --- | --- |
 | `report.md` | Final answer shown by the desktop app | Source of truth for completed task output. May include appended artifact markdown. |
-| `reasoning_log.jsonl` | Append-only debug/event log | Primary source for historical timeline replay. |
+| `timeline.jsonl` | Canonical typed task timeline | Source of truth for live and historical desktop timeline rows for new runs. |
+| `reasoning_log.jsonl` | Append-only debug/event log | Debug log and legacy fallback source for historical timeline replay. |
 | `conversation.json` | Final system prompt and message history snapshot | Useful for debugging/model replay. |
 | `agent_log.json` | Run summary | Includes task, model, turns, token counts, paths to run files. |
 | `tool_results/<turn>_<seq>_<tool>.json` | Full tool result bodies | `reasoning_log.jsonl` only stores compact summaries. |
@@ -88,14 +89,16 @@ One JSON object per line. Current important event types include:
 
 - `task_start`
 - `llm_response`
+- `reasoning`
 - `tool_call_start`
 - `tool_result`
 - `api_error`
 - `turn_end`
 - `task_end`
 
-The desktop app replays timeline rows from this file first. If it is absent or
-empty, the app falls back to `run_state/events.jsonl`.
+For new runs, the desktop app replays timeline rows from `timeline.jsonl` first.
+If `timeline.jsonl` is absent or empty, the app falls back to this file and then
+to `run_state/events.jsonl` for legacy runs.
 
 ## Desktop task index: `tasks.json`
 
@@ -135,34 +138,64 @@ Rules:
 
 ## Desktop timeline state
 
-Live event rows are held in frontend memory while a task is running. They are
-streamed over Tauri's `agent_task:event` event as:
+New task timeline rows are appended to `<run_dir>/timeline.jsonl` before they are
+emitted to the webview. The Tauri `agent_task:event` stream is a live delivery
+mechanism for already-persisted rows; frontend memory is only a view cache.
+
+Timeline rows use a typed discriminated shape with `kind` at the top level. For
+example:
 
 ```json
 {
   "task_id": "task-1790000000000-1",
   "kind": "tool_call",
+  "id": "toolu_123",
+  "turn": 1,
+  "sequence_in_turn": 1,
+  "name": "search_notes",
+  "label": "searched xiaohongshu",
+  "args": { "query": "..." },
+  "repeat_count": 1,
   "text": "search_notes({\"query\":\"...\"})",
-  "snapshot": null,
-  "sequence": 0,
+  "sequence": 4,
   "created_at": 1790000005000
 }
 ```
 
+Tool results can additionally carry normalized inline entities:
+
+```json
+{
+  "task_id": "task-1790000000000-1",
+  "kind": "tool_result",
+  "id": "toolu_123",
+  "name": "search_notes",
+  "label": "searched xiaohongshu",
+  "ok": true,
+  "duration_ms": 1400,
+  "entities": [{ "type": "xhs_note_card_grid", "data": [] }],
+  "text": "search_notes (1400ms): ...",
+  "sequence": 5,
+  "created_at": 1790000006500
+}
+```
+
 After restart or webview reload, the app does not read a separate app event
-cache. Instead, `agent_task_events(task_id)` reconstructs rows from the task's
+cache. Instead, `agent_task_events(task_id)` reads rows from the task's
 `run_dir`:
 
-1. `<run_dir>/reasoning_log.jsonl`
-2. fallback: `<run_dir>/run_state/events.jsonl`
-3. terminal status metadata from `tasks.json` when applicable
+1. `<run_dir>/timeline.jsonl`
+2. legacy fallback: `<run_dir>/reasoning_log.jsonl` plus `tool_results/*.json`
+3. legacy fallback: `<run_dir>/run_state/events.jsonl`
+4. terminal status metadata from `tasks.json` when applicable
 
 This keeps timeline and final answer data rooted in the run directory.
 
-## Realtime event stream vs `reasoning_log.jsonl`
+## Realtime event stream vs `timeline.jsonl` / `reasoning_log.jsonl`
 
-`reasoning_log.jsonl` is not an exact byte-for-byte copy of what the user sees
-in realtime.
+For new runs, `timeline.jsonl` is the canonical source for both realtime and
+historical timeline rows. The live UI receives rows only after they have been
+written to that file.
 
 The live UI receives two classes of events:
 
@@ -171,25 +204,25 @@ The live UI receives two classes of events:
 2. Core agent events emitted by `socai-core`: `started`, `turn`, `assistant`,
    `reasoning`, `tool_call`, `tool_result`, `tool_error`, `api_error`, `done`.
 
-`reasoning_log.jsonl` is a persistent core debug log with enough structured data
-to replay the important run timeline, but some live rows are represented
-differently or not present.
+`reasoning_log.jsonl` remains a persistent core debug log and legacy replay
+fallback. It is not an exact byte-for-byte copy of what the user sees in
+realtime.
 
-| UI row | Live source | `reasoning_log.jsonl` source | Replay behavior |
+| UI row | New-run source | Legacy fallback source | Replay behavior |
 | --- | --- | --- | --- |
-| `queued` | Tauri | Not logged | Not replayed after restart. |
-| `running` | Tauri | Not logged | Not replayed after restart. |
-| `tab` | Tauri | Not logged | Not replayed after restart. |
-| `started` | `AgentEvent::Started` | `task_start` | Replayed. |
-| `turn` | `AgentEvent::Turn` | No standalone row; inferred from `turn` fields | Reconstructed. |
-| `assistant` | `AgentEvent::AssistantText` | `llm_response.text` | Replayed. |
-| `reasoning` | `AgentEvent::Reasoning` | Not currently logged | Not replayed today. |
-| `tool_call` | `AgentEvent::ToolCall` | `tool_call_start` | Replayed. |
-| `tool_result` / `tool_error` | `AgentEvent::ToolResult` | `tool_result` | Replayed from summary/error. |
-| `api_error` | `AgentEvent::ApiError` | `api_error` | Replayed. |
-| `done` | `AgentEvent::Done` | `task_end` | Replayed. |
-| terminal app status | Tauri snapshot update | `tasks.json` status metadata | Reconstructed from task status. |
+| `queued` | `timeline.jsonl` | Not logged | Replayed for new runs. |
+| `running` | `timeline.jsonl` | Not logged | Replayed for new runs. |
+| `tab` | `timeline.jsonl` | Not logged | Replayed for new runs. |
+| `started` | `timeline.jsonl` | `task_start` | Replayed. |
+| `turn` | `timeline.jsonl` | inferred from `turn` fields | Replayed/reconstructed. |
+| `assistant` | `timeline.jsonl` | `llm_response.text` | Replayed. |
+| `reasoning` | `timeline.jsonl` | `reasoning` when present | Replayed for new runs. |
+| `tool_call` | `timeline.jsonl` | `tool_call_start` | Replayed. |
+| `tool_result` / `tool_error` | `timeline.jsonl` | `tool_result` + `tool_results/*.json` | Replayed with normalized entities when possible. |
+| `api_error` | `timeline.jsonl` | `api_error` | Replayed. |
+| `done` | `timeline.jsonl` | `task_end` | Replayed. |
+| terminal app status | `timeline.jsonl` | `tasks.json` status metadata | Replayed/reconstructed. |
 
-If we ever need perfect historical replay, the better foundation would be to
-make the core agent event stream serializable and persist that stream in the run
-directory. It should still live under `run_dir`, not under the app index.
+New runs persist the typed desktop timeline directly in `timeline.jsonl` under
+`run_dir`. `tasks.json` remains an index and must not grow a duplicate timeline
+cache.


### PR DESCRIPTION
## Summary

Foundation PR for #18. This splits the rich timeline work into a canonical data/model layer first, with minimal visual change, and leaves rich card UI rendering for #25.

The key invariant introduced here:

> If the user can see an event in the live task timeline, that event has already been written to `<run_dir>/timeline.jsonl`.

## What changed

### Canonical timeline model

- Added `app/src-tauri/src/timeline.rs` with a typed Serde-tagged timeline event model.
- New task rows are appended to `<run_dir>/timeline.jsonl` before Tauri emits `agent_task:event`.
- `agent_task_events(task_id)` now hydrates from:
  1. `<run_dir>/timeline.jsonl`
  2. legacy `reasoning_log.jsonl` + `tool_results/*.json`
  3. legacy `run_state/events.jsonl`
  4. terminal task status metadata

### Agent event enrichment

- Threads LLM tool ids through core events:
  - `AgentEvent::ToolCall { id, sequence, ... }`
  - `AgentEvent::ToolResult { id, sequence, input, content, ... }`
- Persists `tool_use_id` in `reasoning_log.jsonl` and `tool_results/*.json`.
- Logs reasoning events so replay can include them.

### Entity normalization

Normalizes first-pass XHS entities into `entities: [{ type, data }]` on tool result events:

- `xhs_note_card_grid`
- `xhs_note`
- `xhs_author_profile`
- `xhs_comments`
- `xhs_image_strip`
- `xhs_topic_scan`

Unknown tools/entities still fail open to text/JSON fallback for the next UI PR.

### Frontend compatibility

- Updates TS event type to accept the richer discriminated shape.
- Keeps the current one-line renderer using `kind` + `text`, so this should not introduce a visual redesign yet.

### Local dev ergonomics

Adds:

```bash
cd app
pnpm run dev:desktop:local
```

which writes app state and run artifacts under repo-local `.socai/`:

```text
.socai/app/tasks.json
.socai/runs/<run-dir>/
```

## Out of scope

The rich timeline UI is intentionally left for #25:

- inline note/profile/comment/image cards
- skeleton tool call -> populated tool result linking
- open in user's Chrome action
- cover image loading/proxy spike
- turn grouping and visual polish

## Validation

```bash
git diff --check
cargo test
cd app && pnpm exec tsc --noEmit
```

## Related

- Part of #18
- Follow-up UI implementation: #25
