### PR TITLE
chore: update repository owner links

### DIFF
--- a/.claude/skills/socai-release/SKILL.md
+++ b/.claude/skills/socai-release/SKILL.md
@@ -10,7 +10,7 @@ Use this skill whenever the task is to create or inspect a socai GitHub Release,
 The command-line release path is the source of truth:
 
 ```bash
-gh workflow run release.yml --repo tonyc-ship/socai --ref main -f release_type=patch
+gh workflow run release.yml --repo socai-io/socai --ref main -f release_type=patch
 ```
 
 A helper script wraps this command, finds the created run, watches it, and prints the resulting release:
@@ -55,7 +55,7 @@ Run from the repo root when possible.
 
 ```bash
 gh auth status --hostname github.com
-gh repo view tonyc-ship/socai --json nameWithOwner,defaultBranchRef,url
+gh repo view socai-io/socai --json nameWithOwner,defaultBranchRef,url
 
 git fetch origin main --tags
 git status --short
@@ -104,13 +104,13 @@ Equivalent raw `gh` path:
 
 ```bash
 gh workflow run release.yml \
-  --repo tonyc-ship/socai \
+  --repo socai-io/socai \
   --ref main \
   -f release_type=patch
 
 sleep 8
 run_id="$(gh run list \
-  --repo tonyc-ship/socai \
+  --repo socai-io/socai \
   --workflow release.yml \
   --branch main \
   --event workflow_dispatch \
@@ -118,7 +118,7 @@ run_id="$(gh run list \
   --json databaseId \
   --jq '.[0].databaseId')"
 
-gh run watch "${run_id}" --repo tonyc-ship/socai --exit-status
+gh run watch "${run_id}" --repo socai-io/socai --exit-status
 ```
 
 Use `minor` or `major` instead of `patch` only when requested.
@@ -145,7 +145,7 @@ or:
 
 ```bash
 gh workflow run release.yml \
-  --repo tonyc-ship/socai \
+  --repo socai-io/socai \
   --ref fix/release-some-branch \
   -f release_type=patch
 ```
@@ -155,20 +155,20 @@ gh workflow run release.yml \
 List recent release runs:
 
 ```bash
-gh run list --repo tonyc-ship/socai --workflow release.yml --limit 10
+gh run list --repo socai-io/socai --workflow release.yml --limit 10
 ```
 
 Watch a run:
 
 ```bash
-gh run watch RUN_ID --repo tonyc-ship/socai --exit-status
+gh run watch RUN_ID --repo socai-io/socai --exit-status
 ```
 
 View details/logs:
 
 ```bash
-gh run view RUN_ID --repo tonyc-ship/socai
-gh run view RUN_ID --repo tonyc-ship/socai --log-failed
+gh run view RUN_ID --repo socai-io/socai
+gh run view RUN_ID --repo socai-io/socai --log-failed
 ```
 
 Common failure notes:
@@ -184,7 +184,7 @@ Common failure notes:
 After a successful production run:
 
 ```bash
-gh release view --repo tonyc-ship/socai \
+gh release view --repo socai-io/socai \
   --json tagName,name,url,isDraft,isPrerelease,publishedAt,assets \
   --jq '{tagName,name,url,isDraft,isPrerelease,publishedAt,assets:[.assets[].name]}'
 ```
@@ -198,10 +198,10 @@ Expected:
 Verify download redirects:
 
 ```bash
-tag="$(gh release view --repo tonyc-ship/socai --json tagName --jq '.tagName')"
+tag="$(gh release view --repo socai-io/socai --json tagName --jq '.tagName')"
 curl -I https://socai.io/download
 curl -I -L --max-time 30 -o /dev/null -w 'code=%{http_code}\nfinal=%{url_effective}\n' https://socai.io/download
-curl -sSI https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg | grep -F "/releases/download/${tag}/socai-macos-universal.dmg"
+curl -sSI https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg | grep -F "/releases/download/${tag}/socai-macos-universal.dmg"
 ```
 
 Expected final URL should resolve through GitHub latest release download and produce a successful response. The visible `socai.io` version is only expected to update after the separate site deployment follow-up.
@@ -209,10 +209,10 @@ Expected final URL should resolve through GitHub latest release download and pro
 Optional artifact check:
 
 ```bash
-tag="$(gh release view --repo tonyc-ship/socai --json tagName --jq '.tagName')"
+tag="$(gh release view --repo socai-io/socai --json tagName --jq '.tagName')"
 mkdir -p "/tmp/socai-release-${tag}"
 gh release download "${tag}" \
-  --repo tonyc-ship/socai \
+  --repo socai-io/socai \
   --pattern socai-macos-universal.dmg \
   --dir "/tmp/socai-release-${tag}" \
   --clobber

--- a/.claude/skills/socai-release/scripts/create-release.sh
+++ b/.claude/skills/socai-release/scripts/create-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="tonyc-ship/socai"
+repo="socai-io/socai"
 workflow="release.yml"
 release_type="patch"
 ref="main"
@@ -19,7 +19,7 @@ Options:
   --ref REF         Git ref to dispatch from (default: main). Production
                     releases publish only from main. fix/release-* is for
                     non-publishing workflow tests.
-  --repo OWNER/REPO GitHub repository (default: tonyc-ship/socai)
+  --repo OWNER/REPO GitHub repository (default: socai-io/socai)
   --workflow FILE   Workflow file/name (default: release.yml)
   --no-watch        Trigger and print run URL without waiting for completion
   -h, --help        Show this help

--- a/.claude/skills/socai-site-deployment/SKILL.md
+++ b/.claude/skills/socai-site-deployment/SKILL.md
@@ -19,7 +19,7 @@ This skill is the source-of-truth deployment runbook. [`../../../docs/website-de
 - Canonical host: `socai.io`
 - `www` behavior: `https://www.socai.io/*` should 308/redirect to `https://socai.io/*`
 - Download route: `https://socai.io/download` redirects to GitHub's latest universal macOS DMG
-- GitHub route: `https://socai.io/github` redirects to `https://github.com/tonyc-ship/socai`
+- GitHub route: `https://socai.io/github` redirects to `https://github.com/socai-io/socai`
 
 Expected Vercel project settings:
 
@@ -146,8 +146,8 @@ Expected first-hop behavior:
 
 - `https://socai.io/` returns `200`.
 - `https://www.socai.io/` returns `308` with `location: https://socai.io/`.
-- `https://socai.io/download` returns a Vercel redirect (`307`) to `https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg`.
-- `https://socai.io/github` returns a Vercel redirect (`307`) to `https://github.com/tonyc-ship/socai`.
+- `https://socai.io/download` returns a Vercel redirect (`307`) to `https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg`.
+- `https://socai.io/github` returns a Vercel redirect (`307`) to `https://github.com/socai-io/socai`.
 
 Use `-L` only when you want to follow the chain:
 
@@ -162,16 +162,16 @@ Try:
 ```bash
 cd site
 vercel link --yes --scope socai-d83824c8 --project socai-site
-vercel git connect https://github.com/tonyc-ship/socai --scope socai-d83824c8
+vercel git connect https://github.com/socai-io/socai --scope socai-d83824c8
 ```
 
 If Vercel returns:
 
 ```text
-Failed to link tonyc-ship/socai. You need to add a Login Connection to your GitHub account first.
+Failed to link socai-io/socai. You need to add a Login Connection to your GitHub account first.
 ```
 
-then a Vercel/GitHub account owner must connect the GitHub login/integration in the Vercel dashboard, then connect `socai-site` to `tonyc-ship/socai` with root directory `site`.
+then a Vercel/GitHub account owner must connect the GitHub login/integration in the Vercel dashboard, then connect `socai-site` to `socai-io/socai` with root directory `site`.
 
 ## Troubleshooting
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/tonyc-ship/socai"
+repository = "https://github.com/socai-io/socai"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Desktop App
 
-[Download .dmg for Mac](https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg).
+[Download .dmg for Mac](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg).
 
 For local development:
 

--- a/docs/website-launch-qa.md
+++ b/docs/website-launch-qa.md
@@ -12,9 +12,9 @@ Status: **website launch checks passed on production**, with one release-artifac
 - Latest GitHub release metadata matches the website download target.
 - The latest DMG was downloaded through `https://socai.io/download`; its SHA-256 matches the GitHub Release digest.
 - The mounted `socai.app` is code-signed and accepted as a notarized Developer ID app.
-- The DMG container itself is **not notarized**; tracked separately in [#40](https://github.com/tonyc-ship/socai/issues/40).
+- The DMG container itself is **not notarized**; tracked separately in [#40](https://github.com/socai-io/socai/issues/40).
 - A Lighthouse accessibility contrast issue was found in the app mock window title, fixed, deployed, and re-tested.
-- Vercel Git preview deployments remain blocked until a Vercel/GitHub account owner connects the GitHub login/integration, as documented in [#33](https://github.com/tonyc-ship/socai/issues/33).
+- Vercel Git preview deployments remain blocked until a Vercel/GitHub account owner connects the GitHub login/integration, as documented in [#33](https://github.com/socai-io/socai/issues/33).
 
 ## Build and config validation
 
@@ -70,7 +70,7 @@ Results:
 | `https://www.socai.io/` | Redirect to canonical host | Passed; `HTTP/2 308`, `location: https://socai.io/` |
 | `https://socai.io/download` | Redirect to latest universal DMG | Passed; `HTTP/2 307`, GitHub latest DMG location |
 | `https://socai.io/download/macos` | Redirect to latest universal DMG | Passed; `HTTP/2 307`, GitHub latest DMG location |
-| `https://socai.io/github` | Redirect to repo | Passed; `HTTP/2 307`, `location: https://github.com/tonyc-ship/socai` |
+| `https://socai.io/github` | Redirect to repo | Passed; `HTTP/2 307`, `location: https://github.com/socai-io/socai` |
 | `https://socai.io/robots.txt` | HTTPS 200 | Passed |
 | `https://socai.io/sitemap.xml` | HTTPS 200 | Passed |
 | `https://socai.io/social-card.png` | HTTPS 200 image | Passed |
@@ -80,7 +80,7 @@ Results:
 GitHub latest release checked with:
 
 ```bash
-gh release view --repo tonyc-ship/socai --json tagName,name,url,assets,publishedAt,isDraft,isPrerelease
+gh release view --repo socai-io/socai --json tagName,name,url,assets,publishedAt,isDraft,isPrerelease
 ```
 
 Current latest release:
@@ -89,7 +89,7 @@ Current latest release:
 - Published: `2026-05-27T09:19:10Z`
 - Asset: `socai-macos-universal.dmg`
 - Size: `14,575,965` bytes (`14.6 MB` decimal)
-- Release asset URL: `https://github.com/tonyc-ship/socai/releases/download/v0.1.2/socai-macos-universal.dmg`
+- Release asset URL: `https://github.com/socai-io/socai/releases/download/v0.1.2/socai-macos-universal.dmg`
 - Digest: `sha256:507ff343cc13b3453346d9d3663bb5e12bbda47507ed7e851b0bf65cfc893309`
 
 Downloaded through the production website route:
@@ -141,7 +141,7 @@ source=Notarized Developer ID
 origin=Developer ID Application: Mingrui Zhang (J9B2NB3X6G)
 ```
 
-Conclusion: the app bundle is signed/notarized, but the DMG container should be notarized/stapled before broader public sharing. Follow-up: [#40](https://github.com/tonyc-ship/socai/issues/40).
+Conclusion: the app bundle is signed/notarized, but the DMG container should be notarized/stapled before broader public sharing. Follow-up: [#40](https://github.com/socai-io/socai/issues/40).
 
 ## Desktop and mobile browser checks
 
@@ -173,7 +173,7 @@ Production Lighthouse after fixes and redeploy:
 - Best Practices: 100
 - SEO: 100
 
-Remaining non-blocking performance notes are mostly related to external font loading/cache lifetime and render-blocking font CSS. Existing issue [#8](https://github.com/tonyc-ship/socai/issues/8) already tracks bundling fonts locally.
+Remaining non-blocking performance notes are mostly related to external font loading/cache lifetime and render-blocking font CSS. Existing issue [#8](https://github.com/socai-io/socai/issues/8) already tracks bundling fonts locally.
 
 ## Rollback and update process
 

--- a/site/src/lib/release.ts
+++ b/site/src/lib/release.ts
@@ -26,7 +26,7 @@ async function fetchLatestReleaseVersion(): Promise<string | null> {
         }
 
         const response = await fetch(
-            "https://api.github.com/repos/tonyc-ship/socai/releases/latest",
+            "https://api.github.com/repos/socai-io/socai/releases/latest",
             {
                 headers,
             },

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -5,7 +5,7 @@ import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
 import { resolveReleaseVersion } from "../lib/release";
 
-const githubIssuesUrl = "https://github.com/tonyc-ship/socai/issues";
+const githubIssuesUrl = "https://github.com/socai-io/socai/issues";
 const qrImage = "/wechat-group-qr.jpg";
 const currentYear = new Date().getFullYear();
 const siteUrl = "https://socai.io";
@@ -203,7 +203,7 @@ const releaseVersion = await resolveReleaseVersion();
                                     >
                                 </span>
                                 <span class="contact-alt__value"
-                                    >github.com/tonyc-ship/socai ↗</span
+                                    >github.com/socai-io/socai ↗</span
                                 >
                             </a>
                         </div>

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -35,17 +35,17 @@
     },
     {
       "source": "/download",
-      "destination": "https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg",
+      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg",
       "permanent": false
     },
     {
       "source": "/download/macos",
-      "destination": "https://github.com/tonyc-ship/socai/releases/latest/download/socai-macos-universal.dmg",
+      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg",
       "permanent": false
     },
     {
       "source": "/github",
-      "destination": "https://github.com/tonyc-ship/socai",
+      "destination": "https://github.com/socai-io/socai",
       "permanent": false
     }
   ]


### PR DESCRIPTION
## Summary
- replace remaining `tonyc-ship/socai` references with `socai-io/socai`
- update website redirects, release-version lookup, README/Cargo metadata, and contact links
- update release/site deployment runbooks and helper defaults for the new org repo

## Validation
- `rg -n "tonyc-ship" . .claude -g '!target' -g '!site/node_modules' -g '!app/node_modules' -g '!**/.git/**' -g '!site/dist'`
- `python3 -m json.tool site/vercel.json >/dev/null`
- `bash -n .claude/skills/socai-release/scripts/create-release.sh`
- `cd site && pnpm install && pnpm build`

## Notes
- Production `socai.io` was manually redeployed after these changes and now redirects `/download`, `/download/macos`, and `/github` to `socai-io/socai`.
- Vercel Git integration still needs a Vercel/GitHub Login Connection authorized in the dashboard before automatic Git deployments/PR previews can be reconnected.
