### PR TITLE
feat(dy): add douyin search site

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ socai xhs topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=�
 socai xhs topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest_path
 socai xhs search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai xhs extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
+socai dy search_videos "咖啡" --num-videos 30                                  # 搜索抖音并拿视频卡片信息
 socai config set chrome.profile managed                                    # 以后默认使用 socai 独立 chrome 资料目录
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
 ```
 
-> 命令按站点分组（第一个站点是小红书 `xhs`）。旧的不带站点的写法（如
+> 命令按站点分组（例如小红书 `xhs`、抖音 `dy`）。旧的不带站点的写法（如
 > `socai topic_scan …`）仍然可用，但已废弃并会打印警告，请迁移到 `socai xhs …`。
 
 Options:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # socai
 
 [![release](https://img.shields.io/github/v/release/socai-io/socai?style=flat-square&color=blue&label=release)](https://github.com/socai-io/socai/releases/latest)
-[![rust](https://img.shields.io/badge/built%20with-Rust-orange?style=flat-square&logo=rust&logoColor=white)](https://www.rust-lang.org)
-[![license](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](https://github.com/socai-io/socai/blob/main/LICENSE)
 [![website](https://img.shields.io/badge/website-socai.io-blue?style=flat-square)](https://socai.io)
 
 专为小红书优化的 web use agent，执行小红书调研、内容抽取和自定义 agent 任务。
@@ -22,12 +20,13 @@ socai 有三种用法，内核相同，按你的场景选：
 | [**TUI**](#tui) | 终端里的交互界面，手动跑任务 | 安装 CLI 后运行 `socai` |
 | [**GUI**](#desktop-app-gui) | 图形桌面应用（macOS），点击即用 | [下载 .dmg](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg) |
 
-## CLI
+## 1. CLI
 
 socai 的核心，给 Claude Code、Codex 等 AI agent 提供开箱即用的小红书工具。
 
 https://github.com/user-attachments/assets/8aebcded-f365-4f12-b9c4-102cc1fa964d
 
+### CLI安装
 优先安装预编译 CLI binary（不需要 Rust/Cargo）：
 
 macOS:
@@ -53,20 +52,16 @@ cd socai
 cargo install --path cli --force
 ```
 
-常用命令：
+### CLI使用
+小红书常用命令：
 
 ```bash
 socai xhs topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
 socai xhs topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest_path
 socai xhs search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai xhs extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
-socai dy search_videos "咖啡" --num-videos 30                                  # 搜索抖音并拿视频卡片信息
-socai config set chrome.profile managed                                    # 以后默认使用 socai 独立 chrome 资料目录
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
 ```
-
-> 命令按站点分组（例如小红书 `xhs`、抖音 `dy`）。旧的不带站点的写法（如
-> `socai topic_scan …`）仍然可用，但已废弃并会打印警告，请迁移到 `socai xhs …`。
 
 Options:
 
@@ -91,14 +86,21 @@ Options:
 continuation command: a prior `search_notes` / `topic_scan` must have left the
 tool tab on a waterfall containing the target card.
 
-Browser profile:
+
+**新增了抖音支持**：
+```bash
+socai dy search "咖啡" --num 30         # 搜索关键词并拿n条视频的信息
+```
+
+
+### 控制浏览器profile:
 
 - `chrome.profile` values: `existing`, `managed`, `auto`.
 - Default: `existing` — attach to your existing browser/profile with CDP enabled.
 - To opt into socai's isolated profile persistently:
 
   ```bash
-  socai config set chrome.profile managed
+  socai config set chrome.profile managed # 以后默认使用 socai 独立 chrome 资料目录
   socai stop   # only needed if the daemon is already running
   ```
 
@@ -119,7 +121,7 @@ Browser profile:
 - Config lives in `~/.socai/config.json`. Advanced endpoint overrides still use
   `SOCAI_CDP_WS` / `SOCAI_CDP_URL`.
 
-## TUI
+## 2. TUI
 
 安装方式与 CLI 相同，安装后不带子命令运行 `socai` 即可打开终端交互界面：
 
@@ -127,7 +129,7 @@ Browser profile:
 socai   # 不带子命令即打开 TUI
 ```
 
-## Desktop App (GUI)
+## 3. Desktop App (GUI)
 
 [Download .dmg for Mac](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg).
 

--- a/core/src/sites/dy/entities.rs
+++ b/core/src/sites/dy/entities.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DouyinVideoCard {
+    pub video_id: String,
+    pub url: String,
+    pub title: String,
+    pub author: String,
+    pub author_url: String,
+    pub likes: String,
+    pub comments: String,
+    pub shares: String,
+    pub cover_url: String,
+    pub position: usize,
+}
+
+pub fn normalize_douyin_url(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if trimmed.starts_with("//") {
+        return format!("https:{trimmed}");
+    }
+    if trimmed.starts_with('/') {
+        return format!("https://www.douyin.com{trimmed}");
+    }
+    trimmed.to_string()
+}
+
+pub fn extract_video_id(url: &str) -> String {
+    for marker in ["/video/", "/note/"] {
+        if let Some(rest) = url.split(marker).nth(1) {
+            let id = rest
+                .split(['?', '#', '/', '&'])
+                .next()
+                .unwrap_or_default()
+                .trim();
+            if !id.is_empty() {
+                return id.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_relative_douyin_url() {
+        assert_eq!(
+            normalize_douyin_url("/video/123"),
+            "https://www.douyin.com/video/123"
+        );
+        assert_eq!(
+            normalize_douyin_url("//www.douyin.com/video/123"),
+            "https://www.douyin.com/video/123"
+        );
+    }
+
+    #[test]
+    fn extracts_video_id_from_video_or_note_url() {
+        assert_eq!(
+            extract_video_id("https://www.douyin.com/video/7354264417699204363?foo=1"),
+            "7354264417699204363"
+        );
+        assert_eq!(
+            extract_video_id("https://www.douyin.com/note/123456#comment"),
+            "123456"
+        );
+    }
+}

--- a/core/src/sites/dy/knowledge.md
+++ b/core/src/sites/dy/knowledge.md
@@ -1,0 +1,22 @@
+# Douyin site notes
+
+- Site id: `dy`; home URL: `https://www.douyin.com/`.
+- Douyin web may throttle by keeping the page visually blank for 4-5 minutes.
+  Commands therefore use long waits by default and report
+  `blank_or_throttled` instead of treating a blank page as an immediate hard
+  failure.
+- Current first-step tool: `page_state`. Use it with `--debug-snapshot` to
+  verify whether the homepage/search UI is visible before implementing or
+  relying on deeper workflows.
+- `search_videos` starts from the homepage/top search box, enters the keyword,
+  submits with Enter, then extracts cards from the search-result waterfall.
+  Use `--num-videos` to scroll for more cards; default is 30.
+- Observed stable-ish selectors on 2026-06-11:
+  `data-e2e="searchbar-input"`, `data-e2e="searchbar-button"`,
+  `.search-result-card`, parent ids like `waterfall_item_<video_id>`,
+  `.videoImage`, `.RBpYLmIg` for title text, `.lGzJpEad` for author, and
+  `.GiEcbsyC span` for visible like/play count text.
+- Search-result "综合" includes non-video modules such as live rooms and topic
+  cards. The extractor filters obvious live cards and keeps cards with video
+  signals; fields absent from the search card, such as comments/shares, are
+  returned as empty strings.

--- a/core/src/sites/dy/knowledge.md
+++ b/core/src/sites/dy/knowledge.md
@@ -8,9 +8,9 @@
 - Current first-step tool: `page_state`. Use it with `--debug-snapshot` to
   verify whether the homepage/search UI is visible before implementing or
   relying on deeper workflows.
-- `search_videos` starts from the homepage/top search box, enters the keyword,
+- `search` starts from the homepage/top search box, enters the keyword,
   submits with Enter, then extracts cards from the search-result waterfall.
-  Use `--num-videos` to scroll for more cards; default is 30.
+  Use `--num` to scroll for more cards; default is 10.
 - Observed stable-ish selectors on 2026-06-11:
   `data-e2e="searchbar-input"`, `data-e2e="searchbar-button"`,
   `.search-result-card`, parent ids like `waterfall_item_<video_id>`,

--- a/core/src/sites/dy/mod.rs
+++ b/core/src/sites/dy/mod.rs
@@ -1,0 +1,10 @@
+pub mod entities;
+pub mod page;
+pub mod tools;
+
+pub use self::entities::DouyinVideoCard;
+pub use self::page::{DouyinPageRuntime, DOUYIN_HOME_URL};
+pub use self::tools::{
+    dy_agent_instructions, dy_agent_tools, dy_tools, dy_tools_with_llm_provider, DY_KNOWLEDGE,
+    DY_SITE,
+};

--- a/core/src/sites/dy/page.rs
+++ b/core/src/sites/dy/page.rs
@@ -1,0 +1,357 @@
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use serde_json::{json, Map, Value};
+
+use crate::cdp::PageSession;
+use crate::sites::dy::entities::DouyinVideoCard;
+
+pub const DOUYIN_HOME_URL: &str = "https://www.douyin.com/";
+
+const PAGE_SCRIPTS_JS: &str = include_str!("page_scripts.js");
+const DOUYIN_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
+    "pageState",
+    "searchInput",
+    "setSearchInput",
+    "searchState",
+    "videoCards",
+    "scrollFeed",
+];
+const SEARCH_TRANSITION_TIMEOUT_S: f64 = 20.0;
+
+pub struct DouyinPageRuntime<'a> {
+    page: &'a PageSession,
+}
+
+impl<'a> DouyinPageRuntime<'a> {
+    pub fn new(page: &'a PageSession) -> Self {
+        Self { page }
+    }
+
+    pub async fn run_script(&self, name: &str, arg: Option<&Value>) -> Result<Value> {
+        if !DOUYIN_PAGE_SCRIPT_FUNCTIONS.contains(&name) {
+            anyhow::bail!("Unknown Douyin page script: {name}");
+        }
+        let args = match arg {
+            None => String::new(),
+            Some(v) => serde_json::to_string(v)?,
+        };
+        let expr = format!(
+            "(function() {{\n{PAGE_SCRIPTS_JS}\n// SOCAI_DOUYIN_CALL: {name}\nreturn SocaiDouyinPageScripts.{name}({args});\n}})()"
+        );
+        self.page.evaluate_json(&expr).await
+    }
+
+    pub async fn current_url(&self) -> Result<String> {
+        Ok(self
+            .page
+            .page_info()
+            .await?
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string())
+    }
+
+    pub async fn ensure_douyin(
+        &self,
+        navigate_if_needed: bool,
+        _timeout_seconds: f64,
+    ) -> Result<()> {
+        let url = self.current_url().await.unwrap_or_default();
+        if url.contains("douyin.com") {
+            return Ok(());
+        }
+        if navigate_if_needed {
+            self.soft_navigate(DOUYIN_HOME_URL).await?;
+            return Ok(());
+        }
+        anyhow::bail!(
+            "Current page is not Douyin: {}",
+            if url.is_empty() { "unknown" } else { &url }
+        );
+    }
+
+    pub async fn wait_until_interactive(&self, timeout_seconds: f64) -> Result<Value> {
+        let deadline = Instant::now() + Duration::from_secs_f64(timeout_seconds.max(0.5));
+        let mut latest = json!({
+            "ok": false,
+            "blank_or_throttled": true,
+            "reason": "waiting_for_douyin",
+        });
+        while Instant::now() < deadline {
+            latest = match self.detect_state().await {
+                Ok(state) => state,
+                Err(err) => json!({
+                    "ok": false,
+                    "blank_or_throttled": true,
+                    "reason": "detect_state_failed",
+                    "error": err.to_string(),
+                    "url": self.current_url().await.unwrap_or_default(),
+                }),
+            };
+            if !latest
+                .get("blank_or_throttled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+            {
+                return Ok(latest);
+            }
+            sleep_ms(1000).await;
+        }
+        Ok(latest)
+    }
+
+    async fn soft_navigate(&self, url: &str) -> Result<()> {
+        let url = serde_json::to_string(url)?;
+        let expr = format!(
+            "window.location.assign({url}); return {{ ok: true, url: window.location.href }};"
+        );
+        match self.page.evaluate_json(&expr).await {
+            Ok(_) => Ok(()),
+            // The page may start unloading before Chrome returns the evaluate
+            // result. Treat that as a successful navigation trigger; the
+            // polling path will verify where we actually landed.
+            Err(_) => Ok(()),
+        }
+    }
+
+    pub async fn detect_state(&self) -> Result<Value> {
+        self.ensure_douyin(false, 0.0).await?;
+        self.expect_object("pageState", None).await
+    }
+
+    pub async fn search_videos(
+        &self,
+        query: &str,
+        wait_seconds: f64,
+        num_videos: usize,
+    ) -> Result<Value> {
+        let keyword = query.trim();
+        if keyword.is_empty() {
+            anyhow::bail!("query is required");
+        }
+        self.ensure_douyin(true, wait_seconds.max(330.0)).await?;
+        let initial = self
+            .wait_until_interactive(wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
+            .await?;
+        if initial
+            .get("blank_or_throttled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Ok(json!({
+                "ok": false,
+                "query": keyword,
+                "reason": "blank_or_throttled",
+                "state": initial,
+                "count": 0,
+                "cards": [],
+            }));
+        }
+
+        let submit = self.submit_search(keyword, wait_seconds).await?;
+        let ok = script_ok(&submit);
+        let cards = if ok {
+            self.collect_video_cards(num_videos.max(1)).await?
+        } else {
+            Vec::new()
+        };
+        Ok(json!({
+            "ok": ok,
+            "query": keyword,
+            "submit": submit,
+            "url": self.current_url().await?,
+            "count": cards.len(),
+            "cards": cards,
+            "reason": if ok { "" } else { submit.get("error").and_then(Value::as_str).unwrap_or("search_submit_failed") },
+        }))
+    }
+
+    async fn submit_search(&self, query: &str, wait_seconds: f64) -> Result<Value> {
+        let loc = self.expect_object("searchInput", None).await?;
+        if !script_ok(&loc) {
+            return Ok(json!({
+                "ok": false,
+                "strategy": "search_input_unavailable",
+                "error": loc.get("error").and_then(Value::as_str).unwrap_or_default(),
+                "state": loc,
+            }));
+        }
+        if let Some(input) = loc.get("input") {
+            self.page
+                .click(number(input, "x"), number(input, "y"))
+                .await?;
+            sleep_ms(150).await;
+        }
+        let set = self
+            .expect_object("setSearchInput", Some(&json!({ "query": query })))
+            .await?;
+        if !script_ok(&set) {
+            return Ok(json!({
+                "ok": false,
+                "strategy": "set_search_input_failed",
+                "error": set.get("error").and_then(Value::as_str).unwrap_or_default(),
+                "state": set,
+            }));
+        }
+
+        self.page.press_key("Enter").await?;
+        let state = self
+            .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
+            .await?;
+        if search_transition_ok(&state) {
+            return Ok(json!({
+                "ok": true,
+                "strategy": "input_enter",
+                "state": state,
+                "url": self.current_url().await?,
+            }));
+        }
+
+        if let Some(submit) = loc.get("submit") {
+            let x = number(submit, "x");
+            let y = number(submit, "y");
+            if x > 0.0 && y > 0.0 {
+                self.page.click(x, y).await?;
+                let state = self
+                    .wait_for_search_transition(
+                        query,
+                        wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
+                    )
+                    .await?;
+                if search_transition_ok(&state) {
+                    return Ok(json!({
+                        "ok": true,
+                        "strategy": "search_button_click",
+                        "state": state,
+                        "url": self.current_url().await?,
+                    }));
+                }
+            }
+        }
+
+        Ok(json!({
+            "ok": false,
+            "strategy": "manual_submit_failed",
+            "state": state,
+            "url": self.current_url().await?,
+            "error": if state.get("blank_or_throttled").and_then(Value::as_bool).unwrap_or(false) {
+                "blank_or_throttled"
+            } else if state.get("login_required").and_then(Value::as_bool).unwrap_or(false) {
+                "login_required"
+            } else {
+                "Search did not transition to a Douyin result page"
+            },
+        }))
+    }
+
+    async fn wait_for_search_transition(&self, query: &str, timeout_s: f64) -> Result<Value> {
+        let deadline = Instant::now() + Duration::from_secs_f64(timeout_s.max(0.5));
+        let mut latest = Value::Object(Map::new());
+        while Instant::now() < deadline {
+            latest = self
+                .expect_object("searchState", Some(&json!({ "query": query })))
+                .await?;
+            if search_transition_ok(&latest) {
+                return Ok(latest);
+            }
+            sleep_ms(400).await;
+        }
+        Ok(latest)
+    }
+
+    async fn extract_video_cards(&self, limit: usize) -> Result<Vec<DouyinVideoCard>> {
+        let raw = self
+            .expect_array("videoCards", Some(&json!({ "limit": limit })))
+            .await?;
+        Ok(raw
+            .into_iter()
+            .filter_map(|item| serde_json::from_value(item).ok())
+            .collect())
+    }
+
+    async fn collect_video_cards(&self, target: usize) -> Result<Vec<DouyinVideoCard>> {
+        const MAX_STALLS: usize = 4;
+        let mut cards = self.extract_video_cards(target).await?;
+        let mut stalls = 0usize;
+        while cards.len() < target && stalls < MAX_STALLS {
+            let before = cards.len();
+            self.expect_object("scrollFeed", Some(&json!({ "nudge_up": false })))
+                .await?;
+            sleep_ms(1200).await;
+            cards = self.extract_video_cards(target).await?;
+            if cards.len() <= before {
+                self.expect_object("scrollFeed", Some(&json!({ "nudge_up": true })))
+                    .await?;
+                sleep_ms(700).await;
+                cards = self.extract_video_cards(target).await?;
+            }
+            if cards.len() <= before {
+                stalls += 1;
+            } else {
+                stalls = 0;
+            }
+        }
+        cards.truncate(target);
+        Ok(cards)
+    }
+
+    async fn expect_object(&self, name: &str, arg: Option<&Value>) -> Result<Value> {
+        let value = self.run_script(name, arg).await?;
+        if value.is_object() {
+            Ok(value)
+        } else {
+            anyhow::bail!(
+                "Douyin page script {name} returned {}, expected object",
+                value_type(&value)
+            );
+        }
+    }
+
+    async fn expect_array(&self, name: &str, arg: Option<&Value>) -> Result<Vec<Value>> {
+        let value = self.run_script(name, arg).await?;
+        value.as_array().cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Douyin page script {name} returned {}, expected array",
+                value_type(&value)
+            )
+        })
+    }
+}
+
+fn search_transition_ok(value: &Value) -> bool {
+    value
+        .get("blank_or_throttled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        == false
+        && (value.get("card_count").and_then(Value::as_u64).unwrap_or(0) > 0
+            || value
+                .get("has_no_results")
+                .and_then(Value::as_bool)
+                .unwrap_or(false))
+}
+
+fn number(value: &Value, key: &str) -> f64 {
+    value.get(key).and_then(Value::as_f64).unwrap_or(0.0)
+}
+
+fn script_ok(value: &Value) -> bool {
+    value.get("ok").and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+async fn sleep_ms(ms: u64) {
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+}

--- a/core/src/sites/dy/page_scripts.js
+++ b/core/src/sites/dy/page_scripts.js
@@ -1,0 +1,243 @@
+(function () {
+  function text(node) {
+    return (node && (node.innerText || node.textContent) || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function normUrl(value) {
+    if (!value) return '';
+    try {
+      return new URL(value, location.href).href;
+    } catch (_) {
+      return String(value || '');
+    }
+  }
+
+  function visible(el) {
+    if (!el || !el.getBoundingClientRect) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+  }
+
+  function center(el) {
+    const rect = el.getBoundingClientRect();
+    return {
+      x: Math.max(1, Math.min(window.innerWidth - 1, rect.left + rect.width / 2)),
+      y: Math.max(1, Math.min(window.innerHeight - 1, rect.top + rect.height / 2)),
+      w: rect.width,
+      h: rect.height,
+    };
+  }
+
+  function hasUsefulBody() {
+    return text(document.body).length > 20 || document.querySelectorAll('input, textarea, [contenteditable="true"], a[href], video').length > 0;
+  }
+
+  function pageState() {
+    const bodyText = text(document.body);
+    const inputs = Array.from(document.querySelectorAll('input, textarea, [contenteditable="true"], [role="searchbox"]'))
+      .filter(visible)
+      .slice(0, 8)
+      .map((el) => {
+        const rect = center(el);
+        return {
+          tag: el.tagName.toLowerCase(),
+          role: el.getAttribute('role') || '',
+          placeholder: el.getAttribute('placeholder') || '',
+          aria_label: el.getAttribute('aria-label') || '',
+          text: text(el).slice(0, 80),
+          x: rect.x,
+          y: rect.y,
+          w: rect.w,
+          h: rect.h,
+        };
+      });
+    const loginRequired = /登录|验证码|扫码|手机号/.test(bodyText) && /登录后|立即登录|扫码登录|验证码/.test(bodyText);
+    const blankOrThrottled = document.readyState !== 'complete' || !hasUsefulBody();
+    return {
+      ok: true,
+      site: 'dy',
+      url: location.href,
+      title: document.title || '',
+      ready_state: document.readyState,
+      body_text_len: bodyText.length,
+      blank_or_throttled: blankOrThrottled,
+      login_required: loginRequired,
+      search_inputs: inputs,
+    };
+  }
+
+  function searchInput() {
+    const candidates = [
+      '[data-e2e="searchbar-input"]',
+      'input[placeholder*="搜索"]',
+      'textarea[placeholder*="搜索"]',
+      '[contenteditable="true"][data-e2e*="search"]',
+      '[role="searchbox"]',
+    ];
+    const input = candidates.flatMap((selector) => Array.from(document.querySelectorAll(selector))).find(visible);
+    if (!input) {
+      return { ok: false, error: 'search_input_not_found', state: pageState() };
+    }
+    const submit = document.querySelector('[data-e2e="searchbar-button"]') ||
+      Array.from(document.querySelectorAll('button')).find((btn) => visible(btn) && /搜索/.test(text(btn)));
+    return {
+      ok: true,
+      input: center(input),
+      submit: submit && visible(submit) ? center(submit) : null,
+      placeholder: input.getAttribute('placeholder') || '',
+      value: input.value || text(input),
+    };
+  }
+
+  function setNativeValue(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (descriptor && descriptor.set) {
+      descriptor.set.call(el, value);
+    } else {
+      el.value = value;
+    }
+  }
+
+  function setSearchInput(arg) {
+    const query = String((arg && arg.query) || '').trim();
+    const loc = searchInput();
+    if (!loc.ok) return loc;
+    const input = document.elementFromPoint(loc.input.x, loc.input.y);
+    const target = input && (input.matches('input, textarea, [contenteditable="true"]')
+      ? input
+      : input.closest('input, textarea, [contenteditable="true"]'));
+    if (!target) {
+      return { ok: false, error: 'search_input_target_missing', loc };
+    }
+    target.focus();
+    if (target.isContentEditable) {
+      target.textContent = query;
+    } else {
+      setNativeValue(target, query);
+    }
+    target.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: query }));
+    target.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true, query, value: target.value || text(target), loc: searchInput() };
+  }
+
+  function cardNodes() {
+    const nodes = Array.from(document.querySelectorAll(
+      '.search-result-card, [id^="waterfall_item_"], [data-aweme-id], a[href*="/video/"], [href*="/video/"]'
+    ));
+    const cards = [];
+    const seen = new Set();
+    for (const node of nodes) {
+      const card = node.closest('[id^="waterfall_item_"]') ||
+        node.closest('.search-result-card') ||
+        node.closest('[data-aweme-id]') ||
+        node.closest('a[href*="/video/"], [href*="/video/"]') ||
+        node;
+      if (!card || seen.has(card)) continue;
+      seen.add(card);
+      if (!visible(card)) continue;
+      cards.push(card);
+    }
+    return cards;
+  }
+
+  function videoIdFromUrl(url) {
+    const match = String(url || '').match(/\/(?:video|note)\/([^/?#]+)/);
+    return match ? match[1] : '';
+  }
+
+  function videoCards(arg) {
+    const limit = Math.max(1, Number((arg && arg.limit) || 30));
+    const cards = [];
+    const seen = new Set();
+    for (const card of cardNodes()) {
+      const linkNode = card.matches('a[href*="/video/"], [href*="/video/"]')
+        ? card
+        : card.querySelector('a[href*="/video/"], [href*="/video/"]');
+      const isLive = !!card.querySelector('a[href*="live.douyin.com"]') || /直播中|直播间/.test(text(card));
+      const hasVideoSignal = !!card.querySelector('.videoImage, [class*="videoImage"]') ||
+        !!card.querySelector('[class*="duration"], .cxEIO6RG') ||
+        !!linkNode ||
+        !!card.getAttribute('data-aweme-id');
+      if (isLive || !hasVideoSignal) continue;
+      const rawHref = (linkNode && (linkNode.href || linkNode.getAttribute('href'))) ||
+        card.getAttribute('href') ||
+        '';
+      const idMatch = (card.id || '').match(/^waterfall_item_(\d+)/);
+      const videoId = card.getAttribute('data-aweme-id') || videoIdFromUrl(rawHref) || (idMatch ? idMatch[1] : '');
+      const url = normUrl(rawHref || (videoId ? `/video/${videoId}` : ''));
+      if (!videoId && !url) continue;
+      const key = videoId || url;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const img = card.querySelector('img');
+      const allText = text(card);
+      const titleNode = card.querySelector('[title], [aria-label]') ||
+        card.querySelector('.RBpYLmIg, .trjxC5lo, [class*="title"], [class*="desc"]');
+      let title = (img && img.alt) || text(titleNode) || '';
+      if (!title) {
+        const lines = allText.split(/\s{2,}|(?=@)/).map((line) => line.trim()).filter(Boolean);
+        title = lines.find((line) => !line.startsWith('@')) || allText;
+      }
+      const author = text(card.querySelector('.lGzJpEad, .j5CaTxWe')) ||
+        ((allText.match(/@([^\s·]+)/) || [])[1] || '');
+      const likeNode = card.querySelector('.GiEcbsyC span');
+      const countMatches = Array.from(allText.matchAll(/(\d+(?:\.\d+)?\s*(?:万|w|W|k|K)?)/g)).map((m) => m[1].replace(/\s+/g, ''));
+      cards.push({
+        video_id: videoId,
+        url,
+        title: title.trim(),
+        author,
+        author_url: normUrl((card.querySelector('a[href*="/user/"]') || {}).href || ''),
+        likes: text(likeNode) || countMatches[0] || '',
+        comments: '',
+        shares: '',
+        cover_url: normUrl((img && (img.currentSrc || img.src)) || ''),
+        position: cards.length,
+      });
+      if (cards.length >= limit) break;
+    }
+    return cards;
+  }
+
+  function searchState(arg) {
+    const query = String((arg && arg.query) || '').trim();
+    const cards = videoCards({ limit: 3 });
+    const bodyText = text(document.body);
+    return {
+      ok: true,
+      url: location.href,
+      title: document.title || '',
+      ready_state: document.readyState,
+      query,
+      query_visible: query ? bodyText.includes(query) || decodeURIComponent(location.href).includes(query) : false,
+      card_count: cards.length,
+      blank_or_throttled: document.readyState !== 'complete' || !hasUsefulBody(),
+      login_required: /登录后|扫码登录|验证码|立即登录/.test(bodyText),
+      has_no_results: /暂无|没有找到|无结果|换个词/.test(bodyText),
+    };
+  }
+
+  function scrollFeed(arg) {
+    const down = !(arg && arg.nudge_up);
+    const delta = down ? Math.floor(window.innerHeight * 0.85) : -Math.floor(window.innerHeight * 0.35);
+    const candidates = Array.from(document.querySelectorAll('.route-scroll-container, [class*="scroll"], main, body, html'));
+    const scrollable = candidates.find((el) => {
+      if (!visible(el) && el !== document.body && el !== document.documentElement) return false;
+      return el.scrollHeight > el.clientHeight + 20;
+    }) || document.scrollingElement || document.documentElement;
+    scrollable.scrollBy({ top: delta, left: 0, behavior: 'instant' });
+    return { ok: true, delta, y: scrollable.scrollTop || window.scrollY, card_count: videoCards({ limit: 999 }).length };
+  }
+
+  window.SocaiDouyinPageScripts = {
+    pageState,
+    searchInput,
+    setSearchInput,
+    searchState,
+    videoCards,
+    scrollFeed,
+  };
+})();

--- a/core/src/sites/dy/tools.rs
+++ b/core/src/sites/dy/tools.rs
@@ -1,0 +1,245 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::agent::{Backend as LlmProvider, Tool, ToolContext, ToolResult};
+use crate::cdp::PageSession;
+use crate::sites::dy::DouyinPageRuntime;
+use crate::sites::registry::{
+    required_string, ArgKind, BoxFuture, CommandArg, SiteCommand, SiteSpec, SlowWhen,
+};
+use crate::sites::runner::{get_f64, get_i64, json_result, run_tool_command, ToolCommand};
+
+pub const DY_KNOWLEDGE: &str = include_str!("knowledge.md");
+
+pub fn dy_tools(page: Arc<PageSession>) -> Vec<Arc<dyn Tool>> {
+    dy_tools_with_llm_provider(page, None)
+}
+
+pub fn dy_tools_with_llm_provider(
+    page: Arc<PageSession>,
+    _llm_provider: Option<Arc<dyn LlmProvider>>,
+) -> Vec<Arc<dyn Tool>> {
+    vec![
+        Arc::new(SearchVideosTool { page: page.clone() }) as Arc<dyn Tool>,
+        Arc::new(PageStateTool { page }),
+    ]
+}
+
+pub async fn dy_agent_tools(
+    page: Arc<PageSession>,
+    llm_provider: Arc<dyn LlmProvider>,
+) -> anyhow::Result<Vec<Arc<dyn Tool>>> {
+    let _ = DouyinPageRuntime::new(&page)
+        .ensure_douyin(true, 330.0)
+        .await;
+    Ok(dy_tools_with_llm_provider(page, Some(llm_provider)))
+}
+
+pub fn dy_agent_instructions(extra: &str) -> String {
+    let base = DY_KNOWLEDGE.trim().to_string();
+    let extra = extra.trim();
+    if extra.is_empty() {
+        base
+    } else {
+        format!("{extra}\n\n{base}")
+    }
+}
+
+pub static DY_SITE: SiteSpec = SiteSpec {
+    id: "dy",
+    about: "Douyin (douyin.com)",
+    // Let Douyin tools own first navigation so they can use a much longer
+    // timeout for the site's occasional 4-5 minute blank-page throttling.
+    home_url: "",
+    agent_tools: |page, llm| Box::pin(dy_agent_tools(page, llm)),
+    agent_instructions: dy_agent_instructions,
+    commands: &[
+        SiteCommand {
+            name: "search_videos",
+            tool_name: "search_videos",
+            about: "Search Douyin and print video result cards as JSON.",
+            args: &[
+                CommandArg {
+                    key: "query",
+                    long: None,
+                    value_name: "QUERY",
+                    help: "Search query",
+                    required: true,
+                    kind: ArgKind::Str,
+                },
+                CommandArg {
+                    key: "num_videos",
+                    long: Some("num-videos"),
+                    value_name: "N",
+                    help: "Number of video cards to collect by scrolling. Defaults to 30.",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+                CommandArg {
+                    key: "wait_seconds",
+                    long: Some("wait-seconds"),
+                    value_name: "SECONDS",
+                    help: "Maximum wait for page/search transitions. Use 300+ when Douyin web is throttled.",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+            ],
+            slow: SlowWhen::Always,
+            run: run_search_videos,
+        },
+        SiteCommand {
+            name: "page_state",
+            tool_name: "page_state",
+            about: "Open or reuse Douyin and print page state as JSON.",
+            args: &[CommandArg {
+                key: "wait_seconds",
+                long: Some("wait-seconds"),
+                value_name: "SECONDS",
+                help: "Maximum wait for a non-blank Douyin page. Use 300+ when the web page is throttled.",
+                required: false,
+                kind: ArgKind::Int,
+            }],
+            slow: SlowWhen::Always,
+            run: run_page_state,
+        },
+    ],
+};
+
+fn run_search_videos(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+) -> BoxFuture<Value> {
+    Box::pin(async move {
+        run_tool_command(
+            ToolCommand {
+                site_id: "dy",
+                command_name: "search_videos",
+                tool_name: "search_videos",
+                before: None,
+                after: None,
+            },
+            page.clone(),
+            &dy_tools(page),
+            args,
+            debug_snapshot,
+        )
+        .await
+    })
+}
+
+fn run_page_state(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+    Box::pin(async move {
+        let wait_seconds = get_f64(&args, "wait_seconds", 330.0);
+        run_tool_command(
+            ToolCommand {
+                site_id: "dy",
+                command_name: "page_state",
+                tool_name: "page_state",
+                before: Some(Box::new(move |page| {
+                    Box::pin(async move {
+                        let runtime = DouyinPageRuntime::new(&page);
+                        runtime.ensure_douyin(true, wait_seconds).await?;
+                        let _ = runtime.wait_until_interactive(wait_seconds).await?;
+                        Ok(())
+                    })
+                })),
+                after: None,
+            },
+            page.clone(),
+            &dy_tools(page),
+            args,
+            debug_snapshot,
+        )
+        .await
+    })
+}
+
+pub struct SearchVideosTool {
+    page: Arc<PageSession>,
+}
+
+#[async_trait]
+impl Tool for SearchVideosTool {
+    fn name(&self) -> &str {
+        "search_videos"
+    }
+
+    fn description(&self) -> &str {
+        "Search Douyin for videos matching `query` and return visible result \
+         cards (video id, URL, title, author, cover, and any engagement text \
+         the page exposes). Defaults to 30 cards and may wait several minutes \
+         if Douyin web is throttled."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Search query" },
+                "num_videos": {
+                    "type": "integer",
+                    "description": "Number of video cards to collect by scrolling.",
+                    "default": 30,
+                    "minimum": 1
+                },
+                "wait_seconds": {
+                    "type": "number",
+                    "description": "Maximum wait for page/search transitions.",
+                    "default": 330
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let query = required_string(&input, "query")?;
+        let wait_seconds = get_f64(&input, "wait_seconds", 330.0);
+        let num_videos = get_i64(&input, "num_videos", 30).max(1) as usize;
+        let runtime = DouyinPageRuntime::new(&self.page);
+        let value = runtime
+            .search_videos(&query, wait_seconds, num_videos)
+            .await?;
+        Ok(json_result(&value))
+    }
+}
+
+pub struct PageStateTool {
+    page: Arc<PageSession>,
+}
+
+#[async_trait]
+impl Tool for PageStateTool {
+    fn name(&self) -> &str {
+        "page_state"
+    }
+
+    fn description(&self) -> &str {
+        "Read Douyin page state, including URL, title, candidate search inputs, \
+         login hints, and whether the page still looks blank/throttled. This \
+         may wait several minutes on Douyin web throttling."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "wait_seconds": {
+                    "type": "number",
+                    "description": "Maximum wait for the Douyin page to become non-blank.",
+                    "default": 330
+                }
+            }
+        })
+    }
+
+    async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let wait_seconds = get_f64(&input, "wait_seconds", 330.0);
+        let runtime = DouyinPageRuntime::new(&self.page);
+        let state = runtime.wait_until_interactive(wait_seconds).await?;
+        Ok(json_result(&state))
+    }
+}

--- a/core/src/sites/dy/tools.rs
+++ b/core/src/sites/dy/tools.rs
@@ -22,7 +22,7 @@ pub fn dy_tools_with_llm_provider(
     _llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     vec![
-        Arc::new(SearchVideosTool { page: page.clone() }) as Arc<dyn Tool>,
+        Arc::new(SearchTool { page: page.clone() }) as Arc<dyn Tool>,
         Arc::new(PageStateTool { page }),
     ]
 }
@@ -57,8 +57,8 @@ pub static DY_SITE: SiteSpec = SiteSpec {
     agent_instructions: dy_agent_instructions,
     commands: &[
         SiteCommand {
-            name: "search_videos",
-            tool_name: "search_videos",
+            name: "search",
+            tool_name: "search",
             about: "Search Douyin and print video result cards as JSON.",
             args: &[
                 CommandArg {
@@ -70,10 +70,10 @@ pub static DY_SITE: SiteSpec = SiteSpec {
                     kind: ArgKind::Str,
                 },
                 CommandArg {
-                    key: "num_videos",
-                    long: Some("num-videos"),
+                    key: "num",
+                    long: Some("num"),
                     value_name: "N",
-                    help: "Number of video cards to collect by scrolling. Defaults to 30.",
+                    help: "Number of video cards to collect by scrolling. Defaults to 10.",
                     required: false,
                     kind: ArgKind::Int,
                 },
@@ -87,7 +87,7 @@ pub static DY_SITE: SiteSpec = SiteSpec {
                 },
             ],
             slow: SlowWhen::Always,
-            run: run_search_videos,
+            run: run_search,
         },
         SiteCommand {
             name: "page_state",
@@ -107,17 +107,13 @@ pub static DY_SITE: SiteSpec = SiteSpec {
     ],
 };
 
-fn run_search_videos(
-    page: Arc<PageSession>,
-    args: Value,
-    debug_snapshot: bool,
-) -> BoxFuture<Value> {
+fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
     Box::pin(async move {
         run_tool_command(
             ToolCommand {
                 site_id: "dy",
-                command_name: "search_videos",
-                tool_name: "search_videos",
+                command_name: "search",
+                tool_name: "search",
                 before: None,
                 after: None,
             },
@@ -157,20 +153,20 @@ fn run_page_state(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> 
     })
 }
 
-pub struct SearchVideosTool {
+pub struct SearchTool {
     page: Arc<PageSession>,
 }
 
 #[async_trait]
-impl Tool for SearchVideosTool {
+impl Tool for SearchTool {
     fn name(&self) -> &str {
-        "search_videos"
+        "search"
     }
 
     fn description(&self) -> &str {
         "Search Douyin for videos matching `query` and return visible result \
          cards (video id, URL, title, author, cover, and any engagement text \
-         the page exposes). Defaults to 30 cards and may wait several minutes \
+         the page exposes). Defaults to 10 cards and may wait several minutes \
          if Douyin web is throttled."
     }
 
@@ -179,10 +175,10 @@ impl Tool for SearchVideosTool {
             "type": "object",
             "properties": {
                 "query": { "type": "string", "description": "Search query" },
-                "num_videos": {
+                "num": {
                     "type": "integer",
                     "description": "Number of video cards to collect by scrolling.",
-                    "default": 30,
+                    "default": 10,
                     "minimum": 1
                 },
                 "wait_seconds": {
@@ -198,7 +194,7 @@ impl Tool for SearchVideosTool {
     async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         let query = required_string(&input, "query")?;
         let wait_seconds = get_f64(&input, "wait_seconds", 330.0);
-        let num_videos = get_i64(&input, "num_videos", 30).max(1) as usize;
+        let num_videos = get_i64(&input, "num", 10).max(1) as usize;
         let runtime = DouyinPageRuntime::new(&self.page);
         let value = runtime
             .search_videos(&query, wait_seconds, num_videos)

--- a/core/src/sites/mod.rs
+++ b/core/src/sites/mod.rs
@@ -1,3 +1,4 @@
+pub mod dy;
 pub mod registry;
 pub mod runner;
 pub mod xhs;

--- a/core/src/sites/registry.rs
+++ b/core/src/sites/registry.rs
@@ -92,7 +92,7 @@ impl SiteSpec {
 }
 
 /// Every registered site. Site order is also CLI help order.
-static SITES: &[&SiteSpec] = &[&crate::sites::xhs::XHS_SITE];
+static SITES: &[&SiteSpec] = &[&crate::sites::xhs::XHS_SITE, &crate::sites::dy::DY_SITE];
 
 pub fn all_sites() -> &'static [&'static SiteSpec] {
     SITES


### PR DESCRIPTION
## Summary
- add a fresh `dy` site module for Douyin page state and video search
- expose `socai dy search_videos <query> --num-videos <N>` through the site registry
- document the Douyin command and observed page selectors/limits
- include `dy5_codex.txt` with the Codex session record

## Stacking
This PR is stacked on top of #103 (`self-creation -> main`) and uses `self-creation` as its base so the diff only shows the Douyin-specific changes.

## Validation
- `cargo test -q`
- `cargo check -q`
- `cargo run -q -p socai-cli -- dy --help`
- `git diff --check`
- live smoke tests for `咖啡`, `露营`, and `AI工具` searches