### PR TITLE
Improve topic scan: increase num_notes limits; fix daemon cancellation; ensure comments fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ From the repo root:
 ```bash
 cargo install --path cli
 
-socai search_notes "运营爆款思路"                         # search + return note cards
-socai topic_scan "运营爆款思路"                           # default-depth scan + read top notes
-socai extract_note --note-id <id>                         # open a note from the current page
-socai stop                                                # stop the daemon (closes the tool tab)
+socai topic_scan "运营爆款思路" --num-notes 30            # 搜索并逐个获取帖子
+socai search_notes "运营爆款思路"                         # 只打开搜索结果页
+socai extract_note --note-id <id>                       # open a note from the current page
+socai stop                                              # stop the daemon (closes the tool tab)
 ```
 
 Add `--pretty` to any tool command for indented JSON.

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -73,10 +73,11 @@ pub async fn tool_search_notes(
 pub async fn tool_topic_scan(
     runtime: State<'_, SocaiRuntime>,
     query: String,
+    num_notes: Option<i64>,
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · topic_scan").await?;
-    let result = topic_scan_command(page.clone(), &query, "standard", None).await;
+    let result = topic_scan_command(page.clone(), &query, None, num_notes).await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -195,13 +195,10 @@ impl DaemonState {
 
     async fn topic_scan(&mut self, args: Value) -> Result<Value> {
         let query = required_string(&args, "query")?;
-        let depth = args
-            .get("depth")
-            .and_then(Value::as_str)
-            .unwrap_or("standard");
         let tab_label = args.get("tab_label").and_then(Value::as_str);
+        let num_notes = args.get("num_notes").and_then(Value::as_i64);
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        topic_scan_command(page, &query, depth, tab_label).await
+        topic_scan_command(page, &query, tab_label, num_notes).await
     }
 
     async fn extract_note(&mut self, args: Value) -> Result<Value> {

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -132,11 +132,21 @@ async fn serve_client(
 
     while reader.read_line(&mut line).await? != 0 {
         let request: DaemonRequest = serde_json::from_str(line.trim_end())?;
-        let response = handle_request(request, state.clone(), stop.clone()).await;
-        writer
-            .write_all(serde_json::to_string(&response)?.as_bytes())
-            .await?;
-        writer.write_all(b"\n").await?;
+        let mut disconnect_probe = String::new();
+        tokio::select! {
+            response = handle_request(request, state.clone(), stop.clone()) => {
+                writer
+                    .write_all(serde_json::to_string(&response)?.as_bytes())
+                    .await?;
+                writer.write_all(b"\n").await?;
+            }
+            read = reader.read_line(&mut disconnect_probe) => {
+                if read? == 0 {
+                    return Ok(());
+                }
+                anyhow::bail!("daemon client sent another request before the previous response");
+            }
+        }
         line.clear();
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,19 +15,23 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Search Xiaohongshu and print visible note cards as JSON.
+    /// Search Xiaohongshu and print the first results page's note cards as JSON.
     #[command(name = "search_notes")]
     SearchNotes {
         query: String,
         #[arg(long)]
         pretty: bool,
     },
-    /// Run the default-depth Xiaohongshu topic scan.
+    /// Run a Xiaohongshu topic scan (note body + top comments per note).
     #[command(name = "topic_scan")]
     TopicScan {
         query: String,
         #[arg(long)]
         tab: Option<String>,
+        /// Number of notes to read; scrolls the feed only if the first page
+        /// holds fewer.
+        #[arg(long = "num-notes")]
+        num_notes: Option<i64>,
         #[arg(long)]
         pretty: bool,
     },
@@ -69,13 +73,18 @@ async fn main() -> Result<()> {
             .await?;
             print_command_result(&result, pretty)?;
         }
-        Command::TopicScan { query, tab, pretty } => {
-            let mut input = serde_json::json!({
-                "query": query,
-                "depth": "standard"
-            });
+        Command::TopicScan {
+            query,
+            tab,
+            num_notes,
+            pretty,
+        } => {
+            let mut input = serde_json::json!({ "query": query });
             if let Some(tab) = tab {
                 input["tab_label"] = Value::String(tab);
+            }
+            if let Some(n) = num_notes {
+                input["num_notes"] = serde_json::json!(n.max(1));
             }
 
             let result =

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -70,11 +70,14 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
 
 ## Workflows
 
-- Topic research: call `topic_scan(query=..., depth="standard")`. It
-  searches, optionally switches tab, samples visible cards in page order,
-  writes artifacts, closes note modals, and marks already analyzed posts.
-- Quick breadth scan: use `search_notes` or `extract_search_cards` to
-  inspect cards without opening notes.
+- Topic research: call `topic_scan(query=..., num_notes=N)`. It searches,
+  optionally switches tab, then reads notes top-to-bottom in feed order —
+  opening each (which pages the next cards in as it scrolls), reading its body
+  + top comments, writing artifacts, closing note modals, and marking already
+  analyzed posts. Default `num_notes` is 10.
+- Quick breadth scan: use `search_notes` (atomic — returns the first results
+  page's cards, no scrolling) or `extract_search_cards` to inspect cards
+  without opening notes.
 - Manual note read: use `read_note(index=N)` or `read_note(note_id=...)`.
   Use `level="card"` for metadata only, `level="lite"` for body/comments, and
   `level="deep"` plus `include_media=true` only when images, OCR, video, or

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -27,6 +27,7 @@ const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "closeNote",
     "noteOpen",
     "comments",
+    "commentsWithWait",
     "scrollInNote",
     "carouselImages",
     "profileInfo",
@@ -498,6 +499,23 @@ impl<'a> XhsPageRuntime<'a> {
             )
             .await?;
         Ok(raw.into_iter().filter(Value::is_object).collect())
+    }
+
+    pub async fn extract_comments_with_wait(
+        &self,
+        max_comments: i64,
+        wait_seconds: f64,
+    ) -> Result<Value> {
+        self.ensure_xhs(false).await?;
+        self.expect_object(
+            "commentsWithWait",
+            Some(&json!({
+                "prefer_hot": true,
+                "max_comments": max_comments,
+                "timeout_ms": (wait_seconds.max(0.5) * 1000.0) as i64,
+            })),
+        )
+        .await
     }
 
     pub async fn collect_carousel_images(&self, max_images: i64) -> Result<Vec<String>> {

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -473,23 +473,12 @@ impl<'a> XhsPageRuntime<'a> {
             .extract_note_with_options(wait_seconds, options.clone())
             .await?;
         if !note_id.is_empty() && !note.note_id.is_empty() && note.note_id != note_id {
-            if let Some(link) = tokenized_open_link(&open, note_id) {
-                self.page.navigate_with_timeout(&link, 60.0).await?;
-                let note = self
-                    .extract_note_with_options(wait_seconds, options)
-                    .await?;
-                if note.note_id == note_id {
-                    return Ok(json!({
-                        "ok": true,
-                        "entity": note,
-                        "open": open,
-                        "fallback": {
-                            "strategy": "tokenized_link_navigation",
-                            "url": link,
-                        },
-                    }));
-                }
-            }
+            // Opened the wrong note. Do NOT fall back to a full-page navigate
+            // to the tokenized URL: that loads the note full-screen and tears
+            // down the search grid + `__INITIAL_STATE__.search` state, which
+            // breaks every subsequent open in a topic scan. Report a soft
+            // failure; the caller closes the overlay and moves on intact.
+            let _ = options;
             return Ok(json!({
                 "ok": false,
                 "entity": note,
@@ -1062,21 +1051,6 @@ fn normalize_image_url(value: &str) -> String {
         return String::new();
     }
     trimmed.replacen("http://", "https://", 1)
-}
-
-fn tokenized_open_link(open: &Option<Value>, note_id: &str) -> Option<String> {
-    let link = open
-        .as_ref()?
-        .get("target")?
-        .get("link")?
-        .as_str()?
-        .trim()
-        .to_string();
-    if link.contains(note_id) {
-        Some(link)
-    } else {
-        None
-    }
 }
 
 fn note_is_open(state: &Value) -> bool {

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -735,6 +735,60 @@ const SocaiXhsPageScripts = (() => {
     return out;
   }
 
+  function commentsSignature(items) {
+    return items
+      .map((item) => `${item.username || ''}:${String(item.text || '').slice(0, 40)}`)
+      .join('|');
+  }
+
+  function commentsWithWait(opts = {}) {
+    const timeoutMs = Math.max(500, Number(opts.timeout_ms) || 5000);
+    const settleMs = Math.max(300, Number(opts.settle_ms) || 900);
+    const emptySettleMs = Math.max(700, Number(opts.empty_settle_ms) || 1800);
+    return new Promise((resolve) => {
+      const startedAt = Date.now();
+      let latest = [];
+      let lastSig = '';
+      let stableSince = startedAt;
+      let emptyShellSeenAt = 0;
+      let attempts = 0;
+      const tick = () => {
+        attempts += 1;
+        const root = getNoteRoot();
+        const items = comments(opts);
+        const sig = commentsSignature(items);
+        if (sig !== lastSig) {
+          lastSig = sig;
+          stableSince = Date.now();
+        }
+        latest = items;
+
+        if (items.length > 0 && Date.now() - stableSince >= settleMs) {
+          resolve({ ready: true, reason: 'comments_ready', waited_ms: Date.now() - startedAt, attempts, comments: items });
+          return;
+        }
+
+        const noCommentCopy = /这是一片荒地|还没有评论哦|暂无评论|还没有评论|抢首评/.test(norm(text(root)).slice(0, 1200));
+        if (!items.length && noCommentCopy && !pendingHydration(root)) {
+          if (!emptyShellSeenAt) emptyShellSeenAt = Date.now();
+          if (Date.now() - emptyShellSeenAt >= emptySettleMs) {
+            resolve({ ready: true, reason: 'no_comments', waited_ms: Date.now() - startedAt, attempts, comments: [] });
+            return;
+          }
+        } else {
+          emptyShellSeenAt = 0;
+        }
+
+        if (Date.now() - startedAt >= timeoutMs) {
+          resolve({ ready: items.length > 0, reason: items.length > 0 ? 'timeout_with_comments' : 'timeout', waited_ms: Date.now() - startedAt, attempts, comments: latest });
+          return;
+        }
+        setTimeout(tick, 250);
+      };
+      tick();
+    });
+  }
+
   // ── modal-internal scroll (Promise-resolved) ─────────────────
   function scrollInNote(opts = {}) {
     const pixels = Number(opts.pixels) || 400;
@@ -805,6 +859,7 @@ const SocaiXhsPageScripts = (() => {
     closeNote,
     noteOpen,
     comments,
+    commentsWithWait,
     scrollInNote,
     carouselImages,
     profileInfo,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -15,6 +15,9 @@ use serde_json::{json, Value};
 
 use crate::sites::xhs::{ReadNoteOptions, XhsHistoryStore, XhsNoteCard, XhsPageRuntime};
 
+/// Default number of notes `topic_scan` reads when the caller doesn't specify.
+const DEFAULT_NUM_NOTES: i64 = 10;
+
 /// XHS agent playbook: browser-lock rule, tool inventory, anti-bot rules,
 /// page states, entity fields, workflows, reading levels, evidence rules,
 /// and Chinese UI hints. Embedded at compile time so the agent prompt always
@@ -129,13 +132,13 @@ pub async fn search_notes_command(page: Arc<PageSession>, query: &str) -> anyhow
 pub async fn topic_scan_command(
     page: Arc<PageSession>,
     query: &str,
-    depth: &str,
     tab_label: Option<&str>,
+    num_notes: Option<i64>,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         TOPIC_SCAN_COMMAND,
-        topic_scan_input(query, depth, tab_label)?,
+        topic_scan_input(query, tab_label, num_notes)?,
     )
     .await
 }
@@ -151,12 +154,18 @@ fn search_notes_input(query: &str) -> anyhow::Result<Value> {
     }))
 }
 
-fn topic_scan_input(query: &str, depth: &str, tab_label: Option<&str>) -> anyhow::Result<Value> {
+fn topic_scan_input(
+    query: &str,
+    tab_label: Option<&str>,
+    num_notes: Option<i64>,
+) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
-        "depth": defaulted_str(depth, "standard"),
     });
     insert_optional_str(&mut input, "tab_label", tab_label);
+    if let Some(n) = num_notes {
+        input["num_notes"] = json!(n.max(1));
+    }
     Ok(input)
 }
 
@@ -268,15 +277,6 @@ fn trimmed_required(value: &str, label: &str) -> anyhow::Result<String> {
     Ok(trimmed.to_string())
 }
 
-fn defaulted_str<'a>(value: &'a str, default: &'a str) -> &'a str {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        default
-    } else {
-        trimmed
-    }
-}
-
 fn insert_optional_str(input: &mut Value, key: &str, value: Option<&str>) {
     let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
         return;
@@ -344,9 +344,10 @@ impl Tool for SearchNotesTool {
     }
 
     fn description(&self) -> &str {
-        "Search Xiaohongshu for notes matching `query`. Returns the cards \
-         visible on the results page (id, title, author, image). Use this \
-         before `open_note` to pick which note to read."
+        "Search Xiaohongshu for notes matching `query`. Atomic: submits the \
+         search and returns the first results page's cards (id, title, author, \
+         image) without scrolling. Use this before `open_note` to pick which \
+         note to read; to research a topic in one call use `topic_scan`."
     }
 
     fn input_schema(&self) -> Value {
@@ -856,52 +857,27 @@ impl Tool for ExtractProfileTool {
     }
 }
 
-/// topic_scan(query, tab_label?, depth?) -> aggregated topic bundle
+/// topic_scan(query, tab_label?, num_notes?) -> aggregated topic bundle
 ///
-/// Composite macro: search → optional tab switch → sample N visible cards in
-/// page order → read each (deep or lite depending on depth profile) →
-/// bundle into one artifact. Prefer this for any "research a topic on XHS"
-/// task — it returns search results plus the note bodies plus comments in
-/// one tool call, so the agent doesn't have to chain 10+ tools by hand.
+/// Composite macro: search → optional tab switch → collect up to `num_notes`
+/// cards in page order (scrolling the feed only when the first page is too
+/// small) → open each note and extract its body + top comments → bundle into
+/// one artifact. Prefer this for any "research a topic on XHS" task — it
+/// returns search results plus the note bodies plus comments in one tool
+/// call, so the agent doesn't have to chain 10+ tools by hand.
+///
+/// Defaults to `DEFAULT_NUM_NOTES` notes; pass a larger `num_notes` to scan
+/// more (each note is opened, so latency grows roughly linearly).
 pub struct TopicScanTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
 }
 
-struct ScanProfile {
-    deep: usize,
-    lite: usize,
-    deep_comments: i64,
-    lite_comments: i64,
-    include_media: bool,
-}
-
-fn scan_profile_for(depth: &str) -> ScanProfile {
-    match depth.to_ascii_lowercase().as_str() {
-        "quick" => ScanProfile {
-            deep: 2,
-            lite: 4,
-            deep_comments: 6,
-            lite_comments: 0,
-            include_media: false,
-        },
-        "deep" => ScanProfile {
-            deep: 6,
-            lite: 4,
-            deep_comments: 20,
-            lite_comments: 4,
-            include_media: true,
-        },
-        _ => ScanProfile {
-            deep: 3,
-            lite: 5,
-            deep_comments: 12,
-            lite_comments: 0,
-            include_media: false,
-        },
-    }
-}
+/// Number of top comments pulled per scanned note. Comments are read for free
+/// from the already-open note modal's DOM (one extra JS read, no extra
+/// navigation), so every scan includes them.
+const TOPIC_SCAN_COMMENTS: i64 = 12;
 
 #[async_trait]
 impl Tool for TopicScanTool {
@@ -911,11 +887,13 @@ impl Tool for TopicScanTool {
 
     fn description(&self) -> &str {
         "Xiaohongshu topic research macro: search → optional tab switch → \
-         sample top visible cards in page order → read deep/lite notes → \
-         return one compact bundle (search results + selected cards + note \
-         bodies + comments). Prefer this for XHS topic research. Do not \
-         repeat the same scan at a deeper depth unless the previous scan \
-         was clearly insufficient."
+         collect up to `num_notes` cards in page order (scrolling only if the \
+         first page is too small) → open each note and read its body + top \
+         comments → return one compact bundle (search results + selected cards \
+         + note bodies + comments). Defaults to 10 notes; pass a larger \
+         `num_notes` to scan more (each note is opened, so latency scales with \
+         it). Prefer this for XHS topic research. Do not repeat the same scan \
+         unless the previous one was clearly insufficient."
     }
 
     fn input_schema(&self) -> Value {
@@ -927,10 +905,11 @@ impl Tool for TopicScanTool {
                     "type": "string",
                     "enum": ["全部", "图文", "视频", "用户"]
                 },
-                "depth": {
-                    "type": "string",
-                    "enum": ["quick", "standard", "deep"],
-                    "default": "standard"
+                "num_notes": {
+                    "type": "integer",
+                    "description": "Number of notes to read (body + top comments each). The first results page is used directly; only if it holds fewer than this does the feed scroll for more. Each note is opened, so latency scales with this.",
+                    "default": DEFAULT_NUM_NOTES,
+                    "minimum": 1
                 }
             },
             "required": ["query"]
@@ -941,11 +920,14 @@ impl Tool for TopicScanTool {
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
             .to_string();
-        let depth = get_str(&input, "depth").unwrap_or("standard").to_string();
+        let num_notes = get_i64(&input, "num_notes", DEFAULT_NUM_NOTES).max(1);
         let tab_label = get_str(&input, "tab_label").unwrap_or("").to_string();
-        let profile = scan_profile_for(&depth);
+        // Every scanned note is read the same way: open it, extract the body,
+        // and pull top comments. Per-note image vision is off (it's the one
+        // genuinely expensive enrichment and not needed for topic research).
+        let include_media = false;
 
-        let media = media_for(ctx, self.llm_provider.clone(), profile.include_media)?;
+        let media = media_for(ctx, self.llm_provider.clone(), include_media)?;
         let media_baseline: Option<TimingSnapshot> = media.as_ref().map(|m| m.timing().snapshot());
         let xhs = XhsPageRuntime::new_with_media(&self.page, media.clone());
 
@@ -957,43 +939,61 @@ impl Tool for TopicScanTool {
 
         let search = xhs.search_notes(&query, 2.0).await?;
 
-        // Optional tab switch + re-extract cards.
+        // Optional tab switch (re-runs the search under the chosen tab).
         let mut tab_result = Value::Object(serde_json::Map::new());
-        let cards: Vec<XhsNoteCard> = if !tab_label.is_empty() {
+        if !tab_label.is_empty() {
             tab_result = xhs.click_search_tab(&tab_label, 1.5).await?;
-            xhs.extract_search_cards().await?
-        } else {
-            search
-                .get("cards")
-                .and_then(Value::as_array)
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|v| serde_json::from_value::<XhsNoteCard>(v).ok())
-                .collect()
-        };
+        }
 
-        let total_limit = profile.deep + profile.lite;
-        let selected: Vec<&XhsNoteCard> = cards.iter().take(total_limit).collect();
-        let sampled_ids: Vec<String> = selected
-            .iter()
-            .filter(|c| !c.note_id.is_empty())
-            .map(|c| c.note_id.clone())
-            .collect();
-        ctx.add_topic_scan_note_ids(&sampled_ids);
+        // Every sampled note is read with the same extraction level (body +
+        // top comments).
+        let level = "deep";
+        let comment_count = TOPIC_SCAN_COMMENTS;
+        let requested_media = include_media;
+        let want = num_notes.max(1) as usize;
 
+        // Read top-to-bottom: pull cards from the results state (which only
+        // grows) in feed order and open each. Opening a card scrolls it into
+        // view, which pages the later cards in on its own — there's no
+        // separate "scroll to the bottom and collect everything first" phase.
+        // When we've consumed every loaded card, wait briefly for that async
+        // paging to land; if nothing more loads after a few tries, stop.
         let mut notes: Vec<Value> = Vec::new();
-        for (idx, card) in selected.iter().enumerate() {
-            let level = if idx < profile.deep { "deep" } else { "lite" };
-            let comment_count = if level == "deep" {
-                profile.deep_comments
+        let mut selected: Vec<XhsNoteCard> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut cursor = 0usize;
+        let mut stalls = 0usize;
+
+        while notes.len() < want {
+            let cards = xhs.extract_search_cards().await?;
+            if cursor >= cards.len() {
+                if stalls >= 3 {
+                    break;
+                }
+                stalls += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+                continue;
+            }
+            stalls = 0;
+            let card = cards[cursor].clone();
+            cursor += 1;
+            let dedup = if !card.note_id.is_empty() {
+                card.note_id.clone()
+            } else if !card.link.is_empty() {
+                card.link.clone()
             } else {
-                profile.lite_comments
+                format!("pos:{}", card.position)
             };
+            if !seen.insert(dedup) {
+                continue;
+            }
+            if !card.note_id.is_empty() {
+                ctx.add_topic_scan_note_ids(std::slice::from_ref(&card.note_id));
+            }
+            selected.push(card.clone());
 
             // Dedup: skip notes already processed at this level or deeper
             // within the same run OR in a previous run (cross-run history).
-            let requested_media = profile.include_media && level == "deep";
             if !card.note_id.is_empty()
                 && ctx.has_processed_note(&card.note_id, level, requested_media)
             {
@@ -1001,7 +1001,7 @@ impl Tool for TopicScanTool {
                     "scan_level": level,
                     "source_position": card.position,
                     "skipped": {"reason": "already_processed"},
-                    "entity": card,
+                    "entity": &card,
                 }));
                 continue;
             }
@@ -1015,7 +1015,7 @@ impl Tool for TopicScanTool {
                     "scan_level": level,
                     "source_position": card.position,
                     "skipped": {"reason": "already_analyzed", "history": entry},
-                    "entity": card,
+                    "entity": &card,
                 }));
                 ctx.mark_processed_note(&card.note_id, level, requested_media);
                 continue;
@@ -1047,7 +1047,7 @@ impl Tool for TopicScanTool {
                     "scan_level": level,
                     "source_position": card.position,
                     "ok": false,
-                    "entity": card,
+                    "entity": &card,
                     "error": format!("{e:#}"),
                 }),
             };
@@ -1088,23 +1088,21 @@ impl Tool for TopicScanTool {
         if let Some(cards) = search.get_mut("cards") {
             history_snapshot.annotate_cards(cards);
         }
-        let mut selected_cards =
-            serde_json::to_value(selected.iter().map(|c| (*c).clone()).collect::<Vec<_>>())?;
+        let mut selected_cards = serde_json::to_value(&selected)?;
         history_snapshot.annotate_cards(&mut selected_cards);
 
         let payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
             "query": query,
-            "depth": depth,
             "tab": tab_result,
             "search": search,
             "selected_cards": selected_cards,
             "notes": notes,
             "sampling": {
-                "max_deep_notes": profile.deep,
-                "max_lite_notes": profile.lite,
-                "depth": depth,
-                "include_media": profile.include_media,
+                "num_notes": num_notes,
+                "selected": selected.len(),
+                "comments_per_note": TOPIC_SCAN_COMMENTS,
+                "include_media": include_media,
             },
             "timing": {
                 "media": media_timing,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1052,12 +1052,29 @@ impl Tool for TopicScanTool {
                 }),
             };
 
-            // Pull comments separately for deep notes.
+            // Pull comments separately after waiting for the slower comment
+            // list to hydrate. Body content often appears before comments.
             if level == "deep" && comment_count > 0 {
-                if let Ok(comments) = xhs.extract_comments(comment_count).await {
+                if let Ok(comments_payload) =
+                    xhs.extract_comments_with_wait(comment_count, 5.0).await
+                {
+                    let comments = comments_payload
+                        .get("comments")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default();
                     let entity_map = entry.get_mut("entity").and_then(|v| v.as_object_mut());
                     if let Some(map) = entity_map {
                         map.insert("top_comments".into(), Value::Array(comments));
+                        map.insert(
+                            "top_comments_wait".into(),
+                            json!({
+                                "ready": comments_payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
+                                "reason": comments_payload.get("reason").and_then(Value::as_str).unwrap_or(""),
+                                "waited_ms": comments_payload.get("waited_ms").and_then(Value::as_i64).unwrap_or(0),
+                                "attempts": comments_payload.get("attempts").and_then(Value::as_i64).unwrap_or(0),
+                            }),
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## What changed

- Cancels an in-flight daemon request when the foreground CLI client disconnects, so Ctrl-C during a long `topic_scan` stops further browser actions.
- Adds a comment-wait path for `topic_scan`, waiting for comment hydration or a known no-comment state before closing each note overlay.
- Records `top_comments_wait` metadata so scan artifacts show whether comments were ready, timed out, or explicitly absent.

## Why

Large topic scans can run for a long time. Previously, interrupting the CLI only stopped the local command while the detached daemon kept operating the browser. Also, note body content can hydrate before comments, so scans could close overlays before comments had loaded.

## Validation

- `cargo test -q`
- `git diff --check`
