### PR TITLE
CI: fix Windows release smoke HOME variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,15 +617,15 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $home = Join-Path $env:RUNNER_TEMP 'socai-daemon-home'
-          Remove-Item -Recurse -Force $home -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Force -Path $home | Out-Null
-          $stdout = Join-Path $home 'daemon.stdout.log'
-          $stderr = Join-Path $home 'daemon.stderr.log'
-          $env:SOCAI_HOME = $home
+          $socaiHome = Join-Path $env:RUNNER_TEMP 'socai-daemon-home'
+          Remove-Item -Recurse -Force $socaiHome -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $socaiHome | Out-Null
+          $stdout = Join-Path $socaiHome 'daemon.stdout.log'
+          $stderr = Join-Path $socaiHome 'daemon.stderr.log'
+          $env:SOCAI_HOME = $socaiHome
           $daemon = Start-Process -FilePath .\target\release\socai.exe -ArgumentList '__daemon' -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru
           try {
-            $endpoint = Join-Path $home 'rust-daemon-endpoint.json'
+            $endpoint = Join-Path $socaiHome 'rust-daemon-endpoint.json'
             $ready = $false
             for ($i = 0; $i -lt 120; $i++) {
               if (Test-Path $endpoint) {


### PR DESCRIPTION
## summary
- fix the Windows release smoke test by avoiding PowerShell's read-only `$HOME` variable alias
- keep the existing daemon smoke behavior unchanged

## validation
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`

## context
The `v0.1.8` patch release run failed before publish because the Windows smoke step assigned to `$home`, which PowerShell treats as the read-only `$HOME` variable on Windows runners.
