### PR TITLE
Add media downloads to topic_scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cargo install --path cli --force
 
 ```bash
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
+socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 同时下载帖子图片/视频到 run_dir/site_media/
 socai search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
@@ -75,6 +76,8 @@ Options:
   `search_notes`: cards to collect by auto-scrolling (titles/likes/covers only,
   no bodies — stays fast). Both scroll only if the first page holds fewer; omit
   for the first page only (~19).
+- `--download-media` — `topic_scan` only: download note images/videos into the
+  printed `run_dir` (`site_media/`) and add `local_path` fields to the JSON.
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -78,7 +78,8 @@ pub async fn tool_topic_scan(
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · topic_scan").await?;
-    let result = topic_scan_command(page.clone(), &query, None, None, num_notes, false).await;
+    let result =
+        topic_scan_command(page.clone(), &query, None, None, num_notes, false, false).await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -75,11 +75,20 @@ pub async fn tool_topic_scan(
     runtime: State<'_, SocaiRuntime>,
     query: String,
     num_notes: Option<i64>,
+    download_media: Option<bool>,
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · topic_scan").await?;
-    let result =
-        topic_scan_command(page.clone(), &query, None, None, num_notes, false, false).await;
+    let result = topic_scan_command(
+        page.clone(),
+        &query,
+        None,
+        None,
+        num_notes,
+        download_media.unwrap_or(false),
+        false,
+    )
+    .await;
     close_page(page).await;
     result.map_err(|e| format!("{e:#}"))
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -341,7 +341,6 @@ fn find_codex_binary() -> Option<PathBuf> {
     .find(|path| path.is_file())
 }
 
-
 #[tauri::command]
 pub async fn agent_task_start(
     app: AppHandle,

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -314,9 +314,22 @@ impl DaemonState {
             let tab_label = args.get("tab_label").and_then(Value::as_str);
             let filters = args.get("filters");
             let num_notes = args.get("num_notes").and_then(Value::as_i64);
+            let download_media = args
+                .get("download_media")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             let debug_snapshot = debug_snapshot_flag(&args);
             let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-            topic_scan_command(page, &query, tab_label, filters, num_notes, debug_snapshot).await
+            topic_scan_command(
+                page,
+                &query,
+                tab_label,
+                filters,
+                num_notes,
+                download_media,
+                debug_snapshot,
+            )
+            .await
         }
         .await;
         self.track_tool_trace(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,6 +54,10 @@ enum Command {
         /// holds fewer.
         #[arg(long = "num-notes")]
         num_notes: Option<i64>,
+        /// Download note images/videos into the command run_dir and include
+        /// local_path fields in the JSON output.
+        #[arg(long = "download-media")]
+        download_media: bool,
         #[arg(long)]
         pretty: bool,
         /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
@@ -138,6 +142,7 @@ async fn main() -> Result<()> {
             tab,
             filter,
             num_notes,
+            download_media,
             pretty,
             debug_snapshot,
         } => {
@@ -150,6 +155,9 @@ async fn main() -> Result<()> {
             }
             if let Some(n) = num_notes {
                 input["num_notes"] = serde_json::json!(n.max(1));
+            }
+            if download_media {
+                input["download_media"] = serde_json::json!(true);
             }
 
             let result =

--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -4,12 +4,16 @@ use std::time::Instant;
 use crate::agent::{Block, Message, MessageRole, ToolSchema};
 use anyhow::Result;
 use base64::Engine;
+use futures::StreamExt;
 use serde_json::Value;
 
 use crate::media::common::{detect_media_type, insert_string, short, url_suffix, MediaUnavailable};
 use crate::media::md5;
 use crate::media::processor::MediaProcessor;
 
+/// Max simultaneous image downloads for one note. Topic-scan media downloads
+/// may request a full carousel, so keep CDN requests bounded.
+const IMAGE_DOWNLOAD_CONCURRENCY: usize = 8;
 /// Max simultaneous vision (LLM) calls when enriching a note's images. Bounded
 /// so a 12-image note doesn't fire a dozen concurrent requests at the provider.
 const VISION_CONCURRENCY: usize = 4;
@@ -149,18 +153,23 @@ impl MediaProcessor {
         }
 
         let t_batch = Instant::now();
-        let downloads = images
+        let urls: Vec<String> = images
             .iter()
             .map(|image| {
-                let url = image
+                image
                     .get("url")
                     .and_then(Value::as_str)
                     .unwrap_or("")
-                    .to_string();
-                self.safe_download(url, referer.to_string())
+                    .to_string()
             })
-            .collect::<Vec<_>>();
-        let download_results = futures::future::join_all(downloads).await;
+            .collect();
+        let downloads = urls
+            .into_iter()
+            .map(|url| self.safe_download(url, referer.to_string()));
+        let download_results: Vec<_> = futures::stream::iter(downloads)
+            .buffered(IMAGE_DOWNLOAD_CONCURRENCY)
+            .collect()
+            .await;
         self.timing
             .record("image_download_batch", t_batch.elapsed());
 

--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -132,10 +132,73 @@ impl MediaProcessor {
             )
             .await?;
         self.timing.record("vision_grid", t0.elapsed());
-        Ok(parse_grid_descriptions(
-            &response.text_blocks.join("\n"),
-            n,
-        ))
+        Ok(parse_grid_descriptions(&response.text_blocks.join("\n"), n))
+    }
+
+    /// Download note images to the run's media directory without OCR or vision
+    /// enrichment. The returned image objects preserve the input shape and add
+    /// `local_path` (or a `download_error` / `save_error`) per image.
+    pub async fn download_images(
+        &self,
+        images: &[Value],
+        referer: &str,
+        label: &str,
+    ) -> Vec<Value> {
+        if images.is_empty() {
+            return Vec::new();
+        }
+
+        let t_batch = Instant::now();
+        let downloads = images
+            .iter()
+            .map(|image| {
+                let url = image
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                self.safe_download(url, referer.to_string())
+            })
+            .collect::<Vec<_>>();
+        let download_results = futures::future::join_all(downloads).await;
+        self.timing
+            .record("image_download_batch", t_batch.elapsed());
+
+        images
+            .iter()
+            .zip(download_results)
+            .enumerate()
+            .map(|(idx, (image, (payload, error)))| {
+                let url = image
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                let mut item = image.clone();
+                if url.is_empty() {
+                    insert_string(&mut item, "download_error", "image URL is empty");
+                    return item;
+                }
+                if let Some(error) = error {
+                    insert_string(&mut item, "download_error", error);
+                    return item;
+                }
+                if payload.is_empty() {
+                    insert_string(&mut item, "download_error", "download returned no bytes");
+                    return item;
+                }
+                let path = self.save_bytes(
+                    &payload,
+                    &format!("{label}_{}", idx + 1),
+                    &url_suffix(url, ".jpg"),
+                );
+                match path {
+                    Ok(path) => insert_string(&mut item, "local_path", path.to_string_lossy()),
+                    Err(err) => insert_string(&mut item, "save_error", format!("{err:#}")),
+                }
+                item
+            })
+            .collect()
     }
 
     pub async fn enrich_images(
@@ -253,7 +316,11 @@ impl MediaProcessor {
                         for (k, &idx) in batch.iter().enumerate() {
                             match descs.get(k) {
                                 Some(text) if !text.trim().is_empty() => {
-                                    insert_string(&mut items[idx].0, "vision_description", text.clone());
+                                    insert_string(
+                                        &mut items[idx].0,
+                                        "vision_description",
+                                        text.clone(),
+                                    );
                                 }
                                 _ => {}
                             }

--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -167,8 +167,7 @@ impl MediaProcessor {
         images
             .iter()
             .zip(download_results)
-            .enumerate()
-            .map(|(idx, (image, (payload, error)))| {
+            .map(|(image, (payload, error))| {
                 let url = image
                     .get("url")
                     .and_then(Value::as_str)
@@ -187,11 +186,7 @@ impl MediaProcessor {
                     insert_string(&mut item, "download_error", "download returned no bytes");
                     return item;
                 }
-                let path = self.save_bytes(
-                    &payload,
-                    &format!("{label}_{}", idx + 1),
-                    &url_suffix(url, ".jpg"),
-                );
+                let path = self.save_bytes(&payload, label, &url_suffix(url, ".jpg"));
                 match path {
                     Ok(path) => insert_string(&mut item, "local_path", path.to_string_lossy()),
                     Err(err) => insert_string(&mut item, "save_error", format!("{err:#}")),
@@ -252,11 +247,7 @@ impl MediaProcessor {
             if !seen.insert(digest) {
                 continue;
             }
-            let path = self.save_bytes(
-                &payload,
-                &format!("{label}_{}", deduped.len() + 1),
-                &url_suffix(url, ".jpg"),
-            );
+            let path = self.save_bytes(&payload, label, &url_suffix(url, ".jpg"));
             match path {
                 Ok(path) => insert_string(&mut item, "local_path", path.to_string_lossy()),
                 Err(err) => insert_string(&mut item, "save_error", format!("{err:#}")),

--- a/core/src/media/processor.rs
+++ b/core/src/media/processor.rs
@@ -55,13 +55,27 @@ impl MediaProcessor {
     }
 
     pub async fn download_bytes(&self, url: &str, referer: &str) -> Result<Vec<u8>> {
+        self.download_bytes_with_timeout(
+            url,
+            referer,
+            Duration::from_secs(self.config.request_timeout_s),
+        )
+        .await
+    }
+
+    pub async fn download_bytes_with_timeout(
+        &self,
+        url: &str,
+        referer: &str,
+        timeout: Duration,
+    ) -> Result<Vec<u8>> {
         let t0 = Instant::now();
         let result = async {
             let target = url.trim();
             if target.is_empty() {
                 return Ok(Vec::new());
             }
-            let mut request = self.client.get(target);
+            let mut request = self.client.get(target).timeout(timeout);
             if !referer.trim().is_empty() {
                 request = request.header("Referer", referer.trim());
             }
@@ -85,6 +99,20 @@ impl MediaProcessor {
         suffix: &str,
     ) -> Result<PathBuf> {
         let payload = self.download_bytes(url, referer).await?;
+        self.save_bytes(&payload, label, suffix)
+    }
+
+    pub async fn download_file_with_timeout(
+        &self,
+        url: &str,
+        referer: &str,
+        label: &str,
+        suffix: &str,
+        timeout: Duration,
+    ) -> Result<PathBuf> {
+        let payload = self
+            .download_bytes_with_timeout(url, referer, timeout)
+            .await?;
         self.save_bytes(&payload, label, suffix)
     }
 

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -153,11 +153,7 @@ impl MediaProcessor {
     ) {
         match self.download_bytes(poster_url, referer).await {
             Ok(poster) if !poster.is_empty() => {
-                match self.save_bytes(
-                    &poster,
-                    label,
-                    &url_suffix(poster_url, ".jpg"),
-                ) {
+                match self.save_bytes(&poster, label, &url_suffix(poster_url, ".jpg")) {
                     Ok(path) => insert_string(result, "poster_local_path", path.to_string_lossy()),
                     Err(err) => insert_string(result, "poster_save_error", format!("{err:#}")),
                 }

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -13,6 +13,79 @@ use crate::media::md5;
 use crate::media::processor::MediaProcessor;
 
 impl MediaProcessor {
+    /// Download the playable video (and poster, when present) to the run's
+    /// media directory without transcription, frame extraction, OCR, or vision.
+    /// The returned video object preserves the input shape and adds
+    /// `local_path` / `poster_local_path` where downloads succeed.
+    pub async fn download_video(
+        &self,
+        video: &Value,
+        note_id: &str,
+        title: &str,
+        referer: &str,
+    ) -> Value {
+        let mut result = video.clone();
+        if !result.is_object() {
+            result = crate::media::common::empty_object();
+        }
+        let label = if !note_id.trim().is_empty() {
+            note_id
+        } else if !title.trim().is_empty() {
+            title
+        } else {
+            "video"
+        };
+
+        let poster_url = result
+            .get("poster_url")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        if !poster_url.is_empty() {
+            match self
+                .download_file(
+                    &poster_url,
+                    referer,
+                    &format!("{label}_poster"),
+                    &url_suffix(&poster_url, ".jpg"),
+                )
+                .await
+            {
+                Ok(path) => insert_string(&mut result, "poster_local_path", path.to_string_lossy()),
+                Err(err) => insert_string(&mut result, "poster_download_error", format!("{err:#}")),
+            }
+        }
+
+        let source = downloadable_video_url(&result);
+        if source.is_empty() {
+            insert_string(
+                &mut result,
+                "download_error",
+                "downloadable video URL not found (blob: URLs cannot be downloaded)",
+            );
+            return result;
+        }
+
+        match self
+            .download_file_with_timeout(
+                &source,
+                referer,
+                label,
+                &url_suffix(&source, ".mp4"),
+                Duration::from_secs(
+                    self.config
+                        .ffmpeg_timeout_s
+                        .max(self.config.request_timeout_s),
+                ),
+            )
+            .await
+        {
+            Ok(path) => insert_string(&mut result, "local_path", path.to_string_lossy()),
+            Err(err) => insert_string(&mut result, "download_error", format!("{err:#}")),
+        }
+        result
+    }
+
     pub async fn enrich_video(
         &self,
         video: &Value,
@@ -238,4 +311,43 @@ impl MediaProcessor {
         paths.sort();
         Ok(paths)
     }
+}
+
+fn downloadable_video_url(video: &Value) -> String {
+    fn clean(value: &str) -> Option<String> {
+        let trimmed = value.trim();
+        if (trimmed.starts_with("http://") || trimmed.starts_with("https://"))
+            && !trimmed.starts_with("blob:")
+        {
+            Some(trimmed.to_string())
+        } else {
+            None
+        }
+    }
+
+    for key in ["resolved_url", "master_url", "url"] {
+        if let Some(url) = video.get(key).and_then(Value::as_str).and_then(clean) {
+            return url;
+        }
+    }
+
+    for key in ["source_urls", "backup_urls"] {
+        if let Some(arr) = video.get(key).and_then(Value::as_array) {
+            for item in arr {
+                if let Some(url) = item.as_str().and_then(clean) {
+                    return url;
+                }
+            }
+        }
+    }
+
+    if let Some(candidates) = video.get("candidates").and_then(Value::as_array) {
+        for item in candidates {
+            if let Some(url) = item.get("url").and_then(Value::as_str).and_then(clean) {
+                return url;
+            }
+        }
+    }
+
+    String::new()
 }

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -46,7 +46,7 @@ impl MediaProcessor {
                 .download_file(
                     &poster_url,
                     referer,
-                    &format!("{label}_poster"),
+                    label,
                     &url_suffix(&poster_url, ".jpg"),
                 )
                 .await
@@ -155,7 +155,7 @@ impl MediaProcessor {
             Ok(poster) if !poster.is_empty() => {
                 match self.save_bytes(
                     &poster,
-                    &format!("{label}_poster"),
+                    label,
                     &url_suffix(poster_url, ".jpg"),
                 ) {
                     Ok(path) => insert_string(result, "poster_local_path", path.to_string_lossy()),

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -91,7 +91,8 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
 - Manual note read: use `read_note(index=N)` or `read_note(note_id=...)`.
   Use `level="card"` for metadata only, `level="lite"` for body/comments, and
   `level="deep"` plus `include_media=true` only when images, OCR, video, or
-  visual evidence materially matters.
+  visual evidence materially matters. Use `download_media=true` when the user
+  explicitly wants local image/video files rather than OCR/vision enrichment.
 - Creator analysis: navigate/open a profile, then use `extract_profile`.
   Keep creator inventory/style analysis separate from keyword/topic sampling
   unless the user explicitly asks for both.
@@ -99,6 +100,8 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
   then `extract_comments` when more visible comments are needed.
 - Media-heavy tasks: use deep reads sparingly. OCR, vision, transcription, and
   frame extraction depend on optional local/cloud capabilities and can be slow.
+  `download_media=true` only downloads files into the run dir and avoids those
+  expensive enrichment steps.
 
 ## Reading Levels
 
@@ -120,7 +123,8 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
   short-circuit notes already covered at the requested level and media
   setting — the returned payload has `skipped: true` plus the prior
   `history` entry. To deepen prior analysis, request a higher `level` (e.g.
-  `deep` after a `lite`) or set `include_media: true`.
+  `deep` after a `lite`) or set `include_media: true`. Media downloads are not
+  cache-skipped because fresh local files are expected in the current run dir.
 - Keep DOM text, comment evidence, image OCR/vision, and video transcript/frame
   evidence labeled separately in final answers.
 - If a read returns a stale-note warning or note-id mismatch, close the current

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -55,8 +55,16 @@ pub(crate) const XHS_SEARCH_FILTERS: &[(&str, &str, &[&str])] = &[
         &["综合", "最新", "最多点赞", "最多评论", "最多收藏"],
     ),
     ("note_type", "笔记类型", &["不限", "视频", "图文"]),
-    ("publish_time", "发布时间", &["不限", "一天内", "一周内", "半年内"]),
-    ("search_scope", "搜索范围", &["不限", "已看过", "未看过", "已关注"]),
+    (
+        "publish_time",
+        "发布时间",
+        &["不限", "一天内", "一周内", "半年内"],
+    ),
+    (
+        "search_scope",
+        "搜索范围",
+        &["不限", "已看过", "未看过", "已关注"],
+    ),
     ("distance", "位置距离", &["不限", "同城", "附近"]),
 ];
 
@@ -64,6 +72,7 @@ pub(crate) const XHS_SEARCH_FILTERS: &[(&str, &str, &[&str])] = &[
 pub struct ReadNoteOptions {
     pub level: String,
     pub include_media: bool,
+    pub download_media: bool,
     pub max_images: usize,
     pub max_video_frames: usize,
 }
@@ -73,6 +82,7 @@ impl Default for ReadNoteOptions {
         Self {
             level: "lite".into(),
             include_media: false,
+            download_media: false,
             max_images: 12,
             max_video_frames: 4,
         }
@@ -265,7 +275,10 @@ impl<'a> XhsPageRuntime<'a> {
             if x > 0.0 && y > 0.0 {
                 self.page.click(x, y).await?;
                 let state = self
-                    .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
+                    .wait_for_search_transition(
+                        query,
+                        wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
+                    )
                     .await?;
                 if search_transition_ok(&state, query) {
                     return Ok(json!({
@@ -1036,8 +1049,62 @@ impl<'a> XhsPageRuntime<'a> {
             self.enrich_note_media(&mut note, options.max_images, options.max_video_frames)
                 .await?;
         }
+        if options.download_media {
+            self.download_note_media(&mut note, options.max_images)
+                .await?;
+        }
 
         Ok(note)
+    }
+
+    async fn download_note_media(&self, note: &mut XhsNote, max_images: usize) -> Result<()> {
+        let Some(media) = &self.media else {
+            if note.r#type == "video" {
+                insert_value_string(
+                    &mut note.video,
+                    "download_error",
+                    "media processor unavailable",
+                );
+            } else {
+                for image in &mut note.images {
+                    insert_value_string(image, "download_error", "media processor unavailable");
+                }
+            }
+            return Ok(());
+        };
+
+        let label = if note.note_id.is_empty() {
+            if note.title.is_empty() {
+                "xhs_note"
+            } else {
+                &note.title
+            }
+        } else {
+            &note.note_id
+        };
+
+        if note.r#type == "video" {
+            note.video = media
+                .download_video(&note.video, &note.note_id, &note.title, &note.url)
+                .await;
+            return Ok(());
+        }
+
+        if note.images.is_empty() {
+            let urls = self.collect_carousel_images(max_images as i64).await?;
+            note.images = urls
+                .into_iter()
+                .take(max_images)
+                .enumerate()
+                .map(|(index, url)| json!({ "url": url, "index": index as i64 }))
+                .collect();
+            note.image_count = note.images.len() as i64;
+        }
+
+        let images: Vec<Value> = note.images.iter().take(max_images).cloned().collect();
+        note.images = media.download_images(&images, &note.url, label).await;
+        note.image_count = note.images.len() as i64;
+        Ok(())
     }
 
     async fn enrich_note_media(

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -523,6 +523,20 @@ const SocaiXhsPageScripts = (() => {
     return urls;
   }
 
+  function mergeUrls(...groups) {
+    const out = [];
+    const seen = new Set();
+    for (const group of groups) {
+      for (const raw of group || []) {
+        const url = cleanImageUrl(raw);
+        if (!url || seen.has(url)) continue;
+        seen.add(url);
+        out.push(url);
+      }
+    }
+    return out;
+  }
+
   function cleanLocationText(value) {
     const cleaned = norm(value);
     if (!cleaned) return '';
@@ -563,6 +577,69 @@ const SocaiXhsPageScripts = (() => {
       }
     } catch (e) {}
     return null;
+  }
+
+  function imageUrlFromStateObject(item) {
+    item = unwrapStateValue(item);
+    if (typeof item === 'string') return cleanImageUrl(item);
+    if (!item || typeof item !== 'object') return '';
+
+    // XHS note detail state usually exposes one object per carousel image.
+    // Prefer a single canonical/high-quality URL per object so we don't
+    // download thumbnail + preview variants of the same image as duplicates.
+    const directKeys = [
+      'urlDefault', 'url_default', 'urlSizeLarge', 'url_size_large',
+      'urlPre', 'url_pre', 'url', 'originalUrl', 'original_url',
+    ];
+    for (const key of directKeys) {
+      const url = cleanImageUrl(item[key]);
+      if (url) return url;
+    }
+
+    const infoList = unwrapStateValue(item.infoList || item.info_list || item.infos || item.imageInfo);
+    if (Array.isArray(infoList)) {
+      const infos = infoList
+        .map(unwrapStateValue)
+        .filter((info) => info && typeof info === 'object');
+      const preferred =
+        infos.find((info) => /dft|default|large|origin/i.test(String(info.imageScene || info.scene || info.type || ''))) ||
+        infos[0];
+      if (preferred) {
+        for (const key of ['url', 'urlDefault', 'url_default', 'urlPre', 'url_pre']) {
+          const url = cleanImageUrl(preferred[key]);
+          if (url) return url;
+        }
+      }
+    }
+
+    return '';
+  }
+
+  function imageUrlsFromInitialState(noteId) {
+    const note = noteFromInitialState(noteId);
+    if (!note || typeof note !== 'object') return [];
+    const out = [];
+    const seen = new Set();
+    const push = (url) => {
+      url = cleanImageUrl(url);
+      if (!url || seen.has(url)) return;
+      seen.add(url);
+      out.push(url);
+    };
+    const collectList = (value) => {
+      value = unwrapStateValue(value);
+      if (!value) return;
+      if (Array.isArray(value)) {
+        for (const item of value) push(imageUrlFromStateObject(item));
+      } else {
+        push(imageUrlFromStateObject(value));
+      }
+    };
+
+    for (const key of ['imageList', 'image_list', 'imagesList', 'images', 'image']) {
+      collectList(note[key]);
+    }
+    return out;
   }
 
   function collectStateStreamVariants(stream) {
@@ -611,8 +688,9 @@ const SocaiXhsPageScripts = (() => {
     const media = note?.video?.media || note?.video || null;
     const stream = media?.stream || media?.streams || null;
     const variants = collectStateStreamVariants(stream);
+    let directUrl = '';
     if (media && typeof media === 'object') {
-      const directUrl = media.masterUrl || media.master_url || media.url || media.playUrl || '';
+      directUrl = media.masterUrl || media.master_url || media.url || media.playUrl || '';
       if (directUrl && !variants.some((item) => item.url === absUrl(directUrl))) {
         variants.push({
           url: absUrl(directUrl),
@@ -638,7 +716,7 @@ const SocaiXhsPageScripts = (() => {
       }
     }
     return {
-      is_video: !!(note?.type === 'video' || note?.video || media || best || variants.length),
+      is_video: /video|视频/.test(String(note?.type || note?.noteType || note?.cardType || '').toLowerCase()) || !!(best?.url || directUrl || variants.length),
       best_url: best?.url || '',
       width: best?.width || null,
       height: best?.height || null,
@@ -769,7 +847,7 @@ const SocaiXhsPageScripts = (() => {
     const noteId = extractNoteIdFromUrl();
     const stateVideo = videoInfoFromInitialState(noteId);
     const type = detectNoteType(root, stateVideo);
-    const imageUrls = type === 'video' ? [] : collectImageUrls(root);
+    const imageUrls = type === 'video' ? [] : mergeUrls(imageUrlsFromInitialState(noteId), collectImageUrls(root));
     const video = type === 'video' ? collectVideoInfo(root, stateVideo) : null;
     return {
       note_id: noteId,
@@ -797,7 +875,7 @@ const SocaiXhsPageScripts = (() => {
 
   function carouselImages(opts = {}) {
     const root = getNoteRoot();
-    const urls = collectImageUrls(root);
+    const urls = mergeUrls(imageUrlsFromInitialState(extractNoteIdFromUrl()), collectImageUrls(root));
     const max = Number(opts.max_images) || 12;
     return {
       ok: true,

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -457,8 +457,10 @@ const SocaiXhsPageScripts = (() => {
   }
 
   // ── note content extraction (root-scoped + visible-only) ─────
-  function detectNoteType(root) {
-    return root?.querySelector?.('video') ? 'video' : 'image';
+  function detectNoteType(root, stateVideo = null) {
+    if (root?.querySelector?.('video')) return 'video';
+    if (stateVideo?.is_video || stateVideo?.best_url || (stateVideo?.streams || []).length) return 'video';
+    return 'image';
   }
 
   function extractNoteIdFromUrl() {
@@ -536,14 +538,129 @@ const SocaiXhsPageScripts = (() => {
     return cleaned;
   }
 
-  function collectVideoInfo(root) {
+  function unwrapStateValue(value) {
+    if (value && typeof value === 'object') {
+      if ('_value' in value) return value._value;
+      if ('value' in value && Object.keys(value).length <= 2) return value.value;
+    }
+    return value;
+  }
+
+  function noteFromInitialState(noteId) {
+    try {
+      const state = window.__INITIAL_STATE__ || {};
+      const noteState = unwrapStateValue(state.note) || {};
+      const detailMap = unwrapStateValue(noteState.noteDetailMap) || {};
+      const keys = [];
+      if (noteId) keys.push(noteId);
+      for (const key of Object.keys(detailMap)) {
+        if (!keys.includes(key)) keys.push(key);
+      }
+      for (const key of keys) {
+        const detail = unwrapStateValue(detailMap[key]);
+        const note = unwrapStateValue(detail?.note || detail);
+        if (note && typeof note === 'object') return note;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function collectStateStreamVariants(stream) {
+    const variants = [];
+    const seen = new Set();
+    const pushVariant = (item, codec) => {
+      item = unwrapStateValue(item);
+      if (!item || typeof item !== 'object') return;
+      const backupUrls = Array.isArray(item.backupUrls) ? item.backupUrls
+        : (Array.isArray(item.backup_urls) ? item.backup_urls : []);
+      const url = item.masterUrl || item.master_url || item.url || item.urlDefault || backupUrls[0] || '';
+      const value = absUrl(url || '');
+      if (!value || seen.has(value)) return;
+      seen.add(value);
+      variants.push({
+        url: value,
+        backup_urls: backupUrls.map(absUrl).filter(Boolean),
+        width: Number(item.width) || null,
+        height: Number(item.height) || null,
+        size: Number(item.size) || null,
+        codec: item.videoCodec || item.video_codec || codec || '',
+        format: item.format || item.videoFormat || '',
+      });
+    };
+    const pushBucket = (bucket, codec) => {
+      bucket = unwrapStateValue(bucket);
+      if (Array.isArray(bucket)) {
+        for (const item of bucket) pushVariant(item, codec);
+      } else if (bucket && typeof bucket === 'object') {
+        pushVariant(bucket, codec);
+      }
+    };
+    if (stream && typeof stream === 'object') {
+      pushBucket(stream.h265, 'h265');
+      pushBucket(stream.h264, 'h264');
+      pushBucket(stream.av1, 'av1');
+      for (const [codec, bucket] of Object.entries(stream)) {
+        if (!['h265', 'h264', 'av1'].includes(codec)) pushBucket(bucket, codec);
+      }
+    }
+    return variants;
+  }
+
+  function videoInfoFromInitialState(noteId) {
+    const note = noteFromInitialState(noteId);
+    const media = note?.video?.media || note?.video || null;
+    const stream = media?.stream || media?.streams || null;
+    const variants = collectStateStreamVariants(stream);
+    if (media && typeof media === 'object') {
+      const directUrl = media.masterUrl || media.master_url || media.url || media.playUrl || '';
+      if (directUrl && !variants.some((item) => item.url === absUrl(directUrl))) {
+        variants.push({
+          url: absUrl(directUrl),
+          backup_urls: [],
+          width: Number(media.width) || null,
+          height: Number(media.height) || null,
+          size: Number(media.size) || null,
+          codec: media.videoCodec || media.video_codec || '',
+          format: media.format || '',
+        });
+      }
+    }
+    const h2651080 = variants.find((item) => /h265/i.test(item.codec) && Number(item.width) === 1080);
+    const score = (item) => {
+      const codecScore = /h265/i.test(item.codec) ? 3 : (/h264/i.test(item.codec) ? 2 : 1);
+      return codecScore * 1e12 + (Number(item.width) || 0) * 1e8 + (Number(item.size) || 0);
+    };
+    const best = h2651080 || variants.slice().sort((a, b) => score(b) - score(a))[0] || null;
+    const sourceUrls = [];
+    for (const item of variants) {
+      for (const url of [item.url, ...(item.backup_urls || [])]) {
+        if (url && !sourceUrls.includes(url)) sourceUrls.push(url);
+      }
+    }
+    return {
+      is_video: !!(note?.type === 'video' || note?.video || media || best || variants.length),
+      best_url: best?.url || '',
+      width: best?.width || null,
+      height: best?.height || null,
+      size: best?.size || null,
+      codec: best?.codec || '',
+      duration_s: Number(media?.video?.duration ?? media?.duration ?? note?.video?.duration) || null,
+      source_urls: sourceUrls,
+      streams: variants,
+    };
+  }
+
+  function collectVideoInfo(root, stateVideo = null) {
     const video = root.querySelector?.('video');
+    stateVideo = stateVideo || videoInfoFromInitialState(extractNoteIdFromUrl());
     const candidates = [];
     const push = (url, source) => {
       const value = absUrl(url || '');
       if (!value || candidates.some((item) => item.url === value)) return;
       candidates.push({ url: value, source });
     };
+    push(stateVideo.best_url, 'initial_state');
+    for (const url of stateVideo.source_urls || []) push(url, 'initial_state');
     if (video) {
       push(video.currentSrc, 'video.currentSrc');
       push(video.src, 'video.src');
@@ -558,13 +675,20 @@ const SocaiXhsPageScripts = (() => {
       }
     } catch (e) {}
     const poster = video?.poster || root.querySelector?.('img')?.src || '';
+    const resolvedUrl = candidates.find((item) => /^https?:/.test(item.url) && !item.url.startsWith('blob:'))?.url || candidates[0]?.url || '';
     return {
       url: candidates[0]?.url || '',
-      resolved_url: candidates.find((item) => /^https?:/.test(item.url) && !item.url.startsWith('blob:'))?.url || candidates[0]?.url || '',
+      resolved_url: resolvedUrl,
+      master_url: stateVideo.best_url || '',
       poster_url: cleanImageUrl(poster),
-      duration_s: Number.isFinite(video?.duration) ? video.duration : null,
+      duration_s: Number.isFinite(video?.duration) ? video.duration : stateVideo.duration_s,
+      width: stateVideo.width,
+      height: stateVideo.height,
+      size: stateVideo.size,
+      codec: stateVideo.codec,
       source_urls: candidates.map((item) => item.url),
       candidates,
+      state_streams: stateVideo.streams || [],
     };
   }
 
@@ -642,11 +766,13 @@ const SocaiXhsPageScripts = (() => {
     const locationText = cleanLocationText(
       firstVisibleText(['.location, .poi, [class*="location"], [class*="poi"]'], root, { excludeComments: true })
     );
-    const type = detectNoteType(root);
-    const imageUrls = collectImageUrls(root);
-    const video = type === 'video' ? collectVideoInfo(root) : null;
+    const noteId = extractNoteIdFromUrl();
+    const stateVideo = videoInfoFromInitialState(noteId);
+    const type = detectNoteType(root, stateVideo);
+    const imageUrls = type === 'video' ? [] : collectImageUrls(root);
+    const video = type === 'video' ? collectVideoInfo(root, stateVideo) : null;
     return {
-      note_id: extractNoteIdFromUrl(),
+      note_id: noteId,
       url: location.href,
       type,
       title,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -150,12 +150,13 @@ pub async fn topic_scan_command(
     tab_label: Option<&str>,
     filters: Option<&Value>,
     num_notes: Option<i64>,
+    download_media: bool,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         TOPIC_SCAN_COMMAND,
-        topic_scan_input(query, tab_label, filters, num_notes)?,
+        topic_scan_input(query, tab_label, filters, num_notes, download_media)?,
         debug_snapshot,
     )
     .await
@@ -198,6 +199,7 @@ fn topic_scan_input(
     tab_label: Option<&str>,
     filters: Option<&Value>,
     num_notes: Option<i64>,
+    download_media: bool,
 ) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
@@ -208,6 +210,9 @@ fn topic_scan_input(
     }
     if let Some(n) = num_notes {
         input["num_notes"] = json!(n.max(1));
+    }
+    if download_media {
+        input["download_media"] = json!(true);
     }
     Ok(input)
 }
@@ -377,6 +382,7 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
     ReadNoteOptions {
         level: get_str(input, "level").unwrap_or("lite").to_string(),
         include_media: get_bool(input, "include_media", false),
+        download_media: get_bool(input, "download_media", false),
         max_images: get_i64(input, "max_images", 12).max(1) as usize,
         max_video_frames: get_i64(input, "max_video_frames", 4).max(1) as usize,
     }
@@ -446,7 +452,10 @@ impl Tool for SearchNotesTool {
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
             .to_string();
-        let filters = input.get("filters").filter(|value| !value.is_null()).cloned();
+        let filters = input
+            .get("filters")
+            .filter(|value| !value.is_null())
+            .cloned();
         let wait_seconds = get_f64(&input, "wait_seconds", 2.0);
         let num_notes = input
             .get("num_notes")
@@ -569,6 +578,7 @@ impl Tool for ReadNoteTool {
                 "wait_seconds": { "type": "number", "default": 6.0 },
                 "level": { "type": "string", "enum": ["card", "lite", "deep"], "default": "lite" },
                 "include_media": { "type": "boolean", "default": false },
+                "download_media": { "type": "boolean", "default": false },
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 },
                 "max_video_frames": { "type": "integer", "default": 4, "minimum": 1 }
             }
@@ -586,11 +596,13 @@ impl Tool for ReadNoteTool {
 
         // Cross-run dedup: short-circuit when a previous run already covers
         // this note at the requested level + media. Only fires when note_id
-        // is known up front.
+        // is known up front. Downloads are intentionally never skipped because
+        // the caller expects fresh local files in the current run dir.
         if let Some(id) = note_id.as_deref().filter(|s| !s.trim().is_empty()) {
-            if self
-                .history
-                .is_satisfied_by(id, &options.level, options.include_media)
+            if !options.download_media
+                && self
+                    .history
+                    .is_satisfied_by(id, &options.level, options.include_media)
             {
                 let entry = self.history.get(id).unwrap_or_default();
                 return Ok(json_result(&json!({
@@ -600,6 +612,7 @@ impl Tool for ReadNoteTool {
                     "note_id": id,
                     "requested_level": options.level,
                     "requested_include_media": options.include_media,
+                    "requested_download_media": options.download_media,
                     "history": entry,
                 })));
             }
@@ -607,7 +620,11 @@ impl Tool for ReadNoteTool {
 
         let xhs = XhsPageRuntime::new_with_media(
             &self.page,
-            media_for(ctx, self.llm_provider.clone(), options.include_media)?,
+            media_for(
+                ctx,
+                self.llm_provider.clone(),
+                options.include_media || options.download_media,
+            )?,
         );
         let value = xhs
             .read_note_with_options(
@@ -619,8 +636,11 @@ impl Tool for ReadNoteTool {
             .await?;
         if value.get("ok").and_then(Value::as_bool).unwrap_or(false) {
             if let Some(entity) = value.get("entity") {
-                self.history
-                    .record(entity, &options.level, options.include_media);
+                self.history.record(
+                    entity,
+                    &options.level,
+                    options.include_media || options.download_media,
+                );
             }
         }
         Ok(json_result(&value))
@@ -652,6 +672,7 @@ impl Tool for ExtractNoteTool {
                 "wait_seconds": { "type": "number", "default": 8.0 },
                 "level": { "type": "string", "enum": ["card", "lite", "deep"], "default": "lite" },
                 "include_media": { "type": "boolean", "default": false },
+                "download_media": { "type": "boolean", "default": false },
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 },
                 "max_video_frames": { "type": "integer", "default": 4, "minimum": 1 }
             }
@@ -663,14 +684,21 @@ impl Tool for ExtractNoteTool {
         let options = read_note_options(&input);
         let xhs = XhsPageRuntime::new_with_media(
             &self.page,
-            media_for(ctx, self.llm_provider.clone(), options.include_media)?,
+            media_for(
+                ctx,
+                self.llm_provider.clone(),
+                options.include_media || options.download_media,
+            )?,
         );
         let note = xhs
             .extract_note_with_options(wait_seconds, options.clone())
             .await?;
         let value = serde_json::to_value(&note)?;
-        self.history
-            .record(&value, &options.level, options.include_media);
+        self.history.record(
+            &value,
+            &options.level,
+            options.include_media || options.download_media,
+        );
         Ok(json_result(&value))
     }
 }
@@ -1007,7 +1035,7 @@ impl Tool for ExtractProfileTool {
     }
 }
 
-/// topic_scan(query, tab_label?, filters?, num_notes?) -> aggregated topic bundle
+/// topic_scan(query, tab_label?, filters?, num_notes?, download_media?) -> aggregated topic bundle
 ///
 /// Composite macro: search → optional tab switch → optional search filters →
 /// collect up to `num_notes` cards in page order (scrolling the feed only when
@@ -1041,10 +1069,12 @@ impl Tool for TopicScanTool {
          collect up to `num_notes` cards in page order (scrolling only if the \
          first page is too small) → open each note and read its body + top \
          comments → return one compact bundle (search results + selected cards \
-         + note bodies + comments). Defaults to 10 notes; pass a larger \
-         `num_notes` to scan more (each note is opened, so latency scales with \
-         it). Prefer this for XHS topic research. Do not repeat the same scan \
-         unless the previous one was clearly insufficient."
+         + note bodies + comments). Pass `download_media=true` to download \
+         note images/videos into the run dir and include local paths. Defaults \
+         to 10 notes; pass a larger `num_notes` to scan more (each note is \
+         opened, so latency scales with it). Prefer this for XHS topic \
+         research. Do not repeat the same scan unless the previous one was \
+         clearly insufficient."
     }
 
     fn input_schema(&self) -> Value {
@@ -1062,6 +1092,11 @@ impl Tool for TopicScanTool {
                     "description": "Number of notes to read (body + top comments each). The first results page is used directly; only if it holds fewer than this does the feed scroll for more. Each note is opened, so latency scales with this.",
                     "default": DEFAULT_NUM_NOTES,
                     "minimum": 1
+                },
+                "download_media": {
+                    "type": "boolean",
+                    "description": "Download note images/videos into the command run_dir and include local_path fields in returned notes.",
+                    "default": false
                 }
             },
             "required": ["query"]
@@ -1082,8 +1117,13 @@ impl Tool for TopicScanTool {
         // and pull top comments. Per-note image vision is off (it's the one
         // genuinely expensive enrichment and not needed for topic research).
         let include_media = false;
+        let download_media = get_bool(&input, "download_media", false);
 
-        let media = media_for(ctx, self.llm_provider.clone(), include_media)?;
+        let media = media_for(
+            ctx,
+            self.llm_provider.clone(),
+            include_media || download_media,
+        )?;
         let media_baseline: Option<TimingSnapshot> = media.as_ref().map(|m| m.timing().snapshot());
         let xhs = XhsPageRuntime::new_with_media(&self.page, media.clone());
 
@@ -1113,7 +1153,8 @@ impl Tool for TopicScanTool {
         // top comments).
         let level = "deep";
         let comment_count = TOPIC_SCAN_COMMENTS;
-        let requested_media = include_media;
+        let requested_media = include_media || download_media;
+        let can_use_cached_reads = !download_media;
         let want = num_notes.max(1) as usize;
 
         // Read top-to-bottom: pull cards from the results state (which only
@@ -1158,7 +1199,10 @@ impl Tool for TopicScanTool {
 
             // Dedup: skip notes already processed at this level or deeper
             // within the same run OR in a previous run (cross-run history).
-            if !card.note_id.is_empty()
+            // Media downloads are never cache-skipped: the caller expects
+            // fresh files under this command's run_dir.
+            if can_use_cached_reads
+                && !card.note_id.is_empty()
                 && ctx.has_processed_note(&card.note_id, level, requested_media)
             {
                 notes.push(json!({
@@ -1169,7 +1213,8 @@ impl Tool for TopicScanTool {
                 }));
                 continue;
             }
-            if !card.note_id.is_empty()
+            if can_use_cached_reads
+                && !card.note_id.is_empty()
                 && self
                     .history
                     .is_satisfied_by(&card.note_id, level, requested_media)
@@ -1191,7 +1236,8 @@ impl Tool for TopicScanTool {
                     6.0,
                     ReadNoteOptions {
                         level: level.to_string(),
-                        include_media: requested_media,
+                        include_media,
+                        download_media,
                         max_images: 12,
                         max_video_frames: 4,
                     },
@@ -1285,6 +1331,7 @@ impl Tool for TopicScanTool {
                 "selected": selected.len(),
                 "comments_per_note": TOPIC_SCAN_COMMENTS,
                 "include_media": include_media,
+                "download_media": download_media,
             },
             "timing": {
                 "media": media_timing,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -636,11 +636,8 @@ impl Tool for ReadNoteTool {
             .await?;
         if value.get("ok").and_then(Value::as_bool).unwrap_or(false) {
             if let Some(entity) = value.get("entity") {
-                self.history.record(
-                    entity,
-                    &options.level,
-                    options.include_media || options.download_media,
-                );
+                self.history
+                    .record(entity, &options.level, options.include_media);
             }
         }
         Ok(json_result(&value))
@@ -694,11 +691,8 @@ impl Tool for ExtractNoteTool {
             .extract_note_with_options(wait_seconds, options.clone())
             .await?;
         let value = serde_json::to_value(&note)?;
-        self.history.record(
-            &value,
-            &options.level,
-            options.include_media || options.download_media,
-        );
+        self.history
+            .record(&value, &options.level, options.include_media);
         Ok(json_result(&value))
     }
 }
@@ -1153,7 +1147,7 @@ impl Tool for TopicScanTool {
         // top comments).
         let level = "deep";
         let comment_count = TOPIC_SCAN_COMMENTS;
-        let requested_media = include_media || download_media;
+        let requested_media = include_media;
         let can_use_cached_reads = !download_media;
         let want = num_notes.max(1) as usize;
 
@@ -1401,4 +1395,28 @@ fn sanitize_for_filename(value: &str) -> String {
         .chars()
         .take(48)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn download_media_does_not_imply_include_media() {
+        let options = read_note_options(&json!({ "download_media": true }));
+
+        assert!(options.download_media);
+        assert!(!options.include_media);
+    }
+
+    #[test]
+    fn include_media_remains_independent_from_download_media() {
+        let options = read_note_options(&json!({
+            "include_media": true,
+            "download_media": false,
+        }));
+
+        assert!(options.include_media);
+        assert!(!options.download_media);
+    }
 }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1238,7 +1238,10 @@ impl Tool for TopicScanTool {
                         level: level.to_string(),
                         include_media,
                         download_media,
-                        max_images: 12,
+                        // Pure downloads are cheap compared with OCR/vision,
+                        // so allow full XHS carousels instead of the smaller
+                        // enrichment-oriented default.
+                        max_images: if download_media { 100 } else { 12 },
                         max_video_frames: 4,
                     },
                 )


### PR DESCRIPTION
## Summary
- add a `--download-media` flag for `socai topic_scan` and thread it through the daemon/core tool path
- download note images/videos into the command run dir with `local_path` metadata
- keep all media for a note in a single `site_media/<note_id>/` folder
- extract XHS video master URLs from `window.__INITIAL_STATE__` so downloads avoid blob URLs
- extract carousel image URLs from XHS detail state so multi-image posts download all exposed images, not just the visible slide

## Validation
- `cargo check`
- `cargo test -p socai-core`
- local smoke test confirmed downloaded files appear under `run_dir/site_media`