### PR TITLE
feat(cli): scriptable XHS research commands + deep note reads

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -3,9 +3,13 @@ use crate::tracking::{query_text_enabled, telemetry_enabled, Telemetry};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
-use socai_core::runtime::SocaiRuntime;
+use socai_core::agent::{local_agent_tools, make_run_dir, AgentEvent};
+use socai_core::runtime::{
+    create_llm_provider, run_agent_task as run_agent_with_tools, AgentRunConfig, SocaiRuntime,
+};
 use socai_core::sites::xhs::{
-    extract_note_command, search_notes_command, topic_scan_command, XHS_HOME_URL,
+    extract_note_command, extract_profile_command, search_notes_command, topic_scan_command,
+    xhs_agent_instructions, xhs_agent_tools, XHS_HOME_URL,
 };
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -205,6 +209,8 @@ async fn handle_request(
             "search_notes" => state.search_notes(&id, request.args, &telemetry).await,
             "topic_scan" => state.topic_scan(&id, request.args, &telemetry).await,
             "extract_note" => state.extract_note(&id, request.args, &telemetry).await,
+            "extract_profile" => state.extract_profile(&id, request.args, &telemetry).await,
+            "agent_task" => state.agent_task(&id, request.args, &telemetry).await,
             other => Err(anyhow!("unknown daemon command: {other}")),
         }
     }
@@ -290,15 +296,104 @@ impl DaemonState {
         let started = Instant::now();
         let result = async {
             let note_id = required_string(&args, "note_id")?;
+            let level = args.get("level").and_then(Value::as_str).unwrap_or("lite");
             let debug_snapshot = debug_snapshot_flag(&args);
             let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
-            extract_note_command(page, &note_id, debug_snapshot).await
+            extract_note_command(page, &note_id, level, debug_snapshot).await
         }
         .await;
         self.track_tool_trace(
             request_id,
             "extract_note",
             "read_note",
+            &args,
+            telemetry,
+            started,
+            &result,
+        );
+        result
+    }
+
+    /// 导航到作者主页并抽取 profile（判断博主立场用）。key-free。
+    async fn extract_profile(
+        &mut self,
+        request_id: &str,
+        args: Value,
+        telemetry: &DaemonTelemetry,
+    ) -> Result<Value> {
+        let started = Instant::now();
+        let result = async {
+            let profile_url = required_string(&args, "profile_url")?;
+            let max_notes = args.get("max_notes").and_then(Value::as_i64).unwrap_or(20);
+            let scroll_rounds = args.get("scroll_rounds").and_then(Value::as_i64).unwrap_or(6);
+            let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
+            extract_profile_command(page, &profile_url, max_notes, scroll_rounds).await
+        }
+        .await;
+        self.track_tool_trace(
+            request_id,
+            "extract_profile",
+            "extract_profile",
+            &args,
+            telemetry,
+            started,
+            &result,
+        );
+        result
+    }
+
+    /// 通用自由任务入口：跑一次 agent loop（带全套 XHS 工具 + 本地工具），返回 JSON。
+    /// 复用常驻浏览器会话；按 AGENTS.md 约定，理想形态应把下面这段接线下沉到
+    /// core（如 sites/xhs 的一个 run_xhs_agent_task helper），daemon 只做薄转发。
+    async fn agent_task(
+        &mut self,
+        request_id: &str,
+        args: Value,
+        telemetry: &DaemonTelemetry,
+    ) -> Result<Value> {
+        let started = Instant::now();
+        let result = async {
+            let prompt = required_string(&args, "prompt")?;
+            let instructions = args
+                .get("instructions")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let model = args.get("model").and_then(Value::as_str).map(str::to_string);
+
+            let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
+            let provider = create_llm_provider(model.as_deref())?;
+
+            let mut tools = xhs_agent_tools(page, provider.clone()).await?;
+            tools.extend(local_agent_tools());
+
+            let run_dir = make_run_dir(&prompt);
+            let _ = std::fs::create_dir_all(&run_dir);
+
+            let config = AgentRunConfig {
+                extra_instructions: xhs_agent_instructions(instructions.as_deref().unwrap_or("")),
+                enabled_sites: vec!["xhs".to_string()],
+                run_dir: Some(run_dir),
+                ..AgentRunConfig::default()
+            };
+
+            // 守护进程路径下没有实时消费 agent 事件的 UI——丢弃事件流即可。
+            let (tx, _rx) = tokio::sync::broadcast::channel::<AgentEvent>(256);
+            let outcome = run_agent_with_tools(&prompt, provider, tools, config, tx).await?;
+
+            Ok(json!({
+                "final_text": outcome.final_text,
+                "run_dir": outcome.run_dir.display().to_string(),
+                "report_file": "report.md",
+                "turns": outcome.turns,
+                "input_tokens": outcome.total_input_tokens,
+                "output_tokens": outcome.total_output_tokens,
+            }))
+        }
+        .await;
+        self.track_tool_trace(
+            request_id,
+            "agent_task",
+            "agent_task",
             &args,
             telemetry,
             started,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,12 +49,39 @@ enum Command {
     ExtractNote {
         #[arg(long = "note-id")]
         note_id: String,
+        /// Read at `deep` level (includes top comments). Default is `lite` (body only).
+        #[arg(long)]
+        deep: bool,
         #[arg(long)]
         pretty: bool,
         /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
         /// at every page change between tool operations.
         #[arg(long = "debug-snapshot")]
         debug_snapshot: bool,
+    },
+    /// Open a Xiaohongshu author profile by URL and print it as JSON.
+    #[command(name = "extract_profile")]
+    ExtractProfile {
+        /// Profile URL — e.g. the `author_url` field from a search/topic card.
+        #[arg(long = "url")]
+        profile_url: String,
+        #[arg(long = "max-notes")]
+        max_notes: Option<i64>,
+        #[arg(long = "scroll-rounds")]
+        scroll_rounds: Option<i64>,
+        #[arg(long)]
+        pretty: bool,
+    },
+    /// Run a free-form agent task over Xiaohongshu and print the result as JSON.
+    #[command(name = "task")]
+    Task {
+        /// Natural-language task, e.g. "搜索纸尿裤测评，判断哪些是软广".
+        prompt: String,
+        /// Extra steering instructions, prepended to the XHS playbook.
+        #[arg(long)]
+        instructions: Option<String>,
+        #[arg(long)]
+        pretty: bool,
     },
     /// Stop the background socai rust daemon.
     Stop,
@@ -111,13 +138,49 @@ async fn main() -> Result<()> {
         }
         Command::ExtractNote {
             note_id,
+            deep,
             pretty,
             debug_snapshot,
         } => {
             let result = daemon::send_or_spawn(
                 "extract_note",
-                serde_json::json!({ "note_id": note_id, "debug_snapshot": debug_snapshot }),
+                serde_json::json!({
+                    "note_id": note_id,
+                    "level": if deep { "deep" } else { "lite" },
+                    "debug_snapshot": debug_snapshot,
+                }),
                 daemon::DEFAULT_COMMAND_TIMEOUT,
+            )
+            .await?;
+            print_command_result(&result, pretty)?;
+        }
+        Command::ExtractProfile {
+            profile_url,
+            max_notes,
+            scroll_rounds,
+            pretty,
+        } => {
+            let mut input = serde_json::json!({ "profile_url": profile_url });
+            if let Some(n) = max_notes {
+                input["max_notes"] = serde_json::json!(n);
+            }
+            if let Some(r) = scroll_rounds {
+                input["scroll_rounds"] = serde_json::json!(r);
+            }
+            let result =
+                daemon::send_or_spawn("extract_profile", input, daemon::LONG_COMMAND_TIMEOUT)
+                    .await?;
+            print_command_result(&result, pretty)?;
+        }
+        Command::Task {
+            prompt,
+            instructions,
+            pretty,
+        } => {
+            let result = daemon::send_or_spawn(
+                "agent_task",
+                serde_json::json!({ "prompt": prompt, "instructions": instructions }),
+                daemon::LONG_COMMAND_TIMEOUT,
             )
             .await?;
             print_command_result(&result, pretty)?;

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -7,7 +7,7 @@ pub use self::entities::{parse_count_text, XhsAuthorProfile, XhsNote, XhsNoteCar
 pub use self::history::{HistoryEntry, HistorySnapshot, XhsHistoryStore};
 pub use self::page::{ReadNoteOptions, XhsPageRuntime, XHS_HOME_URL};
 pub use self::tools::{
-    close_open_note, ensure_search_ready, extract_note_command, search_notes_command,
-    topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_tools,
+    close_open_note, ensure_search_ready, extract_note_command, extract_profile_command,
+    search_notes_command, topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_tools,
     xhs_tools_with_llm_provider, XHS_KNOWLEDGE,
 };

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -158,15 +158,35 @@ pub async fn topic_scan_command(
 pub async fn extract_note_command(
     page: Arc<PageSession>,
     note_id: &str,
+    level: &str,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         EXTRACT_NOTE_COMMAND,
-        extract_note_input(note_id)?,
+        extract_note_input(note_id, level)?,
         debug_snapshot,
     )
     .await
+}
+
+/// 导航到某个作者主页 URL，抽取其 profile（昵称/xhs_id/bio/粉丝数/笔记列表）。
+/// 与其它命令不同：它先 `navigate` 到主页再抽（ExtractProfileTool 只抽当前页）。
+/// key-free —— 纯浏览器抽取，不构造任何 LLM。
+pub async fn extract_profile_command(
+    page: Arc<PageSession>,
+    profile_url: &str,
+    max_notes: i64,
+    scroll_rounds: i64,
+) -> anyhow::Result<Value> {
+    page.navigate_with_timeout(profile_url, 60.0).await?;
+    let profile = XhsPageRuntime::new(&page)
+        .extract_profile(max_notes, scroll_rounds)
+        .await?;
+    Ok(json!({
+        "command": "extract_profile",
+        "data": profile.to_value(),
+    }))
 }
 
 fn search_notes_input(query: &str) -> anyhow::Result<Value> {
@@ -191,9 +211,10 @@ fn topic_scan_input(
     Ok(input)
 }
 
-fn extract_note_input(note_id: &str) -> anyhow::Result<Value> {
+fn extract_note_input(note_id: &str, level: &str) -> anyhow::Result<Value> {
     Ok(json!({
         "note_id": trimmed_required(note_id, "note_id")?,
+        "level": level,
         "wait_seconds": 6.0,
     }))
 }
@@ -556,7 +577,7 @@ impl Tool for ReadNoteTool {
             &self.page,
             media_for(ctx, self.llm_provider.clone(), options.include_media)?,
         );
-        let value = xhs
+        let mut value = xhs
             .read_note_with_options(
                 note_id.as_deref().unwrap_or(""),
                 index,
@@ -564,7 +585,28 @@ impl Tool for ReadNoteTool {
                 options.clone(),
             )
             .await?;
-        if value.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        let read_ok = value.get("ok").and_then(Value::as_bool).unwrap_or(false);
+        // Deep reads pull comments too. `read_note_with_options` only returns
+        // body/meta — the comment list hydrates slower and is fetched
+        // separately, the same way `topic_scan` does it. Without this,
+        // `extract_note --deep` returned a note with 0 comments even when it
+        // had dozens.
+        if read_ok && options.level == "deep" {
+            let comment_count = get_i64(&input, "comment_count", 20);
+            if comment_count > 0 {
+                if let Ok(payload) = xhs.extract_comments_with_wait(comment_count, 5.0).await {
+                    let comments = payload
+                        .get("comments")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default();
+                    if let Some(map) = value.get_mut("entity").and_then(|v| v.as_object_mut()) {
+                        map.insert("top_comments".into(), Value::Array(comments));
+                    }
+                }
+            }
+        }
+        if read_ok {
             if let Some(entity) = value.get("entity") {
                 self.history
                     .record(entity, &options.level, options.include_media);


### PR DESCRIPTION
Add key-free, scriptable subcommands so an external driver (e.g. Claude Code) can run Xiaohongshu research without the interactive TUI:

- `extract_profile --url <author_url>`: open an author profile and emit bio/stats/notes as JSON — key-free; useful for judging a 博主's stance (挂车 / single-brand detection). Supports `--max-notes` / `--scroll-rounds`.
- `task "<prompt>"`: run a free-form agent task over the XHS playbook and emit the result as JSON (requires an API key). Optional `--instructions` prepends extra steering.
- `extract_note --deep`: thread `read_note`'s `level=deep` so callers can request top comments instead of body-only.

Also fix deep note reads actually returning comments: `read_note` hydrates the comment list slower and never fetched it on the read path (only `topic_scan` did, via `extract_comments_with_wait`). Deep reads now mirror `topic_scan` — call `extract_comments_with_wait` and merge `top_comments` into the entity — so a deep read returns its comments.

Per AGENTS.md the daemon stays thin: the new subcommands wrap existing `XhsPageRuntime` / site tools rather than duplicating XHS logic.