### PR TITLE
test: add telemetry regression coverage

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -488,6 +488,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn command_summary_includes_query_text_by_default() {
+        let summary = command_arg_summary(
+            &DaemonTelemetry::default(),
+            &json!({ "query": "运营爆款思路" }),
+        );
+        let object = summary.as_object().expect("summary is an object");
+        assert_eq!(object.get("query_text"), Some(&json!("运营爆款思路")));
+        assert_eq!(object.get("query_text_enabled"), Some(&json!(true)));
+        assert_eq!(object.get("query_len"), Some(&json!(6)));
+    }
+
+    #[test]
+    fn command_summary_redacts_query_text_when_disabled() {
+        let telemetry = DaemonTelemetry {
+            enabled: true,
+            include_query_text: false,
+        };
+        let summary = command_arg_summary(&telemetry, &json!({ "query": "运营爆款思路" }));
+        let object = summary.as_object().expect("summary is an object");
+        assert!(!object.contains_key("query_text"));
+        assert_eq!(object.get("query_text_enabled"), Some(&json!(false)));
+        assert_eq!(object.get("query_len"), Some(&json!(6)));
+    }
+
+    #[test]
     fn command_summary_omits_defaulted_optional_params() {
         let summary = command_arg_summary(
             &DaemonTelemetry::default(),
@@ -518,6 +543,34 @@ mod tests {
         assert_eq!(metadata.get("debug_snapshot"), Some(&json!(true)));
         assert!(!object.contains_key("tab_label"));
         assert!(!object.contains_key("num_notes"));
+    }
+
+    #[test]
+    fn result_metrics_extracts_safe_counts() {
+        let metrics = result_metrics(&json!({
+            "run_dir": "/tmp/socai-run",
+            "data": {
+                "ok": true,
+                "cards": [{}, {}],
+                "search": { "cards": [{}, {}, {}] },
+                "selected_cards": [{}],
+                "notes": [
+                    { "id": "1", "body": "must not be copied" },
+                    { "skipped": "missing note" },
+                    { "skipped": true, "comments": ["must not be copied"] }
+                ]
+            }
+        }));
+        let object = metrics.as_object().expect("metrics is an object");
+        assert_eq!(object.get("result_ok"), Some(&json!(true)));
+        assert_eq!(object.get("cards_count"), Some(&json!(2)));
+        assert_eq!(object.get("search_cards_count"), Some(&json!(3)));
+        assert_eq!(object.get("selected_cards_count"), Some(&json!(1)));
+        assert_eq!(object.get("notes_count"), Some(&json!(3)));
+        assert_eq!(object.get("notes_skipped_count"), Some(&json!(2)));
+        assert_eq!(object.get("has_run_dir"), Some(&json!(true)));
+        assert!(!object.contains_key("body"));
+        assert!(!object.contains_key("comments"));
     }
 }
 

--- a/cli/src/tracking.rs
+++ b/cli/src/tracking.rs
@@ -406,3 +406,115 @@ fn env_value_is(name: &str, values: &[&str]) -> bool {
     let value = value.trim().to_ascii_lowercase();
     values.iter().any(|candidate| value == *candidate)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: Option<&str>) -> Self {
+            let previous = std::env::var_os(name);
+            if let Some(value) = value {
+                std::env::set_var(name, value);
+            } else {
+                std::env::remove_var(name);
+            }
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.name, previous);
+            } else {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+
+    fn with_env<T>(name: &'static str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _lock = env_lock().lock().expect("env lock is not poisoned");
+        let _guard = EnvGuard::set(name, value);
+        f()
+    }
+
+    #[test]
+    fn telemetry_enabled_defaults_to_on() {
+        with_env("SOCAI_TELEMETRY", None, || {
+            assert!(telemetry_enabled());
+        });
+    }
+
+    #[test]
+    fn telemetry_enabled_accepts_off_values() {
+        for value in ["0", "false", "off", "disabled", "no", " OFF "] {
+            with_env("SOCAI_TELEMETRY", Some(value), || {
+                assert!(
+                    !telemetry_enabled(),
+                    "value {value:?} should disable telemetry"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn telemetry_enabled_ignores_unknown_values() {
+        for value in ["1", "true", "on", "yes"] {
+            with_env("SOCAI_TELEMETRY", Some(value), || {
+                assert!(
+                    telemetry_enabled(),
+                    "value {value:?} should keep telemetry enabled"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn query_text_enabled_defaults_to_on() {
+        with_env("SOCAI_TELEMETRY_QUERY_TEXT", None, || {
+            assert!(query_text_enabled());
+        });
+    }
+
+    #[test]
+    fn query_text_enabled_accepts_off_values() {
+        for value in ["0", "false", "off", "disabled", "no", " OFF "] {
+            with_env("SOCAI_TELEMETRY_QUERY_TEXT", Some(value), || {
+                assert!(
+                    !query_text_enabled(),
+                    "value {value:?} should disable query text"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn remote_event_drops_client_timestamp_before_proxy_send() {
+        let event = remote_event(
+            "socai_cli_tool_trace",
+            "install-1",
+            &json!({
+                "created_at_ms": 123,
+                "command": "topic_scan",
+                "tool_name": "topic_scan"
+            }),
+        );
+        let object = event.as_object().expect("remote event is an object");
+        assert_eq!(object.get("event"), Some(&json!("socai_cli_tool_trace")));
+        assert_eq!(object.get("install_id"), Some(&json!("install-1")));
+        assert!(!object.contains_key("created_at_ms"));
+    }
+}

--- a/site/api/telemetry.js
+++ b/site/api/telemetry.js
@@ -322,3 +322,8 @@ function setSecurityHeaders(res) {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   res.setHeader('Cache-Control', 'no-store');
 }
+
+export const __testing = {
+  normalizeEvents,
+  sanitizeEvent,
+};

--- a/site/api/telemetry.test.js
+++ b/site/api/telemetry.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { __testing } from './telemetry.js';
+
+test('sanitizeEvent strips fields that should not reach Axiom', () => {
+  const sanitized = __testing.sanitizeEvent({
+    event: 'socai_cli_tool_trace',
+    install_id: 'install-1',
+    daemon_session_id: 'legacy-session-1',
+    request_id: 'request-1',
+    command: 'topic_scan',
+    tool_name: 'topic_scan',
+    query_text_enabled: false,
+    metadata: {
+      num_notes: 12,
+      tab: 'latest',
+      debug_snapshot: true,
+    },
+    arch: 'arm64',
+    created_at_ms: 1,
+    client_created_at_ms: 2,
+    received_at_ms: 3,
+    query_redacted: true,
+    num_notes: 99,
+    tab_label: 'should_drop',
+  });
+
+  assert.equal(sanitized.install_id, 'install-1');
+  assert.equal(sanitized.session_id, 'legacy-session-1');
+  assert.equal(sanitized.request_id, 'request-1');
+  assert.equal(sanitized.command, 'topic_scan');
+  assert.equal(sanitized.tool_name, 'topic_scan');
+  assert.deepEqual(sanitized.metadata, {
+    num_notes: 12,
+    tab: 'latest',
+    debug_snapshot: true,
+  });
+
+  for (const key of [
+    'event',
+    'arch',
+    'created_at_ms',
+    'client_created_at_ms',
+    'received_at_ms',
+    'query_redacted',
+    'num_notes',
+    'tab_label',
+    'daemon_session_id',
+  ]) {
+    assert.equal(Object.hasOwn(sanitized, key), false, `${key} should be stripped`);
+  }
+});
+
+test('sanitizeEvent preserves shallow primitive metadata and rejects unsafe metadata', () => {
+  const sanitized = __testing.sanitizeEvent({
+    event: 'socai_cli_tool_trace',
+    install_id: 'install-1',
+    command: 'topic_scan',
+    metadata: {
+      num_notes: 5,
+      tab: ' latest ',
+      enabled: true,
+      null_value: null,
+      nested: { unsafe: true },
+      array: ['unsafe'],
+      nan_value: Number.NaN,
+      'bad key': 'unsafe',
+      'bad$key': 'unsafe',
+    },
+  });
+
+  assert.deepEqual(sanitized.metadata, {
+    num_notes: 5,
+    tab: 'latest',
+    enabled: true,
+    null_value: null,
+  });
+});
+
+test('sanitizeEvent rejects missing or non-socai event names', () => {
+  assert.equal(__testing.sanitizeEvent({ command: 'topic_scan' }), null);
+  assert.equal(
+    __testing.sanitizeEvent({ event: 'other_event', command: 'topic_scan' }),
+    null,
+  );
+});
+
+test('sanitizeEvent flattens legacy properties without leaking disallowed fields', () => {
+  const sanitized = __testing.sanitizeEvent({
+    event: 'socai_cli_tool_trace',
+    distinct_id: 'install-from-distinct',
+    properties: {
+      request_id: 'request-1',
+      command: 'search_notes',
+      query_text: '  Bloc1 V4  ',
+      created_at_ms: 123,
+      metadata: { tab: 'discover' },
+    },
+  });
+
+  assert.equal(sanitized.install_id, 'install-from-distinct');
+  assert.equal(sanitized.request_id, 'request-1');
+  assert.equal(sanitized.command, 'search_notes');
+  assert.equal(sanitized.query_text, 'Bloc1 V4');
+  assert.deepEqual(sanitized.metadata, { tab: 'discover' });
+  assert.equal(Object.hasOwn(sanitized, 'event'), false);
+  assert.equal(Object.hasOwn(sanitized, 'created_at_ms'), false);
+});

--- a/site/tests/telemetry.test.js
+++ b/site/tests/telemetry.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { __testing } from './telemetry.js';
+import { __testing } from '../api/telemetry.js';
 
 test('sanitizeEvent strips fields that should not reach Axiom', () => {
   const sanitized = __testing.sanitizeEvent({


### PR DESCRIPTION
## Summary
- add Rust unit tests for telemetry env parsing, query text default/redaction behavior, explicit metadata handling, and safe result metrics
- add Node built-in tests for proxy sanitization without network/Axiom dependencies
- expose narrow proxy testing helpers while preserving the default Vercel handler

## Validation
- cargo test -p socai-cli -- --nocapture
- cargo check -p socai-cli
- node --check site/api/telemetry.js
- node --test site/api/telemetry.test.js
- python3 -m json.tool site/vercel.json >/dev/null
- cd site && pnpm install && pnpm build

Closes #60