### PR TITLE
CI: write Windows checksum asset with LF endings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -680,7 +680,11 @@ jobs:
           $archive = Join-Path $dist 'socai-cli-windows-x86_64.zip'
           Compress-Archive -Path (Join-Path $packageDir 'socai.exe'), (Join-Path $packageDir 'manifest.json') -DestinationPath $archive
           $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
-          "$hash  socai-cli-windows-x86_64.zip" | Set-Content -Encoding ascii "$archive.sha256"
+          $checksumPath = "$archive.sha256"
+          [System.IO.File]::WriteAllText($checksumPath, "$hash  socai-cli-windows-x86_64.zip`n", [System.Text.Encoding]::ASCII)
+          if ([System.IO.File]::ReadAllText($checksumPath).Contains("`r")) {
+            throw 'Windows checksum file must use LF line endings'
+          }
           Copy-Item scripts\install-cli.ps1 (Join-Path $dist 'install.ps1')
 
           $verifyDir = Join-Path $env:RUNNER_TEMP 'socai-cli-windows-verify'


### PR DESCRIPTION
## summary
- write the Windows CLI checksum asset with explicit LF line endings
- fail the Windows release build if the checksum file contains CR characters

## validation
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`

## context
While validating `v0.1.8`, the Windows `.sha256` asset verified in PowerShell but failed `shasum -c` on macOS because the filename included a trailing CR from CRLF line endings.
