### PR TITLE
docs: add telemetry runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Desktop App
 
-[Download .dmg for Mac](https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg). 
+[Download .dmg for Mac](https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg).
 
 For local development:
 
@@ -44,12 +44,17 @@ Add `--pretty` to any tool command for indented JSON.
 continuation command: a prior `search_notes` / `topic_scan` must have left the
 tool tab on a waterfall containing the target card.
 
-Telementry can be turned off with additional flags
+CLI telemetry sends one sanitized trace per tool command to the first-party
+socai proxy. Query text is included by default; use these environment variables
+when you want to redact or disable telemetry for a command:
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
 SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路"               # disable telemetry for this command
 ```
+
+See the [telemetry runbook](docs/telemetry-runbook.md) for user-facing behavior,
+local buffer paths, maintainer operations, and smoke-test steps.
 
 ## TUI
 
@@ -76,6 +81,7 @@ The build output is written to `site/dist/`. Deployment settings are documented 
 ## Documentation
 
 - [Data model](docs/data-model.md) — run artifacts, desktop task index, and timeline replay.
+- [Telemetry runbook](docs/telemetry-runbook.md) — CLI telemetry controls, local buffer, and maintainer operations.
 
 ## 欢迎加群交流
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,14 @@ Add `--pretty` to any tool command for indented JSON.
 continuation command: a prior `search_notes` / `topic_scan` must have left the
 tool tab on a waterfall containing the target card.
 
-CLI telemetry sends one sanitized trace per tool command to the first-party
-socai proxy. Query text is included by default; use these environment variables
-when you want to redact or disable telemetry for a command:
+CLI telemetry is enabled by default, and search query text is included by
+default. Use these environment variables when you want to redact query text or
+disable telemetry for a command:
 
 ```bash
 SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"    # keep telemetry, redact query text
 SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路"               # disable telemetry for this command
 ```
-
-See the [telemetry runbook](docs/telemetry-runbook.md) for user-facing behavior,
-local buffer paths, maintainer operations, and smoke-test steps.
 
 ## TUI
 
@@ -81,7 +78,6 @@ The build output is written to `site/dist/`. Deployment settings are documented 
 ## Documentation
 
 - [Data model](docs/data-model.md) — run artifacts, desktop task index, and timeline replay.
-- [Telemetry runbook](docs/telemetry-runbook.md) — CLI telemetry controls, local buffer, and maintainer operations.
 
 ## 欢迎加群交流
 

--- a/docs/development/telemetry-runbook.md
+++ b/docs/development/telemetry-runbook.md
@@ -1,13 +1,14 @@
-# socai telemetry runbook
+# socai telemetry maintainer runbook
 
-This page describes socai CLI telemetry for users and maintainers. The final
-implementation sends one sanitized trace per top-level CLI tool command through
-the first-party endpoint at `https://socai.io/v1/events`.
+This is development/maintainer documentation for operating socai CLI telemetry.
+It intentionally lives outside the README: the README should stay focused on
+what CLI users need to run socai and control telemetry.
 
-For the exact field contract, see the telemetry schema doc when issue #55 lands.
-This runbook focuses on user controls and operational procedures.
+The final implementation sends one sanitized trace per top-level CLI tool
+command through the first-party endpoint at `https://socai.io/v1/events`.
+For the exact field contract, see [`../telemetry-schema.md`](../telemetry-schema.md).
 
-## User-facing behavior
+## Product behavior summary
 
 socai uses telemetry to understand whether CLI commands work reliably, how long
 they take, which tools are used, and what result sizes look like. This helps us
@@ -31,6 +32,8 @@ socai does not intentionally send note bodies, comments, images, browser cookies
 API keys, raw tool output bodies, or Axiom credentials.
 
 ## User controls
+
+The README should document only these user controls, not proxy/Axiom internals.
 
 Disable telemetry for a single command:
 
@@ -133,7 +136,7 @@ Do not put environment variable values in the repo, in docs, in PR comments, or
 in public build logs.
 
 Deployment details for the site project live in
-[`docs/website-deployment.md`](website-deployment.md).
+[`../website-deployment.md`](../website-deployment.md).
 
 ## Axiom datasets
 

--- a/docs/telemetry-runbook.md
+++ b/docs/telemetry-runbook.md
@@ -1,0 +1,243 @@
+# socai telemetry runbook
+
+This page describes socai CLI telemetry for users and maintainers. The final
+implementation sends one sanitized trace per top-level CLI tool command through
+the first-party endpoint at `https://socai.io/v1/events`.
+
+For the exact field contract, see the telemetry schema doc when issue #55 lands.
+This runbook focuses on user controls and operational procedures.
+
+## User-facing behavior
+
+socai uses telemetry to understand whether CLI commands work reliably, how long
+they take, which tools are used, and what result sizes look like. This helps us
+prioritize fixes for search, note extraction, and topic scans.
+
+Telemetry is enabled by default. Search query text is included by default because
+it is the main signal for understanding user intent and result quality.
+
+Each supported daemon command emits one trace:
+
+- `search_notes`
+- `topic_scan`
+- `extract_note`
+
+The trace includes safe operational context such as command name, tool name,
+duration, success/failure, result counts, app version, platform, OS details,
+approximate device capacity, terminal app, and explicitly provided optional CLI
+parameters under `metadata`.
+
+socai does not intentionally send note bodies, comments, images, browser cookies,
+API keys, raw tool output bodies, or Axiom credentials.
+
+## User controls
+
+Disable telemetry for a single command:
+
+```bash
+SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路"
+```
+
+Redact query text while keeping the rest of the telemetry trace:
+
+```bash
+SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路"
+```
+
+Accepted off values are:
+
+```text
+0
+false
+off
+disabled
+no
+```
+
+These controls are evaluated by the CLI request, so they also work when reusing
+an existing daemon process.
+
+## Local telemetry buffer
+
+The daemon writes a local JSONL buffer for debugging and replay:
+
+```text
+~/.socai/telemetry/events.jsonl
+```
+
+If `SOCAI_HOME` is set, the path is:
+
+```text
+$SOCAI_HOME/telemetry/events.jsonl
+```
+
+Example inspection:
+
+```bash
+tail -n 5 ~/.socai/telemetry/events.jsonl
+```
+
+The local buffer is a debugging aid. It can contain internal fields, such as the
+client-side validation event name and local creation timestamp, that the proxy
+strips before forwarding to Axiom.
+
+## Upgrade note: restart old daemons
+
+A previously running daemon keeps using the code from the old installed binary.
+After upgrading socai, stop the old daemon before validating telemetry behavior:
+
+```bash
+socai stop
+```
+
+The next CLI command will start a fresh daemon from the new binary.
+
+## Maintainer architecture
+
+```text
+socai CLI daemon
+  -> local JSONL buffer
+  -> https://socai.io/v1/events
+  -> Vercel serverless proxy
+  -> Axiom dataset
+```
+
+Important files:
+
+- CLI telemetry worker: `cli/src/tracking.rs`
+- daemon instrumentation: `cli/src/daemon.rs`
+- Vercel proxy: `site/api/telemetry.js`
+- Vercel rewrite/runtime config: `site/vercel.json`
+
+The public CLI must never embed an Axiom token. The CLI sends unauthenticated
+telemetry to the first-party socai endpoint, and the server-side proxy adds the
+Axiom authorization from Vercel environment variables.
+
+## Vercel configuration
+
+Production project:
+
+- Vercel team/scope: `socai-d83824c8`
+- Vercel project: `socai-site`
+- Production domain: `https://socai.io`
+- Telemetry route: `https://socai.io/v1/events`
+
+Server-side environment variable names:
+
+- `AXIOM_TOKEN`
+- `AXIOM_DATASET`
+- `AXIOM_URL`
+- `AXIOM_ORG_ID`
+
+Do not put environment variable values in the repo, in docs, in PR comments, or
+in public build logs.
+
+Deployment details for the site project live in
+[`docs/website-deployment.md`](website-deployment.md).
+
+## Axiom datasets
+
+Current datasets:
+
+- production: `socai-cli-prod`
+- development/testing: `socai-cli-dev`
+
+Older rows in the production dataset may have created columns that the current
+proxy no longer forwards, such as `event`, `arch`, or custom timestamp fields.
+Axiom can still show those fields as `null` on new rows because the dataset has
+historical schema state.
+
+## Production smoke test
+
+Use this only when validating the proxy/deploy path. It sends a synthetic trace
+to the production dataset through `https://socai.io/v1/events`.
+
+```bash
+request_id="runbook-smoke-$(date +%s)"
+
+curl -sS -X POST https://socai.io/v1/events \
+  -H 'Content-Type: application/json' \
+  --data "{\"events\":[{\"event\":\"socai_runbook_smoke_test\",\"install_id\":\"00000000-0000-4000-8000-000000000061\",\"session_id\":\"00000000-0000-4000-8000-000000000062\",\"request_id\":\"${request_id}\",\"source\":\"runbook_smoke_test\",\"command\":\"topic_scan\",\"tool_name\":\"topic_scan\",\"query_text_enabled\":false,\"metadata\":{\"num_notes\":1},\"duration_ms\":1,\"ok\":true}]}"
+```
+
+Expected response:
+
+```json
+{"ok":true,"accepted":1}
+```
+
+If you have Axiom CLI access, verify ingestion:
+
+```bash
+axiom query "['socai-cli-prod'] | where request_id == '${request_id}' | limit 1" \
+  --start-time=-15m \
+  --format=json \
+  --no-spinner
+```
+
+The resulting row should include `request_id`, `command`, `tool_name`, `ok`, and
+`metadata.num_notes`. It should not include non-null custom `event`, `arch`,
+`created_at_ms`, `client_created_at_ms`, or `received_at_ms` values.
+
+## CLI smoke checks
+
+When validating a release candidate or local build, restart the daemon first:
+
+```bash
+socai stop || true
+```
+
+Then run one command that should emit one trace:
+
+```bash
+socai topic_scan "运营爆款思路" --num-notes 1
+```
+
+Validate query redaction:
+
+```bash
+SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路" --num-notes 1
+```
+
+Validate full telemetry disable:
+
+```bash
+SOCAI_TELEMETRY=off socai topic_scan "运营爆款思路" --num-notes 1
+```
+
+Use Axiom or the local JSONL buffer to confirm the expected behavior.
+
+## Troubleshooting missing events
+
+1. Stop the old daemon and rerun the command:
+
+   ```bash
+   socai stop || true
+   ```
+
+2. Confirm the CLI request did not disable telemetry with `SOCAI_TELEMETRY=off`.
+3. Check the local JSONL buffer. If the local trace is missing, inspect daemon
+   logs and command errors first.
+4. Confirm the proxy responds:
+
+   ```bash
+   curl -i -X OPTIONS https://socai.io/v1/events
+   ```
+
+5. Confirm Vercel project env vars are present for production and that the
+   deployment includes `site/api/telemetry.js` and `site/vercel.json`.
+6. Check Vercel function logs for `telemetry forward failed`.
+7. Check Axiom query time range, dataset selection, and field filters. Remember
+   that old schema columns can appear as `null` on new rows.
+8. If the endpoint works but Axiom has no row, verify the server-side Axiom token
+   and dataset configuration in Vercel without exposing the values.
+
+## Security and privacy rules
+
+- Never commit Axiom token values.
+- Never commit local `.socai` telemetry files.
+- Never add a public CLI telemetry endpoint override.
+- Keep the Axiom token server-side in Vercel only.
+- Use synthetic IDs and no real query text for manual production smoke tests.
+- Treat query text as user data; use `SOCAI_TELEMETRY_QUERY_TEXT=off` in demos or
+  tests where the query should not leave the machine.


### PR DESCRIPTION
## Summary
- add a user-facing telemetry behavior guide and maintainer runbook
- document telemetry controls, local JSONL buffer paths, daemon restart note, fixed proxy endpoint, Vercel env var names, Axiom datasets, smoke tests, and troubleshooting
- link the runbook from the README telemetry section and docs list

Closes #61

## Validation
- verified linked docs exist with a Python link check
- checked README/runbook whitespace sanity
- scanned the diff for token-looking strings and local secret-file references
- markdownlint not installed locally; skipped

## Notes
- no token values or local .socai data are included
- this intentionally avoids duplicating the full field-by-field schema work tracked by #55