### PR TITLE
CLI install docs: add agent-first install.md and SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: socai-cli
+description: Research Xiaohongshu content with the socai CLI from a coding agent. Use when running socai search_notes, topic_scan, extract_note, or stop, parsing their stdout JSON and stderr run_dir contract, choosing the right command, or installing/updating the socai binary before a research task.
+---
+
 # socai CLI skill
 
 Use this skill when a user asks a coding agent to research Xiaohongshu content

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,221 @@
+# socai CLI skill
+
+Use this skill when a user asks a coding agent to research Xiaohongshu content
+with the `socai` CLI.
+
+## before you run commands
+
+- If `socai` is missing, broken, or needs updating, read `install.md` or
+  `~/.socai/share/socai/install.md` and follow the install mode runbook.
+- Keep the product name lowercase: `socai`.
+- `socai` drives a real browser through CDP. The user may need to log in,
+  approve remote debugging, or solve a CAPTCHA manually.
+- Prefer modest, targeted research requests. Do not turn `socai` into a bulk
+  scraper.
+
+## stdout and stderr contract
+
+Parse stdout as the tool result:
+
+- `socai search_notes ...` prints JSON to stdout.
+- `socai topic_scan ...` prints JSON to stdout.
+- `socai extract_note ...` prints JSON to stdout.
+- `--pretty` makes stdout indented JSON for easier inspection.
+
+Treat stderr as metadata or diagnostics:
+
+- Successful tool commands print `run_dir: <path>` to stderr.
+- Save the `run_dir` path. It contains command inputs, artifacts, and optional
+  debug snapshots.
+- Do not parse stderr as JSON.
+- `socai stop` prints daemon status to stderr and does not produce a JSON tool
+  payload.
+
+## command selection
+
+### `topic_scan`
+
+Use `topic_scan` for topic research, trend review, competitive analysis, and
+requests that need note bodies or comments.
+
+Examples:
+
+```sh
+socai topic_scan "运营爆款思路" --num-notes 12 --pretty
+socai topic_scan "露营装备" --tab 图文 --filter publish_time=一周内 --filter note_type=图文 --num-notes 20
+```
+
+What it does:
+
+- Searches Xiaohongshu for the query.
+- Optionally switches search tab.
+- Optionally applies search-result filters.
+- Reads notes in feed order up to `--num-notes`.
+- Returns a JSON bundle with search cards, selected cards, notes, and skipped
+  notes when prior history applies.
+
+Use `--debug-snapshot` only when diagnosing page extraction problems because it
+adds DOM, accessibility tree, and screenshot artifacts under the run directory.
+
+### `search_notes`
+
+Use `search_notes` for a quick first-page card scan, note discovery, or when
+you need note IDs before choosing a smaller set to read.
+
+Examples:
+
+```sh
+socai search_notes "运营爆款思路" --pretty
+socai search_notes "露营装备" --filter sort=最新 --filter publish_time=一天内 --pretty
+```
+
+What it does:
+
+- Searches Xiaohongshu like a user.
+- Returns the first results page's note cards as JSON.
+- Leaves the controlled tool tab on the search waterfall so a follow-up
+  `extract_note` can click one of those cards.
+
+### `extract_note`
+
+Use `extract_note` only as a continuation command after `search_notes` or
+`topic_scan` has left the current daemon-controlled tab on a search/topic
+waterfall containing the target card.
+
+Do not use `extract_note` as a standalone note fetch. If the daemon was stopped,
+the tab was navigated away, or you do not have a note ID from the current search
+results, run `search_notes` or `topic_scan` again first.
+
+Example:
+
+```sh
+socai search_notes "运营爆款思路" --pretty
+socai extract_note --note-id <note_id_from_card> --pretty
+```
+
+### `stop`
+
+Use `socai stop` when:
+
+- You are done with a session and want to close the controlled tool tab.
+- You updated or replaced the `socai` binary and want to avoid stale daemon code.
+- Browser automation appears stuck and you want the next command to spawn a
+  fresh daemon.
+
+Example:
+
+```sh
+socai stop || true
+```
+
+### `doctor`
+
+Use `socai doctor` when available to inspect install mode, executable path,
+daemon state, browser/CDP readiness, and update status.
+
+Run it:
+
+- after install or update;
+- before live research if setup health is unclear;
+- after browser/CDP or daemon failures;
+- when the install mode appears to be `unknown`.
+
+If the installed build does not list `doctor` in `socai --help`, do not try to
+implement it during the user task. Read `install.md` and use the manual checks
+there instead.
+
+## options to remember
+
+Common options:
+
+- `--pretty` — print indented JSON on stdout.
+- `--debug-snapshot` — record DOM, accessibility tree, and screenshots under
+  `<run_dir>/snapshots/` for page-change debugging.
+
+`topic_scan` only:
+
+- `--num-notes <N>` — number of notes to read. Defaults to the CLI's current
+  built-in value; choose a modest explicit number for repeatable research.
+- `--tab <TAB>` — switch search tab. Valid labels are `全部`, `图文`, `视频`,
+  and `用户`.
+
+`topic_scan` and `search_notes`:
+
+- `--filter <GROUP=OPTION>` — repeatable search-result filter. Omitted groups
+  reset to default.
+
+Known filter groups and options:
+
+- `sort`: `综合`, `最新`, `最多点赞`, `最多评论`, `最多收藏`
+- `note_type`: `不限`, `视频`, `图文`
+- `publish_time`: `不限`, `一天内`, `一周内`, `半年内`
+- `search_scope`: `不限`, `已看过`, `未看过`, `已关注`
+- `distance`: `不限`, `同城`, `附近`
+
+## workflow patterns
+
+### broad topic research
+
+1. Run `topic_scan` with the user's query and a modest `--num-notes`.
+2. Parse stdout JSON.
+3. Capture stderr and save `run_dir`.
+4. Summarize findings with links or note IDs from the JSON.
+5. Inspect artifacts in `run_dir` only if the JSON is not enough.
+
+### shortlist first, then read one note
+
+1. Run `search_notes "query" --pretty`.
+2. Choose a card from stdout JSON.
+3. Run `extract_note --note-id <id> --pretty` before stopping the daemon or
+   changing the page context.
+4. If `extract_note` says the card is unavailable, rerun `search_notes` and
+   choose a note from the fresh result set.
+
+### update or repair before use
+
+1. Run `socai --help`.
+2. Run `socai doctor` if available.
+3. If install mode is `managed-binary`, follow the managed-binary update in
+   `install.md`.
+4. If install mode is `source-cargo`, follow the source/Cargo update in
+   `install.md`.
+5. If install mode is `unknown`, reinstall through a known mode rather than
+   guessing how it was installed.
+
+## browser and CDP reminders
+
+If a command fails with a Chrome/CDP connection error:
+
+1. Ask the user to open or approve Chrome remote debugging if manual permission
+   is needed.
+2. Open `chrome://inspect/#remote-debugging` in Chrome.
+3. Check `http://127.0.0.1:9222/json/version` and
+   `http://127.0.0.1:9223/json/version`.
+4. Set one of these when Chrome is on a non-default endpoint:
+
+   ```sh
+   export SOCAI_CDP_URL="http://127.0.0.1:9222"
+   export SOCAI_CDP_WS="ws://127.0.0.1:9222/devtools/browser/<id>"
+   ```
+
+5. Retry the `socai` command. If it still fails, run `socai stop || true` and
+   inspect `~/.socai/rust-daemon.log`.
+
+## output handling example
+
+Keep stdout and stderr separate so JSON parsing is reliable:
+
+```sh
+err_file="$(mktemp)"
+json_file="$(mktemp)"
+if socai topic_scan "运营爆款思路" --num-notes 10 --pretty >"$json_file" 2>"$err_file"; then
+  cat "$json_file"
+  grep '^run_dir: ' "$err_file" >&2 || true
+else
+  cat "$err_file" >&2
+  exit 1
+fi
+```
+
+Use your agent's JSON parser on `json_file`; use `run_dir` only as artifact
+metadata.

--- a/install.md
+++ b/install.md
@@ -163,6 +163,8 @@ install -m 0644 SKILL.md "$HOME/.socai/share/socai/SKILL.md"
 install -m 0644 install.md "$HOME/.socai/share/socai/install.md"
 
 export PATH="$HOME/.cargo/bin:$PATH"
+# Stop any daemon left from a previous build before validating the new CLI.
+socai stop || true
 socai --help
 ```
 
@@ -323,13 +325,28 @@ Useful checks and fixes:
 
 4. If no debug endpoint is running, start Chrome with a remote-debugging port.
    A separate user-data directory avoids profile lock conflicts but may require
-   the user to log in again:
+   the user to log in again.
+
+   macOS only:
 
    ```sh
    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
      --remote-debugging-port=9222 \
      --user-data-dir="$HOME/.socai/chrome-debug-profile"
    ```
+
+   Linux or WSL with a Linux GUI browser:
+
+   ```sh
+   google-chrome \
+     --remote-debugging-port=9222 \
+     --user-data-dir="$HOME/.socai/chrome-debug-profile"
+   ```
+
+   If `google-chrome` is unavailable, try `google-chrome-stable`, `chromium`,
+   or `chromium-browser`. If using Windows Chrome from WSL, ask the user to
+   start Chrome on Windows with `--remote-debugging-port=9222`, then set
+   `SOCAI_CDP_URL` to the reachable local endpoint.
 
 5. If commands still fail, inspect daemon files:
 

--- a/install.md
+++ b/install.md
@@ -1,0 +1,366 @@
+# socai CLI install runbook for coding agents
+
+This file is the agent-facing setup, update, and troubleshooting runbook for the
+`socai` CLI. Prefer it over README snippets when a user asks a coding agent to
+set up or repair `socai`.
+
+## scope and invariants
+
+- Keep the product name lowercase: `socai`.
+- Install only the CLI and its agent docs here. Do not update README or site
+  docs as part of this runbook.
+- Normal managed-binary installs must not require Rust or Cargo.
+- Use the source/Cargo fallback only when no compatible release binary exists,
+  the platform is unsupported, or the user explicitly asks for a source or
+  development install.
+- Do not implement missing commands while installing. In particular, `socai
+  doctor`, daemon version handshake, and release packaging are tracked by
+  separate issues. Use the best available released CLI and the manual checks
+  below when those features are not present yet.
+
+## install modes
+
+Agents should keep the user's install in one of these modes:
+
+- `managed-binary` — preferred when a compatible GitHub Release CLI asset exists.
+  The stable executable path is `~/.socai/bin/socai`. Agent docs are copied to
+  `~/.socai/share/socai/SKILL.md` and `~/.socai/share/socai/install.md`.
+- `source-cargo` — fallback for unsupported platforms or explicit development
+  installs. Clone the repo to a durable path, update with `git pull --ff-only`,
+  and install with `cargo install --path cli --force`.
+- `unknown` — diagnostic state for any ambiguous executable path or install that
+  cannot be tied to the two known modes. Do not guess an update procedure;
+  reinstall through `managed-binary` or `source-cargo`.
+
+Quick local mode check:
+
+```sh
+socai_path="$(command -v socai || true)"
+case "$socai_path" in
+  "$HOME/.socai/bin/socai") echo managed-binary ;;
+  "$HOME/.cargo/bin/socai") echo source-cargo ;;
+  "") echo missing ;;
+  *) echo unknown ;;
+esac
+```
+
+## choose an install path
+
+1. Detect the platform:
+
+   ```sh
+   uname -s
+   uname -m
+   ```
+
+2. On macOS (`Darwin`, `arm64` or `x86_64`), try `managed-binary` first using
+   the latest GitHub Release asset named `socai-cli-macos-universal.tar.gz` and
+   its checksum file `socai-cli-macos-universal.tar.gz.sha256`.
+3. If that asset is missing, the download fails, or the platform is not covered
+   by a release asset, use `source-cargo`.
+4. On Windows, distinguish WSL from native Windows:
+   - WSL: use the Linux/source fallback unless a verified release asset exists.
+   - Native Windows: treat as unverified until issue #77 is resolved. The
+     current daemon path uses Unix sockets, so prefer WSL or another verified
+     environment instead of promising native Windows support.
+5. If an existing `socai` is on an unexpected path, treat it as `unknown` and
+   reinstall through a known mode. Avoid deleting unknown binaries unless the
+   user explicitly approves.
+
+## managed-binary install: macOS universal
+
+Use this path only when the GitHub Release contains a compatible CLI asset.
+This path does not use Rust or Cargo.
+
+```sh
+set -euo pipefail
+
+repo="tonyc-ship/socai"
+asset="socai-cli-macos-universal.tar.gz"
+checksum="${asset}.sha256"
+prefix="${SOCAI_PREFIX:-$HOME/.socai}"
+bin_dir="$prefix/bin"
+share_dir="$prefix/share/socai"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+base_url="https://github.com/${repo}/releases/latest/download"
+archive="$tmp_dir/$asset"
+checksum_file="$tmp_dir/$checksum"
+unpack_dir="$tmp_dir/unpack"
+
+curl -fL "$base_url/$asset" -o "$archive"
+curl -fL "$base_url/$checksum" -o "$checksum_file"
+(cd "$tmp_dir" && shasum -a 256 -c "$checksum")
+
+mkdir -p "$unpack_dir" "$bin_dir" "$share_dir"
+tar -xzf "$archive" -C "$unpack_dir"
+
+if [ ! -f "$unpack_dir/socai" ]; then
+  echo "release archive did not contain ./socai" >&2
+  exit 1
+fi
+
+install -m 0755 "$unpack_dir/socai" "$bin_dir/socai"
+[ -f "$unpack_dir/SKILL.md" ] && install -m 0644 "$unpack_dir/SKILL.md" "$share_dir/SKILL.md"
+[ -f "$unpack_dir/install.md" ] && install -m 0644 "$unpack_dir/install.md" "$share_dir/install.md"
+[ -f "$unpack_dir/manifest.json" ] && install -m 0644 "$unpack_dir/manifest.json" "$share_dir/manifest.json"
+
+export PATH="$bin_dir:$PATH"
+"$bin_dir/socai" --help
+```
+
+If the asset does not exist in the latest release, do not download the desktop
+`.dmg` as a substitute for the CLI. Use `source-cargo` instead. The dedicated
+CLI release asset is tracked separately by issue #67.
+
+Make `~/.socai/bin` persistent in the user's shell if it is not already on
+`PATH`:
+
+```sh
+case ":$PATH:" in
+  *":$HOME/.socai/bin:"*) ;;
+  *)
+    shell_rc="$HOME/.zshrc"
+    [ -n "${BASH_VERSION:-}" ] && shell_rc="$HOME/.bashrc"
+    printf '\n# socai CLI\nexport PATH="$HOME/.socai/bin:$PATH"\n' >> "$shell_rc"
+    ;;
+esac
+```
+
+If macOS blocks the binary because it was downloaded from the internet, confirm
+with the user before changing quarantine metadata, then run:
+
+```sh
+xattr -d com.apple.quarantine "$HOME/.socai/bin/socai" 2>/dev/null || true
+```
+
+## source-cargo fallback install
+
+Use this path when no compatible release binary exists, the user asked for a
+source/development install, or the platform is not yet covered by a managed
+binary. This path requires Git plus Rust/Cargo. Ask before installing missing
+system dependencies if the session policy requires permission.
+
+```sh
+set -euo pipefail
+
+src_root="${SOCAI_SOURCE_ROOT:-$HOME/.socai/src}"
+repo_dir="$src_root/socai"
+mkdir -p "$src_root"
+
+if [ -d "$repo_dir/.git" ]; then
+  git -C "$repo_dir" pull --ff-only
+else
+  git clone https://github.com/tonyc-ship/socai.git "$repo_dir"
+fi
+
+cd "$repo_dir"
+cargo install --path cli --force
+
+mkdir -p "$HOME/.socai/share/socai"
+install -m 0644 SKILL.md "$HOME/.socai/share/socai/SKILL.md"
+install -m 0644 install.md "$HOME/.socai/share/socai/install.md"
+
+export PATH="$HOME/.cargo/bin:$PATH"
+socai --help
+```
+
+Make `~/.cargo/bin` persistent if needed:
+
+```sh
+case ":$PATH:" in
+  *":$HOME/.cargo/bin:"*) ;;
+  *)
+    shell_rc="$HOME/.zshrc"
+    [ -n "${BASH_VERSION:-}" ] && shell_rc="$HOME/.bashrc"
+    printf '\n# cargo-installed CLIs\nexport PATH="$HOME/.cargo/bin:$PATH"\n' >> "$shell_rc"
+    ;;
+esac
+```
+
+## skill registration
+
+Always leave a canonical copy at `~/.socai/share/socai/SKILL.md`. Then register
+or point the user's coding agent at that file.
+
+### Claude Code
+
+Preferred user-level registration:
+
+```sh
+mkdir -p "$HOME/.claude/skills/socai"
+cp "$HOME/.socai/share/socai/SKILL.md" "$HOME/.claude/skills/socai/SKILL.md"
+```
+
+If the user wants project-local registration instead, copy the same file to the
+project's `.claude/skills/socai/SKILL.md` after confirming that project-local
+agent instructions should be changed.
+
+### Codex
+
+Use a durable copy plus an instruction pointer. Codex versions differ in how
+they discover skills, so do both when possible:
+
+```sh
+mkdir -p "$HOME/.codex/skills/socai"
+cp "$HOME/.socai/share/socai/SKILL.md" "$HOME/.codex/skills/socai/SKILL.md"
+mkdir -p "$HOME/.codex"
+touch "$HOME/.codex/AGENTS.md"
+```
+
+Append this section to `~/.codex/AGENTS.md` if it is not already present:
+
+```md
+## socai
+
+When asked to use the socai CLI for Xiaohongshu research, read
+`~/.socai/share/socai/SKILL.md` first and follow its stdout/stderr contract.
+```
+
+Do not overwrite unrelated Codex instructions.
+
+## update runbooks
+
+### update `managed-binary`
+
+1. Download the latest `socai-cli-macos-universal.tar.gz` and checksum exactly
+   as in the managed-binary install steps.
+2. Verify the checksum when the `.sha256` file is available.
+3. Replace `~/.socai/bin/socai` and the docs in `~/.socai/share/socai/`.
+4. Stop stale daemon state:
+
+   ```sh
+   socai stop || true
+   ```
+
+5. Run diagnostics:
+
+   ```sh
+   if socai --help | grep -q 'doctor'; then
+     socai doctor
+   else
+     socai --help
+   fi
+   ```
+
+   If this installed build does not yet list `doctor` in `socai --help`, use the
+   manual checks in this file and run `socai --help` as the minimum validation.
+
+### update `source-cargo`
+
+```sh
+set -euo pipefail
+repo_dir="${SOCAI_SOURCE_REPO:-$HOME/.socai/src/socai}"
+git -C "$repo_dir" pull --ff-only
+cd "$repo_dir"
+cargo install --path cli --force
+mkdir -p "$HOME/.socai/share/socai"
+install -m 0644 SKILL.md "$HOME/.socai/share/socai/SKILL.md"
+install -m 0644 install.md "$HOME/.socai/share/socai/install.md"
+socai stop || true
+if socai --help | grep -q 'doctor'; then
+  socai doctor
+else
+  socai --help
+fi
+```
+
+If `socai doctor` is not available in the installed build, validate with
+`socai --help` and the browser/CDP checks below. Once daemon version handshake
+exists, normal commands should restart mismatched daemons automatically; until
+then, keep `socai stop || true` in the update path.
+
+### repair `unknown`
+
+1. Record the current path and help output for the user:
+
+   ```sh
+   command -v socai || true
+   socai --help || true
+   ```
+
+2. Do not infer the update mechanism from an unknown path.
+3. Pick a known install path using the decision tree above.
+4. Install through `managed-binary` or `source-cargo`.
+5. Run `socai stop || true`, then `socai doctor` when available.
+
+## browser and CDP troubleshooting
+
+`socai` controls the user's browser through the Chrome DevTools Protocol (CDP).
+The user may need to be logged into Xiaohongshu in the controlled browser.
+Manual browser permission, login, and CAPTCHA steps are user actions; ask the
+user to complete those when required.
+
+Useful checks and fixes:
+
+1. Open Chrome's remote-debugging page:
+
+   ```sh
+   open -a "Google Chrome" 'chrome://inspect/#remote-debugging'
+   ```
+
+   On non-macOS systems, open `chrome://inspect/#remote-debugging` in Chrome or
+   a compatible Chromium browser.
+
+2. Check common local CDP ports:
+
+   ```sh
+   curl -fsS http://127.0.0.1:9222/json/version || true
+   curl -fsS http://127.0.0.1:9223/json/version || true
+   ```
+
+3. If Chrome uses a non-default debug endpoint, set one of:
+
+   ```sh
+   export SOCAI_CDP_URL="http://127.0.0.1:9222"
+   export SOCAI_CDP_WS="ws://127.0.0.1:9222/devtools/browser/<id>"
+   ```
+
+   `SOCAI_CDP_WS` points directly at the browser websocket. `SOCAI_CDP_URL`
+   points at the HTTP endpoint whose `/json/version` response contains the
+   websocket URL.
+
+4. If no debug endpoint is running, start Chrome with a remote-debugging port.
+   A separate user-data directory avoids profile lock conflicts but may require
+   the user to log in again:
+
+   ```sh
+   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+     --remote-debugging-port=9222 \
+     --user-data-dir="$HOME/.socai/chrome-debug-profile"
+   ```
+
+5. If commands still fail, inspect daemon files:
+
+   ```sh
+   ls -la "$HOME/.socai"
+   tail -n 200 "$HOME/.socai/rust-daemon.log" 2>/dev/null || true
+   socai stop || true
+   ```
+
+## CLI stdout and stderr contract
+
+Agent code should parse tool output from stdout only:
+
+- `search_notes`, `topic_scan`, and `extract_note` print JSON to stdout.
+- `--pretty` changes formatting but stdout remains JSON.
+- `run_dir: ...` is printed to stderr as artifact metadata, not as JSON.
+- `stop` prints daemon status to stderr.
+
+When capturing output, keep stdout and stderr separate. Record `run_dir` so the
+agent can inspect command inputs, artifacts, and optional debug snapshots later.
+
+## command smoke checks
+
+Use non-destructive checks first:
+
+```sh
+socai --help
+socai search_notes --help
+socai topic_scan --help
+socai extract_note --help
+```
+
+Only run live Xiaohongshu commands after browser/CDP is ready and the user is
+comfortable using their logged-in browser session.


### PR DESCRIPTION
## summary

- Add top-level `install.md` with agent-first install, update, and troubleshooting runbooks.
- Add top-level `SKILL.md` for day-to-day CLI usage by coding agents.
- Cover install modes `managed-binary`, `source-cargo`, and `unknown`, plus Codex/Claude Code registration and CDP troubleshooting.

Closes #66
Part of #65

## validation

- `git diff --check`
- `markdownlint install.md SKILL.md` skipped because markdownlint is not installed in this environment.
- `cargo run -q -p socai-cli -- --help`
- Required-term check for install modes, agent registration, CDP env vars, stderr `run_dir`, and `extract_note` continuation docs.
