### PR TITLE
CLI: add version command and update prompt

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod daemon;
 mod tracking;
 mod tui;
+mod version;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -72,6 +73,17 @@ enum Command {
         #[arg(long = "debug-snapshot")]
         debug_snapshot: bool,
     },
+    /// Print installed version and latest release status.
+    Version {
+        /// Only print the installed version; do not check GitHub Releases.
+        #[arg(long = "no-check")]
+        no_check: bool,
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update the macOS release-binary install to the latest version.
+    Update,
     /// Stop the background socai rust daemon.
     Stop,
     #[command(name = "__daemon", hide = true)]
@@ -92,6 +104,10 @@ async fn main() -> Result<()> {
         tui::run().await?;
         return Ok(());
     };
+    if should_warn_for_update(&command) {
+        version::maybe_warn_if_outdated().await;
+    }
+
     match command {
         Command::SearchNotes {
             query,
@@ -100,8 +116,7 @@ async fn main() -> Result<()> {
             pretty,
             debug_snapshot,
         } => {
-            let mut input =
-                serde_json::json!({ "query": query, "debug_snapshot": debug_snapshot });
+            let mut input = serde_json::json!({ "query": query, "debug_snapshot": debug_snapshot });
             if !filter.is_empty() {
                 input["filters"] = Value::Object(parse_filters(&filter)?);
             }
@@ -154,6 +169,10 @@ async fn main() -> Result<()> {
             .await?;
             print_command_result(&result, pretty)?;
         }
+        Command::Version { no_check, json } => {
+            version::print_version_command(no_check, json).await?
+        }
+        Command::Update => version::run_update_command().await?,
         Command::Stop => {
             if daemon::stop_daemon().await? {
                 eprintln!("socai rust daemon stopped");
@@ -182,6 +201,13 @@ fn parse_filters(filters: &[String]) -> Result<serde_json::Map<String, Value>> {
         );
     }
     Ok(map)
+}
+
+fn should_warn_for_update(command: &Command) -> bool {
+    !matches!(
+        command,
+        Command::Daemon | Command::Update | Command::Version { .. }
+    )
 }
 
 fn print_command_result(result: &Value, pretty: bool) -> Result<()> {

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,0 +1,581 @@
+use std::cmp::Ordering;
+use std::fs;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const LATEST_RELEASE_URL: &str = "https://github.com/socai-io/socai/releases/latest";
+const MACOS_INSTALL_SCRIPT_URL: &str =
+    "https://github.com/socai-io/socai/releases/latest/download/install.sh";
+const MACOS_UPDATE_COMMAND: &str = "socai update";
+const CHECK_INTERVAL: u64 = 24 * 60 * 60;
+const FAILED_CHECK_INTERVAL: u64 = 60 * 60;
+const NOTIFY_INTERVAL: u64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct StrictVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+#[derive(Debug, Clone)]
+struct LatestRelease {
+    version: String,
+    html_url: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct UpdateCache {
+    checked_at: Option<u64>,
+    latest_version: Option<String>,
+    latest_url: Option<String>,
+    last_error_at: Option<u64>,
+    notified_at: Option<u64>,
+    notified_version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct VersionReport<'a> {
+    current_version: &'a str,
+    latest_version: Option<&'a str>,
+    status: &'a str,
+    update_available: bool,
+    release_url: Option<&'a str>,
+    upgrade_command: Option<String>,
+    error: Option<&'a str>,
+}
+
+pub async fn print_version_command(no_check: bool, json: bool) -> Result<()> {
+    if no_check {
+        print_report(
+            VersionReport {
+                current_version: CURRENT_VERSION,
+                latest_version: None,
+                status: "not-checked",
+                update_available: false,
+                release_url: None,
+                upgrade_command: None,
+                error: None,
+            },
+            json,
+        )?;
+        return Ok(());
+    }
+
+    match fetch_latest_release(Duration::from_secs(5)).await {
+        Ok(latest) => {
+            let update_available = is_newer_than_current(&latest.version);
+            print_report(
+                VersionReport {
+                    current_version: CURRENT_VERSION,
+                    latest_version: Some(&latest.version),
+                    status: if update_available {
+                        "update-available"
+                    } else {
+                        "up-to-date"
+                    },
+                    update_available,
+                    release_url: latest.html_url.as_deref(),
+                    upgrade_command: update_available.then(suggested_upgrade_command).flatten(),
+                    error: None,
+                },
+                json,
+            )?;
+        }
+        Err(error) => {
+            let error = error.to_string();
+            print_report(
+                VersionReport {
+                    current_version: CURRENT_VERSION,
+                    latest_version: None,
+                    status: "unknown",
+                    update_available: false,
+                    release_url: None,
+                    upgrade_command: None,
+                    error: Some(&error),
+                },
+                json,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn run_update_command() -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        anyhow::bail!(
+            "socai update currently supports macOS release binaries only; see https://github.com/socai-io/socai#cli for the source/Cargo fallback"
+        );
+    }
+
+    let latest = fetch_latest_release(Duration::from_secs(10)).await?;
+    if !is_newer_than_current(&latest.version) {
+        println!("socai {CURRENT_VERSION} is already up to date");
+        return Ok(());
+    }
+
+    let install_dir =
+        managed_install_dir().context("could not determine the managed socai install directory")?;
+    let install_path = install_dir.join("socai");
+    ensure_current_exe_is_managed(&install_path)?;
+
+    println!(
+        "updating socai from {current} to {latest}",
+        current = CURRENT_VERSION,
+        latest = latest.version
+    );
+
+    let tmp_dir = make_update_temp_dir()?;
+    let installer_path = tmp_dir.join("install.sh");
+    let result: Result<()> = async {
+        download_installer(&installer_path).await?;
+        run_installer(&installer_path, &install_dir).await?;
+        verify_installed_version(&install_path, &latest.version).await?;
+        stop_existing_daemon().await;
+        Ok(())
+    }
+    .await;
+    let _ = fs::remove_dir_all(&tmp_dir);
+    result?;
+
+    let _ = clear_cache();
+    Ok(())
+}
+
+pub async fn maybe_warn_if_outdated() {
+    if update_check_disabled() {
+        return;
+    }
+
+    let now = unix_time_secs();
+    let mut cache = load_cache().unwrap_or_default();
+
+    let latest = if cache_success_is_fresh(&cache, now) {
+        cache.latest_version.clone().map(|version| LatestRelease {
+            version,
+            html_url: cache.latest_url.clone(),
+        })
+    } else if cache_error_is_fresh(&cache, now) {
+        None
+    } else {
+        match fetch_latest_release(Duration::from_millis(1500)).await {
+            Ok(latest) => {
+                cache.checked_at = Some(now);
+                cache.latest_version = Some(latest.version.clone());
+                cache.latest_url = latest.html_url.clone();
+                cache.last_error_at = None;
+                let _ = save_cache(&cache);
+                Some(latest)
+            }
+            Err(_) => {
+                cache.last_error_at = Some(now);
+                let _ = save_cache(&cache);
+                None
+            }
+        }
+    };
+
+    let Some(latest) = latest else {
+        return;
+    };
+
+    if !is_newer_than_current(&latest.version) {
+        return;
+    }
+
+    if already_notified(&cache, &latest.version, now) {
+        return;
+    }
+
+    warn_yellow(&format!(
+        "socai {current} is outdated; latest is {latest}. {instruction}",
+        current = CURRENT_VERSION,
+        latest = latest.version,
+        instruction = upgrade_instruction()
+    ));
+
+    cache.notified_at = Some(now);
+    cache.notified_version = Some(latest.version);
+    let _ = save_cache(&cache);
+}
+
+fn print_report(report: VersionReport<'_>, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!("socai {}", report.current_version);
+    if let Some(latest) = report.latest_version {
+        println!("latest {latest}");
+    } else {
+        println!("latest unknown");
+    }
+    println!("status {}", report.status);
+    if let Some(url) = report.release_url {
+        println!("release {url}");
+    }
+    if let Some(command) = report.upgrade_command.as_deref() {
+        println!("upgrade {command}");
+    }
+    if let Some(error) = report.error {
+        eprintln!("could not check latest socai release: {error}");
+    }
+    Ok(())
+}
+
+async fn fetch_latest_release(timeout: Duration) -> Result<LatestRelease> {
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(format!("socai/{CURRENT_VERSION}"))
+        .build()
+        .context("failed to create update-check HTTP client")?;
+
+    let response = client
+        .head(LATEST_RELEASE_URL)
+        .send()
+        .await
+        .context("failed to request latest GitHub release")?;
+
+    if !response.status().is_redirection() {
+        response
+            .error_for_status_ref()
+            .context("latest GitHub release request failed")?;
+    }
+
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| anyhow::anyhow!("latest GitHub release redirect missing Location"))?;
+    let tag_name = release_tag_from_location(location)
+        .ok_or_else(|| anyhow::anyhow!("latest GitHub release redirect missing tag: {location}"))?;
+    let version = normalize_tag_version(tag_name)
+        .ok_or_else(|| anyhow::anyhow!("latest release tag is not strict semver: {tag_name}"))?;
+
+    Ok(LatestRelease {
+        version,
+        html_url: Some(absolute_github_url(location)),
+    })
+}
+
+fn release_tag_from_location(location: &str) -> Option<&str> {
+    location.trim_end_matches('/').rsplit('/').next()
+}
+
+fn absolute_github_url(location: &str) -> String {
+    if location.starts_with("http://") || location.starts_with("https://") {
+        location.to_string()
+    } else {
+        format!("https://github.com{location}")
+    }
+}
+
+fn managed_install_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("SOCAI_INSTALL_DIR") {
+        return Some(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".socai").join("bin"))
+}
+
+fn ensure_current_exe_is_managed(install_path: &Path) -> Result<()> {
+    let current_exe =
+        std::env::current_exe().context("failed to resolve current socai executable")?;
+    let current = fs::canonicalize(&current_exe).unwrap_or(current_exe.clone());
+    let expected = fs::canonicalize(install_path).unwrap_or_else(|_| install_path.to_path_buf());
+    if current != expected {
+        anyhow::bail!(
+            "socai update only manages the release-binary install at {}; current executable is {}. For source/Cargo installs, update from the repo with `cargo install --path cli --force`.",
+            install_path.display(),
+            current_exe.display()
+        );
+    }
+    Ok(())
+}
+
+fn make_update_temp_dir() -> Result<PathBuf> {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "socai-update-{}-{}",
+        std::process::id(),
+        unix_time_secs()
+    ));
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+async fn download_installer(installer_path: &Path) -> Result<()> {
+    println!("downloading installer: {MACOS_INSTALL_SCRIPT_URL}");
+    let status = tokio::process::Command::new("curl")
+        .arg("-fsSL")
+        .arg(MACOS_INSTALL_SCRIPT_URL)
+        .arg("-o")
+        .arg(installer_path)
+        .status()
+        .await
+        .context("failed to run curl for socai installer download")?;
+    if !status.success() {
+        anyhow::bail!("socai installer download failed with status {status}");
+    }
+    Ok(())
+}
+
+async fn run_installer(installer_path: &Path, install_dir: &Path) -> Result<()> {
+    println!("installing to {}", install_dir.display());
+    let status = tokio::process::Command::new("sh")
+        .arg(installer_path)
+        .env("SOCAI_INSTALL_DIR", install_dir)
+        .status()
+        .await
+        .context("failed to run socai installer")?;
+    if !status.success() {
+        anyhow::bail!("socai installer failed with status {status}");
+    }
+    Ok(())
+}
+
+async fn stop_existing_daemon() {
+    if matches!(crate::daemon::stop_daemon().await, Ok(true)) {
+        println!("stopped existing socai daemon; it will restart on the next command");
+    }
+}
+
+async fn verify_installed_version(install_path: &Path, latest_version: &str) -> Result<()> {
+    let output = tokio::process::Command::new(install_path)
+        .arg("--version")
+        .output()
+        .await
+        .with_context(|| format!("failed to run updated socai at {}", install_path.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "updated socai --version failed with status {}",
+            output.status
+        );
+    }
+    let actual = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let expected = format!("socai {latest_version}");
+    if actual != expected {
+        anyhow::bail!("updated socai version mismatch: expected {expected}, got {actual}");
+    }
+    println!("updated {actual}");
+    Ok(())
+}
+
+fn normalize_tag_version(tag: &str) -> Option<String> {
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    parse_strict_version(version).map(|_| version.to_string())
+}
+
+fn is_newer_than_current(latest_version: &str) -> bool {
+    compare_versions(CURRENT_VERSION, latest_version) == Some(Ordering::Less)
+}
+
+fn compare_versions(current: &str, latest: &str) -> Option<Ordering> {
+    let current = parse_strict_version(current)?;
+    let latest = parse_strict_version(latest)?;
+    Some(current.cmp(&latest))
+}
+
+fn parse_strict_version(version: &str) -> Option<StrictVersion> {
+    let mut parts = version.split('.');
+    let major = parse_version_part(parts.next()?)?;
+    let minor = parse_version_part(parts.next()?)?;
+    let patch = parse_version_part(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(StrictVersion {
+        major,
+        minor,
+        patch,
+    })
+}
+
+fn parse_version_part(raw: &str) -> Option<u64> {
+    if raw.is_empty() || !raw.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    raw.parse().ok()
+}
+
+fn update_check_disabled() -> bool {
+    ["SOCAI_SKIP_UPDATE_CHECK", "SOCAI_NO_UPDATE_CHECK"]
+        .into_iter()
+        .any(|name| {
+            std::env::var(name).ok().is_some_and(|value| {
+                matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES")
+            })
+        })
+}
+
+fn cache_success_is_fresh(cache: &UpdateCache, now: u64) -> bool {
+    cache.latest_version.is_some()
+        && cache
+            .checked_at
+            .is_some_and(|checked_at| now.saturating_sub(checked_at) < CHECK_INTERVAL)
+}
+
+fn cache_error_is_fresh(cache: &UpdateCache, now: u64) -> bool {
+    cache
+        .last_error_at
+        .is_some_and(|checked_at| now.saturating_sub(checked_at) < FAILED_CHECK_INTERVAL)
+}
+
+fn already_notified(cache: &UpdateCache, latest_version: &str, now: u64) -> bool {
+    cache.notified_version.as_deref() == Some(latest_version)
+        && cache
+            .notified_at
+            .is_some_and(|notified_at| now.saturating_sub(notified_at) < NOTIFY_INTERVAL)
+}
+
+fn unix_time_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn load_cache() -> Option<UpdateCache> {
+    let path = cache_path()?;
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn save_cache(cache: &UpdateCache) -> Result<()> {
+    let Some(path) = cache_path() else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(cache)?)?;
+    Ok(())
+}
+
+fn clear_cache() -> Result<()> {
+    let Some(path) = cache_path() else {
+        return Ok(());
+    };
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn cache_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("SOCAI_UPDATE_CACHE") {
+        return Some(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".socai").join("update-check.json"))
+}
+
+fn suggested_upgrade_command() -> Option<String> {
+    if cfg!(target_os = "macos")
+        && managed_install_dir()
+            .map(|dir| ensure_current_exe_is_managed(&dir.join("socai")).is_ok())
+            .unwrap_or(false)
+    {
+        Some(MACOS_UPDATE_COMMAND.into())
+    } else {
+        None
+    }
+}
+
+fn upgrade_instruction() -> String {
+    if let Some(command) = suggested_upgrade_command() {
+        format!("Run `{command}` to upgrade.")
+    } else if cfg!(target_os = "macos") {
+        "See https://github.com/socai-io/socai#cli for install/update options.".into()
+    } else {
+        "See https://github.com/socai-io/socai#cli for the source/Cargo fallback.".into()
+    }
+}
+
+fn warn_yellow(message: &str) {
+    if color_stderr() {
+        eprintln!("\x1b[93m{message}\x1b[0m");
+    } else {
+        eprintln!("{message}");
+    }
+}
+
+fn color_stderr() -> bool {
+    std::io::stderr().is_terminal()
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::env::var("TERM").map_or(true, |term| term != "dumb")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_semver_parser_accepts_three_numeric_parts() {
+        assert_eq!(
+            parse_strict_version("1.2.3"),
+            Some(StrictVersion {
+                major: 1,
+                minor: 2,
+                patch: 3
+            })
+        );
+    }
+
+    #[test]
+    fn strict_semver_parser_rejects_non_strict_versions() {
+        assert_eq!(parse_strict_version("1.2"), None);
+        assert_eq!(parse_strict_version("1.2.3.4"), None);
+        assert_eq!(parse_strict_version("1.2.x"), None);
+        assert_eq!(parse_strict_version("1.2.3-beta"), None);
+        assert_eq!(parse_strict_version("v1.2.3"), None);
+    }
+
+    #[test]
+    fn release_tags_normalize_to_strict_versions() {
+        assert_eq!(normalize_tag_version("v1.2.3"), Some("1.2.3".into()));
+        assert_eq!(normalize_tag_version("1.2.3"), Some("1.2.3".into()));
+        assert_eq!(normalize_tag_version("v1.2.3-beta"), None);
+    }
+
+    #[test]
+    fn release_redirect_location_yields_tag() {
+        assert_eq!(
+            release_tag_from_location("https://github.com/socai-io/socai/releases/tag/v1.2.3"),
+            Some("v1.2.3")
+        );
+        assert_eq!(
+            release_tag_from_location("/socai-io/socai/releases/tag/v1.2.3/"),
+            Some("v1.2.3")
+        );
+    }
+
+    #[test]
+    fn version_compare_detects_newer_latest_version() {
+        assert_eq!(compare_versions("1.2.3", "1.2.4"), Some(Ordering::Less));
+        assert_eq!(compare_versions("1.2.3", "1.2.3"), Some(Ordering::Equal));
+        assert_eq!(compare_versions("1.2.3", "1.2.2"), Some(Ordering::Greater));
+        assert_eq!(compare_versions("1.2", "1.2.3"), None);
+    }
+
+    #[test]
+    fn notification_is_throttled_per_latest_version() {
+        let cache = UpdateCache {
+            notified_at: Some(100),
+            notified_version: Some("1.2.4".into()),
+            ..UpdateCache::default()
+        };
+        assert!(already_notified(&cache, "1.2.4", 100 + NOTIFY_INTERVAL - 1));
+        assert!(!already_notified(&cache, "1.2.4", 100 + NOTIFY_INTERVAL));
+        assert!(!already_notified(&cache, "1.2.5", 100 + 1));
+    }
+}


### PR DESCRIPTION
## summary

- adds `socai version` for installed/latest release status
- keeps existing `socai --version` behavior for installed-version-only checks
- adds `socai update` for macOS managed release-binary installs
- checks the latest GitHub Release via the public `/releases/latest` redirect instead of the GitHub API, avoiding unauthenticated API rate limits
- adds best-effort cached update prompts to stderr before normal CLI commands when the installed CLI is older than latest
- renders outdated prompts in bright yellow when stderr is an interactive terminal; respects non-TTY logs, `NO_COLOR`, and `TERM=dumb`
- throttles update prompts per latest version to avoid spamming users
- caches failed update checks briefly so GitHub/network failures do not slow every command
- preserves JSON stdout for tool commands because upgrade prompts go to stderr

Closes #93.
Part of #65.

## validation

- `cargo test -p socai-cli`
- `cargo check -p socai-cli`
- `cargo run -q -p socai-cli -- version` → reports `socai 0.1.6`, latest `0.1.6`, status `up-to-date`
- `cargo run -q -p socai-cli -- version --json`
- `cargo run -q -p socai-cli -- version --no-check`
- `cargo run -q -p socai-cli -- --version` → `socai 0.1.6`
- `cargo run -q -p socai-cli -- update` → reports already up to date when current/latest are both `0.1.6`
- outdated-prompt smoke test using a temp cache with fake latest `9.9.9` prints the upgrade prompt once, then suppresses repeat prompt within the throttle window
- managed-install smoke test by running a copied binary from temp `SOCAI_INSTALL_DIR` shows outdated prompt suggests `socai update`; source/cargo smoke path points users to README install/update options instead
- subagent review verified yellow TTY output, stderr/stdout separation, managed install detection, no unchecked `curl | sh` pipeline, and cross-platform gating
- `git diff --check`

## implementation notes

`socai update` only runs for macOS managed release-binary installs where the current executable matches the managed install path. It downloads `install.sh` to a temp file, checks the download command status, runs the installer with `SOCAI_INSTALL_DIR` pinned to the current managed install dir, verifies the installed binary reports the latest version, stops any existing socai daemon best-effort so the next command restarts fresh, then clears the update cache. It does not use an unchecked `curl | sh` pipeline internally.

README additions for `version`/`update` were intentionally removed after review feedback to keep the quick start concise; these commands are discoverable through `socai --help` / `socai version --help` and can be documented in the later agent install docs.
