### PR TITLE
Release: publish macOS CLI binary and update README install

### DIFF
--- a/.github/scripts/set-app-version.py
+++ b/.github/scripts/set-app-version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update the desktop app version across release metadata files."""
+"""Update release version metadata for the app and Rust workspace."""
 
 from __future__ import annotations
 
@@ -9,6 +9,12 @@ import sys
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+VERSION_LINE_RE = re.compile(r'^(\s*version\s*=\s*")[^"]+(")')
+LOCKED_RUST_PACKAGES = (
+    "socai-cli",
+    "socai-core",
+    "socai_app",
+)
 
 
 def update_json_version(path: Path, version: str) -> None:
@@ -17,17 +23,31 @@ def update_json_version(path: Path, version: str) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def update_app_cargo_toml(path: Path, version: str) -> None:
-    text = path.read_text()
-    text, count = re.subn(
-        r'(?m)^version = "[^"]+"',
-        f'version = "{version}"',
-        text,
-        count=1,
-    )
+def update_section_version(path: Path, section: str, version: str) -> None:
+    lines = path.read_text().splitlines(keepends=True)
+    in_section = False
+    count = 0
+
+    for index, line in enumerate(lines):
+        if re.match(r"^\s*\[[^\]]+\]\s*$", line):
+            in_section = line.strip() == f"[{section}]"
+
+        if not in_section:
+            continue
+
+        body = line[:-1] if line.endswith("\n") else line
+        newline = "\n" if line.endswith("\n") else ""
+        match = VERSION_LINE_RE.match(body)
+        if not match:
+            continue
+
+        lines[index] = f'{match.group(1)}{version}{match.group(2)}{newline}'
+        count += 1
+
     if count != 1:
-        raise SystemExit(f"expected exactly one package version in {path}")
-    path.write_text(text)
+        raise SystemExit(f"expected exactly one {section} version in {path}")
+
+    path.write_text("".join(lines))
 
 
 def update_cargo_lock(path: Path, version: str) -> None:
@@ -35,14 +55,18 @@ def update_cargo_lock(path: Path, version: str) -> None:
         return
 
     text = path.read_text()
-    text, count = re.subn(
-        r'(name = "socai_app"\nversion = ")[^"]+("\n)',
-        rf'\g<1>{version}\2',
-        text,
-        count=1,
-    )
-    if count != 1:
-        raise SystemExit(f"expected exactly one socai_app package entry in {path}")
+    for package_name in LOCKED_RUST_PACKAGES:
+        pattern = re.compile(
+            rf'(?m)^(\[\[package\]\]\nname = "{re.escape(package_name)}"\nversion = ")[^"]+(")'
+        )
+        text, count = pattern.subn(
+            lambda match: f"{match.group(1)}{version}{match.group(2)}",
+            text,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"expected exactly one {package_name} package entry in {path}")
+
     path.write_text(text)
 
 
@@ -56,7 +80,8 @@ def main() -> None:
 
     update_json_version(Path("app/package.json"), version)
     update_json_version(Path("app/src-tauri/tauri.conf.json"), version)
-    update_app_cargo_toml(Path("app/src-tauri/Cargo.toml"), version)
+    update_section_version(Path("app/src-tauri/Cargo.toml"), "package", version)
+    update_section_version(Path("Cargo.toml"), "workspace.package", version)
     update_cargo_lock(Path("Cargo.lock"), version)
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,18 @@ jobs:
       - name: apply release version
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-        run: python3 .github/scripts/set-app-version.py "${VERSION}"
+        run: |
+          set -euo pipefail
+
+          python3 .github/scripts/set-app-version.py "${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
+          git commit -m "chore: release socai v${VERSION}"
+          versioned_sha="$(git rev-parse HEAD)"
+          echo "SOCAI_BUILD_SHA=${versioned_sha}" >> "${GITHUB_ENV}"
+          echo "versioned build tree ${versioned_sha}"
 
       - name: set up pnpm
         uses: pnpm/action-setup@v4
@@ -180,7 +191,41 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf "target/${TARGET}/release/bundle"
+          rm -rf "target/${TARGET}/release/bundle" target/socai-cli-macos-universal
+
+      - name: build CLI universal binary
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          cargo build -p socai-cli --release --target aarch64-apple-darwin
+          cargo build -p socai-cli --release --target x86_64-apple-darwin
+
+          cli_dir="target/socai-cli-macos-universal"
+          mkdir -p "${cli_dir}"
+          lipo -create \
+            target/aarch64-apple-darwin/release/socai \
+            target/x86_64-apple-darwin/release/socai \
+            -output "${cli_dir}/socai"
+          chmod 0755 "${cli_dir}/socai"
+
+          actual_archs="$(lipo -archs "${cli_dir}/socai")"
+          echo "${cli_dir}/socai architectures: ${actual_archs}"
+          for expected_arch in arm64 x86_64; do
+            if [[ " ${actual_archs} " != *" ${expected_arch} "* ]]; then
+              echo "expected ${cli_dir}/socai to include ${expected_arch}, got: ${actual_archs}" >&2
+              exit 1
+            fi
+          done
+
+          version_output="$("${cli_dir}/socai" --version)"
+          echo "${version_output}"
+          if [ "${version_output}" != "socai ${VERSION}" ]; then
+            echo "expected CLI version 'socai ${VERSION}', got: ${version_output}" >&2
+            exit 1
+          fi
 
       - name: configure macos signing
         shell: bash
@@ -389,11 +434,14 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
         run: |
           set -euo pipefail
 
+          BUILD_SHA="${SOCAI_BUILD_SHA:?SOCAI_BUILD_SHA not set by apply release version step}"
           bundle_dir="target/${TARGET}/release/bundle"
           dmg_dir="${bundle_dir}/dmg"
+          cli_binary="target/socai-cli-macos-universal/socai"
           mkdir -p dist-artifacts
 
           dmg="$(find "${dmg_dir}" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
@@ -402,8 +450,49 @@ jobs:
             echo "no dmg found in ${dmg_dir}" >&2
             exit 1
           fi
+          if [ ! -x "${cli_binary}" ]; then
+            echo "no CLI binary found at ${cli_binary}" >&2
+            exit 1
+          fi
 
           cp "${dmg}" "dist-artifacts/socai-macos-universal.dmg"
+
+          package_dir="${RUNNER_TEMP}/socai-cli-package"
+          rm -rf "${package_dir}"
+          mkdir -p "${package_dir}"
+          cp "${cli_binary}" "${package_dir}/socai"
+          chmod 0755 "${package_dir}/socai"
+          created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          cat > "${package_dir}/manifest.json" <<EOF
+          {
+            "base_sha": "${BASE_SHA}",
+            "created_at": "${created_at}",
+            "git_sha": "${BUILD_SHA}",
+            "target": "macos-universal",
+            "version": "${VERSION}"
+          }
+          EOF
+
+          tar -C "${package_dir}" -czf dist-artifacts/socai-cli-macos-universal.tar.gz socai manifest.json
+          (cd dist-artifacts && shasum -a 256 socai-cli-macos-universal.tar.gz > socai-cli-macos-universal.tar.gz.sha256)
+          cp scripts/install-cli.sh dist-artifacts/install.sh
+
+          (cd dist-artifacts && shasum -a 256 -c socai-cli-macos-universal.tar.gz.sha256)
+          archive_listing="${RUNNER_TEMP}/socai-cli-archive-files.txt"
+          tar -tzf dist-artifacts/socai-cli-macos-universal.tar.gz > "${archive_listing}"
+          for required_file in socai manifest.json; do
+            if ! grep -Fxq "${required_file}" "${archive_listing}"; then
+              echo "CLI archive missing ${required_file}" >&2
+              exit 1
+            fi
+          done
+          manifest_path="${RUNNER_TEMP}/socai-cli-manifest.json"
+          tar -xOzf dist-artifacts/socai-cli-macos-universal.tar.gz manifest.json > "${manifest_path}"
+          grep -F "\"version\": \"${VERSION}\"" "${manifest_path}"
+          grep -F "\"target\": \"macos-universal\"" "${manifest_path}"
+          grep -F "\"git_sha\": \"${BUILD_SHA}\"" "${manifest_path}"
+          grep -F "\"base_sha\": \"${BASE_SHA}\"" "${manifest_path}"
+          grep -F '"created_at":' "${manifest_path}"
 
           ls -lah dist-artifacts
 
@@ -455,18 +544,25 @@ jobs:
             exit 1
           fi
 
-          artifact="dist-artifacts/socai-macos-universal.dmg"
-          if [ ! -f "${artifact}" ]; then
-            echo "missing release artifact: ${artifact}" >&2
-            exit 1
-          fi
+          required_artifacts=(
+            dist-artifacts/socai-macos-universal.dmg
+            dist-artifacts/socai-cli-macos-universal.tar.gz
+            dist-artifacts/socai-cli-macos-universal.tar.gz.sha256
+            dist-artifacts/install.sh
+          )
+          for artifact in "${required_artifacts[@]}"; do
+            if [ ! -f "${artifact}" ]; then
+              echo "missing release artifact: ${artifact}" >&2
+              exit 1
+            fi
+          done
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           python3 .github/scripts/set-app-version.py "${VERSION}"
 
-          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
+          git add Cargo.toml app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
           if git diff --cached --quiet; then
             echo "version files already up to date"
           else
@@ -503,8 +599,11 @@ jobs:
           ## downloads
 
           - [universal mac dmg](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-macos-universal.dmg) — supports Apple Silicon and Intel Macs.
+          - [CLI installer](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/install.sh) — one-command macOS CLI install.
+          - [universal mac CLI tarball](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz) — standalone `socai` CLI.
+          - [CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz.sha256)
 
-          This macOS build is signed and notarized.
+          The macOS app build is signed and notarized.
 
           ## changes
 
@@ -530,3 +629,50 @@ jobs:
 
           trap - ERR
           cat release-notes.md
+
+  verify-cli-installer:
+    name: verify latest CLI installer
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - prepare
+      - release
+    runs-on: macos-14
+
+    steps:
+      - name: install CLI from latest release
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          install_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/install.sh"
+          test_home="${RUNNER_TEMP}/socai-install-home"
+          install_dir="${RUNNER_TEMP}/socai-bin"
+          rm -rf "${test_home}" "${install_dir}"
+          mkdir -p "${test_home}"
+
+          installed=false
+          for attempt in {1..12}; do
+            echo "install attempt ${attempt}: ${install_url}"
+            if curl -fsSL "${install_url}" | HOME="${test_home}" SOCAI_INSTALL_DIR="${install_dir}" SHELL=/bin/zsh sh; then
+              installed=true
+              break
+            fi
+            sleep 10
+          done
+
+          if [ "${installed}" != "true" ]; then
+            echo "failed to install socai from latest release" >&2
+            exit 1
+          fi
+
+          version_output="$("${install_dir}/socai" --version)"
+          echo "${version_output}"
+          if [ "${version_output}" != "socai ${VERSION}" ]; then
+            echo "expected CLI version 'socai ${VERSION}', got: ${version_output}" >&2
+            exit 1
+          fi
+
+          "${install_dir}/socai" --help >/dev/null
+          grep -F "${install_dir}" "${test_home}/.zshrc"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,8 +13,8 @@ and an index of the reference docs.
 
 ### CLI / core
 
-The published install path (`cargo install --path cli`) is documented in the
-README. For day-to-day iteration, build and run from the workspace instead:
+The published install path is documented in the README and prefers the release
+CLI binary. For day-to-day iteration, build and run from the workspace instead:
 
 ```bash
 cargo build                 # build the whole workspace (core + cli)

--- a/README.md
+++ b/README.md
@@ -18,24 +18,31 @@ socai 有三种用法，内核相同，按你的场景选：
 
 | 方式 | 是什么 | 如何开始 |
 | --- | --- | --- |
-| [**CLI**](#cli) | 命令行工具，给 Claude Code、Codex 等 AI agent 调用（核心） | `cargo install --path cli` |
-| [**TUI**](#tui) | 终端里的交互界面，手动跑任务 | 安装后运行 `socai` |
+| [**CLI**](#cli) | 命令行工具，给 Claude Code、Codex 等 AI agent 调用（核心） | 下载 macOS CLI binary，或用 Cargo fallback |
+| [**TUI**](#tui) | 终端里的交互界面，手动跑任务 | 安装 CLI 后运行 `socai` |
 | [**GUI**](#desktop-app-gui) | 图形桌面应用（macOS），点击即用 | [下载 .dmg](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg) |
 
 ## CLI
 
 socai 的核心，给 Claude Code、Codex 等 AI agent 提供开箱即用的小红书工具。
 
-
 https://github.com/user-attachments/assets/8aebcded-f365-4f12-b9c4-102cc1fa964d
 
+macOS 用户优先安装预编译 CLI binary（不需要 Rust/Cargo）：
 
-克隆仓库并安装：
+```bash
+curl -fsSL https://github.com/socai-io/socai/releases/latest/download/install.sh | sh
+```
+
+安装脚本会下载并校验 `socai-cli-macos-universal.tar.gz`，安装到
+`~/.socai/bin/socai`，并提示/写入 PATH。
+
+如果当前平台还没有可用的 CLI binary，或你要开发/调试源码，再使用 Cargo fallback：
 
 ```bash
 git clone https://github.com/socai-io/socai.git
 cd socai
-cargo install --path cli
+cargo install --path cli --force
 ```
 
 常用命令：
@@ -72,10 +79,6 @@ tool tab on a waterfall containing the target card.
 安装方式与 CLI 相同，安装后不带子命令运行 `socai` 即可打开终端交互界面：
 
 ```bash
-git clone https://github.com/socai-io/socai.git
-cd socai
-cargo install --path cli
-
 socai   # 不带子命令即打开 TUI
 ```
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 #[derive(Parser, Debug)]
 #[command(name = "socai")]
+#[command(version)]
 #[command(about = "socai — XHS-savvy browser agent")]
 struct Args {
     #[command(subcommand)]

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="socai-io/socai"
+asset="socai-cli-macos-universal.tar.gz"
+checksum="${asset}.sha256"
+base_url="${SOCAI_DOWNLOAD_BASE_URL:-https://github.com/${repo}/releases/latest/download}"
+install_dir="${SOCAI_INSTALL_DIR:-$HOME/.socai/bin}"
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  Darwin) ;;
+  *)
+    echo "socai CLI release binary install currently supports macOS only." >&2
+    echo "For other platforms, use the source/Cargo fallback in README.md." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to install socai" >&2
+  exit 1
+fi
+if ! command -v tar >/dev/null 2>&1; then
+  echo "tar is required to install socai" >&2
+  exit 1
+fi
+if ! command -v shasum >/dev/null 2>&1; then
+  echo "shasum is required to verify socai" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+archive="$tmp_dir/$asset"
+checksum_file="$tmp_dir/$checksum"
+unpack_dir="$tmp_dir/unpack"
+
+printf 'downloading socai CLI from %s\n' "$base_url"
+curl -fL "$base_url/$asset" -o "$archive"
+curl -fL "$base_url/$checksum" -o "$checksum_file"
+(cd "$tmp_dir" && shasum -a 256 -c "$checksum")
+
+mkdir -p "$unpack_dir" "$install_dir"
+tar -xzf "$archive" -C "$unpack_dir"
+
+if [ ! -f "$unpack_dir/socai" ]; then
+  echo "release archive did not contain ./socai" >&2
+  exit 1
+fi
+
+install -m 0755 "$unpack_dir/socai" "$install_dir/socai"
+
+printf 'installed socai to %s\n' "$install_dir/socai"
+"$install_dir/socai" --version
+
+case ":$PATH:" in
+  *":$install_dir:"*)
+    printf '%s is already on PATH in this shell\n' "$install_dir"
+    ;;
+  *)
+    printf '\nAdd socai to PATH for future shells:\n'
+    printf '  export PATH="%s:$PATH"\n' "$install_dir"
+
+    shell_rc=""
+    shell_name="$(basename "${SHELL:-}" 2>/dev/null || true)"
+    case "$shell_name" in
+      zsh) shell_rc="$HOME/.zshrc" ;;
+      bash) shell_rc="$HOME/.bashrc" ;;
+    esac
+
+    if [ -n "$shell_rc" ]; then
+      mkdir -p "$(dirname "$shell_rc")"
+      touch "$shell_rc"
+      if grep -F "$install_dir" "$shell_rc" >/dev/null 2>&1; then
+        printf '%s already mentions %s\n' "$shell_rc" "$install_dir"
+      else
+        {
+          printf '\n# socai CLI\n'
+          printf 'export PATH="%s:$PATH"\n' "$install_dir"
+        } >> "$shell_rc"
+        printf 'updated %s\n' "$shell_rc"
+      fi
+    else
+      printf 'Could not infer shell rc file; add the PATH line above manually.\n'
+    fi
+    ;;
+esac


### PR DESCRIPTION
## summary

This is the standalone Option A PR for the CLI install work: ship the macOS CLI binary/versioning first, and make README prefer a one-command binary install before any larger agent-docs flow.

- builds a standalone universal macOS `socai` CLI in the release workflow
- publishes `install.sh`, `socai-cli-macos-universal.tar.gz`, and `socai-cli-macos-universal.tar.gz.sha256` alongside the existing DMG
- packages the CLI tarball with `socai` and `manifest.json` only
- keeps CLI packaging in shell/GitHub Actions; no Python binary packager script
- adds a post-release macOS smoke test that runs the exact latest-release install pipeline and verifies `socai --version`
- keeps Python only for the pre-existing version-metadata updater, where JSON/TOML/lock editing is useful
- extends release versioning to update the Rust workspace, `socai-cli`, `socai-core`, `socai_app`, and app metadata consistently
- enables `socai --version`
- updates README so macOS users install with:

```bash
curl -fsSL https://github.com/socai-io/socai/releases/latest/download/install.sh | sh
```

Cargo/source install remains as fallback/development path.

Closes #67.
Refs #70.
Supersedes #83.
Part of #65.

## validation

- `python3 -m py_compile .github/scripts/set-app-version.py`
- `python3 .github/scripts/set-app-version.py 9.8.7` verified workspace/app/Cargo.lock versions update, then restored
- `cargo check -p socai-cli`
- `cargo run -q -p socai-cli -- --version` → `socai 0.1.0`
- `cargo build -p socai-cli --release --target aarch64-apple-darwin`
- `cargo build -p socai-cli --release --target x86_64-apple-darwin`
- `lipo -create ...` produced `x86_64 arm64`
- `target/local-standalone-cli-test/socai --version` → `socai 0.1.0`
- local tarball/checksum smoke test using actual universal CLI binary passed
- extracted packaged binary and ran `./socai --version`
- `sh -n scripts/install-cli.sh`
- `bash -n scripts/install-cli.sh`
- end-to-end install script smoke test using `SOCAI_DOWNLOAD_BASE_URL=file://...` passed: downloaded, checksum-verified, installed, wrote PATH line, and installed binary ran `socai 0.1.0`
- added release-workflow `verify-cli-installer` job to run `curl -fsSL https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/install.sh | sh` on macOS after each published release, then assert `socai --version == socai ${VERSION}`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`

## notes

This intentionally does not add `install.md`/`SKILL.md` or the larger agent-first docs stack. Those can be revisited after the binary + versioning path lands.
