### PR TITLE
feat: multi-turn TUI chat sessions + agent/media optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2139,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2530,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3196,6 +3238,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3968,6 +4022,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "futures",
+ "image",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6129,3 +6184,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 use std::io::{self, IsTerminal};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 use inquire::{Select, Text};
@@ -19,6 +19,7 @@ use socai_core::agent::{
     config_for, configured_default_model_for, provider_credential_kind, resolve_provider,
     save_api_key, save_default_model, AgentEvent, Backend, CredentialKind, Provider, PROVIDERS,
 };
+use socai_core::agent::{local_agent_tools, make_run_dir, Session};
 use socai_core::runtime::{
     create_llm_provider, run_agent_task as run_agent_with_tools, AgentRunConfig, SocaiRuntime,
 };
@@ -31,16 +32,35 @@ const PROVIDER_ORDER: &[Provider] = &[
     Provider::Anthropic,
 ];
 
+// Autocomplete-visible slash commands. `/new` is an alias of `/clear` handled
+// in dispatch but intentionally omitted here so only `/clear` is suggested.
 const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("model", "Choose the active LLM model"),
+    ("clear", "Clear the chat and start a new session"),
     ("exit", "Exit the TUI"),
 ];
 
-const TUI_AGENT_PREAMBLE: &str = "You are running inside the Socai TUI.";
+const TUI_AGENT_PREAMBLE: &str =
+    "You are running inside the Socai TUI as a conversational, multi-turn agent. \
+     Besides the Xiaohongshu site tools you have local environment tools: \
+     `read_file` (read text, or view image/screenshot artifacts) and `bash` (run \
+     shell commands to write files, list/grep artifacts, etc.). Maintain \
+     continuity with earlier turns in this chat. When the user asks you to save \
+     or export something, write it with bash in the format they want. Stay within \
+     the files relevant to the task and the user's ~/.socai data — do not run \
+     destructive, networked, or system-wide commands.";
 
-#[derive(Default)]
 struct AppState {
     model: Option<String>,
+    session: Session,
+}
+
+/// Live snapshot of an in-flight run, updated off the event stream so an
+/// interrupted turn can still be recorded with its run_id + partial answer.
+#[derive(Default)]
+struct LiveTurn {
+    run_id: String,
+    assistant: String,
 }
 
 // ---------- rustyline helper: slash completion -----------------------------
@@ -78,19 +98,30 @@ impl Hinter for SocaiHelper {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, _ctx: &rustyline::Context<'_>) -> Option<String> {
-        // Inline ghost suggestion for slash commands — only when cursor is at
-        // the end of a single-line buffer that starts with '/'.
+        // Slash-command hint — only when the cursor is at the end of a
+        // single-line buffer that starts with '/'.
         if pos != line.len() || !line.starts_with('/') || line.contains(' ') {
             return None;
         }
         let prefix = line.trim_start_matches('/');
-        for (name, desc) in SLASH_COMMANDS {
-            if name.starts_with(prefix) && prefix.len() < name.len() {
-                let rest = &name[prefix.len()..];
-                return Some(format!("{rest}  — {desc}"));
+        let matches: Vec<&(&str, &str)> = SLASH_COMMANDS
+            .iter()
+            .filter(|(name, _)| name.starts_with(prefix))
+            .collect();
+        match matches.as_slice() {
+            [] => None,
+            // Exactly one match → inline completion ghost for the rest + desc.
+            [(name, desc)] => {
+                if prefix.len() < name.len() {
+                    Some(format!("{}  — {}", &name[prefix.len()..], desc))
+                } else {
+                    Some(format!("  — {desc}"))
+                }
             }
+            // Several match (e.g. just "/") → point at the interactive menu
+            // (Enter opens it) rather than cramming options into the hint.
+            _ => Some("  ↵ for command menu".to_string()),
         }
-        None
     }
 }
 impl Highlighter for SocaiHelper {
@@ -116,7 +147,11 @@ pub async fn run() -> Result<()> {
     ensure_any_llm_key().await?;
 
     let runtime = SocaiRuntime::new();
-    let mut state = AppState::default();
+    let session = Session::new(None).context("failed to create chat session")?;
+    let mut state = AppState {
+        model: None,
+        session,
+    };
 
     let mut editor = build_editor()?;
     print_header(&state)?;
@@ -141,14 +176,24 @@ pub async fn run() -> Result<()> {
         let _ = editor.add_history_entry(trimmed);
 
         if trimmed.starts_with('/') {
-            if handle_command(trimmed, &mut state).await? {
+            // A bare "/" opens the interactive, filterable command menu;
+            // a fully-typed command (e.g. "/clear") dispatches directly.
+            let command_line = if trimmed == "/" {
+                match slash_menu().await? {
+                    Some(name) => format!("/{name}"),
+                    None => continue, // Esc — back to the prompt
+                }
+            } else {
+                trimmed.to_string()
+            };
+            if handle_command(&command_line, &mut state).await? {
                 break;
             }
             print_header(&state)?;
             continue;
         }
 
-        if let Err(err) = run_agent_task(&runtime, trimmed, state.model.as_deref()).await {
+        if let Err(err) = run_agent_task(&runtime, trimmed, &mut state).await {
             eprintln!("[socai] error: {err:#}");
         }
     }
@@ -190,9 +235,10 @@ fn build_editor() -> Result<Editor<SocaiHelper, DefaultHistory>> {
 fn print_header(state: &AppState) -> Result<()> {
     println!("Current model: {}", active_model(state)?);
     println!(
-        "Enter your task description. Type / for commands (Tab to list). \
-         Alt+Enter for newline (Shift/Ctrl+Enter if your terminal supports it). \
-         Ctrl+C to exit."
+        "Chat with the agent — turns share context within a session. \
+         Type / then Enter for the command menu; /clear starts a new chat. \
+         Ctrl+C interrupts a running task (records it); Ctrl+C at the prompt exits. \
+         Alt+Enter for newline (Shift/Ctrl+Enter if your terminal supports it)."
     );
     Ok(())
 }
@@ -211,12 +257,51 @@ async fn handle_command(line: &str, state: &mut AppState) -> Result<bool> {
             handle_model_command(state, rest).await?;
             Ok(false)
         }
+        // `/new` is an undocumented alias of `/clear`.
+        "clear" | "new" => {
+            handle_clear_command(state)?;
+            Ok(false)
+        }
         "" => Ok(false),
         other => {
             eprintln!("[socai] unknown command: /{other}");
             Ok(false)
         }
     }
+}
+
+// ---------- interactive slash-command menu ---------------------------------
+
+/// Filterable command menu opened by typing a bare `/`. Returns the chosen
+/// command name (e.g. "clear"), or `None` on Esc. Typing narrows the list.
+async fn slash_menu() -> Result<Option<String>> {
+    let options: Vec<String> = SLASH_COMMANDS
+        .iter()
+        .map(|(name, desc)| format!("/{name}  — {desc}"))
+        .collect();
+    let chosen = tokio::task::spawn_blocking(move || {
+        Select::new("Command", options)
+            .with_help_message("type to filter · ↑/↓ to move · enter to run · esc to cancel")
+            .prompt_skippable()
+    })
+    .await
+    .context("slash menu thread panicked")??;
+    Ok(chosen.and_then(|label| {
+        label
+            .trim_start_matches('/')
+            .split_whitespace()
+            .next()
+            .map(str::to_string)
+            .filter(|name| !name.is_empty())
+    }))
+}
+
+// ---------- /clear (and its /new alias) ------------------------------------
+
+fn handle_clear_command(state: &mut AppState) -> Result<()> {
+    state.session = Session::new(state.model.clone()).context("failed to start a new session")?;
+    println!("[socai] chat cleared — new session {}", state.session.id);
+    Ok(())
 }
 
 // ---------- model picker ---------------------------------------------------
@@ -477,29 +562,101 @@ fn active_model(state: &AppState) -> Result<String> {
     Ok(configured_default_model_for(provider))
 }
 
-async fn run_agent_task(runtime: &SocaiRuntime, task: &str, model: Option<&str>) -> Result<()> {
-    let llm_provider = build_llm_provider(model).await?;
+async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState) -> Result<()> {
+    let llm_provider = build_llm_provider(state.model.as_deref()).await?;
     println!();
     println!("[socai] using {}", llm_provider.label());
-    println!("[socai] connecting browser...");
-    let page = runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-    let tools = xhs_agent_tools(page, llm_provider.clone()).await?;
 
+    // Pin the run dir up front (instead of letting the loop allocate it) so an
+    // interrupted or failed turn still knows where partial artifacts live and
+    // can record itself for follow-ups.
+    let run_dir = make_run_dir(task);
+    let _ = std::fs::create_dir_all(&run_dir);
+
+    // Browser/network setup can fail (e.g. DNS ERR_NAME_NOT_RESOLVED). Record
+    // the turn even then, so a follow-up still knows what the user asked.
+    println!("[socai] connecting browser...");
+    let page = match runtime.ensure_site_page("xhs", XHS_HOME_URL).await {
+        Ok(page) => page,
+        Err(err) => {
+            state.session.record_turn(
+                task,
+                &format!("[turn did not run — browser/network error: {err:#}]"),
+                "",
+                &run_dir,
+            );
+            return Err(err);
+        }
+    };
+    let mut tools = xhs_agent_tools(page, llm_provider.clone()).await?;
+    tools.extend(local_agent_tools());
+
+    // Track run_id + latest assistant text live off the event stream so we can
+    // record a meaningful turn even if the run is interrupted mid-flight.
+    let live = Arc::new(Mutex::new(LiveTurn::default()));
+    let live_for_printer = live.clone();
     let (tx, mut rx) = tokio::sync::broadcast::channel::<AgentEvent>(256);
     let printer = tokio::spawn(async move {
         while let Ok(event) = rx.recv().await {
+            if let Ok(mut g) = live_for_printer.lock() {
+                match &event {
+                    AgentEvent::Started { run_id, .. } => g.run_id = run_id.clone(),
+                    AgentEvent::AssistantText { text, .. } => g.assistant = text.clone(),
+                    _ => {}
+                }
+            }
             print_agent_event(&event);
         }
     });
 
+    // Seed the conversation with prior turns and tell the agent which run dirs
+    // belong to this session so it can read back earlier artifacts.
+    let preamble = format!("{TUI_AGENT_PREAMBLE}\n\n{}", state.session.context_note());
     let config = AgentRunConfig {
-        extra_instructions: xhs_agent_instructions(TUI_AGENT_PREAMBLE),
+        extra_instructions: xhs_agent_instructions(&preamble),
         enabled_sites: vec!["xhs".to_string()],
+        seed_messages: state.session.chat_messages(),
+        run_dir: Some(run_dir.clone()),
         ..AgentRunConfig::default()
     };
-    let outcome = run_agent_with_tools(task, llm_provider, tools, config, tx).await;
+    // Race the agent against Ctrl+C so the user can interrupt a long run and
+    // ask a follow-up. (At the idle prompt, rustyline turns Ctrl+C into an exit
+    // instead — these two contexts don't overlap.)
+    let agent = run_agent_with_tools(task, llm_provider, tools, config, tx);
+    tokio::pin!(agent);
+    let outcome = tokio::select! {
+        outcome = &mut agent => outcome,
+        _ = tokio::signal::ctrl_c() => {
+            printer.abort();
+            let (run_id, partial) = live
+                .lock()
+                .map(|g| (g.run_id.clone(), g.assistant.clone()))
+                .unwrap_or_default();
+            let assistant = if partial.trim().is_empty() {
+                "[interrupted by user before producing an answer]".to_string()
+            } else {
+                format!("{}\n\n[interrupted by user]", partial.trim())
+            };
+            // Record the interrupted turn so a follow-up keeps its context.
+            state.session.record_turn(task, &assistant, &run_id, &run_dir);
+            println!("\n[socai] interrupted — recorded; ask a follow-up, or press Ctrl+C at the prompt to exit.");
+            return Ok(());
+        }
+    };
     let _ = printer.await;
-    let outcome = outcome.context("agent loop failed")?;
+    let outcome = match outcome.context("agent loop failed") {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            // Record the failed turn too, so its topic survives for follow-ups.
+            state.session.record_turn(
+                task,
+                &format!("[turn failed: {err:#}]"),
+                "",
+                &run_dir,
+            );
+            return Err(err);
+        }
+    };
 
     println!();
     println!("{}", outcome.final_text.trim());
@@ -510,6 +667,18 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, model: Option<&str>)
     );
     println!("[socai] run_dir={}", outcome.run_dir.display());
     println!();
+
+    // An API error surfaces as an Ok outcome whose final_text is the error.
+    // Record a short marker instead of dumping the whole provider message into
+    // the conversation seed.
+    let recorded = if outcome.final_text.starts_with("API error:") {
+        "[turn failed: LLM API error]".to_string()
+    } else {
+        outcome.final_text.clone()
+    };
+    state
+        .session
+        .record_turn(task, &recorded, &outcome.run_id, &outcome.run_dir);
     Ok(())
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,8 @@ base64.workspace = true
 chromiumoxide.workspace = true
 dirs = "5"
 chrono = { version = "0.4", features = ["serde"] }
+# Image compositing/resizing for batching note images into 2x2 vision grids.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/core/src/agent/compaction.rs
+++ b/core/src/agent/compaction.rs
@@ -9,7 +9,7 @@
 
 use serde_json::{Map, Value};
 
-pub const TOOL_RESULT_TEXT_MAX_CHARS: usize = 2200;
+pub const TOOL_RESULT_TEXT_MAX_CHARS: usize = 10_000;
 pub const ASSISTANT_TEXT_MAX_CHARS: usize = 320;
 
 /// Trim a string to at most `max_chars` characters, suffixing

--- a/core/src/agent/file_bash_tools.rs
+++ b/core/src/agent/file_bash_tools.rs
@@ -1,0 +1,300 @@
+//! Local environment tools for an interactive agent: a structured `read_file`
+//! (the one thing a shell can't do well — feed an image into the model's
+//! vision) plus a general `bash` escape hatch for everything else (write,
+//! list, grep, mkdir, …).
+//!
+//! Scope is intentionally *prompt-enforced*, not sandboxed: the agent runs in
+//! the user's own environment (Claude Code-style). The tool descriptions and
+//! the TUI preamble tell it to stay within the task's files / `~/.socai`.
+//! Paths are resolved against the process working directory when relative; a
+//! leading `~` expands to the home directory. `bash` runs with its working
+//! directory set to the current run dir.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::agent::tool::{SharedTool, Tool, ToolContext, ToolResult, ToolResultBlock};
+
+/// Skip inlining image bytes larger than this (base64 of big images bloats the
+/// context for little gain). The agent still gets the path to cite.
+const MAX_INLINE_IMAGE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_TEXT_BYTES: u64 = 2 * 1024 * 1024;
+const DEFAULT_READ_LIMIT: usize = 2000;
+const BASH_OUTPUT_LIMIT: usize = 16_000;
+const BASH_DEFAULT_TIMEOUT_MS: u64 = 120_000;
+
+fn resolve_path(raw: &str) -> PathBuf {
+    let trimmed = raw.trim();
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    if trimmed == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(trimmed)
+}
+
+fn image_media_type(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => Some("image/png"),
+        Some("jpg") | Some("jpeg") => Some("image/jpeg"),
+        Some("webp") => Some("image/webp"),
+        Some("gif") => Some("image/gif"),
+        _ => None,
+    }
+}
+
+fn truncate_output(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(limit).collect();
+    format!("{head}\n…[output truncated at {limit} chars]")
+}
+
+/// `read_file` — read a text file (optionally a line window) or an image.
+pub struct ReadFileTool;
+
+#[async_trait]
+impl Tool for ReadFileTool {
+    fn name(&self) -> &str {
+        "read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a local file. Text files return their contents (optionally a line \
+         window via `offset`/`limit`); image files (png/jpg/webp/gif) are \
+         returned as an image you can actually see — use this to inspect \
+         screenshot artifacts from earlier run dirs. For plain text you may \
+         also just use `bash` (cat/sed), but images must go through this tool."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "File path (absolute, relative to cwd, or ~/...)." },
+                "offset": { "type": "integer", "description": "1-based start line for text files." },
+                "limit": { "type": "integer", "description": "Max lines to return for text files." }
+            },
+            "required": ["path"]
+        })
+    }
+
+    fn always_available(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let Some(raw) = input.get("path").and_then(Value::as_str) else {
+            anyhow::bail!("read_file requires a `path`");
+        };
+        let path = resolve_path(raw);
+        let meta = std::fs::metadata(&path)
+            .map_err(|e| anyhow::anyhow!("cannot stat {}: {e}", path.display()))?;
+        if meta.is_dir() {
+            anyhow::bail!("{} is a directory; use bash (ls) to list it", path.display());
+        }
+
+        if let Some(media_type) = image_media_type(&path) {
+            if meta.len() > MAX_INLINE_IMAGE_BYTES {
+                return Ok(ToolResult::text(format!(
+                    "Image {} is {} bytes — too large to inline. Reference it by path.",
+                    path.display(),
+                    meta.len()
+                )));
+            }
+            let bytes = std::fs::read(&path)?;
+            use base64::Engine as _;
+            let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            return Ok(ToolResult::blocks(vec![
+                ToolResultBlock::text(format!("Image {}", path.display())),
+                ToolResultBlock::Image {
+                    data,
+                    media_type: media_type.to_string(),
+                },
+            ]));
+        }
+
+        if meta.len() > MAX_TEXT_BYTES {
+            anyhow::bail!(
+                "{} is {} bytes — too large to read; use offset/limit",
+                path.display(),
+                meta.len()
+            );
+        }
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+
+        let offset = input
+            .get("offset")
+            .and_then(Value::as_u64)
+            .map(|o| o.max(1) as usize);
+        let limit = input
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|l| l as usize);
+
+        if offset.is_none() && limit.is_none() {
+            let lines: Vec<&str> = content.lines().collect();
+            if lines.len() > DEFAULT_READ_LIMIT {
+                let shown = lines[..DEFAULT_READ_LIMIT].join("\n");
+                return Ok(ToolResult::text(format!(
+                    "{shown}\n\n[truncated at {DEFAULT_READ_LIMIT} of {} lines; use offset/limit for more]",
+                    lines.len()
+                )));
+            }
+            return Ok(ToolResult::text(content));
+        }
+
+        let start = offset.unwrap_or(1).saturating_sub(1);
+        let take = limit.unwrap_or(DEFAULT_READ_LIMIT);
+        let windowed: Vec<&str> = content.lines().skip(start).take(take).collect();
+        Ok(ToolResult::text(windowed.join("\n")))
+    }
+}
+
+/// `bash` — run a shell command. The flexible escape hatch for writing files,
+/// listing/grepping artifacts, etc. Working directory is the current run dir.
+pub struct BashTool;
+
+#[async_trait]
+impl Tool for BashTool {
+    fn name(&self) -> &str {
+        "bash"
+    }
+
+    fn description(&self) -> &str {
+        "Run a shell command via `sh -c` and return its stdout/stderr and exit \
+         code. Working directory is the current run dir under ~/.socai/runs, so \
+         relative paths land there; use absolute paths for other run dirs or \
+         the session dir. Use this to write output files (e.g. printf/tee), \
+         list and grep artifacts, mkdir, etc. Scope: stay within the files \
+         relevant to this task and the user's ~/.socai data — do not run \
+         destructive, networked, or system-wide commands."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string", "description": "Shell command to run via `sh -c`." },
+                "timeout_ms": { "type": "integer", "description": "Optional timeout in milliseconds (default 120000)." }
+            },
+            "required": ["command"]
+        })
+    }
+
+    fn always_available(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let command = input
+            .get("command")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("bash requires a non-empty `command`"))?;
+        let timeout = Duration::from_millis(
+            input
+                .get("timeout_ms")
+                .and_then(Value::as_u64)
+                .unwrap_or(BASH_DEFAULT_TIMEOUT_MS),
+        );
+
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c").arg(command);
+        if ctx.run_dir.is_dir() {
+            cmd.current_dir(&ctx.run_dir);
+        }
+
+        let output = match tokio::time::timeout(timeout, cmd.output()).await {
+            Ok(result) => result.map_err(|e| anyhow::anyhow!("failed to run command: {e}"))?,
+            Err(_) => anyhow::bail!("command timed out after {:?}", timeout),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let mut parts = Vec::new();
+        if !stdout.trim().is_empty() {
+            parts.push(stdout.into_owned());
+        }
+        if !stderr.trim().is_empty() {
+            parts.push(format!("[stderr]\n{stderr}"));
+        }
+        if !output.status.success() {
+            parts.push(format!("[exit {}]", output.status.code().unwrap_or(-1)));
+        }
+        let body = if parts.is_empty() {
+            "(no output)".to_string()
+        } else {
+            parts.join("\n")
+        };
+        Ok(ToolResult::text(truncate_output(&body, BASH_OUTPUT_LIMIT)))
+    }
+}
+
+/// Local tools for an interactive entrypoint: structured image-capable read +
+/// a general `bash`. Append to a site tool set.
+pub fn local_agent_tools() -> Vec<SharedTool> {
+    vec![
+        std::sync::Arc::new(ReadFileTool),
+        std::sync::Arc::new(BashTool),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext::new("run", std::env::temp_dir())
+    }
+
+    #[tokio::test]
+    async fn read_honors_offset_and_limit() {
+        let dir = std::env::temp_dir().join(format!("socai_fs_win_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("lines.txt");
+        std::fs::write(&file, "a\nb\nc\nd").unwrap();
+
+        let read = ReadFileTool
+            .call(
+                json!({"path": file.to_string_lossy(), "offset": 2, "limit": 2}),
+                &ctx(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.flat_text(), "b\nc");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn bash_runs_and_reports_exit() {
+        let ok = BashTool
+            .call(json!({"command": "echo hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(ok.flat_text().contains("hi"));
+
+        let fail = BashTool
+            .call(json!({"command": "exit 3"}), &ctx())
+            .await
+            .unwrap();
+        assert!(fail.flat_text().contains("[exit 3]"));
+    }
+}

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -99,6 +99,10 @@ pub struct AgentOptions {
     pub keep_recent_messages: usize,
     /// Memory budget for the condensed context_block.
     pub memory_max_chars: usize,
+    /// Prior chat-level messages to seed the conversation with, so a turn can
+    /// continue an ongoing multi-turn session. The current task is appended as
+    /// the final user message. Empty = a fresh, single-shot run.
+    pub seed_messages: Vec<Message>,
 }
 
 impl Default for AgentOptions {
@@ -111,6 +115,7 @@ impl Default for AgentOptions {
             enabled_sites: Vec::new(),
             keep_recent_messages: 12,
             memory_max_chars: 6000,
+            seed_messages: Vec::new(),
         }
     }
 }
@@ -153,7 +158,8 @@ pub async fn run_agent_with_events(
         ctx.enable_site(site.clone());
     }
 
-    let mut messages: Vec<Message> = vec![Message::user(task.to_string())];
+    let mut messages: Vec<Message> = options.seed_messages.clone();
+    messages.push(Message::user(task.to_string()));
 
     debug_log.event(
         "task_start",

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -379,9 +379,27 @@ pub async fn run_agent_with_events(
                 error.as_deref().unwrap_or(""),
             );
 
+            let mut history_content = bound_content_for_history(&result_content);
+            // Break tight loops: when the model fires the *same* call with the
+            // same args repeatedly, the bare result won't change its mind. Tell
+            // it explicitly to stop and work with what it already has.
+            if repeat_count >= 3 {
+                history_content.insert(
+                    0,
+                    ToolResultContent::Text {
+                        text: format!(
+                            "[Note: you have called {name} with these exact arguments \
+                             {repeat_count} times and the result is not changing. Stop \
+                             repeating this call. Proceed with the information you already \
+                             have — if something cannot be found, say so and complete the \
+                             task with what is available.]"
+                        ),
+                    },
+                );
+            }
             tool_result_blocks.push(Block::ToolResult {
                 tool_use_id: id.clone(),
-                content: bound_content_for_history(&result_content),
+                content: history_content,
             });
 
             context_memory.push(format!(

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod api_errors;
 pub mod compaction;
+pub mod file_bash_tools;
 pub mod llm;
 pub mod r#loop;
 pub mod memory;
@@ -13,6 +14,7 @@ pub mod provider;
 pub mod report;
 pub mod run_logging;
 pub mod run_state;
+pub mod session;
 pub mod signature;
 pub mod system_prompt;
 pub mod tool;
@@ -27,9 +29,11 @@ pub use self::provider::{
     resolve_provider, save_api_key, save_default_model, Credential, CredentialKind, Provider,
     ProviderConfig, PROVIDERS,
 };
+pub use self::file_bash_tools::{local_agent_tools, BashTool, ReadFileTool};
 pub use self::r#loop::{run_agent, run_agent_with_events, AgentEvent, AgentOptions, AgentOutcome};
 pub use self::run_logging::{make_run_dir, RunDebugLogger};
 pub use self::run_state::{ArtifactRecord, RunState};
+pub use self::session::{default_sessions_root, Session, Turn};
 pub use self::tool::{
     EchoTool, ProcessedNote, SharedTool, Tool, ToolContext, ToolResult, ToolResultBlock,
 };

--- a/core/src/agent/session.rs
+++ b/core/src/agent/session.rs
@@ -1,0 +1,149 @@
+//! Chat session: a persistent multi-turn conversation built on top of runs.
+//!
+//! Each session is one folder under `~/.socai/sessions/<id>/` (override with
+//! `SOCAI_SESSIONS_DIR`) holding `session.json` — the structured turns
+//! (user / assistant / run pointers), which is also the seed source.
+//!
+//! Run-dir granularity is unchanged: every user turn still produces its own
+//! run dir. The session only records *pointers* to those run dirs plus the
+//! chat-level text, so the agent can refer back to earlier artifacts (via the
+//! local environment tools) without bloating the seed.
+//!
+//! This lives in core so any entrypoint (TUI today, desktop later) can reuse
+//! it. Nothing constructs a `Session` implicitly — entrypoints opt in.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent::llm::{Block, Message};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Turn {
+    pub user: String,
+    pub assistant: String,
+    pub run_id: String,
+    pub run_dir: String,
+    pub ts_ms: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Session {
+    pub id: String,
+    #[serde(skip)]
+    pub dir: PathBuf,
+    pub model: Option<String>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub turns: Vec<Turn>,
+}
+
+impl Session {
+    /// Create a fresh session folder and persist its (empty) index.
+    pub fn new(model: Option<String>) -> std::io::Result<Self> {
+        let now = now_ms();
+        let id = format!("session-{now}");
+        let dir = default_sessions_root().join(&id);
+        std::fs::create_dir_all(&dir)?;
+        let session = Self {
+            id,
+            dir,
+            model,
+            created_at_ms: now,
+            updated_at_ms: now,
+            turns: Vec::new(),
+        };
+        session.persist();
+        Ok(session)
+    }
+
+    /// Record a completed turn and flush to disk.
+    pub fn record_turn(&mut self, user: &str, assistant: &str, run_id: &str, run_dir: &Path) {
+        self.turns.push(Turn {
+            user: user.to_string(),
+            assistant: assistant.to_string(),
+            run_id: run_id.to_string(),
+            run_dir: run_dir.to_string_lossy().to_string(),
+            ts_ms: now_ms(),
+        });
+        self.updated_at_ms = now_ms();
+        self.persist();
+    }
+
+    /// Chat-level seed messages (prior user inputs + assistant answers) used to
+    /// continue the conversation on the next turn.
+    pub fn chat_messages(&self) -> Vec<Message> {
+        let mut out = Vec::with_capacity(self.turns.len() * 2);
+        for turn in &self.turns {
+            out.push(Message::user(turn.user.clone()));
+            out.push(Message::assistant_blocks(vec![Block::Text {
+                text: turn.assistant.clone(),
+            }]));
+        }
+        out
+    }
+
+    /// A short note for the agent instructions so it knows which run dirs
+    /// belong to this session and can read their artifacts on demand.
+    pub fn context_note(&self) -> String {
+        if self.turns.is_empty() {
+            return format!(
+                "This is an ongoing chat session. Session dir: {}. \
+                 Use the local environment tools (read_file, bash) when the user asks \
+                 to inspect earlier results or produce output files.",
+                self.dir.display()
+            );
+        }
+        let mut lines = vec![format!(
+            "This is an ongoing chat session (session dir: {}). Earlier turns saved \
+             artifacts under these run dirs — inspect them with read_file/bash when \
+             the user refers back to them:",
+            self.dir.display()
+        )];
+        for (i, turn) in self.turns.iter().enumerate() {
+            lines.push(format!(
+                "  {}. {} — {}",
+                i + 1,
+                turn.run_dir,
+                preview(&turn.user)
+            ));
+        }
+        lines.join("\n")
+    }
+
+    fn persist(&self) {
+        if let Ok(text) = serde_json::to_string_pretty(self) {
+            let _ = std::fs::write(self.dir.join("session.json"), text);
+        }
+    }
+}
+
+/// Root directory for chat sessions: `$SOCAI_SESSIONS_DIR` or
+/// `~/.socai/sessions`. Mirrors [`crate::agent::run_logging::default_runs_root`].
+pub fn default_sessions_root() -> PathBuf {
+    if let Ok(env) = std::env::var("SOCAI_SESSIONS_DIR") {
+        return PathBuf::from(env);
+    }
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".socai/sessions");
+    }
+    PathBuf::from(".socai/sessions")
+}
+
+fn preview(text: &str) -> String {
+    let line = text.trim().lines().next().unwrap_or("").trim();
+    if line.chars().count() > 60 {
+        let s: String = line.chars().take(60).collect();
+        format!("{s}…")
+    } else {
+        line.to_string()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_default()
+}

--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -10,6 +10,17 @@ use crate::media::common::{detect_media_type, insert_string, short, url_suffix, 
 use crate::media::md5;
 use crate::media::processor::MediaProcessor;
 
+/// Max simultaneous vision (LLM) calls when enriching a note's images. Bounded
+/// so a 12-image note doesn't fire a dozen concurrent requests at the provider.
+const VISION_CONCURRENCY: usize = 4;
+/// Images per 2x2 vision grid.
+const VISION_GRID_BATCH: usize = 4;
+/// Side length of each grid cell (px). 4 cells → a 1024x1024 grid, i.e. roughly
+/// one image's worth of tokens for four images (~1 MP is the sweet spot shared
+/// by OpenAI, Claude and Qwen-VL). Images are letterboxed (aspect preserved,
+/// white padding) into their square cell.
+const VISION_GRID_CELL: u32 = 512;
+
 impl MediaProcessor {
     pub fn ocr_image(&self, _payload: &[u8]) -> Result<String> {
         if !self.config.use_ocr {
@@ -58,6 +69,73 @@ impl MediaProcessor {
             .await?;
         self.timing.record("vision_image", t0.elapsed());
         Ok(response.text_blocks.join("\n").trim().to_string())
+    }
+
+    /// Describe a batch of images with a single vision call by compositing them
+    /// into a 2x2 grid. Returns one description per input image (same order).
+    /// Falls back to a single-image call when there's only one image, or when
+    /// compositing fails.
+    async fn describe_image_batch(&self, payloads: &[&[u8]]) -> Result<Vec<String>> {
+        if payloads.len() == 1 {
+            let desc = self
+                .describe_image(
+                    payloads[0],
+                    "Describe this Xiaohongshu image for the note. Focus on concrete visible facts.",
+                    180,
+                )
+                .await?;
+            return Ok(vec![desc]);
+        }
+        match compose_grid(payloads, VISION_GRID_CELL) {
+            Some(grid) => self.describe_grid(&grid, payloads.len()).await,
+            None => {
+                // Compositing failed (e.g. all decodes failed) — degrade to
+                // empty descriptions rather than scrambling.
+                Ok(vec![String::new(); payloads.len()])
+            }
+        }
+    }
+
+    /// Send one 2x2 grid image and parse `n` per-cell descriptions back out.
+    async fn describe_grid(&self, grid_jpeg: &[u8], n: usize) -> Result<Vec<String>> {
+        let Some(llm_provider) = &self.llm_provider else {
+            anyhow::bail!(MediaUnavailable(
+                "No agent LLM provider was provided for image vision".into()
+            ));
+        };
+        let t0 = Instant::now();
+        let data = base64::engine::general_purpose::STANDARD.encode(grid_jpeg);
+        let prompt = format!(
+            "This is a 2-column grid combining {n} separate Xiaohongshu note images, \
+             numbered left-to-right then top-to-bottom (image 1 = top-left). Each cell \
+             may be letterboxed with white padding. Describe EACH image separately, \
+             focusing on concrete visible facts (text, products, layout). Reply with \
+             exactly {n} lines, each beginning with its number and a colon, e.g.\n\
+             1: <description of image 1>\n2: <description of image 2>\n\
+             Do not merge images or add extra commentary."
+        );
+        let response = llm_provider
+            .send(
+                "You describe images concisely and only state visible evidence.",
+                &[Message {
+                    role: MessageRole::User,
+                    content: crate::agent::MessageContent::Blocks(vec![
+                        Block::Text { text: prompt },
+                        Block::Image {
+                            data,
+                            media_type: "image/jpeg".to_string(),
+                        },
+                    ]),
+                }],
+                &[] as &[ToolSchema],
+                (180 * n as u32).clamp(360, 1024),
+            )
+            .await?;
+        self.timing.record("vision_grid", t0.elapsed());
+        Ok(parse_grid_descriptions(
+            &response.text_blocks.join("\n"),
+            n,
+        ))
     }
 
     pub async fn enrich_images(
@@ -124,41 +202,74 @@ impl MediaProcessor {
         }
 
         let t_enrich = Instant::now();
-        let mut out = Vec::with_capacity(deduped.len());
-        for (mut item, payload) in deduped {
+        let mut items: Vec<(Value, Vec<u8>)> = deduped;
+
+        // OCR is local + synchronous — do it inline.
+        for (item, payload) in items.iter_mut() {
             if !payload.is_empty() && self.config.use_ocr && item.get("ocr_text").is_none() {
-                match self.ocr_image(&payload) {
+                match self.ocr_image(payload) {
                     Ok(text) if !text.trim().is_empty() => {
-                        insert_string(&mut item, "ocr_text", short(&text, 800));
+                        insert_string(item, "ocr_text", short(&text, 800));
                     }
                     Ok(_) => {}
-                    Err(err) => insert_string(&mut item, "ocr_error", format!("{err:#}")),
+                    Err(err) => insert_string(item, "ocr_error", format!("{err:#}")),
                 }
             }
-            if run_vision
-                && !payload.is_empty()
-                && self.config.use_vision
-                && item.get("vision_description").is_none()
-            {
-                match self
-                    .describe_image(
-                        &payload,
-                        "Describe this Xiaohongshu image for the note. Focus on concrete visible facts.",
-                        180,
-                    )
-                    .await
-                {
-                    Ok(text) if !text.trim().is_empty() => {
-                        insert_string(&mut item, "vision_description", text);
-                    }
-                    Ok(_) => {}
-                    Err(err) => insert_string(&mut item, "vision_error", format!("{err:#}")),
-                }
-            }
-            out.push(item);
         }
+
+        // Vision calls hit the LLM and used to run strictly one-at-a-time,
+        // which dominated read_note latency (e.g. 12 images ≈ 5 min). Run them
+        // with bounded concurrency instead.
+        if run_vision && self.config.use_vision {
+            let targets: Vec<usize> = items
+                .iter()
+                .enumerate()
+                .filter(|(_, (item, payload))| {
+                    !payload.is_empty() && item.get("vision_description").is_none()
+                })
+                .map(|(idx, _)| idx)
+                .collect();
+            // Batch images into 2x2 grids (4 per vision call) — ~1/4 the calls,
+            // latency, and image tokens vs one call per image. Batches run with
+            // bounded concurrency.
+            let batches: Vec<Vec<usize>> = targets
+                .chunks(VISION_GRID_BATCH)
+                .map(<[usize]>::to_vec)
+                .collect();
+            let permits = std::sync::Arc::new(tokio::sync::Semaphore::new(VISION_CONCURRENCY));
+            let results = futures::future::join_all(batches.into_iter().map(|batch| {
+                let permits = permits.clone();
+                let payloads: Vec<&[u8]> = batch.iter().map(|&i| items[i].1.as_slice()).collect();
+                async move {
+                    let _permit = permits.acquire().await;
+                    let descs = self.describe_image_batch(&payloads).await;
+                    (batch, descs)
+                }
+            }))
+            .await;
+            for (batch, descs) in results {
+                match descs {
+                    Ok(descs) => {
+                        for (k, &idx) in batch.iter().enumerate() {
+                            match descs.get(k) {
+                                Some(text) if !text.trim().is_empty() => {
+                                    insert_string(&mut items[idx].0, "vision_description", text.clone());
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        for &idx in &batch {
+                            insert_string(&mut items[idx].0, "vision_error", format!("{err:#}"));
+                        }
+                    }
+                }
+            }
+        }
+
         self.timing.record("image_enrich_batch", t_enrich.elapsed());
-        out
+        items.into_iter().map(|(item, _)| item).collect()
     }
 
     async fn safe_download(&self, url: String, referer: String) -> (Vec<u8>, Option<String>) {
@@ -169,5 +280,129 @@ impl MediaProcessor {
             Ok(bytes) => (bytes, None),
             Err(err) => (Vec::new(), Some(format!("{err:#}"))),
         }
+    }
+}
+
+/// Composite up to a handful of images into a 2-column grid, each letterboxed
+/// (aspect preserved, white padding) into a `cell`×`cell` square. Returns JPEG
+/// bytes, or `None` if no image decoded.
+fn compose_grid(payloads: &[&[u8]], cell: u32) -> Option<Vec<u8>> {
+    use image::{imageops, DynamicImage, ImageFormat, Rgb, RgbImage};
+
+    let cols = 2u32;
+    let rows = (payloads.len() as u32).div_ceil(cols);
+    let mut canvas = RgbImage::from_pixel(cols * cell, rows * cell, Rgb([255, 255, 255]));
+    let mut any = false;
+    for (i, payload) in payloads.iter().enumerate() {
+        let Ok(decoded) = image::load_from_memory(payload) else {
+            continue; // leave a blank cell on decode failure
+        };
+        any = true;
+        // `resize` fits within cell×cell preserving aspect ratio.
+        let fitted = decoded
+            .resize(cell, cell, imageops::FilterType::Triangle)
+            .to_rgb8();
+        let (nw, nh) = (fitted.width(), fitted.height());
+        let col = i as u32 % cols;
+        let row = i as u32 / cols;
+        let ox = (col * cell + (cell - nw) / 2) as i64;
+        let oy = (row * cell + (cell - nh) / 2) as i64;
+        imageops::overlay(&mut canvas, &fitted, ox, oy);
+    }
+    if !any {
+        return None;
+    }
+    let mut buf = Vec::new();
+    DynamicImage::ImageRgb8(canvas)
+        .write_to(&mut std::io::Cursor::new(&mut buf), ImageFormat::Jpeg)
+        .ok()?;
+    Some(buf)
+}
+
+/// Parse `N` per-cell descriptions from a grid vision reply. Lines beginning
+/// with `k:` / `k)` / `k.` (k = 1..=n) start description k; subsequent
+/// unlabelled lines extend the current one. Missing entries stay empty rather
+/// than scrambling onto the wrong image.
+fn parse_grid_descriptions(text: &str, n: usize) -> Vec<String> {
+    let mut out = vec![String::new(); n];
+    let mut current: Option<usize> = None;
+    for line in text.lines() {
+        if let Some((num, rest)) = split_leading_index(line.trim_start()) {
+            if (1..=n).contains(&num) {
+                current = Some(num - 1);
+                out[num - 1] = rest.trim().to_string();
+                continue;
+            }
+        }
+        if let Some(idx) = current {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                if !out[idx].is_empty() {
+                    out[idx].push(' ');
+                }
+                out[idx].push_str(trimmed);
+            }
+        }
+    }
+    out
+}
+
+/// `"3: foo"` / `"3) foo"` / `"3. foo"` → `Some((3, "foo"))`.
+fn split_leading_index(text: &str) -> Option<(usize, &str)> {
+    let digits_end = text.find(|c: char| !c.is_ascii_digit())?;
+    if digits_end == 0 {
+        return None;
+    }
+    let num: usize = text[..digits_end].parse().ok()?;
+    let rest = text[digits_end..].trim_start();
+    let rest = rest
+        .strip_prefix(':')
+        .or_else(|| rest.strip_prefix(')'))
+        .or_else(|| rest.strip_prefix('.'))?;
+    Some((num, rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_numbered_grid_descriptions() {
+        let reply = "1: first image\n2: second image\nmore detail\n3: third\n4: fourth";
+        let out = parse_grid_descriptions(reply, 4);
+        assert_eq!(out[0], "first image");
+        assert_eq!(out[1], "second image more detail");
+        assert_eq!(out[2], "third");
+        assert_eq!(out[3], "fourth");
+    }
+
+    #[test]
+    fn missing_entries_stay_empty_not_scrambled() {
+        let out = parse_grid_descriptions("1: only the first", 3);
+        assert_eq!(out[0], "only the first");
+        assert!(out[1].is_empty());
+        assert!(out[2].is_empty());
+    }
+
+    #[test]
+    fn compose_grid_letterboxes_into_2x2() {
+        use image::{DynamicImage, ImageFormat, RgbImage};
+        // Two solid images of different aspect ratios.
+        let mk = |w, h| {
+            let img = RgbImage::from_pixel(w, h, image::Rgb([10, 20, 30]));
+            let mut buf = Vec::new();
+            DynamicImage::ImageRgb8(img)
+                .write_to(&mut std::io::Cursor::new(&mut buf), ImageFormat::Png)
+                .unwrap();
+            buf
+        };
+        let a = mk(200, 400);
+        let b = mk(400, 200);
+        let payloads: Vec<&[u8]> = vec![&a, &b];
+        let grid = compose_grid(&payloads, 512).expect("grid");
+        let decoded = image::load_from_memory(&grid).expect("decode grid");
+        // 2 images → 1 row, 2 cols → 1024x512.
+        assert_eq!(decoded.width(), 1024);
+        assert_eq!(decoded.height(), 512);
     }
 }

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::agent::{
     config_for, configured_default_model_for, load_provider_credential, resolve_provider,
     run_agent_with_events, AgentEvent, AgentOptions, AgentOutcome, AnthropicBackend, Backend,
-    OpenAICompatBackend, Provider, Tool,
+    Message, OpenAICompatBackend, Provider, Tool,
 };
 use crate::cdp::{BrowserEvent, Cdp, PageSession, PageSessionManager, StatusPayload, TargetInfo};
 use anyhow::{anyhow, Result};
@@ -199,6 +199,8 @@ pub struct AgentRunConfig {
     pub extra_instructions: String,
     pub enabled_sites: Vec<String>,
     pub run_dir: Option<PathBuf>,
+    /// Prior chat-level messages to continue a multi-turn session from.
+    pub seed_messages: Vec<Message>,
 }
 
 impl Default for AgentRunConfig {
@@ -211,6 +213,7 @@ impl Default for AgentRunConfig {
             extra_instructions: String::new(),
             enabled_sites: Vec::new(),
             run_dir: None,
+            seed_messages: Vec::new(),
         }
     }
 }
@@ -234,6 +237,7 @@ pub async fn run_agent_task(
         enabled_sites: config.enabled_sites,
         keep_recent_messages: config.keep_recent_messages,
         memory_max_chars: config.memory_max_chars,
+        seed_messages: config.seed_messages,
     };
     run_agent_with_events(task, llm_provider, tools, options, events_tx).await
 }


### PR DESCRIPTION
Turns the TUI into a conversational, multi-turn agent with local filesystem access, and optimizes the existing agent/media path that long looping runs exposed.

## Commit 1 — multi-turn TUI chat sessions + local file/bash tools
- **core `Session`** (persisted under `~/.socai/sessions/`): records each turn's user/assistant text + run-dir pointers, and rebuilds chat seed messages so a turn continues the conversation. Threaded via a new `AgentOptions.seed_messages` / `AgentRunConfig.seed_messages`, default empty so existing entrypoints (desktop) are unaffected.
- **core `file_bash_tools`**: `read_file` (text + image-capable, for viewing screenshot artifacts) and `bash` (general shell escape hatch, cwd pinned to the run dir; scope is prompt-enforced).
- **cli/tui**: conversational loop seeded from the session; `/clear` (and `/new` alias) start a fresh chat; a bare `/` opens a filterable command menu; Ctrl+C interrupts a running turn (recording it for follow-ups) while Ctrl+C at the idle prompt exits. Turns are recorded on browser/agent errors too, so a failed turn's topic survives.

## Commit 2 — cheaper, more robust note image vision + wider tool-result budget
- **media**: batch a note's images into 2×2 vision grids (4 per LLM call), each letterboxed into a 512px cell, run with bounded concurrency instead of one blocking call per image. ~12-image read drops from ~12 sequential vision calls to ~3 (≈1/4 latency + image tokens). Adds the `image` crate.
- **agent**: widen `TOOL_RESULT_TEXT_MAX_CHARS` 2200 → 10000 so a `read_note` result's image paths/descriptions survive truncation instead of being re-discovered via bash.
- **agent**: when the model repeats the exact same tool call ≥3 times, inject a note telling it to stop and proceed, to break tight tool loops.

## Testing
- `cargo build --workspace` (incl. desktop app), `cargo clippy`, and `cargo test -p socai-core` all pass.
- New unit tests cover the file/bash tools and the image grid composition/parsing.
- Interactive behaviors (Ctrl+C interrupt, `/` menu) and real vision-grid quality were not exercised in CI — worth a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)