### PR TITLE
CI: execute Windows installer from downloaded file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -905,14 +905,18 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $installUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/latest/download/install.ps1"
           $installDir = Join-Path $env:RUNNER_TEMP 'socai-bin'
+          $installer = Join-Path $env:RUNNER_TEMP 'socai-install.ps1'
           Remove-Item -Recurse -Force $installDir -ErrorAction SilentlyContinue
+          Remove-Item -Force $installer -ErrorAction SilentlyContinue
           $env:SOCAI_INSTALL_DIR = $installDir
 
           $installed = $false
           for ($attempt = 1; $attempt -le 12; $attempt++) {
             Write-Host "install attempt ${attempt}: $installUrl"
             try {
-              (Invoke-WebRequest -UseBasicParsing -Uri $installUrl).Content | Invoke-Expression
+              Invoke-WebRequest -UseBasicParsing -Uri $installUrl -OutFile $installer
+              Unblock-File $installer
+              & $installer
               $installed = $true
               break
             } catch {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ curl -fsSL https://github.com/socai-io/socai/releases/latest/download/install.sh
 Windows PowerShell:
 
 ```powershell
-(Invoke-WebRequest -UseBasicParsing https://github.com/socai-io/socai/releases/latest/download/install.ps1).Content | Invoke-Expression
+$installer = Join-Path $env:TEMP 'socai-install.ps1'; Invoke-WebRequest -UseBasicParsing https://github.com/socai-io/socai/releases/latest/download/install.ps1 -OutFile $installer; Unblock-File $installer; & $installer
 ```
 
 安装脚本会下载并校验 CLI archive，安装到 `~/.socai/bin/socai`（macOS）或

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -145,7 +145,7 @@ with a temporary `HOME` and `SOCAI_INSTALL_DIR`. It verifies:
 `verify-windows-cli-installer` runs on `windows-latest` and executes:
 
 ```powershell
-(Invoke-WebRequest -UseBasicParsing https://github.com/socai-io/socai/releases/latest/download/install.ps1).Content | Invoke-Expression
+$installer = Join-Path $env:TEMP 'socai-install.ps1'; Invoke-WebRequest -UseBasicParsing https://github.com/socai-io/socai/releases/latest/download/install.ps1 -OutFile $installer; Unblock-File $installer; & $installer
 ```
 
 with a temporary `SOCAI_INSTALL_DIR`. It verifies:


### PR DESCRIPTION
## summary
- replace the Windows installer `Invoke-WebRequest(...).Content | Invoke-Expression` path with a temp-file download + `Unblock-File` + execution
- update README and release-flow docs to use the same Windows install command
- keep installer execution in the current PowerShell session so PATH updates still apply immediately

## validation
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`

## context
The `v0.1.8` release published successfully, but the post-publish Windows installer smoke failed because GitHub served `install.ps1` as bytes and PowerShell piped byte values to `Invoke-Expression` instead of executing the script.
