### PR TITLE
docs: add telemetry release smoke test

### DIFF
--- a/docs/telemetry-release-smoke-test.md
+++ b/docs/telemetry-release-smoke-test.md
@@ -1,0 +1,210 @@
+# Telemetry release smoke test
+
+Use this runbook before publishing a CLI release, and again after installing the
+published artifact, to verify that release telemetry still uses the first-party
+proxy and does not expose Axiom credentials.
+
+The smoke test intentionally does **not** require an Axiom token in the CLI or in
+repo files. Axiom access is only needed by the maintainer running verification,
+through their local `axiom` CLI login or server-side proxy configuration.
+
+## What this verifies
+
+- The release-candidate binary contains the fixed proxy endpoint:
+  `https://socai.io/v1/events`.
+- The client binary does not contain Axiom endpoint/env/token strings.
+- The test starts from a stopped daemon so old daemon processes do not emit old
+  telemetry shapes.
+- A normal CLI command emits one tool trace through the production proxy.
+- `SOCAI_TELEMETRY=off` emits no telemetry row for that command.
+- `SOCAI_TELEMETRY_QUERY_TEXT=off` keeps telemetry on but omits `query_text`.
+
+## Prerequisites
+
+- A release-candidate `socai` binary, or a checkout that can build one with
+  `cargo build -p socai-cli --release`.
+- Browser/session prerequisites needed by the command being tested.
+- Network access to `https://socai.io/v1/events`.
+- For remote Axiom checks: authenticated `axiom` CLI access to `socai-cli-prod`.
+  Do not put Axiom tokens in the repo or pass them to the `socai` binary.
+
+## Automated helper
+
+From the repository root:
+
+```bash
+scripts/telemetry-release-smoke-test.sh
+```
+
+By default the helper performs static binary checks only. It builds
+`target/release/socai` unless `--skip-build` is passed, then verifies:
+
+1. the binary contains `https://socai.io/v1/events`; and
+2. the binary does not contain Axiom-specific client strings such as
+   `AXIOM_TOKEN`, `AXIOM_DATASET`, `AXIOM_URL`, `AXIOM_ORG_ID`, or
+   `api.axiom.co`.
+
+To run live telemetry checks against the production proxy and Axiom:
+
+```bash
+scripts/telemetry-release-smoke-test.sh --live
+```
+
+Useful options:
+
+```bash
+scripts/telemetry-release-smoke-test.sh --bin /path/to/socai --skip-build
+scripts/telemetry-release-smoke-test.sh --live --dataset socai-cli-prod
+scripts/telemetry-release-smoke-test.sh --live --skip-axiom   # local JSONL checks only
+scripts/telemetry-release-smoke-test.sh --live --keep-home    # keep temp SOCAI_HOME
+```
+
+The helper uses an isolated temporary `SOCAI_HOME`, runs `socai stop` before the
+checks, and writes no secrets. In `--live` mode it runs `search_notes` three
+times with unique smoke-test query strings:
+
+1. default telemetry/query behavior;
+2. `SOCAI_TELEMETRY=off`; and
+3. `SOCAI_TELEMETRY_QUERY_TEXT=off`.
+
+Command failures are reported but do not immediately abort the telemetry check,
+because failed tool commands should still emit a failure trace. If no local
+telemetry row appears, the helper fails.
+
+## Manual checks
+
+If the helper is not suitable for the release environment, use these steps.
+
+### 1. Build or install the release candidate
+
+```bash
+cargo build -p socai-cli --release
+bin=target/release/socai
+```
+
+For a packaged artifact, set `bin` to the installed binary path.
+
+### 2. Verify fixed endpoint and no Axiom client config
+
+```bash
+strings "$bin" | grep -F 'https://socai.io/v1/events'
+
+if strings "$bin" | grep -E 'AXIOM_(TOKEN|DATASET|URL|ORG_ID)|api\.axiom\.co'; then
+  echo 'unexpected Axiom client string found' >&2
+  exit 1
+fi
+```
+
+Expected result: the first command prints the first-party proxy endpoint; the
+second command prints nothing and exits through the non-error path.
+
+### 3. Start from a clean daemon
+
+Use an isolated home so this smoke test does not affect the maintainer's normal
+socai daemon or telemetry identity:
+
+```bash
+export SOCAI_HOME="$(mktemp -d "${TMPDIR:-/tmp}/socai-telemetry-smoke.XXXXXX")"
+"$bin" stop || true
+```
+
+### 4. Verify default telemetry emits one trace
+
+```bash
+query="socai-telemetry-smoke-$(date +%s)-default"
+"$bin" search_notes "$query" || true
+```
+
+Inspect the local JSONL buffer:
+
+```bash
+python3 - "$SOCAI_HOME/telemetry/events.jsonl" "$query" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+query = sys.argv[2]
+rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+assert len(rows) == 1, len(rows)
+props = rows[-1]['properties']
+assert props['query_text_enabled'] is True, props
+assert props['query_text'] == query, props
+assert props['request_id'], props
+print(props['request_id'])
+PY
+```
+
+Use the printed `request_id` to confirm production Axiom ingestion:
+
+```bash
+request_id='<printed-request-id>'
+axiom query "['socai-cli-prod'] | where request_id == '$request_id' | limit 1" \
+  --start-time=-30m \
+  --format=json \
+  --no-spinner
+```
+
+Expected result: one Axiom row for that `request_id`. Existing Axiom datasets may
+still show removed legacy columns as `null`; that does not mean the current
+client/proxy sent those fields.
+
+### 5. Verify full opt-out
+
+```bash
+before=$(wc -l < "$SOCAI_HOME/telemetry/events.jsonl")
+query="socai-telemetry-smoke-$(date +%s)-optout"
+SOCAI_TELEMETRY=off "$bin" search_notes "$query" || true
+sleep 5
+after=$(wc -l < "$SOCAI_HOME/telemetry/events.jsonl")
+test "$before" = "$after"
+```
+
+Optionally confirm no production row exists for the unique query text:
+
+```bash
+axiom query "['socai-cli-prod'] | where query_text == '$query' | limit 1" \
+  --start-time=-30m \
+  --format=json \
+  --no-spinner
+```
+
+Expected result: no output.
+
+### 6. Verify query redaction
+
+```bash
+query="socai-telemetry-smoke-$(date +%s)-redacted"
+SOCAI_TELEMETRY_QUERY_TEXT=off "$bin" search_notes "$query" || true
+```
+
+Inspect the newest local row:
+
+```bash
+python3 - "$SOCAI_HOME/telemetry/events.jsonl" <<'PY'
+import json, pathlib, sys
+rows = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+props = rows[-1]['properties']
+assert props['query_text_enabled'] is False, props
+assert 'query_text' not in props, props
+assert props['request_id'], props
+print(props['request_id'])
+PY
+```
+
+Then query Axiom by the printed `request_id` and confirm `query_text` is absent
+or `null`.
+
+### 7. Clean up
+
+```bash
+"$bin" stop || true
+rm -rf "$SOCAI_HOME"
+unset SOCAI_HOME
+```
+
+## Release notes reminder
+
+After installing an updated CLI, users with an existing background daemon should
+restart it so the new telemetry shape is used:
+
+```bash
+socai stop
+```

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -1,0 +1,307 @@
+# CLI telemetry schema
+
+This document is the current schema, privacy, and configuration contract for
+socai CLI daemon telemetry. It describes the implementation merged in PR #63.
+
+The finalized model is **one sanitized trace per top-level CLI tool command**.
+Telemetry is not a stream of lifecycle events, and the public CLI does not talk
+to PostHog or Axiom directly.
+
+## Transport and ownership
+
+```text
+socai CLI daemon
+  -> first-party socai proxy: https://socai.io/v1/events
+      -> Axiom dataset
+```
+
+- The CLI endpoint is fixed at `https://socai.io/v1/events`.
+- The public CLI must not include an Axiom token, Axiom dataset secret, or user
+  configurable telemetry endpoint.
+- The Axiom token and dataset configuration live only in Vercel environment
+  variables for the proxy.
+- Telemetry send failures are best-effort and must not fail user commands.
+- The daemon also writes a local JSONL debug buffer under
+  `~/.socai/telemetry/events.jsonl`, or `$SOCAI_HOME/telemetry/events.jsonl`
+  when `SOCAI_HOME` is set.
+
+Source references:
+
+- CLI enrichment, identity, endpoint, and local JSONL:
+  `cli/src/tracking.rs`
+- Command trace shape and safe result metrics: `cli/src/daemon.rs`
+- Proxy allowlist, sanitization, and Axiom forwarding: `site/api/telemetry.js`
+
+## User controls
+
+Telemetry is enabled by default, and query text is included by default.
+
+| Control | Effect |
+| --- | --- |
+| `SOCAI_TELEMETRY=off` | Disables telemetry for that CLI command request. |
+| `SOCAI_TELEMETRY_QUERY_TEXT=off` | Keeps telemetry enabled but omits `query_text`. |
+
+The off values accepted by the CLI are:
+
+```text
+0, false, off, disabled, no
+```
+
+These controls are evaluated by the short-lived CLI process and included in the
+request to the long-running daemon, so they apply per command even when an
+existing daemon process is reused.
+
+## Trace model
+
+Each successful or failed top-level daemon command emits one trace after the
+command finishes. The command result can fail while telemetry still records the
+attempt with `ok=false` and an error summary.
+
+Supported command/tool mapping:
+
+| CLI daemon command | `command` | `tool_name` |
+| --- | --- | --- |
+| `search_notes` | `search_notes` | `search_notes` |
+| `topic_scan` | `topic_scan` | `topic_scan` |
+| `extract_note` | `extract_note` | `read_note` |
+
+The internal client-to-proxy payload currently includes an internal event name
+for proxy validation. The proxy strips that before forwarding to Axiom. Axiom
+rows for the current schema should not contain a custom `event` value.
+
+## Forwarded Axiom fields
+
+The proxy forwards only allowlisted fields. Fields not listed here should be
+assumed unavailable in Axiom.
+
+### Identity and correlation
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `install_id` | string UUID | Stable anonymous install identity stored in `telemetry/identity.json`. |
+| `session_id` | string UUID | One daemon process lifetime. |
+| `request_id` | string | One CLI request/daemon command invocation. Treat as opaque. |
+| `schema_version` | number | Telemetry schema version. Current value: `1`. |
+
+### App, source, and device context
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `app` | string | Always `socai`. |
+| `source` | string | Current source is `cli_daemon`. |
+| `app_version` | string | CLI crate version. |
+| `platform` | string | Rust target OS, such as `macos` or `linux`. |
+| `os_version` | string | OS version, for example macOS product version or Linux `PRETTY_NAME`. |
+| `os_kernel_version` | string | Kernel version when available. |
+| `memory_total_mb` | number | Total device memory in MiB when available. |
+| `cpu_count` | number | Available CPU parallelism when available. |
+| `terminal_app` | string | Best-effort terminal/app detection, such as Terminal, Ghostty, WezTerm, kitty, VS Code, Codex-related parent process, or `$TERM`. |
+| `parent_process` | string | Best-effort parent process command name on Unix. |
+
+### Command, query, and explicit parameters
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `command` | string | Top-level daemon command name. |
+| `tool_name` | string | Tool label used for usage analysis. |
+| `site` | string | Current site integration, `xhs`. |
+| `query_text_enabled` | boolean | Whether query text was included for this command. |
+| `query_text` | string | Search query text when enabled. Omitted when redacted. |
+| `query_len` | number | Query length in Unicode scalar values. Kept even when text is redacted. |
+| `metadata` | object | Explicit optional CLI parameters only. Defaults are omitted. |
+| `note_id_present` | boolean | `true` when `extract_note` received a note id. The note id itself is not sent. |
+
+Current metadata keys:
+
+| Metadata key | Type | Source CLI flag | Omitted when |
+| --- | --- | --- | --- |
+| `metadata.tab` | string | `topic_scan --tab <value>` | `--tab` is not passed or is empty. |
+| `metadata.num_notes` | number | `topic_scan --num-notes <n>` | `--num-notes` is not passed and the command uses its default. |
+| `metadata.debug_snapshot` | boolean | `--debug-snapshot` | `--debug-snapshot` is not passed / false. |
+
+### Duration, status, and safe result metrics
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `duration_ms` | number | Command runtime in milliseconds. |
+| `ok` | boolean | Whether the command returned successfully. |
+| `error` | string | First-line error summary when `ok=false`. |
+| `result_ok` | boolean | Safe `data.ok` result flag when present. |
+| `cards_count` | number | Count of top-level `cards` result entries when present. |
+| `search_cards_count` | number | Count of `search.cards` entries when present. |
+| `selected_cards_count` | number | Count of selected cards when present. |
+| `notes_count` | number | Count of note result entries when present. |
+| `notes_skipped_count` | number | Count of notes marked skipped when present. |
+| `has_run_dir` | boolean | Whether the command returned a run directory. |
+| `proxy_version` | number | Added by the proxy. Current value: `1`. |
+
+## Fields intentionally not forwarded to Axiom
+
+Current Axiom rows should not include these custom fields:
+
+- `event`
+- `arch`
+- `created_at_ms`
+- `client_created_at_ms`
+- `received_at_ms`
+- `daemon_session_id`
+- `query_redacted`
+- raw `tab_label` or raw top-level `num_notes` outside `metadata`
+
+Axiom still has native time columns:
+
+- `_time`
+- `_sysTime`
+
+Those are Axiom-managed fields, not custom CLI telemetry fields. Historical rows
+in the existing dataset created older columns, so Axiom may still display fields
+such as `event`, `arch`, or `created_at_ms` as `null` on new rows. `null` in
+those old columns does not mean the current proxy forwarded those values.
+
+## Local JSONL caveat
+
+The local JSONL buffer is a debug/replay aid, not the forwarded Axiom schema. It
+may contain local-only fields such as:
+
+- `event`
+- `created_at_ms`
+- `properties.created_at_ms`
+
+The CLI strips the local millisecond timestamp before sending to the proxy, and
+the proxy strips/ignores non-allowlisted fields before forwarding to Axiom.
+
+## Privacy boundaries
+
+The telemetry contract must never send:
+
+- note body text
+- comments
+- image data, screenshots, or media contents
+- browser cookies or session storage
+- API keys, bearer tokens, Axiom tokens, or other secrets
+- raw tool output bodies
+- raw note ids; `extract_note` uses only `note_id_present=true`
+
+Approved content-bearing telemetry is limited to query text, which is included by
+default and can be omitted with `SOCAI_TELEMETRY_QUERY_TEXT=off`.
+
+## Sanitization and limits
+
+Proxy behavior in `site/api/telemetry.js`:
+
+- Accepts only JSON `POST` requests.
+- Enforces a maximum request body size of 128 KiB.
+- Accepts at most 100 events/traces per request envelope.
+- Requires the internal validation event name to start with `socai_`.
+- Uses an allowlist for forwarded fields.
+- Removes ASCII control characters from strings, trims whitespace, and truncates
+  strings longer than 2,000 characters with an ellipsis.
+- Accepts `metadata` as a shallow object only.
+- Limits `metadata` to 20 entries.
+- Allows metadata keys up to 80 characters matching `[A-Za-z0-9_.-]+`.
+- Allows only primitive metadata values: string, finite number, boolean, or null.
+- Applies an in-memory rate limit keyed by install id when available, otherwise
+  by client IP.
+
+CLI behavior in `cli/src/daemon.rs`:
+
+- Error summaries are first-line strings capped to 240 characters before proxy
+  sanitization.
+- Safe result metrics are counts/booleans only, not raw XHS content.
+
+## Example: normal `topic_scan` trace
+
+A user runs:
+
+```bash
+socai topic_scan "运营爆款思路" --num-notes 12 --tab latest
+```
+
+Representative Axiom row after proxy sanitization:
+
+```json
+{
+  "install_id": "11111111-1111-4111-8111-111111111111",
+  "session_id": "22222222-2222-4222-8222-222222222222",
+  "request_id": "12345-1780616790123",
+  "schema_version": 1,
+  "app": "socai",
+  "source": "cli_daemon",
+  "app_version": "0.1.0",
+  "platform": "macos",
+  "os_version": "15.5",
+  "os_kernel_version": "24.5.0",
+  "memory_total_mb": 65536,
+  "cpu_count": 14,
+  "terminal_app": "Ghostty",
+  "parent_process": "zsh",
+  "command": "topic_scan",
+  "tool_name": "topic_scan",
+  "site": "xhs",
+  "query_text_enabled": true,
+  "query_text": "运营爆款思路",
+  "query_len": 6,
+  "metadata": {
+    "num_notes": 12,
+    "tab": "latest"
+  },
+  "duration_ms": 42130,
+  "ok": true,
+  "result_ok": true,
+  "search_cards_count": 20,
+  "selected_cards_count": 12,
+  "notes_count": 12,
+  "notes_skipped_count": 1,
+  "has_run_dir": true,
+  "proxy_version": 1
+}
+```
+
+Axiom will also show native `_time` and `_sysTime` columns for the row.
+
+## Example: query-redacted `topic_scan` trace
+
+A user runs:
+
+```bash
+SOCAI_TELEMETRY_QUERY_TEXT=off socai topic_scan "运营爆款思路" --num-notes 12
+```
+
+Representative Axiom row:
+
+```json
+{
+  "install_id": "11111111-1111-4111-8111-111111111111",
+  "session_id": "22222222-2222-4222-8222-222222222222",
+  "request_id": "12345-1780616790456",
+  "schema_version": 1,
+  "app": "socai",
+  "source": "cli_daemon",
+  "app_version": "0.1.0",
+  "platform": "macos",
+  "command": "topic_scan",
+  "tool_name": "topic_scan",
+  "site": "xhs",
+  "query_text_enabled": false,
+  "query_len": 6,
+  "metadata": {
+    "num_notes": 12
+  },
+  "duration_ms": 42130,
+  "ok": true,
+  "notes_count": 12,
+  "proxy_version": 1
+}
+```
+
+`query_text` is omitted. `query_len` remains available for aggregate product
+analysis without storing the query string.
+
+## Versioning notes
+
+- `schema_version=1` covers the one-trace-per-tool-command schema described in
+  this document.
+- Additive fields may be introduced through the proxy allowlist and documented
+  here.
+- Removing or renaming fields should update this document and any dashboard or
+  release-smoke-test queries that depend on the old names.

--- a/scripts/telemetry-release-smoke-test.sh
+++ b/scripts/telemetry-release-smoke-test.sh
@@ -143,16 +143,25 @@ else:
 PY
 }
 
-wait_for_count() {
+wait_for_exact_count() {
   local expected="$1"
   local deadline=$((SECONDS + 30))
+  local observed
   while [[ "$SECONDS" -lt "$deadline" ]]; do
-    if [[ "$(json_count)" -ge "$expected" ]]; then
+    observed="$(json_count)"
+    if (( observed > expected )); then
+      fail "expected exactly $expected local telemetry row(s), found $observed in $EVENTS_FILE"
+    fi
+    if (( observed == expected )); then
+      sleep 3
+      observed="$(json_count)"
+      [[ "$observed" == "$expected" ]] || fail "expected exactly $expected local telemetry row(s), found $observed in $EVENTS_FILE"
       return 0
     fi
     sleep 1
   done
-  fail "timed out waiting for at least $expected local telemetry row(s) in $EVENTS_FILE"
+  observed="$(json_count)"
+  fail "timed out waiting for exactly $expected local telemetry row(s); found $observed in $EVENTS_FILE"
 }
 
 last_request_id() {
@@ -243,7 +252,7 @@ log "using isolated SOCAI_HOME=$SOCAI_HOME"
 
 DEFAULT_QUERY="${QUERY}-default"
 run_search_notes "default" "$DEFAULT_QUERY" env
-wait_for_count 1
+wait_for_exact_count 1
 DEFAULT_REQUEST_ID="$(validate_last_default_query "$DEFAULT_QUERY")"
 log "default telemetry request_id=$DEFAULT_REQUEST_ID"
 if [[ "$SKIP_AXIOM" -eq 0 ]]; then
@@ -264,7 +273,7 @@ log "opt-out check passed"
 REDACTED_QUERY="${QUERY}-redacted"
 EXPECTED_COUNT=$((AFTER_OPTOUT + 1))
 run_search_notes "redacted" "$REDACTED_QUERY" env SOCAI_TELEMETRY_QUERY_TEXT=off
-wait_for_count "$EXPECTED_COUNT"
+wait_for_exact_count "$EXPECTED_COUNT"
 REDACTED_REQUEST_ID="$(validate_last_redacted_query)"
 log "redacted telemetry request_id=$REDACTED_REQUEST_ID"
 if [[ "$SKIP_AXIOM" -eq 0 ]]; then

--- a/scripts/telemetry-release-smoke-test.sh
+++ b/scripts/telemetry-release-smoke-test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT="https://socai.io/v1/events"
+DEFAULT_BIN="target/release/socai"
+BIN="${SOCAI_BIN:-$DEFAULT_BIN}"
+DATASET="${AXIOM_DATASET:-socai-cli-prod}"
+LIVE=0
+SKIP_BUILD=0
+SKIP_AXIOM=0
+KEEP_HOME=0
+RUN_ID="$(date +%Y%m%d%H%M%S)"
+QUERY="socai-telemetry-smoke-${RUN_ID}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/telemetry-release-smoke-test.sh [options]
+
+Verifies release-candidate CLI telemetry properties without embedding secrets.
+By default it performs static binary checks only. Use --live to run CLI commands
+against the production first-party telemetry proxy and verify Axiom rows.
+
+Options:
+  --bin PATH        CLI binary to test (default: target/release/socai, or SOCAI_BIN)
+  --dataset NAME   Axiom dataset for live verification (default: socai-cli-prod)
+  --live           Run live CLI telemetry checks in an isolated SOCAI_HOME
+  --skip-build     Do not run cargo build when testing target/release/socai
+  --skip-axiom     In --live mode, skip Axiom CLI queries and check local JSONL only
+  --keep-home      Keep the temporary SOCAI_HOME after live checks for inspection
+  --query TEXT     Base smoke-test query text for live checks
+  -h, --help       Show this help
+
+Prerequisites for --live:
+  - Browser/session prerequisites needed by socai commands in this environment.
+  - axiom CLI authenticated for the target dataset, unless --skip-axiom is used.
+  - Network access to https://socai.io/v1/events.
+USAGE
+}
+
+log() {
+  printf '[telemetry-smoke] %s\n' "$*" >&2
+}
+
+fail() {
+  printf '[telemetry-smoke] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin)
+      BIN="${2:-}"
+      [[ -n "$BIN" ]] || fail "--bin requires a path"
+      shift 2
+      ;;
+    --dataset)
+      DATASET="${2:-}"
+      [[ -n "$DATASET" ]] || fail "--dataset requires a name"
+      shift 2
+      ;;
+    --live)
+      LIVE=1
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --skip-axiom)
+      SKIP_AXIOM=1
+      shift
+      ;;
+    --keep-home)
+      KEEP_HOME=1
+      shift
+      ;;
+    --query)
+      QUERY="${2:-}"
+      [[ -n "$QUERY" ]] || fail "--query requires text"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ "$BIN" == "$DEFAULT_BIN" && "$SKIP_BUILD" -eq 0 ]]; then
+  log "building release candidate binary with cargo build -p socai-cli --release"
+  cargo build -p socai-cli --release
+fi
+
+[[ -x "$BIN" ]] || fail "CLI binary is not executable: $BIN"
+command -v strings >/dev/null 2>&1 || fail "strings command is required"
+
+log "checking fixed telemetry endpoint is present in binary strings"
+strings "$BIN" | grep -F "$ENDPOINT" >/dev/null || fail "fixed endpoint not found in binary strings"
+
+log "checking binary strings for Axiom-specific client secrets/config"
+if strings "$BIN" | grep -E 'AXIOM_(TOKEN|DATASET|URL|ORG_ID)|api\.axiom\.co' >/dev/null; then
+  strings "$BIN" | grep -E 'AXIOM_(TOKEN|DATASET|URL|ORG_ID)|api\.axiom\.co' >&2 || true
+  fail "Axiom-specific secret/config string found in client binary"
+fi
+
+log "static binary checks passed"
+
+if [[ "$LIVE" -eq 0 ]]; then
+  log "live telemetry checks skipped; rerun with --live for production proxy/Axiom verification"
+  exit 0
+fi
+
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for --live"
+if [[ "$SKIP_AXIOM" -eq 0 ]]; then
+  command -v axiom >/dev/null 2>&1 || fail "axiom CLI is required for --live unless --skip-axiom is set"
+fi
+
+SMOKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/socai-telemetry-smoke.XXXXXX")"
+EVENTS_FILE="$SMOKE_HOME/telemetry/events.jsonl"
+export SOCAI_HOME="$SMOKE_HOME"
+
+cleanup() {
+  "$BIN" stop >/dev/null 2>&1 || true
+  if [[ "$KEEP_HOME" -eq 1 ]]; then
+    log "kept SOCAI_HOME=$SMOKE_HOME"
+  else
+    rm -rf "$SMOKE_HOME"
+  fi
+}
+trap cleanup EXIT
+
+json_count() {
+  python3 - "$EVENTS_FILE" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+if not path.exists():
+    print(0)
+else:
+    print(sum(1 for line in path.read_text().splitlines() if line.strip()))
+PY
+}
+
+wait_for_count() {
+  local expected="$1"
+  local deadline=$((SECONDS + 30))
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if [[ "$(json_count)" -ge "$expected" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "timed out waiting for at least $expected local telemetry row(s) in $EVENTS_FILE"
+}
+
+last_request_id() {
+  python3 - "$EVENTS_FILE" <<'PY'
+import json, pathlib, sys
+rows = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+props = rows[-1].get('properties', {})
+print(props.get('request_id', ''))
+PY
+}
+
+validate_last_default_query() {
+  local expected_query="$1"
+  python3 - "$EVENTS_FILE" "$expected_query" <<'PY'
+import json, pathlib, sys
+rows = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+props = rows[-1].get('properties', {})
+expected = sys.argv[2]
+assert props.get('query_text_enabled') is True, props
+assert props.get('query_text') == expected, props
+assert props.get('request_id'), props
+print(props['request_id'])
+PY
+}
+
+validate_last_redacted_query() {
+  python3 - "$EVENTS_FILE" <<'PY'
+import json, pathlib, sys
+rows = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+props = rows[-1].get('properties', {})
+assert props.get('query_text_enabled') is False, props
+assert 'query_text' not in props, props
+assert props.get('request_id'), props
+print(props['request_id'])
+PY
+}
+
+run_search_notes() {
+  local label="$1"
+  local query="$2"
+  shift 2
+  log "running ${label}: socai search_notes ${query}"
+  set +e
+  "$@" "$BIN" search_notes "$query" >/tmp/socai-telemetry-smoke-${label}.out 2>/tmp/socai-telemetry-smoke-${label}.err
+  local status=$?
+  set -e
+  if [[ "$status" -ne 0 ]]; then
+    log "${label} command exited with status $status; continuing because failed commands should still emit telemetry"
+    log "stderr saved to /tmp/socai-telemetry-smoke-${label}.err"
+  fi
+}
+
+query_axiom_by_request_id() {
+  local request_id="$1"
+  log "waiting for proxy flush before querying Axiom for request_id=$request_id"
+  sleep 8
+  local output
+  output="$(axiom query "['${DATASET}'] | where request_id == '${request_id}' | limit 1" --start-time=-30m --format=json --no-spinner)"
+  [[ -n "$output" ]] || fail "no Axiom row found for request_id=$request_id"
+  printf '%s\n' "$output"
+}
+
+assert_axiom_no_query_text() {
+  local axiom_row="$1"
+  local forbidden_query="$2"
+  AXIOM_ROW="$axiom_row" python3 - "$forbidden_query" <<'PY'
+import json, os, sys
+forbidden = sys.argv[1]
+text = os.environ.get('AXIOM_ROW', '').strip()
+assert text, 'empty Axiom output'
+row = json.loads(text.splitlines()[0])
+assert row.get('query_text') in (None, ''), row
+assert row.get('query_text') != forbidden, row
+PY
+}
+
+assert_axiom_no_query_row() {
+  local query="$1"
+  log "checking Axiom has no opt-out row for query_text=$query"
+  sleep 8
+  local output
+  output="$(axiom query "['${DATASET}'] | where query_text == '${query}' | limit 1" --start-time=-30m --format=json --no-spinner)"
+  [[ -z "$output" ]] || fail "unexpected Axiom row found for opt-out query_text=$query: $output"
+}
+
+log "using isolated SOCAI_HOME=$SOCAI_HOME"
+"$BIN" stop >/dev/null 2>&1 || true
+
+DEFAULT_QUERY="${QUERY}-default"
+run_search_notes "default" "$DEFAULT_QUERY" env
+wait_for_count 1
+DEFAULT_REQUEST_ID="$(validate_last_default_query "$DEFAULT_QUERY")"
+log "default telemetry request_id=$DEFAULT_REQUEST_ID"
+if [[ "$SKIP_AXIOM" -eq 0 ]]; then
+  query_axiom_by_request_id "$DEFAULT_REQUEST_ID" >/tmp/socai-telemetry-smoke-default.axiom.json
+fi
+
+BEFORE_OPTOUT="$(json_count)"
+OPTOUT_QUERY="${QUERY}-optout"
+run_search_notes "optout" "$OPTOUT_QUERY" env SOCAI_TELEMETRY=off
+sleep 5
+AFTER_OPTOUT="$(json_count)"
+[[ "$AFTER_OPTOUT" == "$BEFORE_OPTOUT" ]] || fail "SOCAI_TELEMETRY=off wrote a local telemetry row"
+if [[ "$SKIP_AXIOM" -eq 0 ]]; then
+  assert_axiom_no_query_row "$OPTOUT_QUERY"
+fi
+log "opt-out check passed"
+
+REDACTED_QUERY="${QUERY}-redacted"
+EXPECTED_COUNT=$((AFTER_OPTOUT + 1))
+run_search_notes "redacted" "$REDACTED_QUERY" env SOCAI_TELEMETRY_QUERY_TEXT=off
+wait_for_count "$EXPECTED_COUNT"
+REDACTED_REQUEST_ID="$(validate_last_redacted_query)"
+log "redacted telemetry request_id=$REDACTED_REQUEST_ID"
+if [[ "$SKIP_AXIOM" -eq 0 ]]; then
+  REDACTED_AXIOM_ROW="$(query_axiom_by_request_id "$REDACTED_REQUEST_ID")"
+  assert_axiom_no_query_text "$REDACTED_AXIOM_ROW" "$REDACTED_QUERY"
+fi
+
+log "live telemetry smoke checks passed"


### PR DESCRIPTION
## Summary

- Add a telemetry release smoke-test runbook for verifying CLI release artifacts.
- Add `scripts/telemetry-release-smoke-test.sh` for static binary checks and optional live production proxy/Axiom checks.
- Cover fixed endpoint presence, no Axiom client strings, daemon restart, one trace, opt-out, and query redaction behavior.

Refs #62.

## Validation

- `bash -n scripts/telemetry-release-smoke-test.sh`
- `shellcheck scripts/telemetry-release-smoke-test.sh` skipped because shellcheck is not installed
- markdown sanity check via Python non-empty/readability check
- `cargo check -p socai-cli`
- `cargo build -p socai-cli --release`
- `scripts/telemetry-release-smoke-test.sh --skip-build`

## Notes

Live `--live` checks were not run in this worker because they depend on browser/XHS/Axiom maintainer credentials. The script documents prerequisites and supports local-only `--skip-axiom` mode for environments without Axiom CLI access.