### PR TITLE
app: add bilingual language toggle

### DIFF
--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -1,0 +1,203 @@
+export type Language = "en" | "zh";
+export type TaskStatusKey = "queued" | "running" | "completed" | "failed" | "cancelled" | "interrupted";
+
+const DEFAULT_LANGUAGE: Language = "zh";
+const STORAGE_KEY = "socai-language";
+const supportedLanguages: Language[] = ["zh", "en"];
+
+const messages = {
+  "language.switcherAria": { en: "language", zh: "语言" },
+
+  "common.loading": { en: "loading…", zh: "加载中…" },
+  "common.or": { en: "or,", zh: "或" },
+  "common.save": { en: "save", zh: "保存" },
+  "common.saving": { en: "saving…", zh: "保存中…" },
+
+  "chrome.label": { en: "chrome", zh: "chrome" },
+  "chrome.connectAria": { en: "connect chrome", zh: "连接 chrome" },
+  "chrome.statusToggleAria": { en: "show chrome connection status", zh: "显示 chrome 连接状态" },
+  "chrome.dialogAria": { en: "chrome connection status", zh: "chrome 连接状态" },
+  "chrome.requiredAria": { en: "chrome required", zh: "需要 chrome" },
+  "chrome.disconnected": { en: "disconnected", zh: "未连接" },
+  "chrome.connecting": { en: "connecting", zh: "连接中" },
+  "chrome.connected": { en: "connected", zh: "已连接" },
+  "chrome.tabs": { en: "tabs", zh: "标签页" },
+  "chrome.browser": { en: "browser", zh: "浏览器" },
+  "chrome.endpoint": { en: "endpoint", zh: "端点" },
+  "chrome.disconnect": { en: "disconnect", zh: "断开连接" },
+  "chrome.lookingForChrome": { en: "looking for chrome…", zh: "正在寻找 chrome…" },
+  "chrome.connectToStart": { en: "connect chrome to start", zh: "连接 chrome 后开始" },
+  "chrome.connectCta": { en: "connect chrome →", zh: "连接 chrome →" },
+  "chrome.connectingCta": { en: "connecting…", zh: "连接中…" },
+  "chrome.remoteDebuggingHelp": {
+    en: "how do i enable remote debugging? ↗",
+    zh: "如何启用远程调试？↗",
+  },
+
+  "agent.label": { en: "agent", zh: "智能体" },
+  "agent.configurationAria": { en: "agent configuration", zh: "智能体设置" },
+  "agent.selectModelAria": { en: "select agent model", zh: "选择智能体模型" },
+  "agent.loading": { en: "loading", zh: "加载中" },
+  "agent.keyNeeded": { en: "key needed", zh: "需要密钥" },
+  "agent.needsCredential": { en: "{model} needs a credential.", zh: "{model} 需要凭据。" },
+  "agent.connectChatgpt": { en: "connect chatgpt subscription", zh: "连接 chatgpt 订阅" },
+  "agent.opening": { en: "opening…", zh: "打开中…" },
+  "agent.pasteApiKey": { en: "paste api key", zh: "粘贴 api 密钥" },
+  "agent.codexLoginMissing": {
+    en: "codex login not detected yet. return to socai after login completes.",
+    zh: "还没有检测到 codex 登录。登录完成后返回 socai。",
+  },
+
+  "task.pagesAria": { en: "task pages", zh: "任务页面" },
+  "task.new": { en: "new task", zh: "新任务" },
+  "task.history": { en: "history", zh: "历史" },
+  "task.historyTitle": { en: "task history", zh: "任务历史" },
+  "task.historyDescription": {
+    en: "review completed, failed, interrupted, and running tasks.",
+    zh: "查看已完成、失败、中断和运行中的任务。",
+  },
+  "task.historyAria": { en: "task history", zh: "任务历史" },
+  "task.selected": { en: "selected task", zh: "已选任务" },
+  "task.selectedAria": { en: "selected task", zh: "已选任务" },
+  "task.noTasks": { en: "no tasks yet.", zh: "暂无任务。" },
+  "task.cancel": { en: "cancel", zh: "取消" },
+  "task.finalAnswer": { en: "final answer", zh: "最终答案" },
+  "task.waitingForEvents": { en: "waiting for events…", zh: "等待事件…" },
+  "task.noTimeline": { en: "no event timeline available.", zh: "暂无事件时间线。" },
+  "task.emptyDetail": { en: "start a task or choose one from history.", zh: "启动一个任务或从历史中选择。" },
+  "task.run": { en: "run", zh: "运行" },
+
+  "task.hero": { en: "what should socai research?", zh: "想让 socai 研究什么？" },
+  "task.lede": {
+    en: "start a one-shot browser task. socai opens a temporary chrome tab, runs the agent, saves the result, then closes the tab.",
+    zh: "启动一次性浏览器任务。socai 会打开临时 chrome 标签页、运行智能体、保存结果，然后关闭标签页。",
+  },
+  "task.modeAria": { en: "task mode", zh: "任务模式" },
+  "task.modeAgent": { en: "agent tasks", zh: "智能体任务" },
+  "task.modeTools": { en: "tool tests", zh: "工具测试" },
+  "task.starting": { en: "starting…", zh: "启动中…" },
+  "task.runTest": { en: "run test", zh: "运行测试" },
+  "task.loadingModels": { en: "loading agent models…", zh: "正在加载智能体模型…" },
+  "task.addKeyHint": { en: "add a key in the agent menu to run this model.", zh: "在智能体菜单中添加密钥后即可运行此模型。" },
+  "task.agentPlaceholder": {
+    en: "tell socai what you want researched…\neach task opens its own temporary chrome tab.",
+    zh: "告诉 socai 你想研究什么…\n每个任务都会打开自己的临时 chrome 标签页。",
+  },
+  "task.recent": { en: "recent", zh: "最近" },
+  "task.viewHistory": { en: "view history", zh: "查看历史" },
+  "task.noRecent": { en: "no recent tasks yet.", zh: "暂无最近任务。" },
+
+  "tool.pickerAria": { en: "tool", zh: "工具" },
+  "tool.searchNotes": { en: "search notes", zh: "搜索笔记" },
+  "tool.topicScan": { en: "topic scan", zh: "话题扫描" },
+  "tool.extractNote": { en: "extract note", zh: "提取笔记" },
+  "tool.hintSearchNotes": {
+    en: "test search_notes on a fresh temporary xiaohongshu tab.",
+    zh: "在新的临时 xiaohongshu 标签页中测试 search_notes。",
+  },
+  "tool.hintTopicScan": {
+    en: "test topic_scan on a fresh temporary xiaohongshu tab.",
+    zh: "在新的临时 xiaohongshu 标签页中测试 topic_scan。",
+  },
+  "tool.hintExtractNote": {
+    en: "paste a note id or url; socai opens a fresh temporary page and extracts it.",
+    zh: "粘贴笔记 id 或 url；socai 会打开新的临时页面并提取内容。",
+  },
+  "tool.placeholderSearch": { en: "search query…", zh: "搜索关键词…" },
+  "tool.placeholderTopic": { en: "topic to scan…", zh: "要扫描的话题…" },
+  "tool.placeholderNote": { en: "note id or url…", zh: "笔记 id 或 url…" },
+  "tool.running": { en: "running", zh: "运行中" },
+  "tool.noResult": { en: "no tool test result yet.", zh: "暂无工具测试结果。" },
+} as const satisfies Record<string, Record<Language, string>>;
+
+const taskStatusLabels = {
+  queued: { en: "queued", zh: "排队中" },
+  running: { en: "running", zh: "运行中" },
+  completed: { en: "completed", zh: "已完成" },
+  failed: { en: "failed", zh: "失败" },
+  cancelled: { en: "cancelled", zh: "已取消" },
+  interrupted: { en: "interrupted", zh: "已中断" },
+} as const satisfies Record<TaskStatusKey, Record<Language, string>>;
+
+type MessageKey = keyof typeof messages;
+
+let currentLanguage: Language = readInitialLanguage();
+
+export function getLanguage(): Language {
+  return currentLanguage;
+}
+
+export function isSupportedLanguage(language: string | null | undefined): language is Language {
+  return !!language && supportedLanguages.includes(language as Language);
+}
+
+export function setLanguage(language: Language): void {
+  currentLanguage = language;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, language);
+  } catch {
+    // Ignore storage failures; the active session can still switch languages.
+  }
+  applyLanguageToDocument();
+}
+
+export function applyLanguageToDocument(): void {
+  document.documentElement.lang = toHtmlLanguage(currentLanguage);
+  document.documentElement.dataset.language = currentLanguage;
+}
+
+export function t(key: MessageKey, params: Record<string, string | number> = {}): string {
+  let message: string = messages[key][currentLanguage];
+  for (const [name, value] of Object.entries(params)) {
+    message = message.replaceAll(`{${name}}`, `${value}`);
+  }
+  return message;
+}
+
+export function getLocale(): string {
+  return toHtmlLanguage(currentLanguage);
+}
+
+export function taskStatusLabel(status: TaskStatusKey): string {
+  return taskStatusLabels[status][currentLanguage];
+}
+
+export function formatTabs(count: number): string {
+  if (currentLanguage === "zh") return `${count} 个标签页`;
+  return `${count} tab${count === 1 ? "" : "s"}`;
+}
+
+export function formatTaskCount(count: number): string {
+  if (currentLanguage === "zh") return `${count} 个任务`;
+  return `${count} task${count === 1 ? "" : "s"}`;
+}
+
+export function formatRunningTaskCount(count: number): string {
+  if (currentLanguage === "zh") return `${count} 个任务运行中`;
+  return `${count} task${count === 1 ? "" : "s"} running`;
+}
+
+export function formatTurns(count: number): string {
+  if (currentLanguage === "zh") return `${count} 轮`;
+  return `${count} turn${count === 1 ? "" : "s"}`;
+}
+
+export function formatTokenUsage(inputTokens: number, outputTokens: number): string {
+  if (currentLanguage === "zh") return `输入 ${inputTokens} / 输出 ${outputTokens} tokens`;
+  return `in ${inputTokens} / out ${outputTokens} tokens`;
+}
+
+function readInitialLanguage(): Language {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isSupportedLanguage(stored)) return stored;
+  } catch {
+    // Ignore storage errors and fall back to the default language.
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+function toHtmlLanguage(language: Language): string {
+  return language === "zh" ? "zh-CN" : "en";
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -3,6 +3,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
+import { applyLanguageToDocument, formatTabs, getLanguage, isSupportedLanguage, setLanguage, t } from "./lib/i18n";
 import { agentPanel } from "./panels/tasks";
 
 export type Status =
@@ -131,6 +132,7 @@ function render(): void {
       <header class="topbar">
         <div class="brand">${MARK_SVG}<span class="brand-name">socai</span></div>
         <div class="topbar-controls">
+          ${renderLanguageSwitch()}
           ${connectionStatusBar()}
           ${agentPanel.renderHeader()}
         </div>
@@ -138,9 +140,31 @@ function render(): void {
       <main class="stack">${sections}</main>
     </div>
   `;
+  bindLanguageSwitch();
   bindConnectionStatusBar();
   agentPanel.bindHeader(state);
   for (const p of PANELS) p.bind(state);
+}
+
+function renderLanguageSwitch(): string {
+  const language = getLanguage();
+  return `
+    <div class="language-toggle" role="group" aria-label="${htmlEsc(t("language.switcherAria"))}">
+      <button class="language-toggle__button" type="button" data-lang-option="zh" aria-pressed="${language === "zh" ? "true" : "false"}">中文</button>
+      <button class="language-toggle__button" type="button" data-lang-option="en" aria-pressed="${language === "en" ? "true" : "false"}">en</button>
+    </div>
+  `;
+}
+
+function bindLanguageSwitch(): void {
+  document.querySelectorAll<HTMLButtonElement>("[data-lang-option]").forEach((option) => {
+    option.addEventListener("click", () => {
+      const nextLanguage = option.dataset.langOption;
+      if (!isSupportedLanguage(nextLanguage) || getLanguage() === nextLanguage) return;
+      setLanguage(nextLanguage);
+      render();
+    });
+  });
 }
 
 function connectionStatusBar(): string {
@@ -155,37 +179,37 @@ function connectionStatusBar(): string {
 function connectionBadge(): string {
   switch (status.state) {
     case "disconnected":
-      return `<button id="chrome-connect" type="button" class="badge badge-button" aria-label="connect chrome"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>chrome · disconnected</button>`;
+      return `<button id="chrome-connect" type="button" class="badge badge-button" aria-label="${htmlEsc(t("chrome.connectAria"))}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>${htmlEsc(t("chrome.label"))} · ${htmlEsc(t("chrome.disconnected"))}</button>`;
     case "connecting":
-      return `<button type="button" class="badge badge-button" disabled><i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>chrome · connecting · ${status.attempt}/3</button>`;
+      return `<button type="button" class="badge badge-button" disabled><i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>${htmlEsc(t("chrome.label"))} · ${htmlEsc(t("chrome.connecting"))} · ${status.attempt}/3</button>`;
     case "connected":
-      return `<button id="chrome-status-toggle" type="button" class="badge badge-button" aria-expanded="${connectionDetailsOpen ? "true" : "false"}" aria-label="show chrome connection status"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>chrome · connected</button>`;
+      return `<button id="chrome-status-toggle" type="button" class="badge badge-button" aria-expanded="${connectionDetailsOpen ? "true" : "false"}" aria-label="${htmlEsc(t("chrome.statusToggleAria"))}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>${htmlEsc(t("chrome.label"))} · ${htmlEsc(t("chrome.connected"))}</button>`;
   }
 }
 
 function renderConnectionDialog(connected: Extract<Status, { state: "connected" }>): string {
-  const tabs = `${connected.page_count} tab${connected.page_count === 1 ? "" : "s"}`;
+  const tabs = formatTabs(connected.page_count);
   return `
-    <div class="topbar-popover connection-dialog" role="dialog" aria-label="chrome connection status">
+    <div class="topbar-popover connection-dialog" role="dialog" aria-label="${htmlEsc(t("chrome.dialogAria"))}">
       <div class="connection-dialog-head">
-        <p class="t-eyebrow connection-dialog-title">chrome</p>
-        <span class="badge"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>connected</span>
+        <p class="t-eyebrow connection-dialog-title">${htmlEsc(t("chrome.label"))}</p>
+        <span class="badge"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>${htmlEsc(t("chrome.connected"))}</span>
       </div>
       <div class="connection-meta">
         <div>
-          <p class="t-eyebrow">tabs</p>
-          <p class="t-mono">${tabs}</p>
+          <p class="t-eyebrow">${htmlEsc(t("chrome.tabs"))}</p>
+          <p class="t-mono">${htmlEsc(tabs)}</p>
         </div>
         <div>
-          <p class="t-eyebrow">browser</p>
+          <p class="t-eyebrow">${htmlEsc(t("chrome.browser"))}</p>
           <p class="t-mono">${htmlEsc(connected.browser_version)}</p>
         </div>
         <div class="connection-meta-wide">
-          <p class="t-eyebrow">endpoint</p>
+          <p class="t-eyebrow">${htmlEsc(t("chrome.endpoint"))}</p>
           <p class="t-mono connection-endpoint">${htmlEsc(connected.endpoint)}</p>
         </div>
       </div>
-      <button id="chrome-disconnect" type="button" class="btn-ghost">disconnect</button>
+      <button id="chrome-disconnect" type="button" class="btn-ghost">${htmlEsc(t("chrome.disconnect"))}</button>
     </div>
   `;
 }
@@ -242,6 +266,8 @@ function eventPathHasClass(event: Event, className: string): boolean {
 }
 
 async function main(): Promise<void> {
+  applyLanguageToDocument();
+
   await listen<Status>("cdp:status_changed", (event) => {
     status = event.payload;
     if (status.state !== "connected") connectionDetailsOpen = false;

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -1,5 +1,6 @@
 import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
+import { formatTaskCount, formatTokenUsage, formatTurns, getLocale, taskStatusLabel, t } from "../lib/i18n";
 import type { AgentTaskView } from "./tasks";
 
 export interface TaskHistoryPageProps {
@@ -13,10 +14,10 @@ export function renderHistoryPage(props: TaskHistoryPageProps): string {
     <div class="history-page">
       <div class="history-page-head">
         <div>
-          <p class="t-eyebrow result-label">task history</p>
-          <p class="t-small subtle">review completed, failed, interrupted, and running tasks.</p>
+          <p class="t-eyebrow result-label">${esc(t("task.historyTitle"))}</p>
+          <p class="t-small subtle">${esc(t("task.historyDescription"))}</p>
         </div>
-        <button id="history-new-task" type="button" class="btn-ghost">new task</button>
+        <button id="history-new-task" type="button" class="btn-ghost">${esc(t("task.new"))}</button>
       </div>
       ${renderTaskWorkspace(props)}
     </div>
@@ -26,16 +27,16 @@ export function renderHistoryPage(props: TaskHistoryPageProps): string {
 function renderTaskWorkspace(props: TaskHistoryPageProps): string {
   return `
     <div class="tasks-layout">
-      <aside class="task-list" aria-label="task history">
+      <aside class="task-list" aria-label="${esc(t("task.historyAria"))}">
         <div class="task-list-head">
-          <p class="t-eyebrow result-label">history</p>
-          <span class="t-small subtle">${props.tasks.length} task${props.tasks.length === 1 ? "" : "s"}</span>
+          <p class="t-eyebrow result-label">${esc(t("task.history"))}</p>
+          <span class="t-small subtle">${esc(formatTaskCount(props.tasks.length))}</span>
         </div>
         <div class="task-list-body">
           ${renderTaskRows(props.tasks, props.selectedTaskId)}
         </div>
       </aside>
-      <section class="task-detail" aria-label="selected task">
+      <section class="task-detail" aria-label="${esc(t("task.selectedAria"))}">
         ${props.selectedTask ? renderSelectedTask(props.selectedTask) : renderNoTaskSelected()}
       </section>
     </div>
@@ -44,7 +45,7 @@ function renderTaskWorkspace(props: TaskHistoryPageProps): string {
 
 function renderTaskRows(tasks: AgentTaskView[], selectedTaskId: string | null): string {
   if (tasks.length === 0) {
-    return `<p class="t-small placeholder task-list-empty">no tasks yet.</p>`;
+    return `<p class="t-small placeholder task-list-empty">${esc(t("task.noTasks"))}</p>`;
   }
   return [...tasks]
     .sort((a, b) => b.created_at - a.created_at)
@@ -55,7 +56,7 @@ function renderTaskRows(tasks: AgentTaskView[], selectedTaskId: string | null): 
           <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true">${taskStatusGlyph(task.status)}</span>
           <span class="task-row-main">
             <span class="task-row-title">${esc(task.task)}</span>
-            <span class="task-row-meta">${esc(task.status)} · ${esc(formatTime(task.created_at))}</span>
+            <span class="task-row-meta">${esc(taskStatusLabel(task.status))} · ${esc(formatTime(task.created_at))}</span>
           </span>
         </button>
       `;
@@ -65,17 +66,17 @@ function renderTaskRows(tasks: AgentTaskView[], selectedTaskId: string | null): 
 
 function renderSelectedTask(task: AgentTaskView): string {
   const tokenLine = task.input_tokens !== null && task.output_tokens !== null
-    ? ` · in ${task.input_tokens} / out ${task.output_tokens} tokens`
+    ? ` · ${formatTokenUsage(task.input_tokens, task.output_tokens)}`
     : "";
   return `
     <div class="task-detail-head">
       <div>
-        <p class="t-eyebrow result-label">selected task</p>
+        <p class="t-eyebrow result-label">${esc(t("task.selected"))}</p>
         <h2 class="t-h3 task-detail-title">${esc(task.task)}</h2>
       </div>
       <div class="task-detail-actions">
-        <span class="badge"><i class="badge-dot ${task.status === "running" ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow"}" aria-hidden="true"></i>${esc(task.status)}</span>
-        ${canCancel(task) ? `<button type="button" class="btn-ghost btn-compact" data-cancel-task="${esc(task.task_id)}">cancel</button>` : ""}
+        <span class="badge"><i class="badge-dot ${task.status === "running" ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow"}" aria-hidden="true"></i>${esc(taskStatusLabel(task.status))}</span>
+        ${canCancel(task) ? `<button type="button" class="btn-ghost btn-compact" data-cancel-task="${esc(task.task_id)}">${esc(t("task.cancel"))}</button>` : ""}
       </div>
     </div>
 
@@ -90,9 +91,9 @@ function renderSelectedTask(task: AgentTaskView): string {
       task.final_text
         ? `
           <div class="agent-outcome">
-            <p class="t-eyebrow result-label">final answer</p>
+            <p class="t-eyebrow result-label">${esc(t("task.finalAnswer"))}</p>
             <pre class="result-pre">${esc(task.final_text.trim())}</pre>
-            <p class="t-small subtle">run ${esc(task.run_id ?? task.task_id)}${task.turns !== null ? ` · ${task.turns} turns` : ""}${tokenLine}</p>
+            <p class="t-small subtle">${esc(t("task.run"))} ${esc(task.run_id ?? task.task_id)}${task.turns !== null ? ` · ${esc(formatTurns(task.turns))}` : ""}${esc(tokenLine)}</p>
             ${task.run_dir ? `<p class="t-small subtle">run_dir: <span class="t-mono">${esc(task.run_dir)}</span></p>` : ""}
           </div>`
         : ""
@@ -114,20 +115,20 @@ function renderTaskTimeline(task: AgentTaskView): string {
     return `
       <div class="result-block">
         <div class="event-stream" data-agent-events="${esc(task.task_id)}">
-          <p class="t-small placeholder" data-events-placeholder>waiting for events…</p>
+          <p class="t-small placeholder" data-events-placeholder>${esc(t("task.waitingForEvents"))}</p>
         </div>
       </div>
     `;
   }
   if (task.final_text) return "";
-  return `<p class="t-small placeholder">no event timeline available.</p>`;
+  return `<p class="t-small placeholder">${esc(t("task.noTimeline"))}</p>`;
 }
 
 function renderNoTaskSelected(): string {
   return `
     <div class="task-empty-detail">
-      <p class="t-eyebrow result-label">selected task</p>
-      <p class="t-small placeholder">start a task or choose one from history.</p>
+      <p class="t-eyebrow result-label">${esc(t("task.selected"))}</p>
+      <p class="t-small placeholder">${esc(t("task.emptyDetail"))}</p>
     </div>
   `;
 }
@@ -175,5 +176,5 @@ function canCancel(task: AgentTaskView): boolean {
 
 function formatTime(ms: number): string {
   if (!ms) return "";
-  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return new Date(ms).toLocaleTimeString(getLocale(), { hour: "2-digit", minute: "2-digit" });
 }

--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -1,5 +1,11 @@
 import type { ModelInfo, Status, ShellState } from "../main";
 import { esc } from "../lib/html";
+import {
+  formatRunningTaskCount,
+  getLocale,
+  taskStatusLabel,
+  t,
+} from "../lib/i18n";
 import type { AgentTaskView, TaskMode, ToolCommand } from "./tasks";
 
 export interface NewTaskPageProps {
@@ -28,8 +34,8 @@ export function renderNewTaskPage(props: NewTaskPageProps): string {
     <div class="new-task-page">
       <div class="new-task-compose">
         <div class="new-task-copy">
-          <h2 class="t-h2">what should socai research?</h2>
-          <p class="t-small subtle">start a one-shot browser task. socai opens a temporary chrome tab, runs the agent, saves the result, then closes the tab.</p>
+          <h2 class="t-h2">${esc(t("task.hero"))}</h2>
+          <p class="t-small subtle">${esc(t("task.lede"))}</p>
         </div>
         <div class="compose-form-stack ${gated ? "is-masked" : ""}">
           <div class="compose-form-inner" aria-hidden="${gated ? "true" : "false"}">
@@ -64,13 +70,13 @@ function renderTaskForm(
       >${esc(props.draft)}</textarea>
 
       <div class="task-controls">
-        <div class="mode-switch" aria-label="task mode">
-          <button id="mode-agent" type="button" class="mode-button ${agentMode ? "mode-button-active" : ""}">agent tasks</button>
-          <button id="mode-tools" type="button" class="mode-button ${!agentMode ? "mode-button-active" : ""}">tool tests</button>
+        <div class="mode-switch" aria-label="${esc(t("task.modeAria"))}">
+          <button id="mode-agent" type="button" class="mode-button ${agentMode ? "mode-button-active" : ""}">${esc(t("task.modeAgent"))}</button>
+          <button id="mode-tools" type="button" class="mode-button ${!agentMode ? "mode-button-active" : ""}">${esc(t("task.modeTools"))}</button>
         </div>
         ${agentMode ? renderAgentSummary(props.selectedModel) : renderToolPicker(props.toolCommand)}
         <button id="task-submit" type="submit" class="btn-primary" ${runDisabled ? "disabled" : ""}>
-          ${running ? "starting…" : agentMode ? "new task" : "run test"}
+          ${running ? esc(t("task.starting")) : agentMode ? esc(t("task.new")) : esc(t("task.runTest"))}
         </button>
       </div>
     </form>
@@ -79,29 +85,29 @@ function renderTaskForm(
 
 function renderInlineGuard(mode: TaskMode, toolCommand: ToolCommand, selected: ModelInfo | undefined): string {
   if (mode !== "agent") return renderToolHint(toolCommand);
-  if (!selected) return `<p class="t-small subtle">loading agent models…</p>`;
-  if (!selected.has_key) return `<p class="t-small subtle">add a key in the agent menu to run this model.</p>`;
+  if (!selected) return `<p class="t-small subtle">${esc(t("task.loadingModels"))}</p>`;
+  if (!selected.has_key) return `<p class="t-small subtle">${esc(t("task.addKeyHint"))}</p>`;
   return "";
 }
 
 function renderAgentSummary(selected: ModelInfo | undefined): string {
   const summary = selected
-    ? `agent · ${esc(selected.display_name)} · <span class="t-mono">${esc(selected.default_model)}</span>`
-    : "agent · loading";
+    ? `${esc(t("agent.label"))} · ${esc(selected.display_name)} · <span class="t-mono">${esc(selected.default_model)}</span>`
+    : `${esc(t("agent.label"))} · ${esc(t("agent.loading"))}`;
   return `<p class="t-small subtle task-context">${summary}</p>`;
 }
 
 function renderToolPicker(toolCommand: ToolCommand): string {
   const tools: Array<[ToolCommand, string]> = [
-    ["search_notes", "search notes"],
-    ["topic_scan", "topic scan"],
-    ["extract_note", "extract note"],
+    ["search_notes", t("tool.searchNotes")],
+    ["topic_scan", t("tool.topicScan")],
+    ["extract_note", t("tool.extractNote")],
   ];
   return `
-    <div class="tool-picker" aria-label="tool">
+    <div class="tool-picker" aria-label="${esc(t("tool.pickerAria"))}">
       ${tools.map(([cmd, label]) => `
         <button type="button" data-tool="${cmd}" class="tool-choice ${toolCommand === cmd ? "tool-choice-active" : ""}">
-          ${label}
+          ${esc(label)}
         </button>
       `).join("")}
     </div>
@@ -110,48 +116,48 @@ function renderToolPicker(toolCommand: ToolCommand): string {
 
 function renderToolHint(toolCommand: ToolCommand): string {
   const hint = {
-    search_notes: "test search_notes on a fresh temporary xiaohongshu tab.",
-    topic_scan: "test topic_scan on a fresh temporary xiaohongshu tab.",
-    extract_note: "paste a note id or url; socai opens a fresh temporary page and extracts it.",
+    search_notes: t("tool.hintSearchNotes"),
+    topic_scan: t("tool.hintTopicScan"),
+    extract_note: t("tool.hintExtractNote"),
   }[toolCommand];
-  return `<p class="t-small subtle">${hint}</p>`;
+  return `<p class="t-small subtle">${esc(hint)}</p>`;
 }
 
 function taskPlaceholder(mode: TaskMode, toolCommand: ToolCommand): string {
-  if (mode === "agent") return "tell socai what you want researched…\neach task opens its own temporary chrome tab.";
+  if (mode === "agent") return t("task.agentPlaceholder");
   switch (toolCommand) {
-    case "search_notes": return "search query…";
-    case "topic_scan": return "topic to scan…";
-    case "extract_note": return "note id or url…";
+    case "search_notes": return t("tool.placeholderSearch");
+    case "topic_scan": return t("tool.placeholderTopic");
+    case "extract_note": return t("tool.placeholderNote");
   }
 }
 
 function renderConnectOverlay(status: Status): string {
   const connecting = status.state === "connecting";
   const label = connecting
-    ? `chrome · connecting · ${(status as Extract<Status, { state: "connecting" }>).attempt}/3`
-    : "chrome · disconnected";
-  const heading = connecting ? "looking for chrome…" : "connect chrome to start";
-  const cta = connecting ? "connecting…" : "connect chrome →";
+    ? `${t("chrome.label")} · ${t("chrome.connecting")} · ${(status as Extract<Status, { state: "connecting" }>).attempt}/3`
+    : `${t("chrome.label")} · ${t("chrome.disconnected")}`;
+  const heading = connecting ? t("chrome.lookingForChrome") : t("chrome.connectToStart");
+  const cta = connecting ? t("chrome.connectingCta") : t("chrome.connectCta");
   const dotClass = connecting ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow";
   return `
-    <div class="connect-overlay" role="dialog" aria-label="chrome required">
+    <div class="connect-overlay" role="dialog" aria-label="${esc(t("chrome.requiredAria"))}">
       <span class="connect-overlay-pill">
-        <i class="badge-dot ${dotClass}" aria-hidden="true"></i>${label}
+        <i class="badge-dot ${dotClass}" aria-hidden="true"></i>${esc(label)}
       </span>
-      <h3 class="connect-overlay-head">${heading}</h3>
+      <h3 class="connect-overlay-head">${esc(heading)}</h3>
       <button
         id="overlay-chrome-connect"
         type="button"
         class="btn-primary connect-overlay-cta"
         ${connecting ? "disabled" : ""}
-      >${cta}</button>
+      >${esc(cta)}</button>
       <a
         class="connect-overlay-link t-small"
         href="https://developer.chrome.com/docs/devtools/remote-debugging"
         target="_blank"
         rel="noopener noreferrer"
-      >how do i enable remote debugging? ↗</a>
+      >${esc(t("chrome.remoteDebuggingHelp"))}</a>
     </div>
   `;
 }
@@ -163,7 +169,7 @@ function renderRunningChip(tasks: AgentTaskView[]): string {
   if (running.length === 0) return "";
   const first = running[0];
   const isOne = running.length === 1;
-  const count = isOne ? "1 task running" : `${running.length} tasks running`;
+  const count = formatRunningTaskCount(running.length);
   const taskLabel = isOne
     ? `<span class="running-chip-dot" aria-hidden="true">·</span><span class="running-chip-task">${esc(first.task)}</span>`
     : "";
@@ -187,10 +193,10 @@ function renderTaskGlance(tasks: AgentTaskView[]): string {
     <div class="task-glance">
       <section class="task-glance-card">
         <div class="task-glance-head">
-          <p class="t-eyebrow result-label">recent</p>
-          <button id="recent-history-link" type="button" class="btn-ghost btn-compact">view history</button>
+          <p class="t-eyebrow result-label">${esc(t("task.recent"))}</p>
+          <button id="recent-history-link" type="button" class="btn-ghost btn-compact">${esc(t("task.viewHistory"))}</button>
         </div>
-        ${renderTaskSummaryRows(recent, "no recent tasks yet.")}
+        ${renderTaskSummaryRows(recent, t("task.noRecent"))}
       </section>
     </div>
   `;
@@ -198,7 +204,7 @@ function renderTaskGlance(tasks: AgentTaskView[]): string {
 
 function renderTaskSummaryRows(items: AgentTaskView[], emptyText: string): string {
   if (items.length === 0) {
-    return `<p class="t-small placeholder task-summary-empty">${emptyText}</p>`;
+    return `<p class="t-small placeholder task-summary-empty">${esc(emptyText)}</p>`;
   }
   return `
     <div class="task-summary-list">
@@ -207,7 +213,7 @@ function renderTaskSummaryRows(items: AgentTaskView[], emptyText: string): strin
           <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true">${taskStatusGlyph(task.status)}</span>
           <span class="task-row-main">
             <span class="task-row-title">${esc(task.task)}</span>
-            <span class="task-row-meta">${esc(task.status)} · ${esc(formatTime(task.created_at))}</span>
+            <span class="task-row-meta">${esc(taskStatusLabel(task.status))} · ${esc(formatTime(task.created_at))}</span>
           </span>
         </button>
       `).join("")}
@@ -217,7 +223,7 @@ function renderTaskSummaryRows(items: AgentTaskView[], emptyText: string): strin
 
 function renderToolResult(props: NewTaskPageProps): string {
   if (props.toolInFlight) {
-    return `<pre class="result-pre result-running">running: ${esc(props.toolCommand)}(${esc(JSON.stringify(props.draft.trim()))})</pre>`;
+    return `<pre class="result-pre result-running">${esc(t("tool.running"))}: ${esc(props.toolCommand)}(${esc(JSON.stringify(props.draft.trim()))})</pre>`;
   }
   if (props.toolError) {
     return `<pre class="result-pre result-error">${esc(props.toolError)}</pre>`;
@@ -225,7 +231,7 @@ function renderToolResult(props: NewTaskPageProps): string {
   if (props.toolResult) {
     return `<pre class="result-pre">${esc(JSON.stringify(props.toolResult, null, 2))}</pre>`;
   }
-  return `<p class="t-small placeholder">no tool test result yet.</p>`;
+  return `<p class="t-small placeholder">${esc(t("tool.noResult"))}</p>`;
 }
 
 function taskStatusGlyph(status: AgentTaskView["status"]): string {
@@ -241,5 +247,5 @@ function taskStatusGlyph(status: AgentTaskView["status"]): string {
 
 function formatTime(ms: number): string {
   if (!ms) return "";
-  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return new Date(ms).toLocaleTimeString(getLocale(), { hour: "2-digit", minute: "2-digit" });
 }

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -11,6 +11,7 @@ import type {
   ShellState,
 } from "../main";
 import { esc } from "../lib/html";
+import { t } from "../lib/i18n";
 import { renderAgentEvent, renderHistoryPage } from "./task_history";
 import { renderNewTaskPage } from "./task_new";
 
@@ -180,12 +181,12 @@ export namespace agentPanel {
     const selected = selectedModel();
     const expanded = configOpen || selectedNeedsKey() ? "true" : "false";
     if (!selected) {
-      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>agent · loading</button>`;
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(t("agent.loading"))}</button>`;
     }
     if (!selected.has_key) {
-      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>agent · ${esc(selected.display_name)} · key needed</button>`;
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(selected.display_name)} · ${esc(t("agent.keyNeeded"))}</button>`;
     }
-    return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>agent · ${esc(selected.display_name)}</button>`;
+    return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(selected.display_name)}</button>`;
   }
 
   function renderConfigPopover(): string {
@@ -195,7 +196,7 @@ export namespace agentPanel {
       .map((m) => {
         const active = model === m.default_model;
         const dotClass = active ? "badge-dot-ink" : "badge-dot-hollow";
-        const flag = m.has_key ? "" : `<span class="t-small subtle">key needed</span>`;
+        const flag = m.has_key ? "" : `<span class="t-small subtle">${esc(t("agent.keyNeeded"))}</span>`;
         return `
           <button
             type="button"
@@ -214,9 +215,9 @@ export namespace agentPanel {
       .join("");
 
     return `
-      <div class="topbar-popover agent-config-popover" role="dialog" aria-label="agent configuration">
-        <div class="agent-model-list" role="listbox" aria-label="select agent model">
-          ${options || `<p class="t-small subtle">loading…</p>`}
+      <div class="topbar-popover agent-config-popover" role="dialog" aria-label="${esc(t("agent.configurationAria"))}">
+        <div class="agent-model-list" role="listbox" aria-label="${esc(t("agent.selectModelAria"))}">
+          ${options || `<p class="t-small subtle">${esc(t("common.loading"))}</p>`}
         </div>
         ${selected && !selected.has_key ? renderHeaderKeyEntry(selected) : ""}
       </div>
@@ -227,27 +228,27 @@ export namespace agentPanel {
     const openai = selected.provider === "openai";
     return `
       <div class="agent-config-key">
-        <p class="t-small subtle">${esc(selected.display_name)} needs a credential.</p>
+        <p class="t-small subtle">${esc(t("agent.needsCredential", { model: selected.display_name }))}</p>
         ${openai ? `
           <div class="agent-config-actions">
             <button id="agent-header-codex-login" type="button" class="btn-primary btn-compact" ${codexStarting ? "disabled" : ""}>
-              ${codexStarting ? "Opening..." : "Connect My ChatGPT Subscription"}
+              ${codexStarting ? esc(t("agent.opening")) : esc(t("agent.connectChatgpt"))}
             </button>
           </div>
         ` : ""}
-        ${openai ? `<p class="t-small subtle">Or,</p>` : ""}
+        ${openai ? `<p class="t-small subtle">${esc(t("common.or"))}</p>` : ""}
         <div class="agent-config-key-row">
           <input
             id="agent-header-key-input"
             class="input-field"
             type="password"
-            placeholder="paste api key"
+            placeholder="${esc(t("agent.pasteApiKey"))}"
             value="${esc(pendingKey)}"
             autocomplete="off"
             ${savingKey ? "disabled" : ""}
           />
           <button id="agent-header-key-save" type="button" data-provider="${esc(selected.provider)}" class="btn-primary btn-compact" ${savingKey ? "disabled" : ""}>
-            ${savingKey ? "saving…" : "save"}
+            ${savingKey ? esc(t("common.saving")) : esc(t("common.save"))}
           </button>
         </div>
         ${keyMessage ? `<p class="t-small subtle">${esc(keyMessage)}</p>` : ""}
@@ -309,9 +310,9 @@ export namespace agentPanel {
 
   function renderPageTabs(): string {
     return `
-      <div class="page-switch" aria-label="task pages">
-        <button id="page-new" type="button" class="page-switch-button ${page === "new" ? "page-switch-button-active" : ""}">new task</button>
-        <button id="page-history" type="button" class="page-switch-button ${page === "history" ? "page-switch-button-active" : ""}">history</button>
+      <div class="page-switch" aria-label="${esc(t("task.pagesAria"))}">
+        <button id="page-new" type="button" class="page-switch-button ${page === "new" ? "page-switch-button-active" : ""}">${esc(t("task.new"))}</button>
+        <button id="page-history" type="button" class="page-switch-button ${page === "history" ? "page-switch-button-active" : ""}">${esc(t("task.history"))}</button>
       </div>
     `;
   }
@@ -415,7 +416,7 @@ export namespace agentPanel {
     }
 
     keyMessage = "";
-    keyError = "codex login not detected yet. return to socai after login completes.";
+    keyError = t("agent.codexLoginMissing");
     savingKey = false;
     shell.rerender();
   }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -142,8 +142,43 @@ body.has-paper > * { position: relative; z-index: 1; }
   margin-left: auto;
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--sp-2);
+  flex-wrap: wrap;
 }
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 2px;
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+}
+.language-toggle__button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  border-radius: var(--r-pill);
+  color: var(--fg-soft);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  padding: 5px 9px;
+  white-space: nowrap;
+  transition:
+    background-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+.language-toggle__button:hover { color: var(--ink-0); }
+.language-toggle__button[aria-pressed="true"] {
+  background: var(--ink-0);
+  color: var(--ink-9);
+}
+.language-toggle__button[aria-pressed="true"]:hover { color: var(--ink-9); }
 .connection-status,
 .agent-status {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- add app i18n helper with Chinese/English strings and persisted language selection
- add the same 中文/en toggle conventions used by the site (`socai-language`, `data-lang-option`, `aria-pressed`)
- localize Chrome status, agent config, task composer, tool tests, and task history UI

## Tests
- pnpm --dir app build
- pnpm --dir site build