### PR TITLE
Docs: switch CLI setup to agent-first install modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,63 @@ This writes records and artifacts to:
 
 ## CLI (for Claude Code, Codex, etc)
 
-From the repo root:
+The CLI is intended for coding agents first. For setup, give your agent the
+install runbook and skill instead of starting with a source build. The agent
+should install or update `socai`, register `SKILL.md`, and run `socai doctor`
+when the installed build supports it:
+
+- [install.md](install.md) — setup, update, and troubleshooting runbook for
+  agents.
+- [SKILL.md](SKILL.md) — usage contract and command guide agents should read
+  before running `socai`.
+
+Copy/paste prompt for Claude Code or Codex:
+
+```text
+Install or update the socai CLI on this machine from https://github.com/tonyc-ship/socai.
+Read the repo's top-level install.md and SKILL.md first.
+Prefer a compatible GitHub Release CLI binary; use the source/Cargo fallback only when no compatible binary exists, the release download/checksum fails, or I ask for a source/development install.
+Do not use the desktop .dmg as a CLI substitute.
+Register the socai skill for this agent, run socai doctor when available (otherwise run socai --help and the manual checks in install.md), then report the install mode, command -v socai, and validation result.
+```
+
+### install modes
+
+- **Release binary (preferred when compatible):** agents should use the latest
+  GitHub Release CLI asset when it matches the user's OS and CPU. The current
+  managed macOS CLI asset is
+  [`socai-cli-macos-universal.tar.gz`](https://github.com/tonyc-ship/socai/releases/latest/download/socai-cli-macos-universal.tar.gz)
+  with checksum
+  [`socai-cli-macos-universal.tar.gz.sha256`](https://github.com/tonyc-ship/socai/releases/latest/download/socai-cli-macos-universal.tar.gz.sha256);
+  it installs to `~/.socai/bin/socai` and does not require Rust or Cargo.
+- **Source/Cargo fallback:** use this when no compatible CLI binary exists, the
+  release asset cannot be verified, the platform is not covered by a release
+  binary, or a development/source install is requested. This path requires Git
+  plus Rust/Cargo and keeps the source checkout in a durable location.
+
+Do not assume every platform has a prebuilt CLI binary. Linux, WSL, native
+Windows, and future targets should follow the compatibility checks in
+[install.md](install.md) and fall back to source/Cargo when needed.
+
+### source/development fallback
+
+From a source checkout:
 
 ```bash
-cargo install --path cli
+cargo install --path cli --force
+mkdir -p "$HOME/.socai/share/socai"
+install -m 0644 SKILL.md "$HOME/.socai/share/socai/SKILL.md"
+install -m 0644 install.md "$HOME/.socai/share/socai/install.md"
+socai stop || true
+if socai --help | grep -q 'doctor'; then socai doctor; else socai --help; fi
+```
 
+### usage examples
+
+After install or update, run diagnostics first when available:
+
+```bash
+socai doctor                                                              # inspect install/browser/daemon health when available
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个获取帖子
 socai search_notes "运营爆款思路" --filter sort=最新                          # 只打开搜索结果页
 socai extract_note --note-id <id>                                          # open a note from the current page
@@ -51,17 +103,24 @@ Options:
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 
-`extract_note` is a
-continuation command: a prior `search_notes` / `topic_scan` must have left the
-tool tab on a waterfall containing the target card.
+`extract_note` is a continuation command: a prior `search_notes` / `topic_scan`
+must have left the tool tab on a waterfall containing the target card.
 
+For updates or troubleshooting, rerun the agent setup prompt or follow the
+managed-binary, source/Cargo, and browser/CDP repair sections in
+[install.md](install.md). Stop stale daemon state with `socai stop || true`, then
+run `socai doctor` when the installed build supports it; older builds should use
+`socai --help` and the manual checks in `install.md`.
 
 ## TUI
 
+After installing the CLI through a release binary or source fallback:
+
 ```bash
-cargo install --path cli
 socai
 ```
+
+For local TUI development, use the source/development fallback above.
 
 ## Website
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ if socai --help | grep -q 'doctor'; then socai doctor; else socai --help; fi
 After install or update, run diagnostics first when available:
 
 ```bash
-socai doctor                                                              # inspect install/browser/daemon health when available
+if socai --help | grep -q 'doctor'; then socai doctor; fi                  # inspect install/browser/daemon health when the build includes doctor
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个获取帖子
 socai search_notes "运营爆款思路" --filter sort=最新                          # 只打开搜索结果页
 socai extract_note --note-id <id>                                          # open a note from the current page


### PR DESCRIPTION
## Summary
- Update README CLI setup to be agent-first with links to `install.md` and `SKILL.md`.
- Document release-binary-preferred install mode and source/Cargo fallback without claiming every platform has a prebuilt binary.
- Keep CLI usage examples, add `socai doctor`, and point update/troubleshooting to `install.md`.

Closes #70
Part of #65

## Stack / dependencies
- Depends on docs/release PRs #78, #81, and #83.
- Stacked on #83 / `issue-67-cli-release-asset`.
- PR base is `issue-67-cli-release-asset`, not `main`.

## Validation
- `git diff --check`
- `grep -n "install.md\|SKILL.md\|socai doctor\|socai-cli-macos-universal\|cargo install --path cli" README.md`
- `grep -R -n -i -E "cargo install|socai doctor|socai login|socai xhs|install the socai CLI|CLI setup" site --include='*.md' --include='*.astro' --include='*.ts' || true`
- `grep -R -n -i -E "cargo install|socai doctor|socai login|socai xhs|install the socai CLI|CLI setup" docs --include='*.md' || true`
