### PR TITLE
feat: DeepSeek provider + desktop/agent improvements

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,9 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.11.0"
+    "@tauri-apps/api": "^2.11.0",
+    "dompurify": "^3.4.8",
+    "marked": "^18.0.5"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      dompurify:
+        specifier: ^3.4.8
+        version: 3.4.8
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2.11.1
@@ -400,6 +406,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -418,6 +430,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -699,6 +716,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -734,6 +758,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  marked@18.0.5: {}
 
   nanoid@3.3.12: {}
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -3,8 +3,8 @@ use crate::timeline::{agent_event_to_timeline, AgentTaskEventKind, AgentTaskEven
 use anyhow::Result;
 use serde_json::{json, Value};
 use socai_core::agent::{
-    configured_default_model_for, make_run_dir, provider_credential_kind, AgentEvent,
-    CredentialKind, Provider,
+    configured_default_model_for, make_run_dir, provider_credential_kind, resolve_provider,
+    save_default_model, AgentEvent, CredentialKind, Provider,
 };
 use socai_core::runtime::{
     create_llm_provider, ensure_llm_provider_configured, run_agent_task as run_agent_with_tools,
@@ -61,10 +61,11 @@ pub async fn cdp_refresh(_runtime: State<'_, SocaiRuntime>) -> Result<(), String
 pub async fn tool_search_notes(
     runtime: State<'_, SocaiRuntime>,
     query: String,
+    num_notes: Option<i64>,
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · search_notes").await?;
-    let result = search_notes_command(page.clone(), &query, None, false).await;
+    let result = search_notes_command(page.clone(), &query, None, num_notes, false).await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }
@@ -209,6 +210,10 @@ pub async fn agent_save_api_key(provider: String, api_key: String) -> Result<(),
 #[tauri::command]
 pub async fn agent_list_models() -> Result<Vec<Value>, String> {
     use socai_core::agent::PROVIDERS;
+    // The provider that would be used right now (honors the persisted
+    // `defaults.provider`, else first provider with a key). The frontend uses
+    // `is_default` to restore the last-chosen model across relaunches.
+    let default_provider = resolve_provider(None, None).ok();
     let mut out = Vec::new();
     for cfg in PROVIDERS {
         let credential_kind = provider_credential_kind(cfg.provider);
@@ -223,9 +228,21 @@ pub async fn agent_list_models() -> Result<Vec<Value>, String> {
             "default_model": configured_default_model_for(cfg.provider),
             "has_key": credential_kind.is_some(),
             "credential_kind": credential_kind_label,
+            "is_default": default_provider == Some(cfg.provider),
         }));
     }
     Ok(out)
+}
+
+/// Persist the user's model choice so it survives a relaunch. Writes
+/// `defaults.provider` + `defaults.{provider}_model` to `~/.socai/auth.json`.
+#[tauri::command]
+pub async fn agent_set_default_model(provider: String, model: String) -> Result<(), String> {
+    let provider_enum = Provider::from_name(provider.trim())
+        .ok_or_else(|| format!("unknown provider: {provider}"))?;
+    save_default_model(provider_enum, model.trim())
+        .map(|_| ())
+        .map_err(|e| format!("{e:#}"))
 }
 
 /// Open a web URL in the user's default browser. Tauri's webview does not hand

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub fn run() {
             commands::tool_topic_scan,
             commands::tool_extract_note,
             commands::agent_list_models,
+            commands::agent_set_default_model,
             commands::agent_open_codex_login,
             commands::agent_save_api_key,
             commands::agent_task_start,

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -34,15 +34,15 @@ const messages = {
     zh: "如何启用远程调试？↗",
   },
 
-  "agent.label": { en: "agent", zh: "智能体" },
+  "agent.label": { en: "model", zh: "模型" },
   "agent.configurationAria": { en: "agent configuration", zh: "智能体设置" },
   "agent.selectModelAria": { en: "select agent model", zh: "选择智能体模型" },
   "agent.loading": { en: "loading", zh: "加载中" },
-  "agent.keyNeeded": { en: "key needed", zh: "需要密钥" },
-  "agent.needsCredential": { en: "{model} needs a credential.", zh: "{model} 需要凭据。" },
+  "agent.keyNeeded": { en: "api key needed", zh: "需要 api key" },
+  "agent.needsCredential": { en: "{model} needs an api key.", zh: "{model} 需要 api key。" },
   "agent.connectChatgpt": { en: "connect chatgpt subscription", zh: "连接 chatgpt 订阅" },
   "agent.opening": { en: "opening…", zh: "打开中…" },
-  "agent.pasteApiKey": { en: "paste api key", zh: "粘贴 api 密钥" },
+  "agent.pasteApiKey": { en: "paste api key", zh: "粘贴 api key" },
   "agent.codexLoginMissing": {
     en: "codex login not detected yet. return to socai after login completes.",
     zh: "还没有检测到 codex 登录。登录完成后返回 socai。",
@@ -78,7 +78,7 @@ const messages = {
   "task.starting": { en: "starting…", zh: "启动中…" },
   "task.runTest": { en: "run test", zh: "运行测试" },
   "task.loadingModels": { en: "loading agent models…", zh: "正在加载智能体模型…" },
-  "task.addKeyHint": { en: "add a key in the agent menu to run this model.", zh: "在智能体菜单中添加密钥后即可运行此模型。" },
+  "task.addKeyHint": { en: "add an api key in the model menu (top right) to run.", zh: "在右上角模型菜单中添加 api key 后即可运行。" },
   "task.agentPlaceholder": {
     en: "tell socai what you want researched…\neach task opens its own temporary chrome tab.",
     zh: "告诉 socai 你想研究什么…\n每个任务都会打开自己的临时 chrome 标签页。",

--- a/app/src/lib/markdown.ts
+++ b/app/src/lib/markdown.ts
@@ -1,0 +1,22 @@
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+// Markdown → sanitized HTML for agent final answers. `marked` handles GFM
+// (tables, strikethrough, task lists, autolinks, fenced code, …) and
+// `DOMPurify` strips anything unsafe from the result before it reaches the DOM.
+
+marked.setOptions({ gfm: true, breaks: true });
+
+// Open links in a new tab/window and harden against reverse-tabnabbing. Runs
+// after sanitization so the attributes we add are not themselves stripped.
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A") {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
+export function renderMarkdown(src: string): string {
+  const html = marked.parse(src, { async: false });
+  return DOMPurify.sanitize(html);
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -17,6 +17,7 @@ export interface ModelInfo {
   default_model: string;
   has_key: boolean;
   credential_kind?: "api_key" | "codex_oauth" | null;
+  is_default?: boolean;
 }
 
 export type AgentTaskStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "interrupted";

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -1,5 +1,6 @@
 import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
+import { renderMarkdown } from "../lib/markdown";
 import { formatTaskCount, formatTokenUsage, formatTurns, getLocale, taskStatusLabel, t } from "../lib/i18n";
 import type { AgentTaskView } from "./tasks";
 
@@ -92,7 +93,7 @@ function renderSelectedTask(task: AgentTaskView): string {
         ? `
           <div class="agent-outcome">
             <p class="t-eyebrow result-label">${esc(t("task.finalAnswer"))}</p>
-            <pre class="result-pre">${esc(task.final_text.trim())}</pre>
+            <div class="result-pre result-md">${renderMarkdown(task.final_text.trim())}</div>
             <p class="t-small subtle">${esc(t("task.run"))} ${esc(task.run_id ?? task.task_id)}${task.turns !== null ? ` · ${esc(formatTurns(task.turns))}` : ""}${esc(tokenLine)}</p>
             ${task.run_dir ? `<p class="t-small subtle">run_dir: <span class="t-mono">${esc(task.run_dir)}</span></p>` : ""}
           </div>`

--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -92,7 +92,7 @@ function renderInlineGuard(mode: TaskMode, toolCommand: ToolCommand, selected: M
 
 function renderAgentSummary(selected: ModelInfo | undefined): string {
   const summary = selected
-    ? `${esc(t("agent.label"))} · ${esc(selected.display_name)} · <span class="t-mono">${esc(selected.default_model)}</span>`
+    ? `${esc(t("agent.label"))} · <span class="t-mono">${esc(selected.default_model)}</span>`
     : `${esc(t("agent.label"))} · ${esc(t("agent.loading"))}`;
   return `<p class="t-small subtle task-context">${summary}</p>`;
 }

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -50,8 +50,11 @@ export namespace agentPanel {
   export function setModels(models: ModelInfo[]): void {
     modelsCache = models;
     if (!model || !models.some((m) => m.default_model === model)) {
+      // Restore the persisted choice (`is_default`); otherwise fall back to the
+      // first provider that has a key.
+      const persisted = models.find((m) => m.is_default && m.has_key);
       const withKey = models.find((m) => m.has_key);
-      model = (withKey ?? models[0])?.default_model ?? "";
+      model = (persisted ?? withKey ?? models[0])?.default_model ?? "";
     }
   }
 
@@ -114,6 +117,13 @@ export namespace agentPanel {
         keyMessage = "";
         keyError = "";
         pendingKey = "";
+        // Persist the choice so it survives a relaunch.
+        const picked = modelsCache.find((m) => m.default_model === next);
+        if (picked) {
+          invoke("agent_set_default_model", { provider: picked.provider, model: next }).catch(
+            (err) => console.error("agent_set_default_model failed:", err),
+          );
+        }
         // Close the popover when the picked model is ready; keep it open to
         // collect a credential when the model still needs one.
         configOpen = false;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -681,6 +681,64 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .result-error { color: var(--status-error-fg); }
 .result-running { color: var(--fg-soft); }
+
+/* Rendered markdown for the final answer. Reuses the .result-pre container
+   (border/padding/scroll) but switches to prose typography. Targets the plain
+   tags emitted by `marked`. */
+.result-md {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  white-space: normal;
+}
+.result-md > :first-child { margin-top: 0; }
+.result-md > :last-child { margin-bottom: 0; }
+.result-md p { margin: 0 0 var(--sp-2) 0; }
+.result-md h1, .result-md h2, .result-md h3,
+.result-md h4, .result-md h5, .result-md h6 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  line-height: 1.3;
+  margin: var(--sp-3) 0 var(--sp-2) 0;
+  color: var(--ink-0);
+}
+.result-md h1 { font-size: 17px; }
+.result-md h2 { font-size: 15px; }
+.result-md h3, .result-md h4, .result-md h5, .result-md h6 { font-size: 13px; }
+.result-md ul, .result-md ol { margin: 0 0 var(--sp-2) 0; padding-left: var(--sp-4); }
+.result-md li { margin: 0 0 var(--sp-1) 0; }
+.result-md li > ul, .result-md li > ol { margin: var(--sp-1) 0 0 0; }
+.result-md blockquote {
+  margin: 0 0 var(--sp-2) 0;
+  padding: var(--sp-1) var(--sp-3);
+  border-left: 2px solid var(--line);
+  color: var(--fg-soft);
+}
+.result-md hr { border: none; border-top: var(--hairline); margin: var(--sp-3) 0; }
+.result-md a { color: var(--ink-0); text-decoration: underline; }
+.result-md code { font-family: var(--font-mono); font-size: 12px; }
+.result-md pre {
+  margin: 0 0 var(--sp-2) 0;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-2);
+  border-radius: var(--r-2);
+  overflow-x: auto;
+  white-space: pre;
+}
+.result-md pre code { background: none; padding: 0; }
+.result-md table {
+  border-collapse: collapse;
+  margin: 0 0 var(--sp-2) 0;
+  font-size: 12px;
+  width: auto;
+  max-width: 100%;
+}
+.result-md th, .result-md td {
+  border: var(--hairline);
+  padding: var(--sp-1) var(--sp-2);
+  text-align: left;
+  vertical-align: top;
+}
+.result-md th { font-weight: 600; background: var(--surface-2); }
 .placeholder { color: var(--fg-faint); margin: 0; }
 .subtle { margin: 0; color: var(--fg-soft); }
 .event-stream {

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -28,6 +28,7 @@ use socai_core::sites::xhs::{xhs_agent_instructions, xhs_agent_tools, XHS_HOME_U
 const PROVIDER_ORDER: &[Provider] = &[
     Provider::Kimi,
     Provider::Qwen,
+    Provider::DeepSeek,
     Provider::OpenAI,
     Provider::Anthropic,
 ];

--- a/core/src/agent/provider.rs
+++ b/core/src/agent/provider.rs
@@ -17,6 +17,7 @@ pub enum Provider {
     OpenAI,
     Kimi,
     Qwen,
+    DeepSeek,
 }
 
 impl Provider {
@@ -26,6 +27,7 @@ impl Provider {
             Provider::OpenAI => "openai",
             Provider::Kimi => "kimi",
             Provider::Qwen => "qwen",
+            Provider::DeepSeek => "deepseek",
         }
     }
 
@@ -35,6 +37,7 @@ impl Provider {
             "openai" | "gpt" => Some(Self::OpenAI),
             "kimi" | "moonshot" => Some(Self::Kimi),
             "qwen" | "dashscope" => Some(Self::Qwen),
+            "deepseek" => Some(Self::DeepSeek),
             _ => None,
         }
     }
@@ -103,6 +106,14 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         env_keys: &["QWEN_API_KEY", "DASHSCOPE_API_KEY"],
         base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
         model_prefixes: &["qwen", "qwq-", "qvq-"],
+    },
+    ProviderConfig {
+        provider: Provider::DeepSeek,
+        display_name: "DeepSeek",
+        default_model: "deepseek-v4-pro",
+        env_keys: &["DEEPSEEK_API_KEY"],
+        base_url: Some("https://api.deepseek.com/v1"),
+        model_prefixes: &["deepseek-"],
     },
 ];
 
@@ -435,6 +446,7 @@ mod tests {
         assert_eq!(Provider::from_name("claude"), Some(Provider::Anthropic));
         assert_eq!(Provider::from_name("MOONSHOT"), Some(Provider::Kimi));
         assert_eq!(Provider::from_name("DashScope"), Some(Provider::Qwen));
+        assert_eq!(Provider::from_name("DeepSeek"), Some(Provider::DeepSeek));
         assert_eq!(Provider::from_name("nope"), None);
     }
 
@@ -445,6 +457,7 @@ mod tests {
             Provider::OpenAI,
             Provider::Kimi,
             Provider::Qwen,
+            Provider::DeepSeek,
         ] {
             let cfg = config_for(p);
             assert_eq!(cfg.provider, p);

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -13,6 +13,10 @@ Rules:\n\
 
 pub fn build_system_prompt(tool_names: &[&str], extra_instructions: &str) -> String {
     let mut parts: Vec<String> = vec![BASE_SYSTEM_PROMPT.to_string()];
+    parts.push(format!(
+        "Today's date is {}.",
+        chrono::Local::now().format("%Y-%m-%d (%A)")
+    ));
     if !tool_names.is_empty() {
         let listing = tool_names
             .iter()

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -22,9 +22,14 @@ user's task and ground your answer in tool output.
 `collect_carousel_images`, `extract_profile`, `topic_scan`, `page_state`.
 
 Prefer `topic_scan` for any "research a topic" task — it bundles search,
-sample, and read in one call. For one-off lookups: `page_state` →
-`search_notes` → `read_note` (or `open_note` + `extract_note` +
-`extract_comments`). Close any open note modal before searching again.
+sample, and read in one call. `topic_scan` is equivalent to calling
+`search_notes` and then `read_note` on each result one by one, but it is
+faster and uses far fewer tokens — so default to `topic_scan` and only fall
+back to `search_notes` + per-note `read_note` when you have a clear reason to
+read specific notes. For one-off
+lookups: `page_state` → `search_notes` → `read_note` (or `open_note` +
+`extract_note` + `extract_comments`). Close any open note modal before
+searching again.
 
 ## Anti-Bot Rules
 


### PR DESCRIPTION
## Summary

A batch of LLM-provider and desktop-app improvements.

- **DeepSeek provider** — registered as an OpenAI-compatible provider (`DEEPSEEK_API_KEY`, base `https://api.deepseek.com/v1`, model prefix `deepseek-`), defaulting to `deepseek-v4-pro`. Wired into the TUI provider order; CLI/TUI/desktop pick it up from the `PROVIDERS` table automatically.
- **System prompt: today's date** — injected into the shared `build_system_prompt`, so both TUI and desktop agents get a temporal anchor.
- **System prompt: prefer `topic_scan`** — knowledge.md now spells out that `topic_scan` ≡ `search_notes` + per-note `read_note`, but faster/cheaper, so the agent defaults to it.
- **Desktop: markdown final answer** — renders the agent's final answer with `marked` (GFM incl. tables) + `DOMPurify` sanitization, with matching monochrome prose/table styles.
- **Desktop: agent→model wording** — relabels the selector and status line to "模型"/"model", drops the provider name from the status line, and uses explicit "api key" phrasing.
- **Desktop: persist model selection** — the picked model now survives relaunch via a new `agent_set_default_model` command + `is_default` flag (previously it reset to the first provider with a key). Also finishes the `num_notes` wiring for `tool_search_notes` that PR #89 left out (which had broken the app build).

## Test plan

- `cargo build -p socai-core` and `cargo build -p socai_app` — pass.
- `pnpm run build` (tsc + vite) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)