### PR TITLE
Port website Option B landing page

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="socai">
+  <title>socai</title>
+  <rect x="80" y="80" width="864" height="864" rx="194" ry="194" fill="#fafaf9"></rect>
+  <rect x="238.625" y="238.625" width="546.75" height="546.75" rx="60.75" ry="60.75" fill="none" stroke="#000000" stroke-width="32.0625"></rect>
+  <rect x="512" y="512" width="202.5" height="202.5" rx="24.46875" ry="24.46875" fill="#000000"></rect>
+</svg>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -49,7 +49,7 @@ const pageDescription = 'download socai, a web agent for 小红书 research task
         <section class="hero" aria-labelledby="hero-title">
           <h1 id="hero-title">a web agent for 小红书.</h1>
           <p class="hero__subtitle">
-            give socai a research task. it browses 小红书 for you and writes back.
+            socai connect to your 小红书 account via chrome CDP, and finishes tasks for you
           </p>
 
           <div class="hero__actions" aria-label="download and source">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,8 +1,11 @@
 ---
 import '../styles/global.css';
 
-const pageTitle = 'socai — xiaohongshu research agent';
-const pageDescription = 'A lightweight placeholder website for socai downloads and product updates.';
+const githubUrl = 'https://github.com/tonyc-ship/socai';
+const releaseVersion = '0.1.2';
+const currentYear = new Date().getFullYear();
+const pageTitle = 'socai · download';
+const pageDescription = 'download socai, a web agent for 小红书 research tasks.';
 ---
 
 <html lang="en">
@@ -10,21 +13,135 @@ const pageDescription = 'A lightweight placeholder website for socai downloads a
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={pageDescription} />
+    <meta name="theme-color" content="#fafaf9" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <title>{pageTitle}</title>
   </head>
   <body>
-    <main class="page-shell">
-      <section class="hero" aria-labelledby="hero-title">
-        <p class="eyebrow">socai website scaffold</p>
-        <h1 id="hero-title">socai</h1>
-        <p class="lede">
-          A web use agent for xiaohongshu research, extraction, and repeatable content workflows.
-        </p>
-        <div class="actions" aria-label="website status">
-          <span class="pill">static astro site</span>
-          <span class="pill pill--hollow">downloads coming soon</span>
-        </div>
-      </section>
-    </main>
+    <div class="site-shell">
+      <header class="site-header" aria-label="primary navigation">
+        <a class="brand" href="/" aria-label="socai home">
+          <svg class="brand__mark" viewBox="0 0 32 32" width="20" height="20" fill="none" aria-hidden="true">
+            <rect x="2.5" y="2.5" width="27" height="27" rx="3" stroke="currentColor" stroke-width="1.6"></rect>
+            <rect x="16" y="16" width="10" height="10" rx="1.2" fill="currentColor"></rect>
+          </svg>
+          <span>socai</span>
+        </a>
+
+        <nav class="site-nav" aria-label="site links">
+          <a class="nav-link nav-link--github" href={githubUrl}>
+            <svg viewBox="0 0 16 16" width="13" height="13" fill="currentColor" aria-hidden="true">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+            </svg>
+            <span>github</span>
+          </a>
+          <span class="release-chip">v{releaseVersion}</span>
+        </nav>
+      </header>
+
+      <main class="page-main">
+        <section class="hero" aria-labelledby="hero-title">
+          <h1 id="hero-title">a web agent for 小红书.</h1>
+          <p class="hero__subtitle">
+            give socai a research task. it browses 小红书 for you and writes back.
+          </p>
+
+          <div class="hero__actions" aria-label="download and source">
+            <a class="button button--primary" href="/download">
+              <span>download for macOS</span>
+              <span class="button__glyph" aria-hidden="true">↓</span>
+            </a>
+            <a class="button button--secondary" href={githubUrl}>
+              <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+              </svg>
+              <span>view on github</span>
+              <span class="button__external" aria-hidden="true">↗</span>
+            </a>
+          </div>
+
+          <p class="release-meta">macOS 13+ · universal build · v{releaseVersion}</p>
+        </section>
+
+        <section class="app-shot-section" aria-label="socai app preview">
+          <div class="app-window" role="img" aria-label="socai desktop app task composer mockup">
+            <div class="window-bar">
+              <span class="traffic-light"></span>
+              <span class="traffic-light"></span>
+              <span class="traffic-light"></span>
+              <span class="window-title">socai</span>
+            </div>
+
+            <div class="app-topbar">
+              <div class="app-brand">
+                <svg viewBox="0 0 32 32" width="20" height="20" fill="none" aria-hidden="true">
+                  <rect x="2.5" y="2.5" width="27" height="27" rx="3" stroke="currentColor" stroke-width="1.6"></rect>
+                  <rect x="16" y="16" width="10" height="10" rx="1.2" fill="currentColor"></rect>
+                </svg>
+                <span>socai</span>
+              </div>
+
+              <div class="status-group">
+                <span class="status-pill status-pill--active"><i></i> chrome · connected</span>
+                <span class="status-pill">agent · claude · sonnet 4.5</span>
+              </div>
+            </div>
+
+            <div class="composer">
+              <h2>what should socai research?</h2>
+              <p>
+                start a one-shot browser task. socai opens a temporary chrome tab, runs
+                the agent, saves the result, then closes the tab.
+              </p>
+
+              <div class="task-card">
+                <div class="task-input">
+                  <span>找成都好喝的手冲咖啡馆，每家给出地址、人均、特色豆，整理成表格。</span><span class="cursor" aria-hidden="true"></span>
+                </div>
+                <div class="task-controls">
+                  <span class="mode-switch" aria-label="selected mode: agent tasks">
+                    <span class="mode-switch__item mode-switch__item--active">agent tasks</span>
+                    <span class="mode-switch__item">tool tests</span>
+                  </span>
+                  <span class="agent-context">agent · claude · <strong>claude-sonnet-4-5</strong></span>
+                  <span class="new-task-button">new task</span>
+                </div>
+              </div>
+
+              <div class="recent-head">
+                <span>recent</span>
+                <span>view history</span>
+              </div>
+              <div class="recent-list">
+                <div class="recent-row">
+                  <span>✓</span>
+                  <span>成都好喝的手冲咖啡馆</span>
+                  <span>completed · 14:02</span>
+                </div>
+                <div class="recent-row">
+                  <span>✓</span>
+                  <span>小红书露营装备入门 · 读 3 篇</span>
+                  <span>completed · 11:38</span>
+                </div>
+                <div class="recent-row">
+                  <span>✓</span>
+                  <span>上海周末 city walk 路线</span>
+                  <span>completed · yesterday</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <span>© socai · {currentYear}</span>
+        <nav aria-label="footer links">
+          <a href={githubUrl}>github</a>
+          <a href="/download">download</a>
+          <a href="mailto:hi@socai.app">contact</a>
+        </nav>
+      </footer>
+    </div>
   </body>
 </html>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,6 +4,12 @@ import '../styles/global.css';
 const githubUrl = 'https://github.com/tonyc-ship/socai';
 const releaseVersion = '0.1.2';
 const currentYear = new Date().getFullYear();
+const researchPrompts = [
+  '找成都好喝的手冲咖啡馆，每家给出地址、人均、特色豆，整理成表格。',
+  '分析小红书上最近热门的上海周末 city walk 路线，按适合人群分类。',
+  '帮我调研 20 个小红书露营装备入门贴，总结新手最常买错的东西。',
+  '找 10 篇关于东京中古店的高质量笔记，整理店名、区域和推荐理由。',
+];
 const pageTitle = 'socai · download';
 const pageDescription = 'download socai, a web agent for 小红书 research tasks.';
 ---
@@ -96,7 +102,7 @@ const pageDescription = 'download socai, a web agent for 小红书 research task
 
               <div class="task-card">
                 <div class="task-input">
-                  <span>找成都好喝的手冲咖啡馆，每家给出地址、人均、特色豆，整理成表格。</span><span class="cursor" aria-hidden="true"></span>
+                  <span class="typewriter-text" data-typewriter data-phrases={JSON.stringify(researchPrompts)}>{researchPrompts[0]}</span><span class="cursor" aria-hidden="true"></span>
                 </div>
                 <div class="task-controls">
                   <span class="mode-switch" aria-label="selected mode: agent tasks">
@@ -143,5 +149,51 @@ const pageDescription = 'download socai, a web agent for 小红书 research task
         </nav>
       </footer>
     </div>
+
+    <script>
+      const typewriter = document.querySelector('[data-typewriter]');
+
+      if (typewriter instanceof HTMLElement) {
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const phrases = JSON.parse(typewriter.dataset.phrases || '[]');
+        const sleep = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+        if (prefersReducedMotion || phrases.length < 2) {
+          typewriter.textContent = phrases[0] || typewriter.textContent;
+        } else {
+          let phraseIndex = 0;
+
+          const render = (chars) => {
+            typewriter.textContent = chars.join('');
+          };
+
+          const runTypewriter = async () => {
+            await sleep(2200);
+
+            while (true) {
+              const currentPhrase = Array.from(phrases[phraseIndex]);
+
+              for (let i = currentPhrase.length; i >= 0; i -= 1) {
+                render(currentPhrase.slice(0, i));
+                await sleep(20);
+              }
+
+              phraseIndex = (phraseIndex + 1) % phrases.length;
+              const nextPhrase = Array.from(phrases[phraseIndex]);
+              await sleep(280);
+
+              for (let i = 1; i <= nextPhrase.length; i += 1) {
+                render(nextPhrase.slice(0, i));
+                await sleep(44 + Math.random() * 26);
+              }
+
+              await sleep(2600);
+            }
+          };
+
+          runTypewriter();
+        }
+      }
+    </script>
   </body>
 </html>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,11 +1,30 @@
+@import url('https://api.fontshare.com/v2/css?f[]=general-sans@200,300,400,500,600,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&display=swap');
+
 :root {
   color-scheme: light;
-  --canvas: #f7f7f4;
-  --surface: #ffffff;
-  --fg: #151515;
-  --muted: #666666;
-  --line: #deded8;
-  --pill: #f0f0ec;
+  --ink-0: #000000;
+  --ink-1: #0a0a0a;
+  --ink-2: #404040;
+  --ink-3: #737373;
+  --ink-4: #a3a3a3;
+  --ink-5: #d4d4d4;
+  --ink-6: #e5e5e5;
+  --ink-7: #f4f4f4;
+  --ink-8: #fafaf9;
+  --ink-9: #ffffff;
+  --canvas: var(--ink-8);
+  --surface: var(--ink-9);
+  --surface-2: var(--ink-7);
+  --fg: var(--ink-1);
+  --fg-muted: var(--ink-2);
+  --fg-soft: var(--ink-3);
+  --line: var(--ink-6);
+  --line-strong: var(--ink-5);
+  --font-sans: "General Sans", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --ls-display: -0.025em;
+  --ls-mono: -0.005em;
 }
 
 * {
@@ -13,82 +32,651 @@
 }
 
 html {
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-width: 320px;
   background: var(--canvas);
   color: var(--fg);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
+  background: var(--canvas);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "ss02", "cv11";
 }
 
-.page-shell {
-  display: grid;
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 2px solid rgba(0, 0, 0, 0.18);
+  outline-offset: 3px;
+}
+
+.site-shell {
+  display: flex;
   min-height: 100vh;
-  place-items: center;
-  padding: clamp(2rem, 6vw, 5rem);
+  flex-direction: column;
+  background: var(--canvas);
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px clamp(20px, 4vw, 40px);
+}
+
+.brand,
+.app-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink-0);
+  font-weight: 500;
+  letter-spacing: var(--ls-display);
+  line-height: 1;
+}
+
+.brand {
+  font-size: 16px;
+}
+
+.brand__mark,
+.app-brand svg {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.site-nav,
+.site-footer nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.nav-link,
+.release-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.nav-link {
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  transition:
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.nav-link:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-2);
+}
+
+.release-chip,
+.release-meta,
+.site-footer,
+.window-title,
+.status-pill,
+.mode-switch__item,
+.agent-context,
+.recent-head,
+.recent-row > :first-child,
+.recent-row > :last-child,
+.button__glyph,
+.button__external {
+  font-family: var(--font-mono);
+  letter-spacing: var(--ls-mono);
+}
+
+.release-chip {
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.page-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
 }
 
 .hero {
-  width: min(100%, 760px);
-  padding: clamp(2rem, 6vw, 4rem);
+  width: min(100%, 720px);
+  padding: clamp(56px, 8vw, 72px) clamp(20px, 4vw, 40px) 48px;
+  text-align: center;
+}
+
+.hero h1 {
+  max-width: 680px;
+  margin: 0 auto 16px;
+  color: var(--ink-0);
+  font-size: clamp(42px, 7vw, 52px);
+  font-weight: 500;
+  letter-spacing: -0.028em;
+  line-height: 1.02;
+  text-wrap: balance;
+}
+
+.hero__subtitle {
+  max-width: 480px;
+  margin: 0 auto 36px;
+  color: var(--fg-soft);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.hero__actions {
+  display: inline-flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 10px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 52px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1;
+  transition:
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  white-space: nowrap;
+}
+
+.button--primary {
+  gap: 12px;
+  padding: 0 24px;
+  border-color: var(--ink-0);
+  background: var(--ink-0);
+  color: var(--ink-9);
+  font-size: 15px;
+}
+
+.button--primary:hover {
+  background: var(--ink-1);
+}
+
+.button--secondary {
+  gap: 10px;
+  padding: 0 20px;
+  border-color: var(--line);
+  background: var(--surface);
+  color: var(--ink-0);
+  font-size: 14px;
+}
+
+.button--secondary:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-2);
+}
+
+.button__glyph,
+.button__external {
+  color: currentColor;
+  font-size: 13px;
+}
+
+.button__external {
+  color: var(--fg-soft);
+}
+
+.release-meta {
+  margin: 16px 0 0;
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.app-shot-section {
+  width: min(100%, 1080px);
+  padding: 0 clamp(20px, 4vw, 40px) 64px;
+}
+
+.app-window {
+  width: 100%;
+  height: clamp(360px, 46vw, 400px);
+  overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 32px;
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--fg);
+}
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-2);
+}
+
+.traffic-light {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.window-title {
+  margin-left: 18px;
+  color: var(--fg-soft);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+}
+
+.app-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 32px;
+  border-bottom: 1px solid var(--line);
   background: var(--surface);
 }
 
-.eyebrow {
-  margin: 0 0 1rem;
-  color: var(--muted);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  line-height: 1.2;
-  text-transform: uppercase;
+.app-brand {
+  flex: 0 0 auto;
+  font-size: 15px;
 }
 
-h1 {
-  margin: 0;
-  font-size: clamp(4rem, 18vw, 9rem);
-  font-weight: 800;
-  letter-spacing: -0.09em;
-  line-height: 0.85;
-}
-
-.lede {
-  max-width: 34rem;
-  margin: 1.5rem 0 0;
-  color: var(--muted);
-  font-size: clamp(1.15rem, 3vw, 1.5rem);
-  line-height: 1.45;
-}
-
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 2rem;
-}
-
-.pill {
+.status-group {
   display: inline-flex;
   align-items: center;
-  min-height: 2.5rem;
-  padding: 0.6rem 1rem;
-  border: 1px solid var(--fg);
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border: 1px solid var(--line);
   border-radius: 999px;
-  background: var(--fg);
-  color: var(--surface);
-  font-size: 0.85rem;
-  font-weight: 700;
+  background: var(--surface);
+  color: var(--fg-muted);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.status-pill i {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--ink-0);
+}
+
+.status-pill--active {
+  color: var(--fg);
+}
+
+.composer {
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 44px 32px 28px;
+}
+
+.composer h2 {
+  margin: 0 0 8px;
+  color: var(--ink-0);
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+.composer p {
+  margin: 0 0 20px;
+  color: var(--fg-soft);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.task-card {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.task-input {
+  min-height: 110px;
+  padding: 16px 18px;
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.cursor {
+  display: inline-block;
+  width: 1.5px;
+  height: 16px;
+  margin-left: 1px;
+  background: var(--ink-0);
+  vertical-align: text-bottom;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.task-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--line);
+  background: var(--canvas);
+}
+
+.mode-switch {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.mode-switch__item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 26px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.mode-switch__item--active {
+  background: var(--ink-0);
+  color: var(--ink-9);
+}
+
+.agent-context {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-context strong {
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+
+.new-task-button {
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  border-radius: 4px;
+  background: var(--ink-0);
+  color: var(--ink-9);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.recent-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 24px;
+  color: var(--fg-soft);
+  font-size: 11px;
   letter-spacing: 0.04em;
+}
+
+.recent-head > :first-child {
   text-transform: uppercase;
 }
 
-.pill--hollow {
-  background: var(--pill);
-  color: var(--fg);
+.recent-list {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  margin-top: 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--line);
+}
+
+.recent-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  background: var(--surface);
+}
+
+.recent-row > :first-child {
+  width: 14px;
+  color: var(--ink-0);
+  font-size: 12px;
+  text-align: center;
+}
+
+.recent-row > :nth-child(2) {
+  overflow: hidden;
+  color: var(--ink-0);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-row > :last-child {
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.site-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 20px clamp(20px, 4vw, 40px);
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.site-footer nav {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.site-footer a {
+  color: var(--fg-muted);
+}
+
+.site-footer a:hover {
+  color: var(--ink-0);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+
+  .cursor {
+    animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    padding-top: 16px;
+  }
+
+  .hero {
+    padding-top: 56px;
+  }
+
+  .hero__actions {
+    width: min(100%, 360px);
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .app-window {
+    height: 420px;
+  }
+
+  .app-topbar {
+    align-items: flex-start;
+    padding: 14px 18px;
+  }
+
+  .status-group {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+  }
+
+  .composer {
+    padding: 32px 18px 24px;
+  }
+
+  .task-controls {
+    flex-wrap: wrap;
+  }
+
+  .agent-context {
+    order: 3;
+    flex-basis: 100%;
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header,
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-nav,
+  .site-footer nav {
+    flex-wrap: wrap;
+  }
+
+  .hero h1 {
+    font-size: clamp(40px, 12vw, 48px);
+  }
+
+  .app-shot-section {
+    padding-bottom: 48px;
+  }
+
+  .window-title {
+    margin-left: 10px;
+  }
+
+  .app-topbar {
+    flex-direction: column;
+  }
+
+  .status-group {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .status-pill {
+    max-width: 100%;
+  }
+
+  .recent-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .recent-row > :last-child {
+    display: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .release-chip {
+    display: none;
+  }
+
+  .mode-switch,
+  .new-task-button {
+    width: 100%;
+  }
+
+  .mode-switch__item,
+  .new-task-button {
+    flex: 1 1 0;
+  }
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -388,6 +388,10 @@ a:focus-visible {
   line-height: 1.55;
 }
 
+.typewriter-text {
+  white-space: pre-wrap;
+}
+
 .cursor {
   display: inline-block;
   width: 1.5px;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -187,11 +187,12 @@ a:focus-visible {
 }
 
 .hero__subtitle {
-  max-width: 480px;
+  max-width: none;
   margin: 0 auto 36px;
   color: var(--fg-soft);
-  font-size: 16px;
+  font-size: clamp(10px, 1.25vw, 16px);
   line-height: 1.5;
+  white-space: nowrap;
 }
 
 .hero__actions {


### PR DESCRIPTION
## Summary

- port the Option B minimal download-page direction into the Astro site
- replace the scaffold placeholder with static HTML/CSS sections for header, hero, CTAs, release metadata, app preview, and footer
- add a lightweight SVG favicon
- add a tiny vanilla typewriter animation for the app preview research prompt, with reduced-motion support
- keep the page free of React/Babel runtime requirements

## Validation

- `cd site && pnpm build`
- checked built output for React/Babel runtime references

Closes #30
Part of #28 

