### PR TITLE
feat(xhs): add --num-notes to search_notes for scroll-collecting cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ cargo install --path cli
 常用命令：
 
 ```bash
-socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个获取帖子
-socai search_notes "运营爆款思路" --filter sort=最新                          # 只打开搜索结果页
+socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
+socai search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
 ```
@@ -52,7 +52,10 @@ Options:
   `distance` (不限/同城/附近). Omitted groups reset to default.
   e.g. `--filter publish_time=一天内 --filter note_type=图文`
 - `--tab <TAB>` — search tab to switch to, `topic_scan` only (`全部` / `图文` / `视频` / `用户`).
-- `--num-notes <N>` — notes to read, `topic_scan` only (scrolls only if the first page holds fewer).
+- `--num-notes <N>` — `topic_scan`: notes to read (opens each, body + comments).
+  `search_notes`: cards to collect by auto-scrolling (titles/likes/covers only,
+  no bodies — stays fast). Both scroll only if the first page holds fewer; omit
+  for the first page only (~19).
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -237,9 +237,10 @@ impl DaemonState {
         let result = async {
             let query = required_string(&args, "query")?;
             let filters = args.get("filters");
+            let num_notes = args.get("num_notes").and_then(Value::as_i64);
             let debug_snapshot = debug_snapshot_flag(&args);
             let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-            search_notes_command(page, &query, filters, debug_snapshot).await
+            search_notes_command(page, &query, filters, num_notes, debug_snapshot).await
         }
         .await;
         self.track_tool_trace(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,6 +25,11 @@ enum Command {
         /// sort, note_type, publish_time, search_scope, distance.
         #[arg(long = "filter", value_name = "GROUP=OPTION")]
         filter: Vec<String>,
+        /// Auto-scroll the feed to collect at least this many cards
+        /// (titles/likes/covers only — note bodies are not opened). Omit for
+        /// the first page only (~19 cards).
+        #[arg(long = "num-notes")]
+        num_notes: Option<i64>,
         #[arg(long)]
         pretty: bool,
         /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
@@ -90,6 +95,7 @@ async fn main() -> Result<()> {
         Command::SearchNotes {
             query,
             filter,
+            num_notes,
             pretty,
             debug_snapshot,
         } => {
@@ -98,12 +104,17 @@ async fn main() -> Result<()> {
             if !filter.is_empty() {
                 input["filters"] = Value::Object(parse_filters(&filter)?);
             }
-            let result = daemon::send_or_spawn(
-                "search_notes",
-                input,
-                daemon::DEFAULT_COMMAND_TIMEOUT,
-            )
-            .await?;
+            if let Some(n) = num_notes {
+                input["num_notes"] = serde_json::json!(n.max(1));
+            }
+            // Scrolling for a large `num_notes` can take a while; give it the
+            // longer budget rather than the default single-action timeout.
+            let timeout = if num_notes.is_some() {
+                daemon::LONG_COMMAND_TIMEOUT
+            } else {
+                daemon::DEFAULT_COMMAND_TIMEOUT
+            };
+            let result = daemon::send_or_spawn("search_notes", input, timeout).await?;
             print_command_result(&result, pretty)?;
         }
         Command::TopicScan {

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -76,9 +76,13 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
   next cards in as it scrolls), reading its body + top comments, writing
   artifacts, closing note modals, and marking already analyzed posts. Default
   `num_notes` is 10.
-- Quick breadth scan: use `search_notes` (atomic — returns the first results
-  page's cards, no scrolling; accepts optional `filters` to narrow the feed) or
-  `extract_search_cards` to inspect cards without opening notes.
+- Quick breadth scan: use `search_notes` to return search-result cards (accepts
+  optional `filters`). By default returns only the first page (~19 cards, no
+  scrolling); pass `num_notes` to auto-scroll the feed and collect that many
+  cards (titles/likes/covers only — no bodies opened, so it stays fast). This is
+  the right tool to batch-harvest card metadata for filtering/analysis without
+  reading note bodies. Or use `extract_search_cards` to inspect already-loaded
+  cards without opening notes.
 - Manual note read: use `read_note(index=N)` or `read_note(note_id=...)`.
   Use `level="card"` for metadata only, `level="lite"` for body/comments, and
   `level="deep"` plus `include_media=true` only when images, OCR, video, or

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -13,6 +13,12 @@ pub const XHS_HOME_URL: &str = "https://www.xiaohongshu.com/explore";
 
 const PAGE_SCRIPTS_JS: &str = include_str!("page_scripts.js");
 
+/// How long to wait for the search-results page to actually populate cards
+/// after submitting. The wait polls and returns the instant cards appear, so a
+/// generous ceiling only costs time on genuinely slow loads (e.g. over a VPN) —
+/// the fast path is unaffected.
+const SEARCH_TRANSITION_TIMEOUT_S: f64 = 12.0;
+
 const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "note",
     "noteWithWait",
@@ -30,6 +36,7 @@ const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "noteOpen",
     "comments",
     "commentsWithWait",
+    "scrollFeed",
     "scrollInNote",
     "carouselImages",
     "profileInfo",
@@ -161,6 +168,7 @@ impl<'a> XhsPageRuntime<'a> {
         query: &str,
         filters: Option<&Value>,
         wait_seconds: f64,
+        num_notes: Option<usize>,
     ) -> Result<Value> {
         let keyword = query.trim();
         if keyword.is_empty() {
@@ -179,7 +187,13 @@ impl<'a> XhsPageRuntime<'a> {
             }
         }
         let cards = if ok {
-            self.extract_search_cards().await?
+            match num_notes {
+                // Scroll the feed to lazy-load more cards until we reach the
+                // requested count (or the feed stops growing). `None`/`Some(0)`
+                // keeps the cheap first-page-only behaviour.
+                Some(target) if target > 0 => self.collect_search_cards(target).await?,
+                _ => self.extract_search_cards().await?,
+            }
         } else {
             Vec::new()
         };
@@ -234,7 +248,7 @@ impl<'a> XhsPageRuntime<'a> {
         sleep_ms(150).await;
         self.page.press_key("Enter").await?;
         let state = self
-            .wait_for_search_transition(query, wait_seconds.clamp(0.2, 6.0))
+            .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
             .await?;
         if search_transition_ok(&state, query) {
             return Ok(json!({
@@ -251,7 +265,7 @@ impl<'a> XhsPageRuntime<'a> {
             if x > 0.0 && y > 0.0 {
                 self.page.click(x, y).await?;
                 let state = self
-                    .wait_for_search_transition(query, wait_seconds.clamp(0.2, 6.0))
+                    .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
                     .await?;
                 if search_transition_ok(&state, query) {
                     return Ok(json!({
@@ -298,6 +312,78 @@ impl<'a> XhsPageRuntime<'a> {
         self.ensure_xhs(false).await?;
         let raw = self.expect_array("searchCards", None).await?;
         Ok(parse_cards(&raw))
+    }
+
+    /// Scroll the search feed to lazy-load more cards. By default jumps to the
+    /// document bottom (window-size independent, no hard-coded pixel step); with
+    /// `nudge_up` it instead scrolls back up ~1/10 of a screen to jog XHS's
+    /// infinite-scroll observer when a bottom jump failed to trigger a load.
+    pub async fn scroll_feed(&self, nudge_up: bool) -> Result<Value> {
+        self.ensure_xhs(false).await?;
+        self.expect_object("scrollFeed", Some(&json!({ "nudge_up": nudge_up })))
+            .await
+    }
+
+    /// Poll `extract_search_cards` until the count grows past `baseline` or
+    /// `timeout` elapses; returns the latest cards either way.
+    async fn wait_for_card_growth(
+        &self,
+        baseline: usize,
+        timeout: Duration,
+    ) -> Result<Vec<XhsNoteCard>> {
+        const POLL: Duration = Duration::from_millis(400);
+        let deadline = Instant::now() + timeout;
+        loop {
+            sleep_ms(POLL.as_millis() as u64).await;
+            let cards = self.extract_search_cards().await?;
+            if cards.len() > baseline || Instant::now() >= deadline {
+                return Ok(cards);
+            }
+        }
+    }
+
+    /// Collect search cards up to `target`, scrolling the feed and waiting for
+    /// lazy-loaded cards after each scroll. Stops once we have enough cards or
+    /// the feed stops growing across a few consecutive scrolls (real end of
+    /// results). Returns at most `target` cards in feed order.
+    async fn collect_search_cards(&self, target: usize) -> Result<Vec<XhsNoteCard>> {
+        // XHS sometimes ignores a too-fast jump to the bottom and won't fetch
+        // more, so pause before each jump; if a jump still loads nothing within
+        // SETTLE_TIMEOUT, a small reverse (upward) scroll reliably re-triggers
+        // the lazy load. Give up only after MAX_STALLS rounds where even the
+        // nudge fails (the real end of results).
+        const PRE_SCROLL_DELAY: Duration = Duration::from_millis(1500);
+        const SETTLE_TIMEOUT: Duration = Duration::from_millis(5000);
+        const MAX_STALLS: usize = 3;
+
+        let mut cards = self.extract_search_cards().await?;
+        let mut stalls = 0usize;
+        while cards.len() < target {
+            let before = cards.len();
+
+            // 1) Deliberate pause, then jump to the bottom to request more.
+            sleep_ms(PRE_SCROLL_DELAY.as_millis() as u64).await;
+            self.scroll_feed(false).await?;
+            cards = self.wait_for_card_growth(before, SETTLE_TIMEOUT).await?;
+
+            // 2) Nothing loaded in time — nudge back up to jog the observer and
+            //    wait once more before counting this round as a stall.
+            if cards.len() <= before {
+                self.scroll_feed(true).await?;
+                cards = self.wait_for_card_growth(before, SETTLE_TIMEOUT).await?;
+            }
+
+            if cards.len() <= before {
+                stalls += 1;
+                if stalls >= MAX_STALLS {
+                    break;
+                }
+            } else {
+                stalls = 0;
+            }
+        }
+        cards.truncate(target);
+        Ok(cards)
     }
 
     pub async fn open_note(

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -885,6 +885,35 @@ const SocaiXhsPageScripts = (() => {
     });
   }
 
+  // ── search/feed scroll ───────────────────────────────────────
+  // Window-level scroll used to lazy-load more search cards. Default jumps to
+  // the current document bottom (window-size independent, no hard-coded pixel
+  // step) so the site fetches the next page. With `nudge_up`, instead scrolls
+  // back up ~1/10 of a screen: XHS sometimes ignores a too-fast jump to the
+  // bottom and won't load more, but a small reverse scroll reliably jogs its
+  // infinite-scroll observer. The caller waits for new cards by polling
+  // searchCards.
+  function scrollFeed(opts = {}) {
+    const el = document.scrollingElement || document.documentElement;
+    const before = el.scrollTop;
+    const beforeHeight = el.scrollHeight;
+    if (opts && opts.nudge_up) {
+      const step = Math.max(80, Math.round(window.innerHeight / 10));
+      window.scrollBy({ top: -step, left: 0, behavior: 'instant' });
+    } else {
+      window.scrollTo({ top: el.scrollHeight, left: 0, behavior: 'instant' });
+    }
+    const after = el.scrollTop;
+    return {
+      ok: true,
+      before,
+      after,
+      moved: after !== before,
+      scroll_height: beforeHeight,
+      inner_height: window.innerHeight,
+    };
+  }
+
   // ── modal-internal scroll (Promise-resolved) ─────────────────
   function scrollInNote(opts = {}) {
     const pixels = Number(opts.pixels) || 400;
@@ -958,6 +987,7 @@ const SocaiXhsPageScripts = (() => {
     noteOpen,
     comments,
     commentsWithWait,
+    scrollFeed,
     scrollInNote,
     carouselImages,
     profileInfo,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -132,12 +132,13 @@ pub async fn search_notes_command(
     page: Arc<PageSession>,
     query: &str,
     filters: Option<&Value>,
+    num_notes: Option<i64>,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         SEARCH_NOTES_COMMAND,
-        search_notes_input(query, filters)?,
+        search_notes_input(query, filters, num_notes)?,
         debug_snapshot,
     )
     .await
@@ -174,13 +175,20 @@ pub async fn extract_note_command(
     .await
 }
 
-fn search_notes_input(query: &str, filters: Option<&Value>) -> anyhow::Result<Value> {
+fn search_notes_input(
+    query: &str,
+    filters: Option<&Value>,
+    num_notes: Option<i64>,
+) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
         "wait_seconds": 2.0,
     });
     if let Some(filters) = filters {
         input["filters"] = filters.clone();
+    }
+    if let Some(n) = num_notes {
+        input["num_notes"] = json!(n.max(1));
     }
     Ok(input)
 }
@@ -402,12 +410,15 @@ impl Tool for SearchNotesTool {
     }
 
     fn description(&self) -> &str {
-        "Search Xiaohongshu for notes matching `query`. Atomic: submits the \
-         search and returns the first results page's cards (id, title, author, \
-         image) without scrolling. Optionally applies search-result `filters` \
-         (omitted groups reset to defaults); each group is single-select. Use \
-         this before `open_note` to pick which note to read; to research a topic \
-         in one call use `topic_scan`."
+        "Search Xiaohongshu for notes matching `query` and return result cards \
+         (id, title, author, likes, cover image). By default reads only the \
+         first results page (~19 cards, no scrolling). Pass `num_notes` to \
+         auto-scroll the feed, lazy-loading more cards until that many are \
+         collected (titles/likes/covers only — note bodies are NOT opened, so \
+         it stays fast). Optionally applies search-result `filters` (omitted \
+         groups reset to defaults); each group is single-select. Use before \
+         `open_note` to pick a note; to read note bodies + comments in one call \
+         use `topic_scan`."
     }
 
     fn input_schema(&self) -> Value {
@@ -416,6 +427,11 @@ impl Tool for SearchNotesTool {
             "properties": {
                 "query": { "type": "string", "description": "Search query (Chinese works fine)" },
                 "filters": search_filters_schema(),
+                "num_notes": {
+                    "type": "integer",
+                    "description": "Scroll to collect at least this many cards (lazy-loaded). Omit for the first page only.",
+                    "minimum": 1
+                },
                 "wait_seconds": {
                     "type": "number",
                     "description": "Extra seconds to wait for cards to load",
@@ -432,9 +448,14 @@ impl Tool for SearchNotesTool {
             .to_string();
         let filters = input.get("filters").filter(|value| !value.is_null()).cloned();
         let wait_seconds = get_f64(&input, "wait_seconds", 2.0);
+        let num_notes = input
+            .get("num_notes")
+            .and_then(Value::as_i64)
+            .filter(|n| *n > 0)
+            .map(|n| n as usize);
         let xhs = XhsPageRuntime::new(&self.page);
         let mut value = xhs
-            .search_notes(&query, filters.as_ref(), wait_seconds)
+            .search_notes(&query, filters.as_ref(), wait_seconds, num_notes)
             .await?;
         if let Some(cards) = value.get_mut("cards") {
             self.history.annotate_cards(cards);
@@ -1074,7 +1095,7 @@ impl Tool for TopicScanTool {
 
         // Filters are applied after the optional tab switch below (tab switch
         // re-runs the search and would drop them), so don't pass them here.
-        let search = xhs.search_notes(&query, None, 2.0).await?;
+        let search = xhs.search_notes(&query, None, 2.0, None).await?;
 
         // Optional tab switch (re-runs the search under the chosen tab), then
         // optional filter application.

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -115,7 +115,7 @@ Current metadata keys:
 | Metadata key | Type | Source CLI flag | Omitted when |
 | --- | --- | --- | --- |
 | `metadata.tab` | string | `topic_scan --tab <value>` | `--tab` is not passed or is empty. |
-| `metadata.num_notes` | number | `topic_scan --num-notes <n>` | `--num-notes` is not passed and the command uses its default. |
+| `metadata.num_notes` | number | `topic_scan` / `search_notes` `--num-notes <n>` | `--num-notes` is not passed. |
 | `metadata.debug_snapshot` | boolean | `--debug-snapshot` | `--debug-snapshot` is not passed / false. |
 
 ### Duration, status, and safe result metrics


### PR DESCRIPTION
## What

Add `--num-notes` to `search_notes`. By default it still reads only the first results page (~19 cards, no scrolling). With `num_notes`, it auto-scrolls the feed and collects that many cards (id/title/likes/cover) **without opening notes** — fast batch harvest of card metadata for filtering/analysis. This serves the use case of "拿关键词下的标题/点赞/封面用于筛选和分析，不需要正文".

## Scroll stability (slow loads, e.g. over a VPN)

- Pause ~1.5s before each jump to the bottom — a too-fast jump sometimes fails to trigger XHS's lazy load.
- If nothing loads within 5s, nudge **up** ~1/10 screen to jog the infinite-scroll observer, then wait once more. Give up only after 3 consecutive stalled rounds (real end of results), returning what was collected (no error).

## Search-transition timeout fix

Raise the post-submit wait floor to 12s (was effectively 2s). The wait polls and returns the instant cards appear, so the fast path is unaffected; slow loads no longer exit early with `Search did not transition to a valid Xiaohongshu result page`.

## Docs

README (CLI usage), `docs/telemetry-schema.md` (num_notes source), and `core/src/sites/xhs/knowledge.md` (agent tool knowledge) updated.

## Testing

`cargo test -p socai-core -p socai-cli` green (59 tests). Manually verified `search_notes "electro swing" --num-notes 100` returns scrolled cards both with and without VPN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)