### PR TITLE
Add --debug-snapshot recorder (DOM + a11y + screenshot timeline)

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -64,7 +64,7 @@ pub async fn tool_search_notes(
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · search_notes").await?;
-    let result = search_notes_command(page.clone(), &query).await;
+    let result = search_notes_command(page.clone(), &query, false).await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }
@@ -77,7 +77,7 @@ pub async fn tool_topic_scan(
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · topic_scan").await?;
-    let result = topic_scan_command(page.clone(), &query, None, num_notes).await;
+    let result = topic_scan_command(page.clone(), &query, None, num_notes, false).await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -199,22 +199,25 @@ async fn handle_request(
 impl DaemonState {
     async fn search_notes(&mut self, args: Value) -> Result<Value> {
         let query = required_string(&args, "query")?;
+        let debug_snapshot = debug_snapshot_flag(&args);
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        search_notes_command(page, &query).await
+        search_notes_command(page, &query, debug_snapshot).await
     }
 
     async fn topic_scan(&mut self, args: Value) -> Result<Value> {
         let query = required_string(&args, "query")?;
         let tab_label = args.get("tab_label").and_then(Value::as_str);
         let num_notes = args.get("num_notes").and_then(Value::as_i64);
+        let debug_snapshot = debug_snapshot_flag(&args);
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        topic_scan_command(page, &query, tab_label, num_notes).await
+        topic_scan_command(page, &query, tab_label, num_notes, debug_snapshot).await
     }
 
     async fn extract_note(&mut self, args: Value) -> Result<Value> {
         let note_id = required_string(&args, "note_id")?;
+        let debug_snapshot = debug_snapshot_flag(&args);
         let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-        extract_note_command(page, &note_id).await
+        extract_note_command(page, &note_id, debug_snapshot).await
     }
 
     async fn shutdown(&mut self) -> Result<()> {
@@ -311,6 +314,12 @@ async fn spawn_daemon() -> Result<()> {
         "socai rust daemon did not become ready; see {}",
         paths.log.display()
     ))
+}
+
+fn debug_snapshot_flag(args: &Value) -> bool {
+    args.get("debug_snapshot")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn required_string(args: &Value, key: &str) -> Result<String> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,10 @@ enum Command {
         query: String,
         #[arg(long)]
         pretty: bool,
+        /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
+        /// at every page change between tool operations.
+        #[arg(long = "debug-snapshot")]
+        debug_snapshot: bool,
     },
     /// Run a Xiaohongshu topic scan (note body + top comments per note).
     #[command(name = "topic_scan")]
@@ -34,6 +38,10 @@ enum Command {
         num_notes: Option<i64>,
         #[arg(long)]
         pretty: bool,
+        /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
+        /// at every page change between tool operations.
+        #[arg(long = "debug-snapshot")]
+        debug_snapshot: bool,
     },
     /// Open a note from the current search/topic page and print the parsed note.
     #[command(name = "extract_note")]
@@ -42,6 +50,10 @@ enum Command {
         note_id: String,
         #[arg(long)]
         pretty: bool,
+        /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
+        /// at every page change between tool operations.
+        #[arg(long = "debug-snapshot")]
+        debug_snapshot: bool,
     },
     /// Stop the background socai rust daemon.
     Stop,
@@ -64,10 +76,14 @@ async fn main() -> Result<()> {
         return Ok(());
     };
     match command {
-        Command::SearchNotes { query, pretty } => {
+        Command::SearchNotes {
+            query,
+            pretty,
+            debug_snapshot,
+        } => {
             let result = daemon::send_or_spawn(
                 "search_notes",
-                serde_json::json!({ "query": query }),
+                serde_json::json!({ "query": query, "debug_snapshot": debug_snapshot }),
                 daemon::DEFAULT_COMMAND_TIMEOUT,
             )
             .await?;
@@ -78,8 +94,9 @@ async fn main() -> Result<()> {
             tab,
             num_notes,
             pretty,
+            debug_snapshot,
         } => {
-            let mut input = serde_json::json!({ "query": query });
+            let mut input = serde_json::json!({ "query": query, "debug_snapshot": debug_snapshot });
             if let Some(tab) = tab {
                 input["tab_label"] = Value::String(tab);
             }
@@ -91,10 +108,14 @@ async fn main() -> Result<()> {
                 daemon::send_or_spawn("topic_scan", input, daemon::LONG_COMMAND_TIMEOUT).await?;
             print_command_result(&result, pretty)?;
         }
-        Command::ExtractNote { note_id, pretty } => {
+        Command::ExtractNote {
+            note_id,
+            pretty,
+            debug_snapshot,
+        } => {
             let result = daemon::send_or_spawn(
                 "extract_note",
-                serde_json::json!({ "note_id": note_id }),
+                serde_json::json!({ "note_id": note_id, "debug_snapshot": debug_snapshot }),
                 daemon::DEFAULT_COMMAND_TIMEOUT,
             )
             .await?;

--- a/core/src/cdp/mod.rs
+++ b/core/src/cdp/mod.rs
@@ -3,8 +3,10 @@ pub mod endpoint;
 pub mod lifecycle;
 pub mod pages;
 pub mod session;
+pub mod snapshot;
 
 pub use self::connection::{BrowserEvent, Cdp, CdpState, StatusPayload, TargetInfo};
+pub use self::snapshot::{with_snapshot_recording, SnapshotRecorder};
 pub use self::endpoint::{
     discover_existing_chrome_endpoint, open_remote_debugging_page, resolve_explicit_endpoint,
     wait_for_existing_chrome_endpoint, Endpoint,

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -1,21 +1,51 @@
 use std::path::Path;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
+use chromiumoxide::cdp::browser_protocol::accessibility::EnableParams;
 use chromiumoxide::cdp::browser_protocol::input::{
     DispatchKeyEventParams, DispatchKeyEventType, InsertTextParams,
 };
 use chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use chromiumoxide::layout::Point;
 use chromiumoxide::page::ScreenshotParams;
+use chromiumoxide::types::{Command, Method, MethodId};
 use chromiumoxide::Page;
+use serde::Serialize;
 use serde_json::Value;
+
+/// Raw `Accessibility.getFullAXTree` command whose response is left as
+/// untyped JSON. chromiumoxide's generated `GetFullAxTreeParams` deserializes
+/// the reply into its own `AxNode` structs, which lag the live Chrome AX
+/// schema and fail (the historical `uninteresting` serde error). We only want
+/// the JSON for the debug snapshot, so we skip the typed round-trip entirely.
+#[derive(Debug, Serialize)]
+struct GetFullAxTreeRaw {}
+
+impl Method for GetFullAxTreeRaw {
+    fn identifier(&self) -> MethodId {
+        "Accessibility.getFullAXTree".into()
+    }
+}
+
+impl Command for GetFullAxTreeRaw {
+    type Response = Value;
+}
+
+use super::snapshot::SnapshotRecorder;
 
 /// A tab-scoped session. Wraps a chromiumoxide `Page` with the small set of
 /// primitives the agent layer needs: `evaluate_json` (the JS-extractor entry
 /// point), `navigate`, and `page_info`. Higher-level tools (selector waits,
 /// click-by-selector, fill, etc.) live in the sites module.
+///
+/// `recorder` is an optional debug hook: when set (via `--debug-snapshot`),
+/// every `evaluate_json` — the universal perception point for the tools —
+/// first lets the recorder capture a DOM/a11y/screenshot bundle if the page
+/// changed since the last capture. See [`SnapshotRecorder`].
 pub struct PageSession {
     page: Page,
+    recorder: StdMutex<Option<Arc<SnapshotRecorder>>>,
 }
 
 const PAGE_INFO_JS: &str = r#"
@@ -34,11 +64,43 @@ return {
 
 impl PageSession {
     pub(crate) fn new(page: Page) -> Self {
-        Self { page }
+        Self {
+            page,
+            recorder: StdMutex::new(None),
+        }
     }
 
     pub fn target_id(&self) -> &str {
         self.page.target_id().inner()
+    }
+
+    /// Attach a debug snapshot recorder. Captures begin on the next
+    /// `evaluate_json`. Replacing or clearing it is cheap and lock-guarded.
+    pub fn set_recorder(&self, recorder: Arc<SnapshotRecorder>) {
+        if let Ok(mut guard) = self.recorder.lock() {
+            *guard = Some(recorder);
+        }
+    }
+
+    pub fn clear_recorder(&self) {
+        if let Ok(mut guard) = self.recorder.lock() {
+            *guard = None;
+        }
+    }
+
+    fn recorder(&self) -> Option<Arc<SnapshotRecorder>> {
+        self.recorder.lock().ok().and_then(|guard| guard.clone())
+    }
+
+    /// Let an attached recorder capture the page *before* an operation runs.
+    /// Called at the top of every action (`navigate`, `click`, `type_text`,
+    /// `press_key`) and every `evaluate_json`, so the snapshot timeline has a
+    /// frame for each tool operation, showing the state it acted on. Cheap and
+    /// a no-op when no recorder is attached; content-deduped downstream.
+    async fn snapshot_before(&self) {
+        if let Some(recorder) = self.recorder() {
+            recorder.before_operation(self).await;
+        }
     }
 
     /// Navigate to `url` and wait for DOM readiness.
@@ -51,6 +113,7 @@ impl PageSession {
         url: &str,
         timeout_seconds: f64,
     ) -> anyhow::Result<()> {
+        self.snapshot_before().await;
         let timeout = seconds(timeout_seconds);
         tokio::time::timeout(timeout, self.page.goto(url)).await??;
         self.wait_for_load_state("domcontentloaded", timeout_seconds)
@@ -89,11 +152,43 @@ impl PageSession {
     /// `serde_json::Value`. The expression is wrapped in an IIFE when it
     /// contains a top-level `return`, so callers can pass function-body style
     /// snippets.
+    ///
+    /// This is the tools' universal perception point. Before running the
+    /// caller's snippet, it lets an attached [`SnapshotRecorder`] capture the
+    /// *current* DOM — i.e. the state the tool is about to read or act on —
+    /// gated on whether the page changed since the last capture. Capturing
+    /// *before* (not after) means the snapshot reflects exactly what the tool
+    /// saw going into this operation; any change the operation causes is
+    /// captured before the next one.
     pub async fn evaluate_json(&self, expression: &str) -> anyhow::Result<Value> {
+        self.snapshot_before().await;
+        self.evaluate_json_raw(expression).await
+    }
+
+    /// Uninstrumented `evaluate_json`. Used internally by the snapshot recorder
+    /// so its own DOM reads don't recurse back into capture.
+    pub(crate) async fn evaluate_json_raw(&self, expression: &str) -> anyhow::Result<Value> {
         let wrapped = wrap_expression(expression);
         let result = self.page.evaluate(wrapped.as_str()).await?;
         let value: Value = result.into_value()?;
         Ok(value)
+    }
+
+    /// Turn on the CDP Accessibility domain. Not required for `getFullAXTree`
+    /// to return data, but it keeps `AXNodeId`s stable across calls, which makes
+    /// the per-node a11y dumps comparable between snapshots. The recorder calls
+    /// it once. Idempotent; persists across navigations within the target.
+    pub(crate) async fn enable_accessibility(&self) -> anyhow::Result<()> {
+        self.page.execute(EnableParams::default()).await?;
+        Ok(())
+    }
+
+    /// Full accessibility tree for the document as JSON (`{ "nodes": [...] }`).
+    /// Used by the snapshot recorder; backed by CDP `Accessibility.getFullAXTree`
+    /// with an untyped response (see [`GetFullAxTreeRaw`]).
+    pub(crate) async fn ax_tree_json(&self) -> anyhow::Result<Value> {
+        let resp = self.page.execute(GetFullAxTreeRaw {}).await?;
+        Ok(resp.result)
     }
 
     pub async fn page_info(&self) -> anyhow::Result<Value> {
@@ -101,16 +196,19 @@ impl PageSession {
     }
 
     pub async fn click(&self, x: f64, y: f64) -> anyhow::Result<()> {
+        self.snapshot_before().await;
         self.page.click(Point::new(x, y)).await?;
         Ok(())
     }
 
     pub async fn type_text(&self, text: &str) -> anyhow::Result<()> {
+        self.snapshot_before().await;
         self.page.execute(InsertTextParams::new(text)).await?;
         Ok(())
     }
 
     pub async fn press_key(&self, key: &str) -> anyhow::Result<()> {
+        self.snapshot_before().await;
         let (vk, code, text) = key_definition(key);
         let base = |event_type| {
             let mut builder = DispatchKeyEventParams::builder()

--- a/core/src/cdp/snapshot.rs
+++ b/core/src/cdp/snapshot.rs
@@ -1,0 +1,387 @@
+//! Optional page-snapshot recorder for debugging (`--debug-snapshot`).
+//!
+//! Rather than sampling on a fixed timer, the recorder hooks *before* every
+//! tool operation (each `evaluate_json`, plus `navigate`/`click`/`type_text`/
+//! `press_key`). The result is a timeline aligned to what the tool actually
+//! did: every search, scroll, note-open, and the intermediate frames of
+//! multi-second waits.
+//!
+//! Three gates keep the timeline lean, cheapest first:
+//!
+//! 1. A page-injected `MutationObserver` version counter — if the DOM hasn't
+//!    mutated at all since the last poll, skip without reading anything.
+//! 2. A **DOM hash** — if the serialized DOM is identical to the last frame we
+//!    examined, skip before taking a screenshot or reading the a11y tree
+//!    (e.g. the byte-identical skeleton frames a feed cycles through while
+//!    hydrating).
+//! 3. A **screenshot hash** — the DOM changed, but this framework simulates a
+//!    human driving the browser, so the real question is "would a human see
+//!    anything different?" If the viewport renders byte-identically to the last
+//!    written node, skip the frame anyway (e.g. a navigation whose new page
+//!    hasn't painted yet — different DOM/URL, same blank screen).
+//!
+//! Each capture node bundles three views taken back-to-back under one shared
+//! sequence number + timestamp, so DOM / a11y / screenshot line up for
+//! side-by-side debugging:
+//!
+//! ```text
+//! <run_dir>/snapshots/
+//!   index.jsonl                     # one line per node
+//!   00001_153012_482/
+//!     dom.html                      # document.documentElement.outerHTML
+//!     a11y.json                     # slimmed getFullAXTree (screen-reader view)
+//!     screenshot.png                # viewport PNG
+//!   00002_153013_771/
+//!     ...
+//! ```
+//!
+//! Every perception ultimately reads the live DOM (selectors,
+//! `getBoundingClientRect`, `innerText`), so this is a faithful record of what
+//! the tools "saw" at each step.
+
+use std::future::Future;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use super::session::PageSession;
+
+/// Run `fut` with a [`SnapshotRecorder`] attached to `page` for its duration,
+/// writing into `<run_dir>/snapshots`. A no-op when `enabled` is false.
+///
+/// This is the entire per-command surface for snapshot recording: any site's
+/// command runner can wrap its body in this call. The recorder hooks
+/// `evaluate_json` at the generic CDP layer, so the captured timeline needs no
+/// site-specific knowledge. The recorder is detached and a terminal frame
+/// flushed even if `fut` returns an error.
+pub async fn with_snapshot_recording<F, T>(
+    page: &PageSession,
+    run_dir: &Path,
+    enabled: bool,
+    fut: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    let recorder = enabled.then(|| {
+        let recorder = Arc::new(SnapshotRecorder::new(run_dir.join("snapshots")));
+        page.set_recorder(recorder.clone());
+        recorder
+    });
+
+    let out = fut.await;
+
+    if let Some(recorder) = recorder {
+        recorder.finish(page).await;
+        page.clear_recorder();
+    }
+    out
+}
+
+/// Installs a `MutationObserver` (once per page world) that bumps a version
+/// counter on any subtree/attribute/text mutation, and returns the current
+/// version plus URL. After a navigation the page world resets, so `installed`
+/// is false again and the observer is re-installed; the version restarts from
+/// 1, which the recorder detects as a change (via the URL or version delta).
+/// Written as an IIFE so `evaluate_json_raw` does not wrap it.
+const WATCH_JS: &str = r#"
+(function () {
+  var w = window.__socaiDomWatch;
+  if (!w) {
+    w = window.__socaiDomWatch = { v: 1, installed: false };
+  }
+  if (!w.installed) {
+    try {
+      var root = document.documentElement || document;
+      var obs = new MutationObserver(function () { w.v++; });
+      obs.observe(root, { subtree: true, childList: true, attributes: true, characterData: true });
+      w.installed = true;
+    } catch (e) {}
+  }
+  return { v: w.v, url: location.href };
+})()
+"#;
+
+/// Returns the full serialized DOM plus URL.
+const SNAPSHOT_JS: &str = r#"
+return {
+  html: document.documentElement ? document.documentElement.outerHTML : '',
+  url: location.href
+};
+"#;
+
+/// Records DOM/a11y/screenshot bundles whenever the page changes between tool
+/// operations. Attach to a [`PageSession`] via
+/// [`PageSession::set_recorder`](super::session::PageSession::set_recorder).
+pub struct SnapshotRecorder {
+    dir: PathBuf,
+    state: Mutex<RecorderState>,
+}
+
+struct RecorderState {
+    initialized: bool,
+    a11y_enabled: bool,
+    seq: u64,
+    last_version: i64,
+    last_url: String,
+    /// Hash of the last DOM we examined. Lets consecutive identical DOMs skip
+    /// before the (more expensive) screenshot and a11y reads.
+    last_dom_hash: Option<u64>,
+    /// Hash of the last written node's screenshot. Frames whose DOM changed but
+    /// render to a pixel-identical viewport are skipped — a human wouldn't
+    /// perceive them as a new state.
+    last_shot_hash: Option<u64>,
+}
+
+impl SnapshotRecorder {
+    /// `dir` is the snapshots root (e.g. `<run_dir>/snapshots`); created lazily
+    /// on the first captured node.
+    pub fn new(dir: PathBuf) -> Self {
+        Self {
+            dir,
+            state: Mutex::new(RecorderState {
+                initialized: false,
+                a11y_enabled: false,
+                seq: 0,
+                last_version: -1,
+                last_url: String::new(),
+                last_dom_hash: None,
+                last_shot_hash: None,
+            }),
+        }
+    }
+
+    /// Capture the current page if it changed since the last node. Called
+    /// before each tool operation.
+    pub async fn before_operation(&self, page: &PageSession) {
+        let mut state = self.state.lock().await;
+        self.capture(&mut state, page, false).await;
+    }
+
+    /// Capture the terminal page state once, after the command's last
+    /// operation and before the page is closed/reused. By this point the data
+    /// the command produced is already in the DOM (the tool just read it), so a
+    /// single capture suffices; the `force` flag bypasses the version gate so
+    /// this post-operation state is examined even if no further mutation fired.
+    pub async fn finish(&self, page: &PageSession) {
+        let mut state = self.state.lock().await;
+        self.capture(&mut state, page, true).await;
+    }
+
+    async fn capture(&self, state: &mut RecorderState, page: &PageSession, force: bool) {
+        // Cheap version probe (raw eval → no recursion into the recorder).
+        let probe = page.evaluate_json_raw(WATCH_JS).await.ok();
+        let version = probe
+            .as_ref()
+            .and_then(|v| v.get("v"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        let url = probe
+            .as_ref()
+            .and_then(|v| v.get("url"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        // First gate: nothing mutated since the last poll → skip without even
+        // taking a screenshot. Mark version/url as seen so an identical next
+        // poll also early-outs here.
+        let version_changed =
+            !(state.initialized && version == state.last_version && url == state.last_url);
+        if !version_changed && !force {
+            return;
+        }
+        state.initialized = true;
+        state.last_version = version;
+        state.last_url = url.clone();
+
+        // Second gate (cheap): the DOM mutated, but is the serialized DOM
+        // actually different from the last frame we examined? If not, skip
+        // before paying for a screenshot or the a11y tree.
+        let dom = page
+            .evaluate_json_raw(SNAPSHOT_JS)
+            .await
+            .ok()
+            .and_then(|v| v.get("html").and_then(Value::as_str).map(str::to_owned))
+            .unwrap_or_default();
+        let dom_hash = hash_bytes(dom.as_bytes());
+        if state.last_dom_hash == Some(dom_hash) {
+            return;
+        }
+        state.last_dom_hash = Some(dom_hash);
+
+        // Third gate: the DOM differs, but does the page *look* any different?
+        // Take the viewport screenshot and skip the node if it's pixel-identical
+        // to the last one written. A failed screenshot can't be deduped, so fall
+        // through and capture the node anyway.
+        let shot = page.screenshot_png(false).await.ok();
+        if let Some(bytes) = &shot {
+            let shot_hash = hash_bytes(bytes);
+            if state.last_shot_hash == Some(shot_hash) {
+                return;
+            }
+            state.last_shot_hash = Some(shot_hash);
+        }
+
+        // Enable the Accessibility domain once so AXNodeIds stay stable across
+        // nodes (not required for getFullAXTree to return data).
+        if !state.a11y_enabled && page.enable_accessibility().await.is_ok() {
+            state.a11y_enabled = true;
+        }
+
+        state.seq += 1;
+        let seq = state.seq;
+
+        if let Err(err) = self.write_node(page, seq, &url, &dom, shot.as_deref()).await {
+            tracing::warn!("debug-snapshot: node {seq} failed: {err:#}");
+        }
+    }
+
+    async fn write_node(
+        &self,
+        page: &PageSession,
+        seq: u64,
+        url: &str,
+        dom: &str,
+        shot: Option<&[u8]>,
+    ) -> anyhow::Result<()> {
+        // One timestamp + one folder for all three views, so they share a
+        // synchronized timepoint label. DOM and screenshot were captured moments
+        // ago (for the dedup gates); the a11y tree is read here.
+        let now = chrono::Local::now();
+        let node_name = format!("{:05}_{}", seq, now.format("%H%M%S_%3f"));
+        let node_dir = self.dir.join(&node_name);
+        tokio::fs::create_dir_all(&node_dir).await?;
+
+        tokio::fs::write(node_dir.join("dom.html"), dom).await?;
+
+        let (a11y_ok, a11y_nodes) = match page.ax_tree_json().await {
+            Ok(ax) => {
+                // getFullAXTree is a raw debug dump: every node (incl. ignored)
+                // plus protocol metadata (name.sources, chromeRole, frameId, …).
+                // Slim it to the screen-reader view — role + name + states +
+                // structure — which is ~5x smaller.
+                let tree = compact_ax_tree(&ax);
+                let nodes = tree
+                    .get("nodes")
+                    .and_then(Value::as_array)
+                    .map(Vec::len)
+                    .unwrap_or(0);
+                let pretty = serde_json::to_vec_pretty(&tree)?;
+                tokio::fs::write(node_dir.join("a11y.json"), pretty).await?;
+                (true, nodes)
+            }
+            Err(err) => {
+                tracing::warn!("debug-snapshot: a11y for node {seq} failed: {err:#}");
+                (false, 0)
+            }
+        };
+
+        if let Some(bytes) = shot {
+            tokio::fs::write(node_dir.join("screenshot.png"), bytes).await?;
+        }
+
+        let entry = serde_json::json!({
+            "seq": seq,
+            "ts": now.to_rfc3339(),
+            "url": url,
+            "dir": node_name,
+            "dom_bytes": dom.len(),
+            "a11y_nodes": a11y_nodes,
+            "has_a11y": a11y_ok,
+            "has_screenshot": shot.is_some(),
+        });
+        append_jsonl(&self.dir.join("index.jsonl"), &entry).await
+    }
+}
+
+/// Reduce a raw `getFullAXTree` reply to the semantic tree a screen reader
+/// actually navigates: drop `ignored` nodes and keep, per node, only the role,
+/// accessible name, value, meaningful states, and child links. Structure is
+/// preserved via `children` (the original `AXNodeId`s).
+fn compact_ax_tree(ax: &Value) -> Value {
+    let nodes = ax
+        .get("nodes")
+        .and_then(Value::as_array)
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter(|n| !n.get("ignored").and_then(Value::as_bool).unwrap_or(false))
+                .map(compact_ax_node)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    serde_json::json!({ "nodes": nodes })
+}
+
+fn compact_ax_node(node: &Value) -> Value {
+    let mut out = serde_json::Map::new();
+
+    if let Some(id) = node.get("nodeId").cloned() {
+        out.insert("id".into(), id);
+    }
+    if let Some(role) = node.get("role").and_then(|r| r.get("value")).cloned() {
+        out.insert("role".into(), role);
+    }
+    if let Some(name) = node.get("name").and_then(|n| n.get("value")) {
+        if name.as_str() != Some("") {
+            out.insert("name".into(), name.clone());
+        }
+    }
+    if let Some(value) = node.get("value").and_then(|v| v.get("value")) {
+        if value.as_str() != Some("") {
+            out.insert("value".into(), value.clone());
+        }
+    }
+
+    // States/properties, flattened to `{ name: value }`, dropping the noisy
+    // false/empty defaults that dominate the raw tree.
+    let mut states = serde_json::Map::new();
+    if let Some(props) = node.get("properties").and_then(Value::as_array) {
+        for prop in props {
+            let Some(name) = prop.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(value) = prop.get("value").and_then(|v| v.get("value")) else {
+                continue;
+            };
+            if value.as_bool() == Some(false) || value.as_str() == Some("") {
+                continue;
+            }
+            states.insert(name.to_string(), value.clone());
+        }
+    }
+    if !states.is_empty() {
+        out.insert("states".into(), Value::Object(states));
+    }
+
+    if let Some(children) = node.get("childIds").and_then(Value::as_array) {
+        if !children.is_empty() {
+            out.insert("children".into(), Value::Array(children.clone()));
+        }
+    }
+
+    Value::Object(out)
+}
+
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write(bytes);
+    hasher.finish()
+}
+
+async fn append_jsonl(path: &Path, entry: &Value) -> anyhow::Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let mut line = serde_json::to_string(entry)?;
+    line.push('\n');
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    file.write_all(line.as_bytes()).await?;
+    Ok(())
+}

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use crate::agent::{make_run_dir, Backend as LlmProvider, Tool, ToolContext, ToolResult};
-use crate::cdp::PageSession;
+use crate::cdp::{with_snapshot_recording, PageSession};
 use crate::media::{timing_delta, MediaProcessor, TimingSnapshot};
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -125,8 +125,18 @@ const EXTRACT_NOTE_COMMAND: XhsCommandSpec = XhsCommandSpec {
     after: CommandPageAction::CloseOpenNote,
 };
 
-pub async fn search_notes_command(page: Arc<PageSession>, query: &str) -> anyhow::Result<Value> {
-    run_xhs_tool_command(page, SEARCH_NOTES_COMMAND, search_notes_input(query)?).await
+pub async fn search_notes_command(
+    page: Arc<PageSession>,
+    query: &str,
+    debug_snapshot: bool,
+) -> anyhow::Result<Value> {
+    run_xhs_tool_command(
+        page,
+        SEARCH_NOTES_COMMAND,
+        search_notes_input(query)?,
+        debug_snapshot,
+    )
+    .await
 }
 
 pub async fn topic_scan_command(
@@ -134,17 +144,29 @@ pub async fn topic_scan_command(
     query: &str,
     tab_label: Option<&str>,
     num_notes: Option<i64>,
+    debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         TOPIC_SCAN_COMMAND,
         topic_scan_input(query, tab_label, num_notes)?,
+        debug_snapshot,
     )
     .await
 }
 
-pub async fn extract_note_command(page: Arc<PageSession>, note_id: &str) -> anyhow::Result<Value> {
-    run_xhs_tool_command(page, EXTRACT_NOTE_COMMAND, extract_note_input(note_id)?).await
+pub async fn extract_note_command(
+    page: Arc<PageSession>,
+    note_id: &str,
+    debug_snapshot: bool,
+) -> anyhow::Result<Value> {
+    run_xhs_tool_command(
+        page,
+        EXTRACT_NOTE_COMMAND,
+        extract_note_input(note_id)?,
+        debug_snapshot,
+    )
+    .await
 }
 
 fn search_notes_input(query: &str) -> anyhow::Result<Value> {
@@ -180,11 +202,21 @@ async fn run_xhs_tool_command(
     page: Arc<PageSession>,
     spec: XhsCommandSpec,
     input: Value,
+    debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
-    apply_command_page_action(spec.before, &page).await?;
     let (run_dir, ctx) = command_context(spec.command_name);
-    let data = call_xhs_tool(page.clone(), spec.tool_name, input, &ctx).await?;
-    apply_command_page_action(spec.after, &page).await?;
+    // Snapshot recording (when `--debug-snapshot` is on) wraps the whole
+    // command — setup navigation, the tool's clicks/scrolls, and teardown. All
+    // recorder machinery lives in the generic CDP layer; this is the only hook
+    // a site command runner needs.
+    let data = with_snapshot_recording(&page, &ctx.run_dir, debug_snapshot, async {
+        apply_command_page_action(spec.before, &page).await?;
+        let data = call_xhs_tool(page.clone(), spec.tool_name, input, &ctx).await?;
+        apply_command_page_action(spec.after, &page).await?;
+        Ok::<Value, anyhow::Error>(data)
+    })
+    .await?;
+
     Ok(json!({
         "command": spec.command_name,
         "run_dir": run_dir,


### PR DESCRIPTION
Capture a per-operation snapshot timeline for debugging the XHS browser agent. The recorder hooks the generic CDP layer (PageSession) before every tool operation — each evaluate_json plus navigate/click/type_text/press_key — so the timeline is site-agnostic; a site command runner just wraps its body in with_snapshot_recording().

Each captured node bundles three synchronized views under one seq + timestamp:
- dom.html      — document.documentElement.outerHTML
- a11y.json     — getFullAXTree, slimmed to the screen-reader view
- screenshot.png — viewport PNG

Three dedup gates keep the timeline lean (cheapest first): MutationObserver version counter, DOM content hash, then screenshot hash (skip frames a human couldn't visually distinguish). finish() force-captures the terminal state before the page is closed.

Notes:
- a11y uses an untyped raw getFullAXTree command; chromiumoxide_cdp 0.7's typed AxNode lags the live Chrome schema and fails to deserialize.
- a11y.json is compacted to role/name/value/states/children with ignored nodes dropped (~5x smaller than the raw dump).

Wired through the CLI (--debug-snapshot on search_notes/topic_scan/ extract_note) and the daemon; the Tauri app passes false.