### PR TITLE
Release: publish prebuilt macOS universal socai CLI asset

### DIFF
--- a/.github/scripts/package-cli-release.py
+++ b/.github/scripts/package-cli-release.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Package the standalone socai CLI release archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+ARCHIVE_NAME = "socai-cli-macos-universal.tar.gz"
+CHECKSUM_NAME = f"{ARCHIVE_NAME}.sha256"
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def add_file(tar: tarfile.TarFile, path: Path, arcname: str, mode: int) -> None:
+    info = tar.gettarinfo(str(path), arcname=arcname)
+    info.mode = mode
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    with path.open("rb") as source:
+        tar.addfile(info, source)
+
+
+def write_checksum(archive_path: Path, checksum_path: Path) -> None:
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    checksum_path.write_text(f"{digest}  {archive_path.name}\n")
+
+
+def existing_file(value: str) -> Path:
+    path = Path(value)
+    if not path.is_file():
+        raise argparse.ArgumentTypeError(f"not a file: {path}")
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="release version without leading v")
+    parser.add_argument("--target", default="macos-universal", help="release target label")
+    parser.add_argument("--git-sha", required=True, help="git commit SHA used to build the binary")
+    parser.add_argument("--binary", required=True, type=existing_file, help="path to the universal socai binary")
+    parser.add_argument("--skill", default="SKILL.md", type=existing_file, help="path to SKILL.md")
+    parser.add_argument("--install", default="install.md", type=existing_file, help="path to install.md")
+    parser.add_argument("--out-dir", default="dist-artifacts", type=Path, help="directory for release assets")
+    parser.add_argument("--created-at", default=None, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if not SEMVER_RE.fullmatch(args.version):
+        raise SystemExit(f"version must be strict MAJOR.MINOR.PATCH semver, got: {args.version}")
+    if not args.git_sha.strip():
+        raise SystemExit("git SHA must not be empty")
+
+    created_at = args.created_at or utc_timestamp()
+    manifest = {
+        "version": args.version,
+        "target": args.target,
+        "git_sha": args.git_sha,
+        "created_at": created_at,
+    }
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = args.out_dir / ARCHIVE_NAME
+    checksum_path = args.out_dir / CHECKSUM_NAME
+    archive_path.unlink(missing_ok=True)
+    checksum_path.unlink(missing_ok=True)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manifest_path = Path(temp_dir) / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+        with tarfile.open(archive_path, "w:gz") as tar:
+            add_file(tar, args.binary, "socai", 0o755)
+            add_file(tar, args.skill, "SKILL.md", 0o644)
+            add_file(tar, args.install, "install.md", 0o644)
+            add_file(tar, manifest_path, "manifest.json", 0o644)
+
+    write_checksum(archive_path, checksum_path)
+    print(f"created {archive_path}")
+    print(f"created {checksum_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/package-cli-release.py
+++ b/.github/scripts/package-cli-release.py
@@ -48,7 +48,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", required=True, help="release version without leading v")
     parser.add_argument("--target", default="macos-universal", help="release target label")
-    parser.add_argument("--git-sha", required=True, help="git commit SHA used to build the binary")
+    parser.add_argument(
+        "--git-sha",
+        required=True,
+        help="git SHA of the versioned build tree the binary was built from",
+    )
+    parser.add_argument(
+        "--base-sha",
+        default=None,
+        help="git SHA of the release base commit before the version bump (optional)",
+    )
     parser.add_argument("--binary", required=True, type=existing_file, help="path to the universal socai binary")
     parser.add_argument("--skill", default="SKILL.md", type=existing_file, help="path to SKILL.md")
     parser.add_argument("--install", default="install.md", type=existing_file, help="path to install.md")
@@ -60,14 +69,22 @@ def main() -> None:
         raise SystemExit(f"version must be strict MAJOR.MINOR.PATCH semver, got: {args.version}")
     if not args.git_sha.strip():
         raise SystemExit("git SHA must not be empty")
+    base_sha = args.base_sha.strip() if args.base_sha is not None else None
+    if args.base_sha is not None and not base_sha:
+        raise SystemExit("base SHA must not be empty when provided")
 
     created_at = args.created_at or utc_timestamp()
+    # git_sha is the SHA of the versioned build tree that produced this binary
+    # (release base + applied version bump), not the pre-bump base. base_sha is
+    # recorded separately so the original release base stays traceable.
     manifest = {
         "version": args.version,
         "target": args.target,
         "git_sha": args.git_sha,
         "created_at": created_at,
     }
+    if base_sha:
+        manifest["base_sha"] = base_sha
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     archive_path = args.out_dir / ARCHIVE_NAME

--- a/.github/scripts/set-app-version.py
+++ b/.github/scripts/set-app-version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update the desktop app version across release metadata files."""
+"""Update release version metadata for the app and Rust workspace."""
 
 from __future__ import annotations
 
@@ -9,6 +9,12 @@ import sys
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+VERSION_LINE_RE = re.compile(r'^(\s*version\s*=\s*")[^"]+(".*)$')
+LOCKED_RUST_PACKAGES = (
+    "socai-cli",
+    "socai-core",
+    "socai_app",
+)
 
 
 def update_json_version(path: Path, version: str) -> None:
@@ -17,17 +23,31 @@ def update_json_version(path: Path, version: str) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def update_app_cargo_toml(path: Path, version: str) -> None:
-    text = path.read_text()
-    text, count = re.subn(
-        r'(?m)^version = "[^"]+"',
-        f'version = "{version}"',
-        text,
-        count=1,
-    )
+def update_section_version(path: Path, section: str, version: str) -> None:
+    lines = path.read_text().splitlines(keepends=True)
+    in_section = False
+    count = 0
+
+    for index, line in enumerate(lines):
+        if re.match(r"^\s*\[[^\]]+\]\s*$", line):
+            in_section = line.strip() == f"[{section}]"
+
+        if not in_section:
+            continue
+
+        body = line[:-1] if line.endswith("\n") else line
+        newline = "\n" if line.endswith("\n") else ""
+        match = VERSION_LINE_RE.match(body)
+        if not match:
+            continue
+
+        lines[index] = f'{match.group(1)}{version}{match.group(2)}{newline}'
+        count += 1
+
     if count != 1:
-        raise SystemExit(f"expected exactly one package version in {path}")
-    path.write_text(text)
+        raise SystemExit(f"expected exactly one {section} version in {path}")
+
+    path.write_text("".join(lines))
 
 
 def update_cargo_lock(path: Path, version: str) -> None:
@@ -35,14 +55,18 @@ def update_cargo_lock(path: Path, version: str) -> None:
         return
 
     text = path.read_text()
-    text, count = re.subn(
-        r'(name = "socai_app"\nversion = ")[^"]+("\n)',
-        rf'\g<1>{version}\2',
-        text,
-        count=1,
-    )
-    if count != 1:
-        raise SystemExit(f"expected exactly one socai_app package entry in {path}")
+    for package_name in LOCKED_RUST_PACKAGES:
+        pattern = re.compile(
+            rf'(?m)^(\[\[package\]\]\nname = "{re.escape(package_name)}"\nversion = ")[^"]+(")'
+        )
+        text, count = pattern.subn(
+            lambda match: f"{match.group(1)}{version}{match.group(2)}",
+            text,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"expected exactly one {package_name} package entry in {path}")
+
     path.write_text(text)
 
 
@@ -56,7 +80,8 @@ def main() -> None:
 
     update_json_version(Path("app/package.json"), version)
     update_json_version(Path("app/src-tauri/tauri.conf.json"), version)
-    update_app_cargo_toml(Path("app/src-tauri/Cargo.toml"), version)
+    update_section_version(Path("app/src-tauri/Cargo.toml"), "package", version)
+    update_section_version(Path("Cargo.toml"), "workspace.package", version)
     update_cargo_lock(Path("Cargo.lock"), version)
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf "target/${TARGET}/release/bundle"
+          rm -rf "target/${TARGET}/release/bundle" target/socai-cli-macos-universal
+
+      - name: build CLI universal binary
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SOCAI_BUILD_SHA: ${{ needs.prepare.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+
+          cargo build -p socai-cli --release --target aarch64-apple-darwin
+          cargo build -p socai-cli --release --target x86_64-apple-darwin
+
+          cli_dir="target/socai-cli-macos-universal"
+          mkdir -p "${cli_dir}"
+          lipo -create \
+            target/aarch64-apple-darwin/release/socai \
+            target/x86_64-apple-darwin/release/socai \
+            -output "${cli_dir}/socai"
+          chmod 0755 "${cli_dir}/socai"
+
+          actual_archs="$(lipo -archs "${cli_dir}/socai")"
+          echo "${cli_dir}/socai architectures: ${actual_archs}"
+          for expected_arch in arm64 x86_64; do
+            if [[ " ${actual_archs} " != *" ${expected_arch} "* ]]; then
+              echo "expected ${cli_dir}/socai to include ${expected_arch}, got: ${actual_archs}" >&2
+              exit 1
+            fi
+          done
+
+          version_output="$("${cli_dir}/socai" --version)"
+          echo "${version_output}"
+          if [ "${version_output}" != "socai ${VERSION}" ]; then
+            echo "expected CLI version 'socai ${VERSION}', got: ${version_output}" >&2
+            exit 1
+          fi
 
       - name: configure macos signing
         shell: bash
@@ -389,11 +424,13 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          BUILD_SHA: ${{ needs.prepare.outputs.base_sha }}
         run: |
           set -euo pipefail
 
           bundle_dir="target/${TARGET}/release/bundle"
           dmg_dir="${bundle_dir}/dmg"
+          cli_binary="target/socai-cli-macos-universal/socai"
           mkdir -p dist-artifacts
 
           dmg="$(find "${dmg_dir}" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
@@ -402,8 +439,50 @@ jobs:
             echo "no dmg found in ${dmg_dir}" >&2
             exit 1
           fi
+          if [ ! -x "${cli_binary}" ]; then
+            echo "no CLI binary found at ${cli_binary}" >&2
+            exit 1
+          fi
 
           cp "${dmg}" "dist-artifacts/socai-macos-universal.dmg"
+          python3 .github/scripts/package-cli-release.py \
+            --version "${VERSION}" \
+            --target macos-universal \
+            --git-sha "${BUILD_SHA}" \
+            --binary "${cli_binary}" \
+            --out-dir dist-artifacts
+
+          (cd dist-artifacts && shasum -a 256 -c socai-cli-macos-universal.tar.gz.sha256)
+          archive_listing="${RUNNER_TEMP}/socai-cli-archive-files.txt"
+          tar -tzf dist-artifacts/socai-cli-macos-universal.tar.gz > "${archive_listing}"
+          for required_file in socai SKILL.md install.md manifest.json; do
+            if ! grep -Fxq "${required_file}" "${archive_listing}"; then
+              echo "CLI archive missing ${required_file}" >&2
+              exit 1
+            fi
+          done
+          manifest_path="${RUNNER_TEMP}/socai-cli-manifest.json"
+          tar -xOzf dist-artifacts/socai-cli-macos-universal.tar.gz manifest.json > "${manifest_path}"
+          python3 - "${manifest_path}" "${VERSION}" macos-universal "${BUILD_SHA}" <<'PY'
+          import json
+          import sys
+
+          manifest_path, version, target, git_sha = sys.argv[1:]
+          with open(manifest_path) as manifest_file:
+              manifest = json.load(manifest_file)
+
+          expected = {
+              "version": version,
+              "target": target,
+              "git_sha": git_sha,
+          }
+          for key, value in expected.items():
+              if manifest.get(key) != value:
+                  raise SystemExit(f"manifest {key} mismatch: expected {value}, got {manifest.get(key)}")
+          if not manifest.get("created_at"):
+              raise SystemExit("manifest missing created_at")
+          PY
+          python3 -m json.tool "${manifest_path}"
 
           ls -lah dist-artifacts
 
@@ -455,18 +534,24 @@ jobs:
             exit 1
           fi
 
-          artifact="dist-artifacts/socai-macos-universal.dmg"
-          if [ ! -f "${artifact}" ]; then
-            echo "missing release artifact: ${artifact}" >&2
-            exit 1
-          fi
+          required_artifacts=(
+            dist-artifacts/socai-macos-universal.dmg
+            dist-artifacts/socai-cli-macos-universal.tar.gz
+            dist-artifacts/socai-cli-macos-universal.tar.gz.sha256
+          )
+          for artifact in "${required_artifacts[@]}"; do
+            if [ ! -f "${artifact}" ]; then
+              echo "missing release artifact: ${artifact}" >&2
+              exit 1
+            fi
+          done
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           python3 .github/scripts/set-app-version.py "${VERSION}"
 
-          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
+          git add Cargo.toml app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
           if git diff --cached --quiet; then
             echo "version files already up to date"
           else
@@ -503,8 +588,10 @@ jobs:
           ## downloads
 
           - [universal mac dmg](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-macos-universal.dmg) — supports Apple Silicon and Intel Macs.
+          - [universal mac CLI tarball](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz) — standalone `socai` CLI with agent install docs.
+          - [CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz.sha256)
 
-          This macOS build is signed and notarized.
+          The macOS app build is signed and notarized.
 
           ## changes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,9 +143,29 @@ jobs:
           ref: ${{ needs.prepare.outputs.base_sha }}
 
       - name: apply release version
+        shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-        run: python3 .github/scripts/set-app-version.py "${VERSION}"
+        run: |
+          set -euo pipefail
+
+          python3 .github/scripts/set-app-version.py "${VERSION}"
+
+          # Commit the version bump so the packaged CLI manifest can record the
+          # SHA of the versioned build tree the binary is actually built from,
+          # instead of the pre-bump base SHA. This commit stays local to the
+          # runner; it is never pushed.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
+          if git diff --cached --quiet; then
+            echo "version files already up to date"
+          else
+            git commit -m "chore: release socai v${VERSION}"
+          fi
+          build_sha="$(git rev-parse HEAD)"
+          echo "build_sha=${build_sha}"
+          echo "SOCAI_BUILD_SHA=${build_sha}" >> "${GITHUB_ENV}"
 
       - name: set up pnpm
         uses: pnpm/action-setup@v4
@@ -186,7 +206,6 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          SOCAI_BUILD_SHA: ${{ needs.prepare.outputs.base_sha }}
         run: |
           set -euo pipefail
 
@@ -424,7 +443,8 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          BUILD_SHA: ${{ needs.prepare.outputs.base_sha }}
+          BUILD_SHA: ${{ env.SOCAI_BUILD_SHA }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
         run: |
           set -euo pipefail
 
@@ -449,6 +469,7 @@ jobs:
             --version "${VERSION}" \
             --target macos-universal \
             --git-sha "${BUILD_SHA}" \
+            --base-sha "${BASE_SHA}" \
             --binary "${cli_binary}" \
             --out-dir dist-artifacts
 
@@ -463,11 +484,11 @@ jobs:
           done
           manifest_path="${RUNNER_TEMP}/socai-cli-manifest.json"
           tar -xOzf dist-artifacts/socai-cli-macos-universal.tar.gz manifest.json > "${manifest_path}"
-          python3 - "${manifest_path}" "${VERSION}" macos-universal "${BUILD_SHA}" <<'PY'
+          python3 - "${manifest_path}" "${VERSION}" macos-universal "${BUILD_SHA}" "${BASE_SHA}" <<'PY'
           import json
           import sys
 
-          manifest_path, version, target, git_sha = sys.argv[1:]
+          manifest_path, version, target, git_sha, base_sha = sys.argv[1:]
           with open(manifest_path) as manifest_file:
               manifest = json.load(manifest_file)
 
@@ -475,6 +496,7 @@ jobs:
               "version": version,
               "target": target,
               "git_sha": git_sha,
+              "base_sha": base_sha,
           }
           for key, value in expected.items():
               if manifest.get(key) != value:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 #[derive(Parser, Debug)]
 #[command(name = "socai")]
+#[command(version)]
 #[command(about = "socai — XHS-savvy browser agent")]
 struct Args {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- Build a standalone macOS universal `socai` CLI by compiling `aarch64-apple-darwin` and `x86_64-apple-darwin`, then combining them with `lipo`.
- Package `socai-cli-macos-universal.tar.gz` with `socai`, `SKILL.md`, `install.md`, and `manifest.json`, plus `socai-cli-macos-universal.tar.gz.sha256`.
- Extend release versioning so app metadata, the Rust workspace version for `socai-cli`/`socai-core`, and matching `Cargo.lock` entries are updated together.
- Add Clap version metadata so `socai --version` follows the release-applied workspace package version.

Stacked on #81; base branch is `issue-77-windows-source-fallback`.

Closes #67
Part of #65

## Validation
- `python3 -m py_compile .github/scripts/set-app-version.py .github/scripts/package-cli-release.py`
- `python3 .github/scripts/set-app-version.py 9.8.7` and verified app/root Cargo/Cargo.lock versions changed, then restored the versioned files.
- `cargo check -p socai-cli`
- `cargo run -q -p socai-cli -- --version` → `socai 0.1.0`
- `cargo build -p socai-cli --release --target aarch64-apple-darwin`
- `cargo build -p socai-cli --release --target x86_64-apple-darwin`
- `lipo -create ...` local universal binary check → `x86_64 arm64`; `socai --version` → `socai 0.1.0`
- `python3 .github/scripts/package-cli-release.py ...` with the local universal binary; `shasum -a 256 -c` passed and archive contains `socai`, `SKILL.md`, `install.md`, `manifest.json`.
- `git diff --check`

Note: `cargo fmt --check` currently reports pre-existing formatting diffs outside this release packaging change; no broad formatting changes were applied.
