### PR TITLE
feat: add Axiom telemetry proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,7 @@ dependencies = [
  "clap",
  "inquire",
  "libc",
+ "reqwest 0.12.28",
  "rustyline",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,6 +4010,7 @@ dependencies = [
  "socai-core",
  "tokio",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ socai stop                                                # stop the daemon (clo
 
 Add `--pretty` to any tool command for indented JSON.
 
+CLI daemon telemetry is enabled by default. Daemon events are sent to the
+first-party socai telemetry proxy (`https://socai.io/v1/events` by default),
+which forwards sanitized batches to Axiom. Search query text is included by
+default. The daemon also writes a local JSONL buffer at
+`~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
+
+```bash
+SOCAI_TELEMETRY=off socai search_notes "运营爆款思路"             # opt out
+SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
+SOCAI_TELEMETRY_ENDPOINT=http://localhost:3000/v1/events socai search_notes "运营爆款思路"
+```
+
 `extract_note` is a
 continuation command: a prior `search_notes` / `topic_scan` must have left the
 tool tab on a waterfall containing the target card.

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ socai stop                                              # stop the daemon (close
 
 Add `--pretty` to any tool command for indented JSON.
 
-CLI daemon telemetry is always enabled. Daemon events are sent to the
-first-party socai telemetry proxy (`https://socai.io/v1/events` by default),
-which forwards sanitized batches to Axiom. Search query text is included by
-default, but can be redacted. The daemon also writes a local JSONL buffer at
-`~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
+CLI daemon telemetry sends one sanitized trace per tool command to the
+first-party socai telemetry proxy (`https://socai.io/v1/events`), which forwards
+to Axiom. Search query text is included by default, but can be redacted; users
+can also disable telemetry entirely. The daemon also writes a local JSONL buffer
+at `~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
+SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路"               # disable telemetry for this command
 ```
 
 `extract_note` is a

--- a/README.md
+++ b/README.md
@@ -40,22 +40,16 @@ socai stop                                              # stop the daemon (close
 
 Add `--pretty` to any tool command for indented JSON.
 
-CLI daemon telemetry sends one sanitized trace per tool command to the
-first-party socai telemetry proxy (`https://socai.io/v1/events`), which forwards
-to Axiom. Search query text is included by default, but can be redacted; users
-can also disable telemetry entirely. Explicit optional CLI parameters, such as
-`--num-notes`, are captured under `metadata`; defaults are omitted when the user
-does not pass the flag. The daemon also writes a local JSONL buffer at
-`~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
+`extract_note` is a
+continuation command: a prior `search_notes` / `topic_scan` must have left the
+tool tab on a waterfall containing the target card.
+
+Telementry can be turned off with additional flags
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
 SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路"               # disable telemetry for this command
 ```
-
-`extract_note` is a
-continuation command: a prior `search_notes` / `topic_scan` must have left the
-tool tab on a waterfall containing the target card.
 
 ## TUI
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ default, but can be redacted. The daemon also writes a local JSONL buffer at
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
-SOCAI_TELEMETRY_ENDPOINT=http://localhost:3000/v1/events socai search_notes "运营爆款思路"
 ```
 
 `extract_note` is a

--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ socai stop                                                # stop the daemon (clo
 
 Add `--pretty` to any tool command for indented JSON.
 
-CLI daemon telemetry is enabled by default. Daemon events are sent to the
+CLI daemon telemetry is always enabled. Daemon events are sent to the
 first-party socai telemetry proxy (`https://socai.io/v1/events` by default),
 which forwards sanitized batches to Axiom. Search query text is included by
-default. The daemon also writes a local JSONL buffer at
+default, but can be redacted. The daemon also writes a local JSONL buffer at
 `~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
 
 ```bash
-SOCAI_TELEMETRY=off socai search_notes "运营爆款思路"             # opt out
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
 SOCAI_TELEMETRY_ENDPOINT=http://localhost:3000/v1/events socai search_notes "运营爆款思路"
 ```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Add `--pretty` to any tool command for indented JSON.
 CLI daemon telemetry sends one sanitized trace per tool command to the
 first-party socai telemetry proxy (`https://socai.io/v1/events`), which forwards
 to Axiom. Search query text is included by default, but can be redacted; users
-can also disable telemetry entirely. The daemon also writes a local JSONL buffer
-at `~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
+can also disable telemetry entirely. Explicit optional CLI parameters, such as
+`--num-notes`, are captured under `metadata`; defaults are omitted when the user
+does not pass the flag. The daemon also writes a local JSONL buffer at
+`~/.socai/telemetry/events.jsonl` (or `$SOCAI_HOME/telemetry/events.jsonl`).
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 tokio = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 tracing-subscriber.workspace = true
 rustyline.workspace = true
 inquire.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ clap.workspace = true
 libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+reqwest.workspace = true
 tokio = { workspace = true }
 tracing-subscriber.workspace = true
 rustyline.workspace = true

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1,4 +1,4 @@
-use crate::tracking::{query_text_enabled, Telemetry};
+use crate::tracking::{query_text_enabled, telemetry_enabled, Telemetry};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -41,12 +41,15 @@ struct DaemonRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DaemonTelemetry {
     #[serde(default = "default_true")]
+    enabled: bool,
+    #[serde(default = "default_true")]
     include_query_text: bool,
 }
 
 impl Default for DaemonTelemetry {
     fn default() -> Self {
         Self {
+            enabled: true,
             include_query_text: true,
         }
     }
@@ -185,7 +188,6 @@ async fn handle_request(
 ) -> DaemonResponse {
     let id = request.id.clone();
     let command = request.command.clone();
-    let args_for_tracking = request.args.clone();
     let telemetry = request.telemetry.clone();
     let result = async {
         if command == "ping" {
@@ -199,27 +201,12 @@ async fn handle_request(
 
         let mut state = state.lock().await;
         state.last_activity = Instant::now();
-        state.track_command_started(&id, &command, &args_for_tracking, &telemetry);
-        if let Some(query) = args_for_tracking.get("query").and_then(Value::as_str) {
-            state.track_search_intent(&id, &command, query, &args_for_tracking, &telemetry);
-        }
-
-        let started = Instant::now();
-        let result = match command.as_str() {
+        match command.as_str() {
             "search_notes" => state.search_notes(&id, request.args, &telemetry).await,
             "topic_scan" => state.topic_scan(&id, request.args, &telemetry).await,
             "extract_note" => state.extract_note(&id, request.args, &telemetry).await,
             other => Err(anyhow!("unknown daemon command: {other}")),
-        };
-        state.track_command_finished(
-            &id,
-            &command,
-            &args_for_tracking,
-            &telemetry,
-            started,
-            &result,
-        );
-        result
+        }
     }
     .await;
 
@@ -246,12 +233,14 @@ impl DaemonState {
         args: Value,
         telemetry: &DaemonTelemetry,
     ) -> Result<Value> {
-        let query = required_string(&args, "query")?;
-        let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        self.track_tool_call(request_id, "search_notes", "search_notes", &args, telemetry);
         let started = Instant::now();
-        let result = search_notes_command(page, &query).await;
-        self.track_tool_result(
+        let result = async {
+            let query = required_string(&args, "query")?;
+            let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
+            search_notes_command(page, &query).await
+        }
+        .await;
+        self.track_tool_trace(
             request_id,
             "search_notes",
             "search_notes",
@@ -269,14 +258,16 @@ impl DaemonState {
         args: Value,
         telemetry: &DaemonTelemetry,
     ) -> Result<Value> {
-        let query = required_string(&args, "query")?;
-        let tab_label = args.get("tab_label").and_then(Value::as_str);
-        let num_notes = args.get("num_notes").and_then(Value::as_i64);
-        let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        self.track_tool_call(request_id, "topic_scan", "topic_scan", &args, telemetry);
         let started = Instant::now();
-        let result = topic_scan_command(page, &query, tab_label, num_notes).await;
-        self.track_tool_result(
+        let result = async {
+            let query = required_string(&args, "query")?;
+            let tab_label = args.get("tab_label").and_then(Value::as_str);
+            let num_notes = args.get("num_notes").and_then(Value::as_i64);
+            let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
+            topic_scan_command(page, &query, tab_label, num_notes).await
+        }
+        .await;
+        self.track_tool_trace(
             request_id,
             "topic_scan",
             "topic_scan",
@@ -294,12 +285,14 @@ impl DaemonState {
         args: Value,
         telemetry: &DaemonTelemetry,
     ) -> Result<Value> {
-        let note_id = required_string(&args, "note_id")?;
-        let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        self.track_tool_call(request_id, "extract_note", "read_note", &args, telemetry);
         let started = Instant::now();
-        let result = extract_note_command(page, &note_id).await;
-        self.track_tool_result(
+        let result = async {
+            let note_id = required_string(&args, "note_id")?;
+            let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
+            extract_note_command(page, &note_id).await
+        }
+        .await;
+        self.track_tool_trace(
             request_id,
             "extract_note",
             "read_note",
@@ -311,121 +304,39 @@ impl DaemonState {
         result
     }
 
-    fn track_command_started(
+    fn track_tool_trace(
         &self,
         request_id: &str,
         command: &str,
-        args: &Value,
+        tool_name: &str,
+        input: &Value,
         telemetry: &DaemonTelemetry,
+        started: Instant,
+        result: &Result<Value>,
     ) {
-        self.telemetry.capture(
-            "socai_daemon_command_started",
-            props_with_summary(
-                telemetry,
-                json!({
-                    "request_id": request_id,
-                    "command": command,
-                }),
-                args,
-            ),
+        if !telemetry.enabled {
+            return;
+        }
+
+        let mut props = base_trace_props(request_id, command, tool_name);
+        props.insert(
+            "duration_ms".into(),
+            json!(started.elapsed().as_millis() as u64),
         );
-    }
-
-    fn track_search_intent(
-        &self,
-        request_id: &str,
-        command: &str,
-        query: &str,
-        args: &Value,
-        telemetry: &DaemonTelemetry,
-    ) {
-        let mut props = base_event_props(request_id, command);
-        props.insert("site".into(), json!("xhs"));
-        insert_query_props(&mut props, telemetry, query);
-        insert_optional_str_prop(&mut props, args, "tab_label");
-        insert_optional_i64_prop(&mut props, args, "num_notes");
-        self.telemetry
-            .capture("socai_daemon_search_intent", Value::Object(props));
-    }
-
-    fn track_command_finished(
-        &self,
-        request_id: &str,
-        command: &str,
-        args: &Value,
-        telemetry: &DaemonTelemetry,
-        started: Instant,
-        result: &Result<Value>,
-    ) {
-        let duration_ms = started.elapsed().as_millis() as u64;
-        match result {
-            Ok(value) => {
-                let mut props = base_event_props(request_id, command);
-                props.insert("duration_ms".into(), json!(duration_ms));
-                props.insert("ok".into(), json!(true));
-                merge_object(&mut props, command_arg_summary(telemetry, args));
-                merge_object(&mut props, result_metrics(value));
-                self.telemetry
-                    .capture("socai_daemon_command_completed", Value::Object(props));
-            }
-            Err(err) => {
-                let mut props = base_event_props(request_id, command);
-                props.insert("duration_ms".into(), json!(duration_ms));
-                props.insert("ok".into(), json!(false));
-                props.insert("error".into(), json!(error_summary(err)));
-                merge_object(&mut props, command_arg_summary(telemetry, args));
-                self.telemetry
-                    .capture("socai_daemon_command_failed", Value::Object(props));
-            }
-        }
-    }
-
-    fn track_tool_call(
-        &self,
-        request_id: &str,
-        command: &str,
-        tool_name: &str,
-        input: &Value,
-        telemetry: &DaemonTelemetry,
-    ) {
-        let mut props = base_event_props(request_id, command);
-        props.insert("site".into(), json!("xhs"));
-        props.insert("tool_name".into(), json!(tool_name));
-        merge_object(&mut props, command_arg_summary(telemetry, input));
-        self.telemetry
-            .capture("socai_daemon_tool_call", Value::Object(props));
-    }
-
-    fn track_tool_result(
-        &self,
-        request_id: &str,
-        command: &str,
-        tool_name: &str,
-        input: &Value,
-        telemetry: &DaemonTelemetry,
-        started: Instant,
-        result: &Result<Value>,
-    ) {
-        let duration_ms = started.elapsed().as_millis() as u64;
-        let mut props = base_event_props(request_id, command);
-        props.insert("site".into(), json!("xhs"));
-        props.insert("tool_name".into(), json!(tool_name));
-        props.insert("duration_ms".into(), json!(duration_ms));
         merge_object(&mut props, command_arg_summary(telemetry, input));
         match result {
             Ok(value) => {
                 props.insert("ok".into(), json!(true));
                 merge_object(&mut props, result_metrics(value));
-                self.telemetry
-                    .capture("socai_daemon_tool_result", Value::Object(props));
             }
             Err(err) => {
                 props.insert("ok".into(), json!(false));
                 props.insert("error".into(), json!(error_summary(err)));
-                self.telemetry
-                    .capture("socai_daemon_tool_result", Value::Object(props));
             }
         }
+
+        self.telemetry
+            .capture("socai_cli_tool_trace", Value::Object(props));
     }
 
     async fn shutdown(&mut self) -> Result<()> {
@@ -435,19 +346,12 @@ impl DaemonState {
     }
 }
 
-fn base_event_props(request_id: &str, command: &str) -> Map<String, Value> {
+fn base_trace_props(request_id: &str, command: &str, tool_name: &str) -> Map<String, Value> {
     let mut props = Map::new();
     props.insert("request_id".into(), json!(request_id));
     props.insert("command".into(), json!(command));
-    props
-}
-
-fn props_with_summary(telemetry: &DaemonTelemetry, mut props: Value, args: &Value) -> Value {
-    let summary = command_arg_summary(telemetry, args);
-    let Some(props_map) = props.as_object_mut() else {
-        return summary;
-    };
-    merge_object(props_map, summary);
+    props.insert("tool_name".into(), json!(tool_name));
+    props.insert("site".into(), json!("xhs"));
     props
 }
 
@@ -555,6 +459,7 @@ async fn send_request(command: &str, args: Value, request_timeout: Duration) -> 
         command: command.to_string(),
         args,
         telemetry: DaemonTelemetry {
+            enabled: telemetry_enabled(),
             include_query_text: query_text_enabled(),
         },
     };

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -266,8 +266,6 @@ impl DaemonState {
                 json!({
                     "request_id": request_id,
                     "command": command,
-                    "telemetry_enabled": self.telemetry.enabled(),
-                    "remote_enabled": self.telemetry.remote_enabled(),
                 }),
                 args,
             ),

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1,6 +1,8 @@
+use crate::tracking::Telemetry;
+
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use socai_core::runtime::SocaiRuntime;
 use socai_core::sites::xhs::{
     extract_note_command, search_notes_command, topic_scan_command, XHS_HOME_URL,
@@ -53,6 +55,7 @@ struct DaemonPaths {
 
 struct DaemonState {
     runtime: SocaiRuntime,
+    telemetry: Telemetry,
     last_activity: Instant,
 }
 
@@ -70,8 +73,10 @@ pub async fn run_daemon() -> Result<()> {
     fs::write(&paths.pid, std::process::id().to_string()).await?;
 
     let runtime = SocaiRuntime::new();
+    let telemetry = Telemetry::new(&paths.home);
     let state = Arc::new(Mutex::new(DaemonState {
         runtime,
+        telemetry,
         last_activity: Instant::now(),
     }));
     let stop = Arc::new(Notify::new());
@@ -149,24 +154,34 @@ async fn handle_request(
     stop: Arc<Notify>,
 ) -> DaemonResponse {
     let id = request.id.clone();
+    let command = request.command.clone();
+    let args_for_tracking = request.args.clone();
     let result = async {
-        if request.command == "ping" {
+        if command == "ping" {
             return Ok(json!({ "ok": true }));
         }
 
-        if request.command == "shutdown" {
+        if command == "shutdown" {
             stop.notify_waiters();
             return Ok(json!({ "ok": true }));
         }
 
         let mut state = state.lock().await;
         state.last_activity = Instant::now();
-        match request.command.as_str() {
-            "search_notes" => state.search_notes(request.args).await,
-            "topic_scan" => state.topic_scan(request.args).await,
-            "extract_note" => state.extract_note(request.args).await,
-            other => Err(anyhow!("unknown daemon command: {other}")),
+        state.track_command_started(&id, &command, &args_for_tracking);
+        if let Some(query) = args_for_tracking.get("query").and_then(Value::as_str) {
+            state.track_search_intent(&id, &command, query, &args_for_tracking);
         }
+
+        let started = Instant::now();
+        let result = match command.as_str() {
+            "search_notes" => state.search_notes(&id, request.args).await,
+            "topic_scan" => state.topic_scan(&id, request.args).await,
+            "extract_note" => state.extract_note(&id, request.args).await,
+            other => Err(anyhow!("unknown daemon command: {other}")),
+        };
+        state.track_command_finished(&id, &command, &args_for_tracking, started, &result);
+        result
     }
     .await;
 
@@ -187,13 +202,24 @@ async fn handle_request(
 }
 
 impl DaemonState {
-    async fn search_notes(&mut self, args: Value) -> Result<Value> {
+    async fn search_notes(&mut self, request_id: &str, args: Value) -> Result<Value> {
         let query = required_string(&args, "query")?;
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        search_notes_command(page, &query).await
+        self.track_tool_call(request_id, "search_notes", "search_notes", &args);
+        let started = Instant::now();
+        let result = search_notes_command(page, &query).await;
+        self.track_tool_result(
+            request_id,
+            "search_notes",
+            "search_notes",
+            &args,
+            started,
+            &result,
+        );
+        result
     }
 
-    async fn topic_scan(&mut self, args: Value) -> Result<Value> {
+    async fn topic_scan(&mut self, request_id: &str, args: Value) -> Result<Value> {
         let query = required_string(&args, "query")?;
         let depth = args
             .get("depth")
@@ -201,13 +227,132 @@ impl DaemonState {
             .unwrap_or("standard");
         let tab_label = args.get("tab_label").and_then(Value::as_str);
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        topic_scan_command(page, &query, depth, tab_label).await
+        self.track_tool_call(request_id, "topic_scan", "topic_scan", &args);
+        let started = Instant::now();
+        let result = topic_scan_command(page, &query, depth, tab_label).await;
+        self.track_tool_result(
+            request_id,
+            "topic_scan",
+            "topic_scan",
+            &args,
+            started,
+            &result,
+        );
+        result
     }
 
-    async fn extract_note(&mut self, args: Value) -> Result<Value> {
+    async fn extract_note(&mut self, request_id: &str, args: Value) -> Result<Value> {
         let note_id = required_string(&args, "note_id")?;
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        extract_note_command(page, &note_id).await
+        self.track_tool_call(request_id, "extract_note", "read_note", &args);
+        let started = Instant::now();
+        let result = extract_note_command(page, &note_id).await;
+        self.track_tool_result(
+            request_id,
+            "extract_note",
+            "read_note",
+            &args,
+            started,
+            &result,
+        );
+        result
+    }
+
+    fn track_command_started(&self, request_id: &str, command: &str, args: &Value) {
+        self.telemetry.capture(
+            "socai_daemon_command_started",
+            props_with_summary(
+                &self.telemetry,
+                json!({
+                    "request_id": request_id,
+                    "command": command,
+                    "telemetry_enabled": self.telemetry.enabled(),
+                    "remote_enabled": self.telemetry.remote_enabled(),
+                }),
+                args,
+            ),
+        );
+    }
+
+    fn track_search_intent(&self, request_id: &str, command: &str, query: &str, args: &Value) {
+        let mut props = base_event_props(request_id, command);
+        props.insert("site".into(), json!("xhs"));
+        insert_query_props(&mut props, &self.telemetry, query);
+        insert_optional_str_prop(&mut props, args, "depth");
+        insert_optional_str_prop(&mut props, args, "tab_label");
+        self.telemetry
+            .capture("socai_daemon_search_intent", Value::Object(props));
+    }
+
+    fn track_command_finished(
+        &self,
+        request_id: &str,
+        command: &str,
+        args: &Value,
+        started: Instant,
+        result: &Result<Value>,
+    ) {
+        let duration_ms = started.elapsed().as_millis() as u64;
+        match result {
+            Ok(value) => {
+                let mut props = base_event_props(request_id, command);
+                props.insert("duration_ms".into(), json!(duration_ms));
+                props.insert("ok".into(), json!(true));
+                merge_object(&mut props, command_arg_summary(&self.telemetry, args));
+                merge_object(&mut props, result_metrics(value));
+                self.telemetry
+                    .capture("socai_daemon_command_completed", Value::Object(props));
+            }
+            Err(err) => {
+                let mut props = base_event_props(request_id, command);
+                props.insert("duration_ms".into(), json!(duration_ms));
+                props.insert("ok".into(), json!(false));
+                props.insert("error".into(), json!(error_summary(err)));
+                merge_object(&mut props, command_arg_summary(&self.telemetry, args));
+                self.telemetry
+                    .capture("socai_daemon_command_failed", Value::Object(props));
+            }
+        }
+    }
+
+    fn track_tool_call(&self, request_id: &str, command: &str, tool_name: &str, input: &Value) {
+        let mut props = base_event_props(request_id, command);
+        props.insert("site".into(), json!("xhs"));
+        props.insert("tool_name".into(), json!(tool_name));
+        merge_object(&mut props, command_arg_summary(&self.telemetry, input));
+        self.telemetry
+            .capture("socai_daemon_tool_call", Value::Object(props));
+    }
+
+    fn track_tool_result(
+        &self,
+        request_id: &str,
+        command: &str,
+        tool_name: &str,
+        input: &Value,
+        started: Instant,
+        result: &Result<Value>,
+    ) {
+        let duration_ms = started.elapsed().as_millis() as u64;
+        let mut props = base_event_props(request_id, command);
+        props.insert("site".into(), json!("xhs"));
+        props.insert("tool_name".into(), json!(tool_name));
+        props.insert("duration_ms".into(), json!(duration_ms));
+        merge_object(&mut props, command_arg_summary(&self.telemetry, input));
+        match result {
+            Ok(value) => {
+                props.insert("ok".into(), json!(true));
+                merge_object(&mut props, result_metrics(value));
+                self.telemetry
+                    .capture("socai_daemon_tool_result", Value::Object(props));
+            }
+            Err(err) => {
+                props.insert("ok".into(), json!(false));
+                props.insert("error".into(), json!(error_summary(err)));
+                self.telemetry
+                    .capture("socai_daemon_tool_result", Value::Object(props));
+            }
+        }
     }
 
     async fn shutdown(&mut self) -> Result<()> {
@@ -215,6 +360,110 @@ impl DaemonState {
         self.runtime.disconnect_browser().await;
         Ok(())
     }
+}
+
+fn base_event_props(request_id: &str, command: &str) -> Map<String, Value> {
+    let mut props = Map::new();
+    props.insert("request_id".into(), json!(request_id));
+    props.insert("command".into(), json!(command));
+    props
+}
+
+fn props_with_summary(telemetry: &Telemetry, mut props: Value, args: &Value) -> Value {
+    let summary = command_arg_summary(telemetry, args);
+    let Some(props_map) = props.as_object_mut() else {
+        return summary;
+    };
+    merge_object(props_map, summary);
+    props
+}
+
+fn command_arg_summary(telemetry: &Telemetry, args: &Value) -> Value {
+    let mut props = Map::new();
+    if let Some(query) = args.get("query").and_then(Value::as_str) {
+        insert_query_props(&mut props, telemetry, query);
+    }
+    insert_optional_str_prop(&mut props, args, "depth");
+    insert_optional_str_prop(&mut props, args, "tab_label");
+    if args.get("note_id").and_then(Value::as_str).is_some() {
+        props.insert("note_id_present".into(), json!(true));
+    }
+    if let Some(object) = args.as_object() {
+        props.insert(
+            "arg_keys".into(),
+            Value::Array(object.keys().map(|key| json!(key)).collect()),
+        );
+    }
+    Value::Object(props)
+}
+
+fn insert_query_props(props: &mut Map<String, Value>, telemetry: &Telemetry, query: &str) {
+    props.insert("query_len".into(), json!(query.chars().count()));
+    if telemetry.include_query_text() {
+        props.insert("query_text".into(), json!(query));
+    } else {
+        props.insert("query_redacted".into(), json!(true));
+    }
+}
+
+fn insert_optional_str_prop(props: &mut Map<String, Value>, args: &Value, key: &str) {
+    let Some(value) = args
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    props.insert(key.to_string(), json!(value));
+}
+
+fn merge_object(target: &mut Map<String, Value>, value: Value) {
+    let Value::Object(map) = value else {
+        return;
+    };
+    for (key, value) in map {
+        target.insert(key, value);
+    }
+}
+
+fn result_metrics(value: &Value) -> Value {
+    let mut props = Map::new();
+    let data = value.get("data").unwrap_or(value);
+    if let Some(ok) = data.get("ok").and_then(Value::as_bool) {
+        props.insert("result_ok".into(), json!(ok));
+    }
+    if let Some(cards) = data.get("cards").and_then(Value::as_array) {
+        props.insert("cards_count".into(), json!(cards.len()));
+    }
+    if let Some(cards) = data
+        .get("search")
+        .and_then(|search| search.get("cards"))
+        .and_then(Value::as_array)
+    {
+        props.insert("search_cards_count".into(), json!(cards.len()));
+    }
+    if let Some(cards) = data.get("selected_cards").and_then(Value::as_array) {
+        props.insert("selected_cards_count".into(), json!(cards.len()));
+    }
+    if let Some(notes) = data.get("notes").and_then(Value::as_array) {
+        props.insert("notes_count".into(), json!(notes.len()));
+        let skipped = notes
+            .iter()
+            .filter(|note| note.get("skipped").is_some())
+            .count();
+        props.insert("notes_skipped_count".into(), json!(skipped));
+    }
+    if value.get("run_dir").is_some() {
+        props.insert("has_run_dir".into(), json!(true));
+    }
+    Value::Object(props)
+}
+
+fn error_summary(err: &anyhow::Error) -> String {
+    let rendered = format!("{err:#}");
+    let first = rendered.lines().next().unwrap_or("command failed").trim();
+    first.chars().take(240).collect()
 }
 
 async fn send_request(command: &str, args: Value, request_timeout: Duration) -> Result<Value> {

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -478,8 +478,6 @@ fn insert_query_props(props: &mut Map<String, Value>, telemetry: &DaemonTelemetr
     );
     if telemetry.include_query_text {
         props.insert("query_text".into(), json!(query));
-    } else {
-        props.insert("query_redacted".into(), json!(true));
     }
 }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -360,18 +360,24 @@ fn command_arg_summary(telemetry: &DaemonTelemetry, args: &Value) -> Value {
     if let Some(query) = args.get("query").and_then(Value::as_str) {
         insert_query_props(&mut props, telemetry, query);
     }
-    insert_optional_str_prop(&mut props, args, "tab_label");
-    insert_optional_i64_prop(&mut props, args, "num_notes");
+    if let Some(metadata) = explicit_param_metadata(args) {
+        props.insert("metadata".into(), Value::Object(metadata));
+    }
     if args.get("note_id").and_then(Value::as_str).is_some() {
         props.insert("note_id_present".into(), json!(true));
     }
-    if let Some(object) = args.as_object() {
-        props.insert(
-            "arg_keys".into(),
-            Value::Array(object.keys().map(|key| json!(key)).collect()),
-        );
-    }
     Value::Object(props)
+}
+
+fn explicit_param_metadata(args: &Value) -> Option<Map<String, Value>> {
+    let mut metadata = Map::new();
+    insert_optional_str_metadata(&mut metadata, args, "tab_label", "tab");
+    insert_optional_i64_metadata(&mut metadata, args, "num_notes", "num_notes");
+    if metadata.is_empty() {
+        None
+    } else {
+        Some(metadata)
+    }
 }
 
 fn insert_query_props(props: &mut Map<String, Value>, telemetry: &DaemonTelemetry, query: &str) {
@@ -385,23 +391,33 @@ fn insert_query_props(props: &mut Map<String, Value>, telemetry: &DaemonTelemetr
     }
 }
 
-fn insert_optional_str_prop(props: &mut Map<String, Value>, args: &Value, key: &str) {
+fn insert_optional_str_metadata(
+    metadata: &mut Map<String, Value>,
+    args: &Value,
+    arg_key: &str,
+    metadata_key: &str,
+) {
     let Some(value) = args
-        .get(key)
+        .get(arg_key)
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
     else {
         return;
     };
-    props.insert(key.to_string(), json!(value));
+    metadata.insert(metadata_key.to_string(), json!(value));
 }
 
-fn insert_optional_i64_prop(props: &mut Map<String, Value>, args: &Value, key: &str) {
-    let Some(value) = args.get(key).and_then(Value::as_i64) else {
+fn insert_optional_i64_metadata(
+    metadata: &mut Map<String, Value>,
+    args: &Value,
+    arg_key: &str,
+    metadata_key: &str,
+) {
+    let Some(value) = args.get(arg_key).and_then(Value::as_i64) else {
         return;
     };
-    props.insert(key.to_string(), json!(value));
+    metadata.insert(metadata_key.to_string(), json!(value));
 }
 
 fn merge_object(target: &mut Map<String, Value>, value: Value) {
@@ -450,6 +466,35 @@ fn error_summary(err: &anyhow::Error) -> String {
     let rendered = format!("{err:#}");
     let first = rendered.lines().next().unwrap_or("command failed").trim();
     first.chars().take(240).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_summary_omits_defaulted_optional_params() {
+        let summary = command_arg_summary(&DaemonTelemetry::default(), &json!({ "query": "x" }));
+        let object = summary.as_object().expect("summary is an object");
+        assert!(!object.contains_key("metadata"));
+    }
+
+    #[test]
+    fn command_summary_tracks_explicit_optional_params_as_metadata() {
+        let summary = command_arg_summary(
+            &DaemonTelemetry::default(),
+            &json!({ "query": "x", "tab_label": "latest", "num_notes": 12 }),
+        );
+        let object = summary.as_object().expect("summary is an object");
+        let metadata = object
+            .get("metadata")
+            .and_then(Value::as_object)
+            .expect("metadata object");
+        assert_eq!(metadata.get("tab"), Some(&json!("latest")));
+        assert_eq!(metadata.get("num_notes"), Some(&json!(12)));
+        assert!(!object.contains_key("tab_label"));
+        assert!(!object.contains_key("num_notes"));
+    }
 }
 
 async fn send_request(command: &str, args: Value, request_timeout: Duration) -> Result<Value> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod daemon;
+mod tracking;
 mod tui;
 
 use anyhow::Result;

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -8,16 +8,15 @@ use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 
 const EVENT_SCHEMA_VERSION: u32 = 1;
-const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
+const TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
 const CHANNEL_CAPACITY: usize = 512;
 const REMOTE_BATCH_SIZE: usize = 25;
 const REMOTE_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Clone)]
 pub struct Telemetry {
-    sender: Option<mpsc::Sender<QueuedEvent>>,
+    sender: mpsc::Sender<QueuedEvent>,
     include_query_text: bool,
-    remote_enabled: bool,
 }
 
 #[derive(Debug)]
@@ -31,7 +30,6 @@ struct WorkerConfig {
     install_id: String,
     daemon_session_id: String,
     local_path: PathBuf,
-    endpoint: Option<String>,
     include_query_text: bool,
 }
 
@@ -46,51 +44,35 @@ impl Telemetry {
         let install_id = load_or_create_install_id(home);
         let daemon_session_id = new_session_id();
         let local_path = home.join("telemetry/events.jsonl");
-        let endpoint = telemetry_endpoint();
 
         let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
         let config = WorkerConfig {
             install_id,
             daemon_session_id,
             local_path,
-            endpoint,
             include_query_text,
         };
-        let remote_enabled = config.endpoint.is_some();
         tokio::spawn(worker_loop(receiver, config));
 
         let telemetry = Self {
-            sender: Some(sender),
+            sender,
             include_query_text,
-            remote_enabled,
         };
         telemetry.capture(
             "socai_daemon_started",
             json!({
-                "remote_enabled": remote_enabled,
                 "query_text_enabled": include_query_text,
             }),
         );
         telemetry
     }
 
-    pub fn enabled(&self) -> bool {
-        self.sender.is_some()
-    }
-
     pub fn include_query_text(&self) -> bool {
         self.include_query_text
     }
 
-    pub fn remote_enabled(&self) -> bool {
-        self.remote_enabled
-    }
-
     pub fn capture(&self, name: impl Into<String>, properties: Value) {
-        let Some(sender) = &self.sender else {
-            return;
-        };
-        let _ = sender.try_send(QueuedEvent {
+        let _ = self.sender.try_send(QueuedEvent {
             name: name.into(),
             properties,
         });
@@ -114,20 +96,18 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerCo
                 let row = local_row(&event.name, &config.install_id, timestamp_ms, &properties);
                 let _ = append_jsonl(&config.local_path, &row).await;
 
-                if config.endpoint.is_some() {
-                    remote_batch.push(remote_event(&event.name, &config.install_id, timestamp_ms, &properties));
-                    if remote_batch.len() >= REMOTE_BATCH_SIZE {
-                        flush_remote(&client, &config, &mut remote_batch).await;
-                    }
+                remote_batch.push(remote_event(&event.name, &config.install_id, timestamp_ms, &properties));
+                if remote_batch.len() >= REMOTE_BATCH_SIZE {
+                    flush_remote(&client, &mut remote_batch).await;
                 }
             }
             _ = flush_tick.tick() => {
-                flush_remote(&client, &config, &mut remote_batch).await;
+                flush_remote(&client, &mut remote_batch).await;
             }
         }
     }
 
-    flush_remote(&client, &config, &mut remote_batch).await;
+    flush_remote(&client, &mut remote_batch).await;
 }
 
 fn enrich_properties(properties: Value, config: &WorkerConfig, timestamp_ms: u64) -> Value {
@@ -179,18 +159,14 @@ fn remote_event(
     Value::Object(map)
 }
 
-async fn flush_remote(client: &reqwest::Client, config: &WorkerConfig, batch: &mut Vec<Value>) {
-    let Some(endpoint) = config.endpoint.as_deref() else {
-        batch.clear();
-        return;
-    };
+async fn flush_remote(client: &reqwest::Client, batch: &mut Vec<Value>) {
     if batch.is_empty() {
         return;
     }
 
     let events = std::mem::take(batch);
     let body = json!({ "events": events });
-    let _ = client.post(endpoint).json(&body).send().await;
+    let _ = client.post(TELEMETRY_ENDPOINT).json(&body).send().await;
 }
 
 async fn append_jsonl(path: &Path, row: &Value) -> std::io::Result<()> {
@@ -260,21 +236,6 @@ fn query_text_enabled() -> bool {
             "SOCAI_TELEMETRY_QUERY_TEXT",
             &["0", "false", "off", "disabled", "no"],
         ))
-}
-
-fn telemetry_endpoint() -> Option<String> {
-    env_nonempty("SOCAI_TELEMETRY_ENDPOINT")
-        .or_else(|| option_env!("SOCAI_TELEMETRY_ENDPOINT").map(str::to_string))
-        .or_else(|| Some(DEFAULT_TELEMETRY_ENDPOINT.to_string()))
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn env_nonempty(name: &str) -> Option<String> {
-    std::env::var(name)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
 }
 
 fn env_truthy(name: &str) -> bool {

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Map, Value};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
+use uuid::Uuid;
 
 const EVENT_SCHEMA_VERSION: u32 = 1;
 const TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
@@ -27,7 +28,7 @@ struct QueuedEvent {
 #[derive(Clone)]
 struct WorkerConfig {
     install_id: String,
-    daemon_session_id: String,
+    session_id: String,
     local_path: PathBuf,
     include_query_text: bool,
 }
@@ -41,13 +42,13 @@ impl Telemetry {
     pub fn new(home: &Path) -> Self {
         let include_query_text = query_text_enabled();
         let install_id = load_or_create_install_id(home);
-        let daemon_session_id = new_session_id();
+        let session_id = new_session_id();
         let local_path = home.join("telemetry/events.jsonl");
 
         let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
         let config = WorkerConfig {
             install_id,
-            daemon_session_id,
+            session_id,
             local_path,
             include_query_text,
         };
@@ -117,7 +118,7 @@ fn enrich_properties(properties: Value, config: &WorkerConfig, timestamp_ms: u64
     map.insert("app_version".into(), json!(env!("CARGO_PKG_VERSION")));
     map.insert("platform".into(), json!(std::env::consts::OS));
     map.insert("arch".into(), json!(std::env::consts::ARCH));
-    map.insert("daemon_session_id".into(), json!(config.daemon_session_id));
+    map.insert("session_id".into(), json!(config.session_id));
     if !map.contains_key("query_text_enabled") {
         map.insert(
             "query_text_enabled".into(),
@@ -182,7 +183,7 @@ fn load_or_create_install_id(home: &Path) -> String {
     if let Ok(bytes) = std::fs::read(&path) {
         if let Ok(identity) = serde_json::from_slice::<IdentityFile>(&bytes) {
             let id = identity.install_id.trim();
-            if !id.is_empty() {
+            if Uuid::parse_str(id).is_ok() {
                 return id.to_string();
             }
         }
@@ -203,18 +204,11 @@ fn load_or_create_install_id(home: &Path) -> String {
 }
 
 fn new_install_id() -> String {
-    format!(
-        "socai-{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or_default()
-    )
+    Uuid::new_v4().to_string()
 }
 
 fn new_session_id() -> String {
-    format!("daemon-{}-{}", std::process::id(), now_ms())
+    Uuid::new_v4().to_string()
 }
 
 fn now_ms() -> u64 {

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -228,17 +228,14 @@ fn now_ms() -> u64 {
 }
 
 pub fn telemetry_enabled() -> bool {
-    !(env_truthy("DO_NOT_TRACK")
-        || env_truthy("SOCAI_DISABLE_TELEMETRY")
-        || env_value_is("SOCAI_TELEMETRY", &["0", "false", "off", "disabled", "no"]))
+    !env_value_is("SOCAI_TELEMETRY", &["0", "false", "off", "disabled", "no"])
 }
 
 pub fn query_text_enabled() -> bool {
-    !(env_truthy("SOCAI_TELEMETRY_REDACT_QUERIES")
-        || env_value_is(
-            "SOCAI_TELEMETRY_QUERY_TEXT",
-            &["0", "false", "off", "disabled", "no"],
-        ))
+    !env_value_is(
+        "SOCAI_TELEMETRY_QUERY_TEXT",
+        &["0", "false", "off", "disabled", "no"],
+    )
 }
 
 fn device_info() -> &'static DeviceInfo {
@@ -400,10 +397,6 @@ fn command_output(program: &str, args: &[&str]) -> String {
         return String::new();
     }
     String::from_utf8_lossy(&output.stdout).trim().to_string()
-}
-
-fn env_truthy(name: &str) -> bool {
-    env_value_is(name, &["1", "true", "yes", "on"])
 }
 
 fn env_value_is(name: &str, values: &[&str]) -> bool {

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -1,0 +1,310 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
+
+const EVENT_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
+const CHANNEL_CAPACITY: usize = 512;
+const REMOTE_BATCH_SIZE: usize = 25;
+const REMOTE_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct Telemetry {
+    sender: Option<mpsc::Sender<QueuedEvent>>,
+    include_query_text: bool,
+    remote_enabled: bool,
+}
+
+#[derive(Debug)]
+struct QueuedEvent {
+    name: String,
+    properties: Value,
+}
+
+#[derive(Clone)]
+struct WorkerConfig {
+    install_id: String,
+    daemon_session_id: String,
+    local_path: PathBuf,
+    endpoint: Option<String>,
+    include_query_text: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IdentityFile {
+    install_id: String,
+}
+
+impl Telemetry {
+    pub fn new(home: &Path) -> Self {
+        if telemetry_disabled() {
+            return Self {
+                sender: None,
+                include_query_text: false,
+                remote_enabled: false,
+            };
+        }
+
+        let include_query_text = query_text_enabled();
+        let install_id = load_or_create_install_id(home);
+        let daemon_session_id = new_session_id();
+        let local_path = home.join("telemetry/events.jsonl");
+        let endpoint = telemetry_endpoint();
+
+        let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
+        let config = WorkerConfig {
+            install_id,
+            daemon_session_id,
+            local_path,
+            endpoint,
+            include_query_text,
+        };
+        let remote_enabled = config.endpoint.is_some();
+        tokio::spawn(worker_loop(receiver, config));
+
+        let telemetry = Self {
+            sender: Some(sender),
+            include_query_text,
+            remote_enabled,
+        };
+        telemetry.capture(
+            "socai_daemon_started",
+            json!({
+                "remote_enabled": remote_enabled,
+                "query_text_enabled": include_query_text,
+            }),
+        );
+        telemetry
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.sender.is_some()
+    }
+
+    pub fn include_query_text(&self) -> bool {
+        self.include_query_text
+    }
+
+    pub fn remote_enabled(&self) -> bool {
+        self.remote_enabled
+    }
+
+    pub fn capture(&self, name: impl Into<String>, properties: Value) {
+        let Some(sender) = &self.sender else {
+            return;
+        };
+        let _ = sender.try_send(QueuedEvent {
+            name: name.into(),
+            properties,
+        });
+    }
+}
+
+async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerConfig) {
+    let client = reqwest::Client::new();
+    let mut remote_batch: Vec<Value> = Vec::new();
+    let mut flush_tick = tokio::time::interval(REMOTE_FLUSH_INTERVAL);
+    flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            maybe_event = receiver.recv() => {
+                let Some(event) = maybe_event else {
+                    break;
+                };
+                let timestamp_ms = now_ms();
+                let properties = enrich_properties(event.properties, &config, timestamp_ms);
+                let row = local_row(&event.name, &config.install_id, timestamp_ms, &properties);
+                let _ = append_jsonl(&config.local_path, &row).await;
+
+                if config.endpoint.is_some() {
+                    remote_batch.push(remote_event(&event.name, &config.install_id, timestamp_ms, &properties));
+                    if remote_batch.len() >= REMOTE_BATCH_SIZE {
+                        flush_remote(&client, &config, &mut remote_batch).await;
+                    }
+                }
+            }
+            _ = flush_tick.tick() => {
+                flush_remote(&client, &config, &mut remote_batch).await;
+            }
+        }
+    }
+
+    flush_remote(&client, &config, &mut remote_batch).await;
+}
+
+fn enrich_properties(properties: Value, config: &WorkerConfig, timestamp_ms: u64) -> Value {
+    let mut map = match properties {
+        Value::Object(map) => map,
+        other => {
+            let mut map = Map::new();
+            map.insert("value".into(), other);
+            map
+        }
+    };
+    map.insert("schema_version".into(), json!(EVENT_SCHEMA_VERSION));
+    map.insert("app".into(), json!("socai"));
+    map.insert("source".into(), json!("cli_daemon"));
+    map.insert("app_version".into(), json!(env!("CARGO_PKG_VERSION")));
+    map.insert("platform".into(), json!(std::env::consts::OS));
+    map.insert("arch".into(), json!(std::env::consts::ARCH));
+    map.insert("daemon_session_id".into(), json!(config.daemon_session_id));
+    map.insert(
+        "query_text_enabled".into(),
+        json!(config.include_query_text),
+    );
+    map.insert("created_at_ms".into(), json!(timestamp_ms));
+    Value::Object(map)
+}
+
+fn local_row(event_name: &str, install_id: &str, timestamp_ms: u64, properties: &Value) -> Value {
+    json!({
+        "event": event_name,
+        "install_id": install_id,
+        "created_at_ms": timestamp_ms,
+        "properties": properties,
+    })
+}
+
+fn remote_event(
+    event_name: &str,
+    install_id: &str,
+    timestamp_ms: u64,
+    properties: &Value,
+) -> Value {
+    let mut map = match properties {
+        Value::Object(map) => map.clone(),
+        _ => Map::new(),
+    };
+    map.insert("event".into(), json!(event_name));
+    map.insert("install_id".into(), json!(install_id));
+    map.insert("created_at_ms".into(), json!(timestamp_ms));
+    Value::Object(map)
+}
+
+async fn flush_remote(client: &reqwest::Client, config: &WorkerConfig, batch: &mut Vec<Value>) {
+    let Some(endpoint) = config.endpoint.as_deref() else {
+        batch.clear();
+        return;
+    };
+    if batch.is_empty() {
+        return;
+    }
+
+    let events = std::mem::take(batch);
+    let body = json!({ "events": events });
+    let _ = client.post(endpoint).json(&body).send().await;
+}
+
+async fn append_jsonl(path: &Path, row: &Value) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    let line = serde_json::to_string(row).map_err(std::io::Error::other)?;
+    file.write_all(line.as_bytes()).await?;
+    file.write_all(b"\n").await
+}
+
+fn load_or_create_install_id(home: &Path) -> String {
+    let path = home.join("telemetry/identity.json");
+    if let Ok(bytes) = std::fs::read(&path) {
+        if let Ok(identity) = serde_json::from_slice::<IdentityFile>(&bytes) {
+            let id = identity.install_id.trim();
+            if !id.is_empty() {
+                return id.to_string();
+            }
+        }
+    }
+
+    let install_id = new_install_id();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&IdentityFile {
+            install_id: install_id.clone(),
+        })
+        .unwrap_or_else(|_| b"{}".to_vec()),
+    );
+    install_id
+}
+
+fn new_install_id() -> String {
+    format!(
+        "socai-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    )
+}
+
+fn new_session_id() -> String {
+    format!("daemon-{}-{}", std::process::id(), now_ms())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn telemetry_disabled() -> bool {
+    env_truthy("DO_NOT_TRACK")
+        || env_truthy("SOCAI_DISABLE_TELEMETRY")
+        || env_value_is("SOCAI_TELEMETRY", &["0", "false", "off", "disabled", "no"])
+}
+
+fn query_text_enabled() -> bool {
+    !(env_truthy("SOCAI_TELEMETRY_REDACT_QUERIES")
+        || env_value_is(
+            "SOCAI_TELEMETRY_QUERY_TEXT",
+            &["0", "false", "off", "disabled", "no"],
+        ))
+}
+
+fn telemetry_endpoint() -> Option<String> {
+    env_nonempty("SOCAI_TELEMETRY_ENDPOINT")
+        .or_else(|| option_env!("SOCAI_TELEMETRY_ENDPOINT").map(str::to_string))
+        .or_else(|| Some(DEFAULT_TELEMETRY_ENDPOINT.to_string()))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .filter(|value| {
+            !matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "disabled" | "no"
+            )
+        })
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn env_truthy(name: &str) -> bool {
+    env_value_is(name, &["1", "true", "yes", "on"])
+}
+
+fn env_value_is(name: &str, values: &[&str]) -> bool {
+    let Ok(value) = std::env::var(name) else {
+        return false;
+    };
+    let value = value.trim().to_ascii_lowercase();
+    values.iter().any(|candidate| value == *candidate)
+}

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -148,9 +148,10 @@ fn remote_event(
         Value::Object(map) => map.clone(),
         _ => Map::new(),
     };
+    map.remove("created_at_ms");
     map.insert("event".into(), json!(event_name));
     map.insert("install_id".into(), json!(install_id));
-    map.insert("created_at_ms".into(), json!(timestamp_ms));
+    map.insert("client_created_at_ms".into(), json!(timestamp_ms));
     Value::Object(map)
 }
 

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -30,7 +31,16 @@ struct WorkerConfig {
     install_id: String,
     session_id: String,
     local_path: PathBuf,
-    include_query_text: bool,
+}
+
+#[derive(Debug, Clone)]
+struct DeviceInfo {
+    os_version: String,
+    os_kernel_version: String,
+    memory_total_mb: Option<u64>,
+    cpu_count: Option<usize>,
+    terminal_app: String,
+    parent_process: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,7 +50,6 @@ struct IdentityFile {
 
 impl Telemetry {
     pub fn new(home: &Path) -> Self {
-        let include_query_text = query_text_enabled();
         let install_id = load_or_create_install_id(home);
         let session_id = new_session_id();
         let local_path = home.join("telemetry/events.jsonl");
@@ -50,18 +59,10 @@ impl Telemetry {
             install_id,
             session_id,
             local_path,
-            include_query_text,
         };
         tokio::spawn(worker_loop(receiver, config));
 
-        let telemetry = Self { sender };
-        telemetry.capture(
-            "socai_daemon_started",
-            json!({
-                "query_text_enabled": include_query_text,
-            }),
-        );
-        telemetry
+        Self { sender }
     }
 
     pub fn capture(&self, name: impl Into<String>, properties: Value) {
@@ -89,7 +90,7 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerCo
                 let row = local_row(&event.name, &config.install_id, timestamp_ms, &properties);
                 let _ = append_jsonl(&config.local_path, &row).await;
 
-                remote_batch.push(remote_event(&event.name, &config.install_id, timestamp_ms, &properties));
+                remote_batch.push(remote_event(&event.name, &config.install_id, &properties));
                 if remote_batch.len() >= REMOTE_BATCH_SIZE {
                     flush_remote(&client, &mut remote_batch).await;
                 }
@@ -117,16 +118,28 @@ fn enrich_properties(properties: Value, config: &WorkerConfig, timestamp_ms: u64
     map.insert("source".into(), json!("cli_daemon"));
     map.insert("app_version".into(), json!(env!("CARGO_PKG_VERSION")));
     map.insert("platform".into(), json!(std::env::consts::OS));
-    map.insert("arch".into(), json!(std::env::consts::ARCH));
     map.insert("session_id".into(), json!(config.session_id));
-    if !map.contains_key("query_text_enabled") {
-        map.insert(
-            "query_text_enabled".into(),
-            json!(config.include_query_text),
-        );
-    }
     map.insert("created_at_ms".into(), json!(timestamp_ms));
+
+    let device = device_info();
+    insert_nonempty(&mut map, "os_version", &device.os_version);
+    insert_nonempty(&mut map, "os_kernel_version", &device.os_kernel_version);
+    insert_nonempty(&mut map, "terminal_app", &device.terminal_app);
+    insert_nonempty(&mut map, "parent_process", &device.parent_process);
+    if let Some(memory_total_mb) = device.memory_total_mb {
+        map.insert("memory_total_mb".into(), json!(memory_total_mb));
+    }
+    if let Some(cpu_count) = device.cpu_count {
+        map.insert("cpu_count".into(), json!(cpu_count));
+    }
+
     Value::Object(map)
+}
+
+fn insert_nonempty(map: &mut Map<String, Value>, key: &str, value: &str) {
+    if !value.trim().is_empty() {
+        map.insert(key.to_string(), json!(value));
+    }
 }
 
 fn local_row(event_name: &str, install_id: &str, timestamp_ms: u64, properties: &Value) -> Value {
@@ -138,20 +151,15 @@ fn local_row(event_name: &str, install_id: &str, timestamp_ms: u64, properties: 
     })
 }
 
-fn remote_event(
-    event_name: &str,
-    install_id: &str,
-    timestamp_ms: u64,
-    properties: &Value,
-) -> Value {
+fn remote_event(event_name: &str, install_id: &str, properties: &Value) -> Value {
     let mut map = match properties {
         Value::Object(map) => map.clone(),
         _ => Map::new(),
     };
-    map.remove("created_at_ms");
+    // The proxy uses this for validation/routing and strips it before Axiom.
     map.insert("event".into(), json!(event_name));
     map.insert("install_id".into(), json!(install_id));
-    map.insert("client_created_at_ms".into(), json!(timestamp_ms));
+    map.remove("created_at_ms");
     Value::Object(map)
 }
 
@@ -219,12 +227,179 @@ fn now_ms() -> u64 {
         .unwrap_or_default()
 }
 
+pub fn telemetry_enabled() -> bool {
+    !(env_truthy("DO_NOT_TRACK")
+        || env_truthy("SOCAI_DISABLE_TELEMETRY")
+        || env_value_is("SOCAI_TELEMETRY", &["0", "false", "off", "disabled", "no"]))
+}
+
 pub fn query_text_enabled() -> bool {
     !(env_truthy("SOCAI_TELEMETRY_REDACT_QUERIES")
         || env_value_is(
             "SOCAI_TELEMETRY_QUERY_TEXT",
             &["0", "false", "off", "disabled", "no"],
         ))
+}
+
+fn device_info() -> &'static DeviceInfo {
+    static DEVICE_INFO: OnceLock<DeviceInfo> = OnceLock::new();
+    DEVICE_INFO.get_or_init(|| DeviceInfo {
+        os_version: os_version(),
+        os_kernel_version: os_kernel_version(),
+        memory_total_mb: memory_total_mb(),
+        cpu_count: std::thread::available_parallelism()
+            .ok()
+            .map(|count| count.get()),
+        terminal_app: terminal_app(),
+        parent_process: parent_process_name(),
+    })
+}
+
+fn os_version() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        return command_output("sw_vers", &["-productVersion"]);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return linux_pretty_name().unwrap_or_default();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return command_output("cmd", &["/C", "ver"]);
+    }
+    #[allow(unreachable_code)]
+    String::new()
+}
+
+fn os_kernel_version() -> String {
+    #[cfg(unix)]
+    {
+        return command_output("uname", &["-r"]);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return command_output("cmd", &["/C", "ver"]);
+    }
+    #[allow(unreachable_code)]
+    String::new()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_pretty_name() -> Option<String> {
+    let text = std::fs::read_to_string("/etc/os-release").ok()?;
+    for line in text.lines() {
+        let Some(value) = line.strip_prefix("PRETTY_NAME=") else {
+            continue;
+        };
+        return Some(value.trim_matches('"').to_string());
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn memory_total_mb() -> Option<u64> {
+    use std::ffi::CString;
+    let name = CString::new("hw.memsize").ok()?;
+    let mut value: u64 = 0;
+    let mut size = std::mem::size_of::<u64>();
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            (&mut value as *mut u64).cast(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 {
+        Some(value / 1024 / 1024)
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn memory_total_mb() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in text.lines() {
+        let Some(rest) = line.strip_prefix("MemTotal:") else {
+            continue;
+        };
+        let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+        return Some(kb / 1024);
+    }
+    None
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn memory_total_mb() -> Option<u64> {
+    None
+}
+
+fn terminal_app() -> String {
+    if std::env::var_os("GHOSTTY_RESOURCES_DIR").is_some()
+        || std::env::var_os("GHOSTTY_BIN_DIR").is_some()
+    {
+        return "Ghostty".to_string();
+    }
+    if std::env::var_os("WEZTERM_EXECUTABLE").is_some() {
+        return "WezTerm".to_string();
+    }
+    if std::env::var_os("KITTY_WINDOW_ID").is_some() {
+        return "kitty".to_string();
+    }
+    if std::env::var_os("ALACRITTY_WINDOW_ID").is_some() {
+        return "Alacritty".to_string();
+    }
+    if std::env::var_os("VSCODE_PID").is_some() {
+        return "VS Code".to_string();
+    }
+    if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+        let trimmed = term_program.trim();
+        if !trimmed.is_empty() {
+            return match trimmed {
+                "Apple_Terminal" => "Terminal".to_string(),
+                "iTerm.app" => "iTerm".to_string(),
+                other => other.to_string(),
+            };
+        }
+    }
+    if let Ok(lc_terminal) = std::env::var("LC_TERMINAL") {
+        let trimmed = lc_terminal.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if parent_process_name().to_ascii_lowercase().contains("codex") {
+        return "Codex".to_string();
+    }
+    std::env::var("TERM")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn parent_process_name() -> String {
+    let ppid = unsafe { libc::getppid() };
+    command_output("ps", &["-p", &ppid.to_string(), "-o", "comm="])
+}
+
+#[cfg(not(unix))]
+fn parent_process_name() -> String {
+    String::new()
+}
+
+fn command_output(program: &str, args: &[&str]) -> String {
+    let Ok(output) = std::process::Command::new(program).args(args).output() else {
+        return String::new();
+    };
+    if !output.status.success() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
 fn env_truthy(name: &str) -> bool {

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -42,14 +42,6 @@ struct IdentityFile {
 
 impl Telemetry {
     pub fn new(home: &Path) -> Self {
-        if telemetry_disabled() {
-            return Self {
-                sender: None,
-                include_query_text: false,
-                remote_enabled: false,
-            };
-        }
-
         let include_query_text = query_text_enabled();
         let install_id = load_or_create_install_id(home);
         let daemon_session_id = new_session_id();
@@ -262,12 +254,6 @@ fn now_ms() -> u64 {
         .unwrap_or_default()
 }
 
-fn telemetry_disabled() -> bool {
-    env_truthy("DO_NOT_TRACK")
-        || env_truthy("SOCAI_DISABLE_TELEMETRY")
-        || env_value_is("SOCAI_TELEMETRY", &["0", "false", "off", "disabled", "no"])
-}
-
 fn query_text_enabled() -> bool {
     !(env_truthy("SOCAI_TELEMETRY_REDACT_QUERIES")
         || env_value_is(
@@ -282,12 +268,6 @@ fn telemetry_endpoint() -> Option<String> {
         .or_else(|| Some(DEFAULT_TELEMETRY_ENDPOINT.to_string()))
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .filter(|value| {
-            !matches!(
-                value.to_ascii_lowercase().as_str(),
-                "0" | "false" | "off" | "disabled" | "no"
-            )
-        })
 }
 
 fn env_nonempty(name: &str) -> Option<String> {

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -1,0 +1,299 @@
+const DEFAULT_AXIOM_URL = 'https://api.axiom.co';
+const DEFAULT_DATASET = 'socai-cli-prod';
+const MAX_BODY_BYTES = 128 * 1024;
+const MAX_EVENTS_PER_REQUEST = 100;
+const MAX_STRING_CHARS = 2_000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_EVENTS = 1_200;
+
+const ALLOWED_FIELDS = new Set([
+  '_time',
+  'event',
+  'install_id',
+  'distinct_id',
+  'daemon_session_id',
+  'request_id',
+  'schema_version',
+  'app',
+  'source',
+  'app_version',
+  'platform',
+  'arch',
+  'command',
+  'site',
+  'tool_name',
+  'query_text',
+  'query_len',
+  'query_redacted',
+  'query_text_enabled',
+  'depth',
+  'tab_label',
+  'duration_ms',
+  'ok',
+  'error',
+  'result_ok',
+  'cards_count',
+  'search_cards_count',
+  'selected_cards_count',
+  'notes_count',
+  'notes_skipped_count',
+  'has_run_dir',
+  'telemetry_enabled',
+  'remote_enabled',
+  'created_at_ms',
+  'client_created_at_ms',
+  'received_at_ms',
+  'proxy_version',
+]);
+
+const rateLimits = new Map();
+
+export default async function handler(req, res) {
+  setSecurityHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS');
+    res.status(405).json({ ok: false, error: 'method_not_allowed' });
+    return;
+  }
+
+  let input;
+  try {
+    input = await readJsonBody(req);
+  } catch (error) {
+    res.status(error.statusCode || 400).json({ ok: false, error: error.code || 'invalid_json' });
+    return;
+  }
+
+  const events = normalizeEvents(input);
+  if (events.length === 0) {
+    res.status(400).json({ ok: false, error: 'no_events' });
+    return;
+  }
+  if (events.length > MAX_EVENTS_PER_REQUEST) {
+    res.status(413).json({ ok: false, error: 'too_many_events' });
+    return;
+  }
+
+  const rateKey = rateLimitKey(req, events);
+  if (!consumeRateLimit(rateKey, events.length)) {
+    res.status(429).json({ ok: false, error: 'rate_limited' });
+    return;
+  }
+
+  const now = new Date();
+  const sanitized = events
+    .map((event) => sanitizeEvent(event, now))
+    .filter((event) => event !== null);
+
+  if (sanitized.length === 0) {
+    res.status(400).json({ ok: false, error: 'no_valid_events' });
+    return;
+  }
+
+  try {
+    await forwardToAxiom(sanitized);
+  } catch (error) {
+    // Keep the client contract best-effort. The CLI has already handed off the
+    // batch to the proxy; proxy/Axiom outages should not create retry storms or
+    // leak backend details to public clients.
+    console.error('telemetry forward failed', error);
+  }
+
+  res.status(202).json({ ok: true, accepted: sanitized.length });
+}
+
+async function readJsonBody(req) {
+  if (req.body !== undefined && req.body !== null) {
+    return typeof req.body === 'string' ? parseJson(req.body) : req.body;
+  }
+
+  let size = 0;
+  const chunks = [];
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > MAX_BODY_BYTES) {
+      const error = new Error('body_too_large');
+      error.statusCode = 413;
+      error.code = 'body_too_large';
+      throw error;
+    }
+    chunks.push(buffer);
+  }
+
+  return parseJson(Buffer.concat(chunks).toString('utf8'));
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text || 'null');
+  } catch {
+    const error = new Error('invalid_json');
+    error.statusCode = 400;
+    error.code = 'invalid_json';
+    throw error;
+  }
+}
+
+function normalizeEvents(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input && typeof input === 'object' && Array.isArray(input.events)) {
+    return input.events;
+  }
+  if (input && typeof input === 'object') {
+    return [input];
+  }
+  return [];
+}
+
+function sanitizeEvent(raw, now) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const flattened = flattenEvent(raw);
+  const eventName = cleanString(flattened.event);
+  if (!eventName || !eventName.startsWith('socai_')) {
+    return null;
+  }
+
+  const out = {
+    _time: now.toISOString(),
+    event: eventName,
+    received_at_ms: now.getTime(),
+    proxy_version: 1,
+  };
+
+  for (const [key, value] of Object.entries(flattened)) {
+    if (!ALLOWED_FIELDS.has(key) || key === '_time' || key === 'event') {
+      continue;
+    }
+    const safe = sanitizeValue(value);
+    if (safe !== undefined) {
+      out[key] = safe;
+    }
+  }
+
+  if (out.created_at_ms !== undefined && out.client_created_at_ms === undefined) {
+    out.client_created_at_ms = out.created_at_ms;
+  }
+
+  return out;
+}
+
+function flattenEvent(raw) {
+  const flattened = { ...raw };
+  if (raw.properties && typeof raw.properties === 'object' && !Array.isArray(raw.properties)) {
+    for (const [key, value] of Object.entries(raw.properties)) {
+      if (flattened[key] === undefined) {
+        flattened[key] = value;
+      }
+    }
+    delete flattened.properties;
+  }
+  if (flattened.install_id === undefined && typeof flattened.distinct_id === 'string') {
+    flattened.install_id = flattened.distinct_id;
+  }
+  return flattened;
+}
+
+function sanitizeValue(value) {
+  if (value === null) {
+    return null;
+  }
+  switch (typeof value) {
+    case 'string':
+      return cleanString(value);
+    case 'number':
+      return Number.isFinite(value) ? value : undefined;
+    case 'boolean':
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function cleanString(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const cleaned = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '').trim();
+  return cleaned.length > MAX_STRING_CHARS ? `${cleaned.slice(0, MAX_STRING_CHARS)}…` : cleaned;
+}
+
+function rateLimitKey(req, events) {
+  const installId = events
+    .map(flattenEvent)
+    .map((event) => cleanString(event.install_id || event.distinct_id))
+    .find(Boolean);
+  if (installId) {
+    return `install:${installId}`;
+  }
+  const forwardedFor = String(req.headers['x-forwarded-for'] || '').split(',')[0].trim();
+  return `ip:${forwardedFor || req.socket?.remoteAddress || 'unknown'}`;
+}
+
+function consumeRateLimit(key, count) {
+  const now = Date.now();
+  for (const [existingKey, bucket] of rateLimits) {
+    if (now - bucket.startedAt > RATE_LIMIT_WINDOW_MS * 2) {
+      rateLimits.delete(existingKey);
+    }
+  }
+
+  const bucket = rateLimits.get(key);
+  if (!bucket || now - bucket.startedAt > RATE_LIMIT_WINDOW_MS) {
+    rateLimits.set(key, { startedAt: now, count });
+    return count <= RATE_LIMIT_MAX_EVENTS;
+  }
+
+  bucket.count += count;
+  return bucket.count <= RATE_LIMIT_MAX_EVENTS;
+}
+
+async function forwardToAxiom(events) {
+  const token = process.env.AXIOM_TOKEN;
+  if (!token) {
+    console.warn('AXIOM_TOKEN is not configured; dropping telemetry batch');
+    return;
+  }
+
+  const dataset = process.env.AXIOM_DATASET || DEFAULT_DATASET;
+  const baseUrl = (process.env.AXIOM_URL || DEFAULT_AXIOM_URL).replace(/\/+$/, '');
+  const response = await fetch(`${baseUrl}/v1/datasets/${encodeURIComponent(dataset)}/ingest`, {
+    method: 'POST',
+    headers: axiomHeaders(token),
+    body: JSON.stringify(events),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Axiom ingest failed: ${response.status} ${body.slice(0, 300)}`);
+  }
+}
+
+function axiomHeaders(token) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  if (process.env.AXIOM_ORG_ID) {
+    headers['X-Axiom-Org-ID'] = process.env.AXIOM_ORG_ID;
+  }
+  return headers;
+}
+
+function setSecurityHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Cache-Control', 'no-store');
+}

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -7,8 +7,6 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_EVENTS = 1_200;
 
 const ALLOWED_FIELDS = new Set([
-  '_time',
-  'event',
   'install_id',
   'distinct_id',
   'session_id',
@@ -18,15 +16,20 @@ const ALLOWED_FIELDS = new Set([
   'source',
   'app_version',
   'platform',
-  'arch',
+  'os_version',
+  'os_kernel_version',
+  'memory_total_mb',
+  'cpu_count',
+  'terminal_app',
+  'parent_process',
   'command',
   'site',
   'tool_name',
   'query_text',
   'query_len',
   'query_text_enabled',
-  'depth',
   'tab_label',
+  'num_notes',
   'duration_ms',
   'ok',
   'error',
@@ -80,9 +83,8 @@ export default async function handler(req, res) {
     return;
   }
 
-  const now = new Date();
   const sanitized = events
-    .map((event) => sanitizeEvent(event, now))
+    .map((event) => sanitizeEvent(event))
     .filter((event) => event !== null);
 
   if (sanitized.length === 0) {
@@ -148,7 +150,7 @@ function normalizeEvents(input) {
   return [];
 }
 
-function sanitizeEvent(raw, now) {
+function sanitizeEvent(raw) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     return null;
   }
@@ -160,13 +162,11 @@ function sanitizeEvent(raw, now) {
   }
 
   const out = {
-    _time: eventTime(flattened, now),
-    event: eventName,
     proxy_version: 1,
   };
 
   for (const [key, value] of Object.entries(flattened)) {
-    if (!ALLOWED_FIELDS.has(key) || key === '_time' || key === 'event') {
+    if (!ALLOWED_FIELDS.has(key)) {
       continue;
     }
     const safe = sanitizeValue(value);
@@ -176,18 +176,6 @@ function sanitizeEvent(raw, now) {
   }
 
   return out;
-}
-
-function eventTime(event, fallback) {
-  const raw = Number(event.client_created_at_ms ?? event.created_at_ms);
-  if (!Number.isFinite(raw) || raw <= 0) {
-    return fallback.toISOString();
-  }
-  const timestamp = new Date(raw);
-  if (Number.isNaN(timestamp.getTime())) {
-    return fallback.toISOString();
-  }
-  return timestamp.toISOString();
 }
 
 function flattenEvent(raw) {

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -3,6 +3,8 @@ const DEFAULT_DATASET = 'socai-cli-prod';
 const MAX_BODY_BYTES = 128 * 1024;
 const MAX_EVENTS_PER_REQUEST = 100;
 const MAX_STRING_CHARS = 2_000;
+const MAX_METADATA_FIELDS = 20;
+const MAX_METADATA_KEY_CHARS = 80;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_EVENTS = 1_200;
 
@@ -28,8 +30,7 @@ const ALLOWED_FIELDS = new Set([
   'query_text',
   'query_len',
   'query_text_enabled',
-  'tab_label',
-  'num_notes',
+  'metadata',
   'duration_ms',
   'ok',
   'error',
@@ -169,7 +170,7 @@ function sanitizeEvent(raw) {
     if (!ALLOWED_FIELDS.has(key)) {
       continue;
     }
-    const safe = sanitizeValue(value);
+    const safe = key === 'metadata' ? sanitizeMetadata(value) : sanitizeValue(value);
     if (safe !== undefined) {
       out[key] = safe;
     }
@@ -198,6 +199,26 @@ function flattenEvent(raw) {
   return flattened;
 }
 
+function sanitizeMetadata(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const out = {};
+  for (const [rawKey, rawValue] of Object.entries(value).slice(0, MAX_METADATA_FIELDS)) {
+    const key = cleanMetadataKey(rawKey);
+    if (!key) {
+      continue;
+    }
+    const safe = sanitizeValue(rawValue);
+    if (safe !== undefined) {
+      out[key] = safe;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function sanitizeValue(value) {
   if (value === null) {
     return null;
@@ -212,6 +233,17 @@ function sanitizeValue(value) {
     default:
       return undefined;
   }
+}
+
+function cleanMetadataKey(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const key = value.trim().slice(0, MAX_METADATA_KEY_CHARS);
+  if (!/^[A-Za-z0-9_.-]+$/.test(key)) {
+    return undefined;
+  }
+  return key;
 }
 
 function cleanString(value) {

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -24,7 +24,6 @@ const ALLOWED_FIELDS = new Set([
   'tool_name',
   'query_text',
   'query_len',
-  'query_redacted',
   'query_text_enabled',
   'depth',
   'tab_label',
@@ -38,9 +37,6 @@ const ALLOWED_FIELDS = new Set([
   'notes_count',
   'notes_skipped_count',
   'has_run_dir',
-  'created_at_ms',
-  'client_created_at_ms',
-  'received_at_ms',
   'proxy_version',
 ]);
 
@@ -164,9 +160,8 @@ function sanitizeEvent(raw, now) {
   }
 
   const out = {
-    _time: now.toISOString(),
+    _time: eventTime(flattened, now),
     event: eventName,
-    received_at_ms: now.getTime(),
     proxy_version: 1,
   };
 
@@ -180,11 +175,19 @@ function sanitizeEvent(raw, now) {
     }
   }
 
-  if (out.created_at_ms !== undefined && out.client_created_at_ms === undefined) {
-    out.client_created_at_ms = out.created_at_ms;
-  }
-
   return out;
+}
+
+function eventTime(event, fallback) {
+  const raw = Number(event.client_created_at_ms ?? event.created_at_ms);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback.toISOString();
+  }
+  const timestamp = new Date(raw);
+  if (Number.isNaN(timestamp.getTime())) {
+    return fallback.toISOString();
+  }
+  return timestamp.toISOString();
 }
 
 function flattenEvent(raw) {

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -11,7 +11,7 @@ const ALLOWED_FIELDS = new Set([
   'event',
   'install_id',
   'distinct_id',
-  'daemon_session_id',
+  'session_id',
   'request_id',
   'schema_version',
   'app',
@@ -200,6 +200,10 @@ function flattenEvent(raw) {
   if (flattened.install_id === undefined && typeof flattened.distinct_id === 'string') {
     flattened.install_id = flattened.distinct_id;
   }
+  if (flattened.session_id === undefined && typeof flattened.daemon_session_id === 'string') {
+    flattened.session_id = flattened.daemon_session_id;
+  }
+  delete flattened.daemon_session_id;
   return flattened;
 }
 

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -38,8 +38,6 @@ const ALLOWED_FIELDS = new Set([
   'notes_count',
   'notes_skipped_count',
   'has_run_dir',
-  'telemetry_enabled',
-  'remote_enabled',
   'created_at_ms',
   'client_created_at_ms',
   'received_at_ms',

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,15 @@
 {
+  "functions": {
+    "api/telemetry.js": {
+      "maxDuration": 10
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/v1/events",
+      "destination": "/api/telemetry"
+    }
+  ],
   "redirects": [
     {
       "source": "/",


### PR DESCRIPTION
## summary

- add Vercel serverless telemetry proxy at `/v1/events` that validates, allowlists, rate-limits, and forwards events to Axiom
- replace the daemon's PostHog-oriented sender with a batched first-party proxy sender
- instrument CLI daemon command/search/tool lifecycle events and safe result metrics
- document opt-out/query-redaction controls and the default endpoint

## deployment/config

- Vercel env vars configured for `socai-site`:
  - production -> `socai-cli-prod`
  - preview/development -> `socai-cli-dev`
- deployed production manually to `https://socai.io`
- verified `POST https://socai.io/v1/events` returns `202` and events arrive in Axiom `socai-cli-prod`

## validation

- `node --check site/api/telemetry.js`
- `python3 -m json.tool site/vercel.json >/dev/null`
- `cargo check -p socai-cli`
- `cd site && pnpm build`
- preview proxy smoke test via `vercel curl` -> Axiom `socai-cli-dev`
- production proxy smoke test via `curl https://socai.io/v1/events` -> Axiom `socai-cli-prod`
- checked site routes:
  - `https://socai.io/` -> 200
  - `https://www.socai.io/` -> 308 to canonical host
  - `https://socai.io/download` -> GitHub DMG redirect
  - `https://socai.io/github` -> GitHub repo redirect

Part of #54. Contributes to #56, #58, #59, #61, and #62.
