### PR TITLE
Emit topic_scan media manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cargo install --path cli --force
 
 ```bash
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
-socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest
+socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest_path
 socai search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
@@ -78,7 +78,7 @@ Options:
   for the first page only (~19).
 - `--download-media` — `topic_scan` only: download note images/videos into the
   printed `run_dir` (`site_media/`), add `local_path` fields, emit top-level
-  `media_manifest` / `media_manifest_path`, and write `<run_dir>/media_manifest.json`.
+  `media_manifest_path` / `media_manifest_count`, and write `<run_dir>/media_manifest.json`.
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cargo install --path cli --force
 
 ```bash
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
-socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 同时下载帖子图片/视频到 run_dir/site_media/
+socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest
 socai search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
@@ -77,7 +77,8 @@ Options:
   no bodies — stays fast). Both scroll only if the first page holds fewer; omit
   for the first page only (~19).
 - `--download-media` — `topic_scan` only: download note images/videos into the
-  printed `run_dir` (`site_media/`) and add `local_path` fields to the JSON.
+  printed `run_dir` (`site_media/`), add `local_path` fields, emit top-level
+  `media_manifest` / `media_manifest_path`, and write `<run_dir>/media_manifest.json`.
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,8 +54,8 @@ enum Command {
         /// holds fewer.
         #[arg(long = "num-notes")]
         num_notes: Option<i64>,
-        /// Download note images/videos into the command run_dir, include
-        /// local_path fields, and emit media_manifest JSON.
+        /// Download media, add local_path fields, emit media_manifest /
+        /// media_manifest_path, and write <run_dir>/media_manifest.json.
         #[arg(long = "download-media")]
         download_media: bool,
         #[arg(long)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,8 +54,8 @@ enum Command {
         /// holds fewer.
         #[arg(long = "num-notes")]
         num_notes: Option<i64>,
-        /// Download media, add local_path fields, emit media_manifest /
-        /// media_manifest_path, and write <run_dir>/media_manifest.json.
+        /// Download media, add local_path fields, emit media_manifest_path /
+        /// media_manifest_count, and write <run_dir>/media_manifest.json.
         #[arg(long = "download-media")]
         download_media: bool,
         #[arg(long)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,8 +54,8 @@ enum Command {
         /// holds fewer.
         #[arg(long = "num-notes")]
         num_notes: Option<i64>,
-        /// Download note images/videos into the command run_dir and include
-        /// local_path fields in the JSON output.
+        /// Download note images/videos into the command run_dir, include
+        /// local_path fields, and emit media_manifest JSON.
         #[arg(long = "download-media")]
         download_media: bool,
         #[arg(long)]

--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -1,0 +1,747 @@
+//! Stable media manifest generation for XHS topic scans.
+//!
+//! `topic_scan --download-media` keeps the large per-asset manifest in a
+//! run-dir JSON file so command stdout can stay compact while callers still get
+//! a stable path to a machine-readable media registry.
+
+use std::path::{Path, PathBuf};
+
+use crate::agent::ToolContext;
+use serde_json::{json, Value};
+
+use super::entities::XhsNoteCard;
+
+pub(super) fn write_media_manifest_file(
+    ctx: &ToolContext,
+    manifest: &Value,
+) -> std::io::Result<String> {
+    std::fs::create_dir_all(&ctx.run_dir)?;
+    let path = ctx.run_dir.join("media_manifest.json");
+    let rendered = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
+    std::fs::write(&path, rendered)?;
+    let _ = ctx.register_artifact(
+        &path,
+        "media_manifest",
+        "json",
+        "Topic scan media manifest",
+        json!({"site": "xhs", "category": "media_manifest"}),
+        Some(manifest),
+        "topic_scan",
+    );
+    Ok(path.to_string_lossy().to_string())
+}
+
+pub(super) fn topic_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
+    let mut assets = Vec::new();
+    for note in notes {
+        collect_note_media_assets(note, run_dir, &mut assets);
+    }
+    Value::Array(assets)
+}
+
+fn collect_note_media_assets(note_entry: &Value, run_dir: &Path, assets: &mut Vec<Value>) {
+    if note_entry.get("ok").and_then(Value::as_bool) != Some(true) {
+        return;
+    }
+    let Some(entity) = note_entry.get("entity").filter(|v| v.is_object()) else {
+        return;
+    };
+    if entity
+        .get("stale_warning")
+        .and_then(Value::as_str)
+        .is_some_and(|warning| !warning.trim().is_empty())
+    {
+        return;
+    }
+    let note_id = string_field_value(entity, "note_id");
+    if note_id.is_empty() {
+        return;
+    }
+    let note_type = string_field_value(entity, "type");
+
+    if let Some(images) = entity.get("images").and_then(Value::as_array) {
+        for (fallback_index, image) in images.iter().enumerate() {
+            if image.is_object() {
+                assets.push(image_manifest_entry(
+                    &note_id,
+                    image,
+                    fallback_index as i64,
+                    run_dir,
+                ));
+            }
+        }
+    }
+
+    let Some(video) = entity.get("video").filter(|v| v.is_object()) else {
+        return;
+    };
+    if is_video_manifest_candidate(video, &note_type) {
+        assets.push(video_manifest_entry(&note_id, video, run_dir));
+    }
+    if let Some(poster) = poster_manifest_entry(&note_id, video, run_dir) {
+        assets.push(poster);
+    }
+}
+
+pub(super) fn ensure_entity_note_id(entity: &mut Value, card: &XhsNoteCard) {
+    if !string_field_value(entity, "note_id").is_empty() {
+        return;
+    }
+    let fallback_note_id = note_id_fallback(entity, card);
+    if fallback_note_id.is_empty() {
+        return;
+    }
+    let Some(map) = entity.as_object_mut() else {
+        return;
+    };
+    map.insert("note_id".into(), Value::String(fallback_note_id));
+}
+
+fn note_id_fallback(entity: &Value, card: &XhsNoteCard) -> String {
+    let card_note_id = card.note_id.trim();
+    if !card_note_id.is_empty() {
+        return card_note_id.to_string();
+    }
+    note_id_from_url(&string_field_value(entity, "url"))
+        .or_else(|| note_id_from_url(&string_field_value(entity, "link")))
+        .or_else(|| note_id_from_url(&card.link))
+        .unwrap_or_default()
+}
+
+fn note_id_from_url(value: &str) -> Option<String> {
+    let path = value.trim().split(['?', '#']).next().unwrap_or("").trim();
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|segment| !segment.trim().is_empty())
+        .collect();
+    for window in segments.windows(2) {
+        if matches!(window[0], "explore" | "discovery" | "search_result") {
+            let note_id = window[1].trim();
+            if !note_id.is_empty() {
+                return Some(note_id.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn image_manifest_entry(
+    note_id: &str,
+    image: &Value,
+    fallback_index: i64,
+    run_dir: &Path,
+) -> Value {
+    let index = integer_field(image, "index").unwrap_or(fallback_index);
+    let source_url = string_field_value(image, "url");
+    let local_path = string_field_value(image, "local_path");
+    let download_error = first_string_field(image, &["download_error", "save_error"]);
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), image);
+
+    json!({
+        "note_id": note_id,
+        "type": "image",
+        "role": "image",
+        "index": index,
+        "local_path": string_or_null(&local_path),
+        "size_bytes": file_size_or_null(local_file.as_deref()),
+        "width": option_i64_or_null(width),
+        "height": option_i64_or_null(height),
+        "duration_s": Value::Null,
+        "codec": Value::Null,
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": direct_resolution_status(&source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    })
+}
+
+fn video_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Value {
+    let source_url = video_source_url(video);
+    let local_path = string_field_value(video, "local_path");
+    let download_error = first_string_field(video, &["download_error", "save_error"]);
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let size_bytes = file_size(local_file.as_deref());
+
+    json!({
+        "note_id": note_id,
+        "type": "video",
+        "role": "video",
+        "index": Value::Null,
+        "local_path": string_or_null(&local_path),
+        "size_bytes": option_u64_or_null(size_bytes),
+        "width": option_i64_or_null(integer_field(video, "width")),
+        "height": option_i64_or_null(integer_field(video, "height")),
+        "duration_s": option_f64_or_null(f64_field(video, "duration_s")),
+        "codec": string_or_null(&string_field_value(video, "codec")),
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": video_resolution_status(video, &source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    })
+}
+
+fn poster_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Option<Value> {
+    let source_url = string_field_value(video, "poster_url");
+    let local_path = string_field_value(video, "poster_local_path");
+    let download_error = first_string_field(video, &["poster_download_error", "poster_save_error"]);
+    if source_url.is_empty() && local_path.is_empty() && download_error.is_none() {
+        return None;
+    }
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), &Value::Null);
+
+    Some(json!({
+        "note_id": note_id,
+        "type": "image",
+        "index": Value::Null,
+        "role": "video_poster",
+        "local_path": string_or_null(&local_path),
+        "size_bytes": file_size_or_null(local_file.as_deref()),
+        "width": option_i64_or_null(width),
+        "height": option_i64_or_null(height),
+        "duration_s": Value::Null,
+        "codec": Value::Null,
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": direct_resolution_status(&source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    }))
+}
+
+fn is_video_manifest_candidate(video: &Value, note_type: &str) -> bool {
+    note_type == "video"
+        || !string_field_value(video, "local_path").is_empty()
+        || first_string_field(video, &["download_error", "save_error"]).is_some()
+        || has_video_source_candidate(video)
+}
+
+fn download_status_and_error(
+    local_path: &str,
+    local_file: Option<&Path>,
+    source_url: &str,
+    download_error: Option<String>,
+) -> (&'static str, Option<String>) {
+    if let Some(path) = local_file {
+        match std::fs::metadata(path) {
+            Ok(metadata) if metadata.is_file() && metadata.len() > 0 => {
+                return ("downloaded", None)
+            }
+            Ok(metadata) if metadata.is_file() && !local_path.trim().is_empty() => {
+                return ("failed", Some(format!("local file is empty: {local_path}")));
+            }
+            _ => {}
+        }
+    }
+    if !local_path.trim().is_empty() {
+        return (
+            "failed",
+            Some(format!("local file is missing or unreadable: {local_path}")),
+        );
+    }
+    if let Some(error) = download_error.filter(|s| !s.trim().is_empty()) {
+        return ("failed", Some(error));
+    }
+    if source_url.trim().is_empty() {
+        return ("failed", Some("source URL is empty".to_string()));
+    }
+    (
+        "failed",
+        Some("download did not produce local_path".to_string()),
+    )
+}
+
+fn image_dimensions_or_fields(
+    local_file: Option<&Path>,
+    source: &Value,
+) -> (Option<i64>, Option<i64>) {
+    if let Some(path) = local_file {
+        if let Ok((width, height)) = image::image_dimensions(path) {
+            return (Some(i64::from(width)), Some(i64::from(height)));
+        }
+    }
+    (
+        integer_field(source, "width"),
+        integer_field(source, "height"),
+    )
+}
+
+fn file_size(local_file: Option<&Path>) -> Option<u64> {
+    local_file
+        .and_then(|path| std::fs::metadata(path).ok())
+        .map(|metadata| metadata.len())
+}
+
+fn file_size_or_null(local_file: Option<&Path>) -> Value {
+    option_u64_or_null(file_size(local_file))
+}
+
+fn local_path_buf(run_dir: &Path, local_path: &str) -> Option<PathBuf> {
+    let trimmed = local_path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    if path.is_absolute() {
+        return Some(path);
+    }
+    let run_dir_path = run_dir.join(&path);
+    Some(if run_dir_path.exists() {
+        run_dir_path
+    } else if path.exists() {
+        path
+    } else {
+        run_dir_path
+    })
+}
+
+fn string_field_value(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn first_string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        let candidate = string_field_value(value, key);
+        (!candidate.is_empty()).then_some(candidate)
+    })
+}
+
+fn integer_field(value: &Value, key: &str) -> Option<i64> {
+    let value = value.get(key)?;
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| {
+            value
+                .as_f64()
+                .filter(|n| n.is_finite())
+                .map(|n| n.round() as i64)
+        })
+}
+
+fn f64_field(value: &Value, key: &str) -> Option<f64> {
+    value
+        .get(key)
+        .and_then(Value::as_f64)
+        .filter(|n| n.is_finite())
+}
+
+fn string_or_null(value: &str) -> Value {
+    if value.trim().is_empty() {
+        Value::Null
+    } else {
+        json!(value)
+    }
+}
+
+fn option_string_or_null(value: Option<&str>) -> Value {
+    value.map(string_or_null).unwrap_or(Value::Null)
+}
+
+fn option_i64_or_null(value: Option<i64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn option_u64_or_null(value: Option<u64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn option_f64_or_null(value: Option<f64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn direct_resolution_status(source_url: &str) -> &'static str {
+    if source_url.trim().is_empty() {
+        "missing"
+    } else {
+        "resolved"
+    }
+}
+
+fn video_resolution_status(video: &Value, source_url: &str) -> &'static str {
+    if !source_url.trim().is_empty() {
+        "resolved"
+    } else if has_video_source_candidate(video) {
+        "unresolved"
+    } else {
+        "missing"
+    }
+}
+
+fn video_source_url(video: &Value) -> String {
+    for key in ["resolved_url", "master_url", "url"] {
+        if let Some(url) = video
+            .get(key)
+            .and_then(Value::as_str)
+            .and_then(clean_media_url)
+        {
+            return url;
+        }
+    }
+
+    for key in ["source_urls", "backup_urls"] {
+        if let Some(arr) = video.get(key).and_then(Value::as_array) {
+            for item in arr {
+                if let Some(url) = item.as_str().and_then(clean_media_url) {
+                    return url;
+                }
+            }
+        }
+    }
+
+    if let Some(candidates) = video.get("candidates").and_then(Value::as_array) {
+        for item in candidates {
+            if let Some(url) = item
+                .get("url")
+                .and_then(Value::as_str)
+                .and_then(clean_media_url)
+            {
+                return url;
+            }
+        }
+    }
+
+    String::new()
+}
+
+fn clean_media_url(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if (trimmed.starts_with("http://") || trimmed.starts_with("https://"))
+        && !trimmed.starts_with("blob:")
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+fn has_video_source_candidate(video: &Value) -> bool {
+    for key in ["resolved_url", "master_url", "url"] {
+        if !string_field_value(video, key).is_empty() {
+            return true;
+        }
+    }
+    for key in ["source_urls", "backup_urls"] {
+        if video
+            .get(key)
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item.as_str().is_some_and(|s| !s.trim().is_empty()))
+            })
+        {
+            return true;
+        }
+    }
+    video
+        .get("candidates")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.iter().any(|item| {
+                item.get("url")
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.trim().is_empty())
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_entity_note_id_uses_card_and_url_fallbacks_when_missing() {
+        let mut missing = json!({ "note_id": "", "images": [] });
+        ensure_entity_note_id(
+            &mut missing,
+            &XhsNoteCard {
+                note_id: "card-note".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(missing["note_id"], "card-note");
+
+        let mut from_entity_url = json!({
+            "note_id": "",
+            "url": "https://www.xiaohongshu.com/explore/url-note?xsec_token=1",
+        });
+        ensure_entity_note_id(&mut from_entity_url, &XhsNoteCard::default());
+        assert_eq!(from_entity_url["note_id"], "url-note");
+
+        let mut from_card_link = json!({ "note_id": "" });
+        ensure_entity_note_id(
+            &mut from_card_link,
+            &XhsNoteCard {
+                link: "https://www.xiaohongshu.com/search_result/card-link-note".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(from_card_link["note_id"], "card-link-note");
+
+        let mut existing = json!({ "note_id": "entity-note", "images": [] });
+        ensure_entity_note_id(
+            &mut existing,
+            &XhsNoteCard {
+                note_id: "card-note".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(existing["note_id"], "entity-note");
+    }
+
+    #[test]
+    fn media_manifest_note_id_from_url_rejects_query_only_urls() {
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/explore/real-note?xsec_token=1"),
+            Some("real-note".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/discovery/real-discovery#comments"),
+            Some("real-discovery".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("/search_result/real-search?x=1"),
+            Some("real-search".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/search_result?keyword=abc"),
+            None
+        );
+        assert_eq!(note_id_from_url("/explore?x=1"), None);
+        assert_eq!(note_id_from_url("/discovery#hash"), None);
+    }
+
+    #[test]
+    fn media_manifest_local_path_buf_prefers_run_dir_relative_path() {
+        let cwd = std::env::current_dir().unwrap();
+        let cwd_dir = tempfile::Builder::new()
+            .prefix("media-manifest-shadow-")
+            .tempdir_in(&cwd)
+            .unwrap();
+        let recorded_path = cwd_dir.path().strip_prefix(&cwd).unwrap().join("asset.bin");
+        std::fs::write(&recorded_path, b"cwd").unwrap();
+
+        let run_dir = tempfile::tempdir().unwrap();
+        let run_dir_asset = run_dir.path().join(&recorded_path);
+        std::fs::create_dir_all(run_dir_asset.parent().unwrap()).unwrap();
+        std::fs::write(&run_dir_asset, b"run-dir").unwrap();
+
+        let resolved =
+            local_path_buf(run_dir.path(), &recorded_path.to_string_lossy()).expect("path");
+
+        assert_eq!(resolved, run_dir_asset);
+        assert_eq!(file_size(Some(&resolved)), Some(7));
+    }
+
+    #[test]
+    fn local_path_buf_prefers_existing_relative_path_as_recorded() {
+        let cwd = std::env::current_dir().unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("media-manifest-relative-")
+            .tempdir_in(&cwd)
+            .unwrap();
+        let file_path = dir.path().join("asset.bin");
+        std::fs::write(&file_path, b"asset").unwrap();
+        let recorded_path = file_path.strip_prefix(&cwd).unwrap();
+        let unrelated_run_dir = tempfile::tempdir().unwrap();
+
+        let resolved = local_path_buf(unrelated_run_dir.path(), &recorded_path.to_string_lossy())
+            .expect("path");
+
+        assert_eq!(resolved, recorded_path);
+        assert_eq!(file_size(Some(&resolved)), Some(5));
+    }
+
+    #[test]
+    fn media_manifest_skips_unsuccessful_stale_skipped_and_unidentified_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = vec![
+            json!({
+                "ok": false,
+                "entity": {
+                    "note_id": "failed-note",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/failed.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "ok": true,
+                "entity": {
+                    "note_id": "stale-note",
+                    "type": "image",
+                    "stale_warning": "This note was already extracted in the previous read.",
+                    "images": [{ "url": "https://img.example/stale.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "skipped": { "reason": "already_processed" },
+                "entity": {
+                    "note_id": "skipped-note",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/skipped.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "ok": true,
+                "entity": {
+                    "note_id": "",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/unidentified.jpg", "index": 0 }],
+                }
+            }),
+        ];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+
+        assert_eq!(manifest.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn media_manifest_marks_zero_byte_local_file_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("empty.jpg");
+        std::fs::File::create(&image_path).unwrap();
+        let notes = vec![json!({
+            "ok": true,
+            "entity": {
+                "note_id": "empty-image",
+                "type": "image",
+                "images": [{
+                    "url": "https://img.example/empty.jpg",
+                    "index": 0,
+                    "local_path": image_path.to_string_lossy(),
+                }],
+                "video": {},
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["download_status"], "failed");
+        assert_eq!(assets[0]["size_bytes"], 0);
+        assert_eq!(
+            assets[0]["download_error"],
+            format!("local file is empty: {}", image_path.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn media_manifest_records_downloaded_image_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("image.png");
+        let image = image::RgbImage::from_pixel(2, 3, image::Rgb([1, 2, 3]));
+        image.save(&image_path).unwrap();
+        let size = std::fs::metadata(&image_path).unwrap().len();
+        let notes = vec![json!({
+            "ok": true,
+            "entity": {
+                "note_id": "note-image",
+                "type": "image",
+                "images": [{
+                    "url": "https://img.example/1.jpg",
+                    "index": 0,
+                    "local_path": image_path.to_string_lossy(),
+                }],
+                "video": {},
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["note_id"], "note-image");
+        assert_eq!(assets[0]["type"], "image");
+        assert_eq!(assets[0]["index"], 0);
+        assert_eq!(
+            assets[0]["local_path"],
+            image_path.to_string_lossy().as_ref()
+        );
+        assert_eq!(assets[0]["size_bytes"], size);
+        assert_eq!(assets[0]["width"], 2);
+        assert_eq!(assets[0]["height"], 3);
+        assert_eq!(assets[0]["source_url"], "https://img.example/1.jpg");
+        assert_eq!(assets[0]["resolved_url_status"], "resolved");
+        assert_eq!(assets[0]["download_status"], "downloaded");
+        assert!(assets[0]["download_error"].is_null());
+    }
+
+    #[test]
+    fn media_manifest_records_video_failure_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = vec![json!({
+            "ok": true,
+            "entity": {
+                "note_id": "note-video",
+                "type": "video",
+                "video": {
+                    "url": "blob:https://www.xiaohongshu.com/not-downloadable",
+                    "duration_s": 42.5,
+                    "width": 1080,
+                    "height": 1920,
+                    "codec": "h264",
+                    "download_error": "downloadable video URL not found (blob: URLs cannot be downloaded)",
+                }
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["note_id"], "note-video");
+        assert_eq!(assets[0]["type"], "video");
+        assert!(assets[0]["local_path"].is_null());
+        assert!(assets[0]["source_url"].is_null());
+        assert_eq!(assets[0]["resolved_url_status"], "unresolved");
+        assert_eq!(assets[0]["download_status"], "failed");
+        assert_eq!(
+            assets[0]["download_error"],
+            "downloadable video URL not found (blob: URLs cannot be downloaded)"
+        );
+        assert_eq!(assets[0]["duration_s"], 42.5);
+        assert_eq!(assets[0]["width"], 1080);
+        assert_eq!(assets[0]["height"], 1920);
+        assert_eq!(assets[0]["codec"], "h264");
+    }
+
+    #[test]
+    fn media_manifest_writes_stable_run_dir_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::new("run", dir.path());
+        let manifest = json!([{ "note_id": "note-1", "type": "image" }]);
+
+        let path = write_media_manifest_file(&ctx, &manifest).unwrap();
+        let expected = dir.path().join("media_manifest.json");
+        let saved: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+
+        assert_eq!(Path::new(&path), expected.as_path());
+        assert_eq!(saved, manifest);
+    }
+}

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -1,5 +1,6 @@
 pub mod entities;
 pub mod history;
+mod media_manifest;
 pub mod page;
 pub mod tools;
 

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -5,7 +5,6 @@
 //! visible, note modal open, etc.). The caller is responsible for creating
 //! the page and closing it after `run_agent` returns.
 
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::agent::{make_run_dir, Backend as LlmProvider, Tool, ToolContext, ToolResult};
@@ -14,6 +13,9 @@ use crate::media::{timing_delta, MediaProcessor, TimingSnapshot};
 use async_trait::async_trait;
 use serde_json::{json, Map, Value};
 
+use crate::sites::xhs::media_manifest::{
+    ensure_entity_note_id, topic_scan_media_manifest, write_media_manifest_file,
+};
 use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
 use crate::sites::xhs::{ReadNoteOptions, XhsHistoryStore, XhsNoteCard, XhsPageRuntime};
 
@@ -1066,7 +1068,7 @@ impl Tool for TopicScanTool {
          comments → return one compact bundle (search results + selected cards \
          + note bodies + comments). Pass `download_media=true` to download \
          note images/videos into the run dir, include local paths, and emit a \
-         stable media_manifest. Defaults \
+         stable media_manifest_path. Defaults \
          to 10 notes; pass a larger `num_notes` to scan more (each note is \
          opened, so latency scales with it). Prefer this for XHS topic \
          research. Do not repeat the same scan unless the previous one was \
@@ -1091,7 +1093,7 @@ impl Tool for TopicScanTool {
                 },
                 "download_media": {
                     "type": "boolean",
-                    "description": "Download note images/videos into the command run_dir, include local_path fields in returned notes, and emit a stable media_manifest plus media_manifest.json.",
+                    "description": "Download note images/videos into the command run_dir, include local_path fields in returned notes, and write a stable media_manifest.json surfaced by media_manifest_path.",
                     "default": false
                 }
             },
@@ -1318,21 +1320,24 @@ impl Tool for TopicScanTool {
         let mut selected_cards = serde_json::to_value(&selected)?;
         history_snapshot.annotate_cards(&mut selected_cards);
 
-        let media_manifest = if download_media {
-            topic_scan_media_manifest(&notes, &ctx.run_dir)
+        let media_manifest_metadata = if download_media {
+            let media_manifest = topic_scan_media_manifest(&notes, &ctx.run_dir);
+            let media_manifest_count = media_manifest.as_array().map(Vec::len).unwrap_or_default();
+            let (media_manifest_path, media_manifest_error) =
+                match write_media_manifest_file(ctx, &media_manifest) {
+                    Ok(path) => (Some(path), None),
+                    Err(err) => (None, Some(format!("{err:#}"))),
+                };
+            Some((
+                media_manifest_count,
+                media_manifest_path,
+                media_manifest_error,
+            ))
         } else {
-            Value::Array(Vec::new())
-        };
-        let (media_manifest_path, media_manifest_error) = if download_media {
-            match write_media_manifest_file(ctx, &media_manifest) {
-                Ok(path) => (Some(path), None),
-                Err(err) => (None, Some(format!("{err:#}"))),
-            }
-        } else {
-            (None, None)
+            None
         };
 
-        let payload = json!({
+        let mut payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
             "query": query,
             "tab": tab_result,
@@ -1340,9 +1345,6 @@ impl Tool for TopicScanTool {
             "search": search,
             "selected_cards": selected_cards,
             "notes": notes,
-            "media_manifest": media_manifest,
-            "media_manifest_path": media_manifest_path,
-            "media_manifest_error": media_manifest_error,
             "sampling": {
                 "num_notes": num_notes,
                 "selected": selected.len(),
@@ -1354,6 +1356,19 @@ impl Tool for TopicScanTool {
                 "media": media_timing,
             }
         });
+        if let Some((media_manifest_count, media_manifest_path, media_manifest_error)) =
+            media_manifest_metadata
+        {
+            if let Some(map) = payload.as_object_mut() {
+                map.insert("media_manifest_count".into(), json!(media_manifest_count));
+                if let Some(path) = media_manifest_path {
+                    map.insert("media_manifest_path".into(), json!(path));
+                }
+                if let Some(error) = media_manifest_error {
+                    map.insert("media_manifest_error".into(), json!(error));
+                }
+            }
+        }
 
         // Persist as artifact so it shows up in the run dir + working memory.
         let _ = ctx.write_json_artifact(
@@ -1417,461 +1432,6 @@ fn sanitize_for_filename(value: &str) -> String {
         .collect()
 }
 
-fn write_media_manifest_file(ctx: &ToolContext, manifest: &Value) -> std::io::Result<String> {
-    std::fs::create_dir_all(&ctx.run_dir)?;
-    let path = ctx.run_dir.join("media_manifest.json");
-    let rendered = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
-    std::fs::write(&path, rendered)?;
-    let _ = ctx.register_artifact(
-        &path,
-        "media_manifest",
-        "json",
-        "Topic scan media manifest",
-        json!({"site": "xhs", "category": "media_manifest"}),
-        Some(manifest),
-        "topic_scan",
-    );
-    Ok(path.to_string_lossy().to_string())
-}
-
-fn topic_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
-    let mut assets = Vec::new();
-    for note in notes {
-        collect_note_media_assets(note, run_dir, &mut assets);
-    }
-    Value::Array(assets)
-}
-
-fn collect_note_media_assets(note_entry: &Value, run_dir: &Path, assets: &mut Vec<Value>) {
-    if note_entry.get("ok").and_then(Value::as_bool) != Some(true) {
-        return;
-    }
-    let Some(entity) = note_entry.get("entity").filter(|v| v.is_object()) else {
-        return;
-    };
-    if entity
-        .get("stale_warning")
-        .and_then(Value::as_str)
-        .is_some_and(|warning| !warning.trim().is_empty())
-    {
-        return;
-    }
-    let note_id = string_field_value(entity, "note_id");
-    if note_id.is_empty() {
-        return;
-    }
-    let note_type = string_field_value(entity, "type");
-
-    if let Some(images) = entity.get("images").and_then(Value::as_array) {
-        for (fallback_index, image) in images.iter().enumerate() {
-            if image.is_object() {
-                assets.push(image_manifest_entry(
-                    &note_id,
-                    image,
-                    fallback_index as i64,
-                    run_dir,
-                ));
-            }
-        }
-    }
-
-    let Some(video) = entity.get("video").filter(|v| v.is_object()) else {
-        return;
-    };
-    if is_video_manifest_candidate(video, &note_type) {
-        assets.push(video_manifest_entry(&note_id, video, run_dir));
-    }
-    if let Some(poster) = poster_manifest_entry(&note_id, video, run_dir) {
-        assets.push(poster);
-    }
-}
-
-fn ensure_entity_note_id(entity: &mut Value, card: &XhsNoteCard) {
-    if !string_field_value(entity, "note_id").is_empty() {
-        return;
-    }
-    let fallback_note_id = note_id_fallback(entity, card);
-    if fallback_note_id.is_empty() {
-        return;
-    }
-    let Some(map) = entity.as_object_mut() else {
-        return;
-    };
-    map.insert("note_id".into(), Value::String(fallback_note_id));
-}
-
-fn note_id_fallback(entity: &Value, card: &XhsNoteCard) -> String {
-    let card_note_id = card.note_id.trim();
-    if !card_note_id.is_empty() {
-        return card_note_id.to_string();
-    }
-    note_id_from_url(&string_field_value(entity, "url"))
-        .or_else(|| note_id_from_url(&string_field_value(entity, "link")))
-        .or_else(|| note_id_from_url(&card.link))
-        .unwrap_or_default()
-}
-
-fn note_id_from_url(value: &str) -> Option<String> {
-    let path = value.trim().split(['?', '#']).next().unwrap_or("").trim();
-    let segments: Vec<&str> = path
-        .split('/')
-        .filter(|segment| !segment.trim().is_empty())
-        .collect();
-    for window in segments.windows(2) {
-        if matches!(window[0], "explore" | "discovery" | "search_result") {
-            let note_id = window[1].trim();
-            if !note_id.is_empty() {
-                return Some(note_id.to_string());
-            }
-        }
-    }
-    None
-}
-
-fn image_manifest_entry(
-    note_id: &str,
-    image: &Value,
-    fallback_index: i64,
-    run_dir: &Path,
-) -> Value {
-    let index = integer_field(image, "index").unwrap_or(fallback_index);
-    let source_url = string_field_value(image, "url");
-    let local_path = string_field_value(image, "local_path");
-    let download_error = first_string_field(image, &["download_error", "save_error"]);
-    let local_file = local_path_buf(run_dir, &local_path);
-    let (status, error) = download_status_and_error(
-        &local_path,
-        local_file.as_deref(),
-        &source_url,
-        download_error,
-    );
-    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), image);
-
-    json!({
-        "note_id": note_id,
-        "type": "image",
-        "role": "image",
-        "index": index,
-        "local_path": string_or_null(&local_path),
-        "size_bytes": file_size_or_null(local_file.as_deref()),
-        "width": option_i64_or_null(width),
-        "height": option_i64_or_null(height),
-        "duration_s": Value::Null,
-        "codec": Value::Null,
-        "source_url": string_or_null(&source_url),
-        "resolved_url_status": direct_resolution_status(&source_url),
-        "download_status": status,
-        "download_error": option_string_or_null(error.as_deref()),
-    })
-}
-
-fn video_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Value {
-    let source_url = video_source_url(video);
-    let local_path = string_field_value(video, "local_path");
-    let download_error = first_string_field(video, &["download_error", "save_error"]);
-    let local_file = local_path_buf(run_dir, &local_path);
-    let (status, error) = download_status_and_error(
-        &local_path,
-        local_file.as_deref(),
-        &source_url,
-        download_error,
-    );
-    let size_bytes = file_size(local_file.as_deref());
-
-    json!({
-        "note_id": note_id,
-        "type": "video",
-        "role": "video",
-        "index": Value::Null,
-        "local_path": string_or_null(&local_path),
-        "size_bytes": option_u64_or_null(size_bytes),
-        "width": option_i64_or_null(integer_field(video, "width")),
-        "height": option_i64_or_null(integer_field(video, "height")),
-        "duration_s": option_f64_or_null(f64_field(video, "duration_s")),
-        "codec": string_or_null(&string_field_value(video, "codec")),
-        "source_url": string_or_null(&source_url),
-        "resolved_url_status": video_resolution_status(video, &source_url),
-        "download_status": status,
-        "download_error": option_string_or_null(error.as_deref()),
-    })
-}
-
-fn poster_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Option<Value> {
-    let source_url = string_field_value(video, "poster_url");
-    let local_path = string_field_value(video, "poster_local_path");
-    let download_error = first_string_field(video, &["poster_download_error", "poster_save_error"]);
-    if source_url.is_empty() && local_path.is_empty() && download_error.is_none() {
-        return None;
-    }
-    let local_file = local_path_buf(run_dir, &local_path);
-    let (status, error) = download_status_and_error(
-        &local_path,
-        local_file.as_deref(),
-        &source_url,
-        download_error,
-    );
-    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), &Value::Null);
-
-    Some(json!({
-        "note_id": note_id,
-        "type": "image",
-        "index": Value::Null,
-        "role": "video_poster",
-        "local_path": string_or_null(&local_path),
-        "size_bytes": file_size_or_null(local_file.as_deref()),
-        "width": option_i64_or_null(width),
-        "height": option_i64_or_null(height),
-        "duration_s": Value::Null,
-        "codec": Value::Null,
-        "source_url": string_or_null(&source_url),
-        "resolved_url_status": direct_resolution_status(&source_url),
-        "download_status": status,
-        "download_error": option_string_or_null(error.as_deref()),
-    }))
-}
-
-fn is_video_manifest_candidate(video: &Value, note_type: &str) -> bool {
-    note_type == "video"
-        || !string_field_value(video, "local_path").is_empty()
-        || first_string_field(video, &["download_error", "save_error"]).is_some()
-        || has_video_source_candidate(video)
-}
-
-fn download_status_and_error(
-    local_path: &str,
-    local_file: Option<&Path>,
-    source_url: &str,
-    download_error: Option<String>,
-) -> (&'static str, Option<String>) {
-    if let Some(path) = local_file {
-        match std::fs::metadata(path) {
-            Ok(metadata) if metadata.is_file() && metadata.len() > 0 => {
-                return ("downloaded", None)
-            }
-            Ok(metadata) if metadata.is_file() && !local_path.trim().is_empty() => {
-                return ("failed", Some(format!("local file is empty: {local_path}")));
-            }
-            _ => {}
-        }
-    }
-    if !local_path.trim().is_empty() {
-        return (
-            "failed",
-            Some(format!("local file is missing or unreadable: {local_path}")),
-        );
-    }
-    if let Some(error) = download_error.filter(|s| !s.trim().is_empty()) {
-        return ("failed", Some(error));
-    }
-    if source_url.trim().is_empty() {
-        return ("failed", Some("source URL is empty".to_string()));
-    }
-    (
-        "failed",
-        Some("download did not produce local_path".to_string()),
-    )
-}
-
-fn image_dimensions_or_fields(
-    local_file: Option<&Path>,
-    source: &Value,
-) -> (Option<i64>, Option<i64>) {
-    if let Some(path) = local_file {
-        if let Ok((width, height)) = image::image_dimensions(path) {
-            return (Some(i64::from(width)), Some(i64::from(height)));
-        }
-    }
-    (
-        integer_field(source, "width"),
-        integer_field(source, "height"),
-    )
-}
-
-fn file_size(local_file: Option<&Path>) -> Option<u64> {
-    local_file
-        .and_then(|path| std::fs::metadata(path).ok())
-        .map(|metadata| metadata.len())
-}
-
-fn file_size_or_null(local_file: Option<&Path>) -> Value {
-    option_u64_or_null(file_size(local_file))
-}
-
-fn local_path_buf(run_dir: &Path, local_path: &str) -> Option<PathBuf> {
-    let trimmed = local_path.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let path = PathBuf::from(trimmed);
-    if path.is_absolute() {
-        return Some(path);
-    }
-    let run_dir_path = run_dir.join(&path);
-    Some(if run_dir_path.exists() {
-        run_dir_path
-    } else if path.exists() {
-        path
-    } else {
-        run_dir_path
-    })
-}
-
-fn string_field_value(value: &Value, key: &str) -> String {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-fn first_string_field(value: &Value, keys: &[&str]) -> Option<String> {
-    keys.iter().find_map(|key| {
-        let candidate = string_field_value(value, key);
-        (!candidate.is_empty()).then_some(candidate)
-    })
-}
-
-fn integer_field(value: &Value, key: &str) -> Option<i64> {
-    let value = value.get(key)?;
-    value
-        .as_i64()
-        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
-        .or_else(|| {
-            value
-                .as_f64()
-                .filter(|n| n.is_finite())
-                .map(|n| n.round() as i64)
-        })
-}
-
-fn f64_field(value: &Value, key: &str) -> Option<f64> {
-    value
-        .get(key)
-        .and_then(Value::as_f64)
-        .filter(|n| n.is_finite())
-}
-
-fn string_or_null(value: &str) -> Value {
-    if value.trim().is_empty() {
-        Value::Null
-    } else {
-        json!(value)
-    }
-}
-
-fn option_string_or_null(value: Option<&str>) -> Value {
-    value.map(string_or_null).unwrap_or(Value::Null)
-}
-
-fn option_i64_or_null(value: Option<i64>) -> Value {
-    value.map(|n| json!(n)).unwrap_or(Value::Null)
-}
-
-fn option_u64_or_null(value: Option<u64>) -> Value {
-    value.map(|n| json!(n)).unwrap_or(Value::Null)
-}
-
-fn option_f64_or_null(value: Option<f64>) -> Value {
-    value.map(|n| json!(n)).unwrap_or(Value::Null)
-}
-
-fn direct_resolution_status(source_url: &str) -> &'static str {
-    if source_url.trim().is_empty() {
-        "missing"
-    } else {
-        "resolved"
-    }
-}
-
-fn video_resolution_status(video: &Value, source_url: &str) -> &'static str {
-    if !source_url.trim().is_empty() {
-        "resolved"
-    } else if has_video_source_candidate(video) {
-        "unresolved"
-    } else {
-        "missing"
-    }
-}
-
-fn video_source_url(video: &Value) -> String {
-    for key in ["resolved_url", "master_url", "url"] {
-        if let Some(url) = video
-            .get(key)
-            .and_then(Value::as_str)
-            .and_then(clean_media_url)
-        {
-            return url;
-        }
-    }
-
-    for key in ["source_urls", "backup_urls"] {
-        if let Some(arr) = video.get(key).and_then(Value::as_array) {
-            for item in arr {
-                if let Some(url) = item.as_str().and_then(clean_media_url) {
-                    return url;
-                }
-            }
-        }
-    }
-
-    if let Some(candidates) = video.get("candidates").and_then(Value::as_array) {
-        for item in candidates {
-            if let Some(url) = item
-                .get("url")
-                .and_then(Value::as_str)
-                .and_then(clean_media_url)
-            {
-                return url;
-            }
-        }
-    }
-
-    String::new()
-}
-
-fn clean_media_url(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    if (trimmed.starts_with("http://") || trimmed.starts_with("https://"))
-        && !trimmed.starts_with("blob:")
-    {
-        Some(trimmed.to_string())
-    } else {
-        None
-    }
-}
-
-fn has_video_source_candidate(video: &Value) -> bool {
-    for key in ["resolved_url", "master_url", "url"] {
-        if !string_field_value(video, key).is_empty() {
-            return true;
-        }
-    }
-    for key in ["source_urls", "backup_urls"] {
-        if video
-            .get(key)
-            .and_then(Value::as_array)
-            .is_some_and(|items| {
-                items
-                    .iter()
-                    .any(|item| item.as_str().is_some_and(|s| !s.trim().is_empty()))
-            })
-        {
-            return true;
-        }
-    }
-    video
-        .get("candidates")
-        .and_then(Value::as_array)
-        .is_some_and(|items| {
-            items.iter().any(|item| {
-                item.get("url")
-                    .and_then(Value::as_str)
-                    .is_some_and(|s| !s.trim().is_empty())
-            })
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1893,277 +1453,5 @@ mod tests {
 
         assert!(options.include_media);
         assert!(!options.download_media);
-    }
-
-    #[test]
-    fn ensure_entity_note_id_uses_card_and_url_fallbacks_when_missing() {
-        let mut missing = json!({ "note_id": "", "images": [] });
-        ensure_entity_note_id(
-            &mut missing,
-            &XhsNoteCard {
-                note_id: "card-note".into(),
-                ..Default::default()
-            },
-        );
-        assert_eq!(missing["note_id"], "card-note");
-
-        let mut from_entity_url = json!({
-            "note_id": "",
-            "url": "https://www.xiaohongshu.com/explore/url-note?xsec_token=1",
-        });
-        ensure_entity_note_id(&mut from_entity_url, &XhsNoteCard::default());
-        assert_eq!(from_entity_url["note_id"], "url-note");
-
-        let mut from_card_link = json!({ "note_id": "" });
-        ensure_entity_note_id(
-            &mut from_card_link,
-            &XhsNoteCard {
-                link: "https://www.xiaohongshu.com/search_result/card-link-note".into(),
-                ..Default::default()
-            },
-        );
-        assert_eq!(from_card_link["note_id"], "card-link-note");
-
-        let mut existing = json!({ "note_id": "entity-note", "images": [] });
-        ensure_entity_note_id(
-            &mut existing,
-            &XhsNoteCard {
-                note_id: "card-note".into(),
-                ..Default::default()
-            },
-        );
-        assert_eq!(existing["note_id"], "entity-note");
-    }
-
-    #[test]
-    fn media_manifest_note_id_from_url_rejects_query_only_urls() {
-        assert_eq!(
-            note_id_from_url("https://www.xiaohongshu.com/explore/real-note?xsec_token=1"),
-            Some("real-note".to_string())
-        );
-        assert_eq!(
-            note_id_from_url("https://www.xiaohongshu.com/discovery/real-discovery#comments"),
-            Some("real-discovery".to_string())
-        );
-        assert_eq!(
-            note_id_from_url("/search_result/real-search?x=1"),
-            Some("real-search".to_string())
-        );
-        assert_eq!(
-            note_id_from_url("https://www.xiaohongshu.com/search_result?keyword=abc"),
-            None
-        );
-        assert_eq!(note_id_from_url("/explore?x=1"), None);
-        assert_eq!(note_id_from_url("/discovery#hash"), None);
-    }
-
-    #[test]
-    fn media_manifest_local_path_buf_prefers_run_dir_relative_path() {
-        let cwd = std::env::current_dir().unwrap();
-        let cwd_dir = tempfile::Builder::new()
-            .prefix("media-manifest-shadow-")
-            .tempdir_in(&cwd)
-            .unwrap();
-        let recorded_path = cwd_dir.path().strip_prefix(&cwd).unwrap().join("asset.bin");
-        std::fs::write(&recorded_path, b"cwd").unwrap();
-
-        let run_dir = tempfile::tempdir().unwrap();
-        let run_dir_asset = run_dir.path().join(&recorded_path);
-        std::fs::create_dir_all(run_dir_asset.parent().unwrap()).unwrap();
-        std::fs::write(&run_dir_asset, b"run-dir").unwrap();
-
-        let resolved =
-            local_path_buf(run_dir.path(), &recorded_path.to_string_lossy()).expect("path");
-
-        assert_eq!(resolved, run_dir_asset);
-        assert_eq!(file_size(Some(&resolved)), Some(7));
-    }
-
-    #[test]
-    fn local_path_buf_prefers_existing_relative_path_as_recorded() {
-        let cwd = std::env::current_dir().unwrap();
-        let dir = tempfile::Builder::new()
-            .prefix("media-manifest-relative-")
-            .tempdir_in(&cwd)
-            .unwrap();
-        let file_path = dir.path().join("asset.bin");
-        std::fs::write(&file_path, b"asset").unwrap();
-        let recorded_path = file_path.strip_prefix(&cwd).unwrap();
-        let unrelated_run_dir = tempfile::tempdir().unwrap();
-
-        let resolved = local_path_buf(unrelated_run_dir.path(), &recorded_path.to_string_lossy())
-            .expect("path");
-
-        assert_eq!(resolved, recorded_path);
-        assert_eq!(file_size(Some(&resolved)), Some(5));
-    }
-
-    #[test]
-    fn media_manifest_skips_unsuccessful_stale_skipped_and_unidentified_entries() {
-        let dir = tempfile::tempdir().unwrap();
-        let notes = vec![
-            json!({
-                "ok": false,
-                "entity": {
-                    "note_id": "failed-note",
-                    "type": "image",
-                    "images": [{ "url": "https://img.example/failed.jpg", "index": 0 }],
-                }
-            }),
-            json!({
-                "ok": true,
-                "entity": {
-                    "note_id": "stale-note",
-                    "type": "image",
-                    "stale_warning": "This note was already extracted in the previous read.",
-                    "images": [{ "url": "https://img.example/stale.jpg", "index": 0 }],
-                }
-            }),
-            json!({
-                "skipped": { "reason": "already_processed" },
-                "entity": {
-                    "note_id": "skipped-note",
-                    "type": "image",
-                    "images": [{ "url": "https://img.example/skipped.jpg", "index": 0 }],
-                }
-            }),
-            json!({
-                "ok": true,
-                "entity": {
-                    "note_id": "",
-                    "type": "image",
-                    "images": [{ "url": "https://img.example/unidentified.jpg", "index": 0 }],
-                }
-            }),
-        ];
-
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
-
-        assert_eq!(manifest.as_array().unwrap().len(), 0);
-    }
-
-    #[test]
-    fn media_manifest_marks_zero_byte_local_file_failed() {
-        let dir = tempfile::tempdir().unwrap();
-        let image_path = dir.path().join("empty.jpg");
-        std::fs::File::create(&image_path).unwrap();
-        let notes = vec![json!({
-            "ok": true,
-            "entity": {
-                "note_id": "empty-image",
-                "type": "image",
-                "images": [{
-                    "url": "https://img.example/empty.jpg",
-                    "index": 0,
-                    "local_path": image_path.to_string_lossy(),
-                }],
-                "video": {},
-            }
-        })];
-
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
-        let assets = manifest.as_array().unwrap();
-
-        assert_eq!(assets.len(), 1);
-        assert_eq!(assets[0]["download_status"], "failed");
-        assert_eq!(assets[0]["size_bytes"], 0);
-        assert_eq!(
-            assets[0]["download_error"],
-            format!("local file is empty: {}", image_path.to_string_lossy())
-        );
-    }
-
-    #[test]
-    fn media_manifest_records_downloaded_image_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let image_path = dir.path().join("image.png");
-        let image = image::RgbImage::from_pixel(2, 3, image::Rgb([1, 2, 3]));
-        image.save(&image_path).unwrap();
-        let size = std::fs::metadata(&image_path).unwrap().len();
-        let notes = vec![json!({
-            "ok": true,
-            "entity": {
-                "note_id": "note-image",
-                "type": "image",
-                "images": [{
-                    "url": "https://img.example/1.jpg",
-                    "index": 0,
-                    "local_path": image_path.to_string_lossy(),
-                }],
-                "video": {},
-            }
-        })];
-
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
-        let assets = manifest.as_array().unwrap();
-
-        assert_eq!(assets.len(), 1);
-        assert_eq!(assets[0]["note_id"], "note-image");
-        assert_eq!(assets[0]["type"], "image");
-        assert_eq!(assets[0]["index"], 0);
-        assert_eq!(
-            assets[0]["local_path"],
-            image_path.to_string_lossy().as_ref()
-        );
-        assert_eq!(assets[0]["size_bytes"], size);
-        assert_eq!(assets[0]["width"], 2);
-        assert_eq!(assets[0]["height"], 3);
-        assert_eq!(assets[0]["source_url"], "https://img.example/1.jpg");
-        assert_eq!(assets[0]["resolved_url_status"], "resolved");
-        assert_eq!(assets[0]["download_status"], "downloaded");
-        assert!(assets[0]["download_error"].is_null());
-    }
-
-    #[test]
-    fn media_manifest_records_video_failure_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let notes = vec![json!({
-            "ok": true,
-            "entity": {
-                "note_id": "note-video",
-                "type": "video",
-                "video": {
-                    "url": "blob:https://www.xiaohongshu.com/not-downloadable",
-                    "duration_s": 42.5,
-                    "width": 1080,
-                    "height": 1920,
-                    "codec": "h264",
-                    "download_error": "downloadable video URL not found (blob: URLs cannot be downloaded)",
-                }
-            }
-        })];
-
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
-        let assets = manifest.as_array().unwrap();
-
-        assert_eq!(assets.len(), 1);
-        assert_eq!(assets[0]["note_id"], "note-video");
-        assert_eq!(assets[0]["type"], "video");
-        assert!(assets[0]["local_path"].is_null());
-        assert!(assets[0]["source_url"].is_null());
-        assert_eq!(assets[0]["resolved_url_status"], "unresolved");
-        assert_eq!(assets[0]["download_status"], "failed");
-        assert_eq!(
-            assets[0]["download_error"],
-            "downloadable video URL not found (blob: URLs cannot be downloaded)"
-        );
-        assert_eq!(assets[0]["duration_s"], 42.5);
-        assert_eq!(assets[0]["width"], 1080);
-        assert_eq!(assets[0]["height"], 1920);
-        assert_eq!(assets[0]["codec"], "h264");
-    }
-
-    #[test]
-    fn media_manifest_writes_stable_run_dir_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let ctx = ToolContext::new("run", dir.path());
-        let manifest = json!([{ "note_id": "note-1", "type": "image" }]);
-
-        let path = write_media_manifest_file(&ctx, &manifest).unwrap();
-        let expected = dir.path().join("media_manifest.json");
-        let saved: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-
-        assert_eq!(Path::new(&path), expected.as_path());
-        assert_eq!(saved, manifest);
     }
 }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1245,7 +1245,7 @@ impl Tool for TopicScanTool {
             let mut entry = match read_result {
                 Ok(payload) => {
                     let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
-                    ensure_entity_note_id(&mut entity, &card.note_id);
+                    ensure_entity_note_id(&mut entity, &card);
                     json!({
                         "scan_level": level,
                         "source_position": card.position,
@@ -1443,10 +1443,23 @@ fn topic_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
 }
 
 fn collect_note_media_assets(note_entry: &Value, run_dir: &Path, assets: &mut Vec<Value>) {
+    if note_entry.get("ok").and_then(Value::as_bool) != Some(true) {
+        return;
+    }
     let Some(entity) = note_entry.get("entity").filter(|v| v.is_object()) else {
         return;
     };
+    if entity
+        .get("stale_warning")
+        .and_then(Value::as_str)
+        .is_some_and(|warning| !warning.trim().is_empty())
+    {
+        return;
+    }
     let note_id = string_field_value(entity, "note_id");
+    if note_id.is_empty() {
+        return;
+    }
     let note_type = string_field_value(entity, "type");
 
     if let Some(images) = entity.get("images").and_then(Value::as_array) {
@@ -1473,25 +1486,46 @@ fn collect_note_media_assets(note_entry: &Value, run_dir: &Path, assets: &mut Ve
     }
 }
 
-fn ensure_entity_note_id(entity: &mut Value, fallback_note_id: &str) {
-    let fallback_note_id = fallback_note_id.trim();
+fn ensure_entity_note_id(entity: &mut Value, card: &XhsNoteCard) {
+    if !string_field_value(entity, "note_id").is_empty() {
+        return;
+    }
+    let fallback_note_id = note_id_fallback(entity, card);
     if fallback_note_id.is_empty() {
         return;
     }
     let Some(map) = entity.as_object_mut() else {
         return;
     };
-    let current = map
-        .get("note_id")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim();
-    if current.is_empty() {
-        map.insert(
-            "note_id".into(),
-            Value::String(fallback_note_id.to_string()),
-        );
+    map.insert("note_id".into(), Value::String(fallback_note_id));
+}
+
+fn note_id_fallback(entity: &Value, card: &XhsNoteCard) -> String {
+    let card_note_id = card.note_id.trim();
+    if !card_note_id.is_empty() {
+        return card_note_id.to_string();
     }
+    note_id_from_url(&string_field_value(entity, "url"))
+        .or_else(|| note_id_from_url(&string_field_value(entity, "link")))
+        .or_else(|| note_id_from_url(&card.link))
+        .unwrap_or_default()
+}
+
+fn note_id_from_url(value: &str) -> Option<String> {
+    let path = value.trim().split(['?', '#']).next().unwrap_or("").trim();
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|segment| !segment.trim().is_empty())
+        .collect();
+    for window in segments.windows(2) {
+        if matches!(window[0], "explore" | "discovery" | "search_result") {
+            let note_id = window[1].trim();
+            if !note_id.is_empty() {
+                return Some(note_id.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn image_manifest_entry(
@@ -1609,8 +1643,16 @@ fn download_status_and_error(
     source_url: &str,
     download_error: Option<String>,
 ) -> (&'static str, Option<String>) {
-    if local_file.is_some_and(Path::is_file) {
-        return ("downloaded", None);
+    if let Some(path) = local_file {
+        match std::fs::metadata(path) {
+            Ok(metadata) if metadata.is_file() && metadata.len() > 0 => {
+                return ("downloaded", None)
+            }
+            Ok(metadata) if metadata.is_file() && !local_path.trim().is_empty() => {
+                return ("failed", Some(format!("local file is empty: {local_path}")));
+            }
+            _ => {}
+        }
     }
     if !local_path.trim().is_empty() {
         return (
@@ -1661,10 +1703,16 @@ fn local_path_buf(run_dir: &Path, local_path: &str) -> Option<PathBuf> {
         return None;
     }
     let path = PathBuf::from(trimmed);
-    Some(if path.is_absolute() || path.exists() {
+    if path.is_absolute() {
+        return Some(path);
+    }
+    let run_dir_path = run_dir.join(&path);
+    Some(if run_dir_path.exists() {
+        run_dir_path
+    } else if path.exists() {
         path
     } else {
-        run_dir.join(path)
+        run_dir_path
     })
 }
 
@@ -1848,14 +1896,87 @@ mod tests {
     }
 
     #[test]
-    fn ensure_entity_note_id_uses_card_fallback_when_missing() {
+    fn ensure_entity_note_id_uses_card_and_url_fallbacks_when_missing() {
         let mut missing = json!({ "note_id": "", "images": [] });
-        ensure_entity_note_id(&mut missing, "card-note");
+        ensure_entity_note_id(
+            &mut missing,
+            &XhsNoteCard {
+                note_id: "card-note".into(),
+                ..Default::default()
+            },
+        );
         assert_eq!(missing["note_id"], "card-note");
 
+        let mut from_entity_url = json!({
+            "note_id": "",
+            "url": "https://www.xiaohongshu.com/explore/url-note?xsec_token=1",
+        });
+        ensure_entity_note_id(&mut from_entity_url, &XhsNoteCard::default());
+        assert_eq!(from_entity_url["note_id"], "url-note");
+
+        let mut from_card_link = json!({ "note_id": "" });
+        ensure_entity_note_id(
+            &mut from_card_link,
+            &XhsNoteCard {
+                link: "https://www.xiaohongshu.com/search_result/card-link-note".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(from_card_link["note_id"], "card-link-note");
+
         let mut existing = json!({ "note_id": "entity-note", "images": [] });
-        ensure_entity_note_id(&mut existing, "card-note");
+        ensure_entity_note_id(
+            &mut existing,
+            &XhsNoteCard {
+                note_id: "card-note".into(),
+                ..Default::default()
+            },
+        );
         assert_eq!(existing["note_id"], "entity-note");
+    }
+
+    #[test]
+    fn media_manifest_note_id_from_url_rejects_query_only_urls() {
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/explore/real-note?xsec_token=1"),
+            Some("real-note".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/discovery/real-discovery#comments"),
+            Some("real-discovery".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("/search_result/real-search?x=1"),
+            Some("real-search".to_string())
+        );
+        assert_eq!(
+            note_id_from_url("https://www.xiaohongshu.com/search_result?keyword=abc"),
+            None
+        );
+        assert_eq!(note_id_from_url("/explore?x=1"), None);
+        assert_eq!(note_id_from_url("/discovery#hash"), None);
+    }
+
+    #[test]
+    fn media_manifest_local_path_buf_prefers_run_dir_relative_path() {
+        let cwd = std::env::current_dir().unwrap();
+        let cwd_dir = tempfile::Builder::new()
+            .prefix("media-manifest-shadow-")
+            .tempdir_in(&cwd)
+            .unwrap();
+        let recorded_path = cwd_dir.path().strip_prefix(&cwd).unwrap().join("asset.bin");
+        std::fs::write(&recorded_path, b"cwd").unwrap();
+
+        let run_dir = tempfile::tempdir().unwrap();
+        let run_dir_asset = run_dir.path().join(&recorded_path);
+        std::fs::create_dir_all(run_dir_asset.parent().unwrap()).unwrap();
+        std::fs::write(&run_dir_asset, b"run-dir").unwrap();
+
+        let resolved =
+            local_path_buf(run_dir.path(), &recorded_path.to_string_lossy()).expect("path");
+
+        assert_eq!(resolved, run_dir_asset);
+        assert_eq!(file_size(Some(&resolved)), Some(7));
     }
 
     #[test]
@@ -1878,6 +1999,81 @@ mod tests {
     }
 
     #[test]
+    fn media_manifest_skips_unsuccessful_stale_skipped_and_unidentified_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = vec![
+            json!({
+                "ok": false,
+                "entity": {
+                    "note_id": "failed-note",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/failed.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "ok": true,
+                "entity": {
+                    "note_id": "stale-note",
+                    "type": "image",
+                    "stale_warning": "This note was already extracted in the previous read.",
+                    "images": [{ "url": "https://img.example/stale.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "skipped": { "reason": "already_processed" },
+                "entity": {
+                    "note_id": "skipped-note",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/skipped.jpg", "index": 0 }],
+                }
+            }),
+            json!({
+                "ok": true,
+                "entity": {
+                    "note_id": "",
+                    "type": "image",
+                    "images": [{ "url": "https://img.example/unidentified.jpg", "index": 0 }],
+                }
+            }),
+        ];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+
+        assert_eq!(manifest.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn media_manifest_marks_zero_byte_local_file_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("empty.jpg");
+        std::fs::File::create(&image_path).unwrap();
+        let notes = vec![json!({
+            "ok": true,
+            "entity": {
+                "note_id": "empty-image",
+                "type": "image",
+                "images": [{
+                    "url": "https://img.example/empty.jpg",
+                    "index": 0,
+                    "local_path": image_path.to_string_lossy(),
+                }],
+                "video": {},
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["download_status"], "failed");
+        assert_eq!(assets[0]["size_bytes"], 0);
+        assert_eq!(
+            assets[0]["download_error"],
+            format!("local file is empty: {}", image_path.to_string_lossy())
+        );
+    }
+
+    #[test]
     fn media_manifest_records_downloaded_image_metadata() {
         let dir = tempfile::tempdir().unwrap();
         let image_path = dir.path().join("image.png");
@@ -1885,6 +2081,7 @@ mod tests {
         image.save(&image_path).unwrap();
         let size = std::fs::metadata(&image_path).unwrap().len();
         let notes = vec![json!({
+            "ok": true,
             "entity": {
                 "note_id": "note-image",
                 "type": "image",
@@ -1921,6 +2118,7 @@ mod tests {
     fn media_manifest_records_video_failure_metadata() {
         let dir = tempfile::tempdir().unwrap();
         let notes = vec![json!({
+            "ok": true,
             "entity": {
                 "note_id": "note-video",
                 "type": "video",

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -5,6 +5,7 @@
 //! visible, note modal open, etc.). The caller is responsible for creating
 //! the page and closing it after `run_agent` returns.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::agent::{make_run_dir, Backend as LlmProvider, Tool, ToolContext, ToolResult};
@@ -1064,7 +1065,8 @@ impl Tool for TopicScanTool {
          first page is too small) → open each note and read its body + top \
          comments → return one compact bundle (search results + selected cards \
          + note bodies + comments). Pass `download_media=true` to download \
-         note images/videos into the run dir and include local paths. Defaults \
+         note images/videos into the run dir, include local paths, and emit a \
+         stable media_manifest. Defaults \
          to 10 notes; pass a larger `num_notes` to scan more (each note is \
          opened, so latency scales with it). Prefer this for XHS topic \
          research. Do not repeat the same scan unless the previous one was \
@@ -1089,7 +1091,7 @@ impl Tool for TopicScanTool {
                 },
                 "download_media": {
                     "type": "boolean",
-                    "description": "Download note images/videos into the command run_dir and include local_path fields in returned notes.",
+                    "description": "Download note images/videos into the command run_dir, include local_path fields in returned notes, and emit a stable media_manifest plus media_manifest.json.",
                     "default": false
                 }
             },
@@ -1242,7 +1244,8 @@ impl Tool for TopicScanTool {
                 .await;
             let mut entry = match read_result {
                 Ok(payload) => {
-                    let entity = payload.get("entity").cloned().unwrap_or(Value::Null);
+                    let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
+                    ensure_entity_note_id(&mut entity, &card.note_id);
                     json!({
                         "scan_level": level,
                         "source_position": card.position,
@@ -1315,6 +1318,20 @@ impl Tool for TopicScanTool {
         let mut selected_cards = serde_json::to_value(&selected)?;
         history_snapshot.annotate_cards(&mut selected_cards);
 
+        let media_manifest = if download_media {
+            topic_scan_media_manifest(&notes, &ctx.run_dir)
+        } else {
+            Value::Array(Vec::new())
+        };
+        let (media_manifest_path, media_manifest_error) = if download_media {
+            match write_media_manifest_file(ctx, &media_manifest) {
+                Ok(path) => (Some(path), None),
+                Err(err) => (None, Some(format!("{err:#}"))),
+            }
+        } else {
+            (None, None)
+        };
+
         let payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
             "query": query,
@@ -1323,6 +1340,9 @@ impl Tool for TopicScanTool {
             "search": search,
             "selected_cards": selected_cards,
             "notes": notes,
+            "media_manifest": media_manifest,
+            "media_manifest_path": media_manifest_path,
+            "media_manifest_error": media_manifest_error,
             "sampling": {
                 "num_notes": num_notes,
                 "selected": selected.len(),
@@ -1397,6 +1417,413 @@ fn sanitize_for_filename(value: &str) -> String {
         .collect()
 }
 
+fn write_media_manifest_file(ctx: &ToolContext, manifest: &Value) -> std::io::Result<String> {
+    std::fs::create_dir_all(&ctx.run_dir)?;
+    let path = ctx.run_dir.join("media_manifest.json");
+    let rendered = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
+    std::fs::write(&path, rendered)?;
+    let _ = ctx.register_artifact(
+        &path,
+        "media_manifest",
+        "json",
+        "Topic scan media manifest",
+        json!({"site": "xhs", "category": "media_manifest"}),
+        Some(manifest),
+        "topic_scan",
+    );
+    Ok(path.to_string_lossy().to_string())
+}
+
+fn topic_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
+    let mut assets = Vec::new();
+    for note in notes {
+        collect_note_media_assets(note, run_dir, &mut assets);
+    }
+    Value::Array(assets)
+}
+
+fn collect_note_media_assets(note_entry: &Value, run_dir: &Path, assets: &mut Vec<Value>) {
+    let Some(entity) = note_entry.get("entity").filter(|v| v.is_object()) else {
+        return;
+    };
+    let note_id = string_field_value(entity, "note_id");
+    let note_type = string_field_value(entity, "type");
+
+    if let Some(images) = entity.get("images").and_then(Value::as_array) {
+        for (fallback_index, image) in images.iter().enumerate() {
+            if image.is_object() {
+                assets.push(image_manifest_entry(
+                    &note_id,
+                    image,
+                    fallback_index as i64,
+                    run_dir,
+                ));
+            }
+        }
+    }
+
+    let Some(video) = entity.get("video").filter(|v| v.is_object()) else {
+        return;
+    };
+    if is_video_manifest_candidate(video, &note_type) {
+        assets.push(video_manifest_entry(&note_id, video, run_dir));
+    }
+    if let Some(poster) = poster_manifest_entry(&note_id, video, run_dir) {
+        assets.push(poster);
+    }
+}
+
+fn ensure_entity_note_id(entity: &mut Value, fallback_note_id: &str) {
+    let fallback_note_id = fallback_note_id.trim();
+    if fallback_note_id.is_empty() {
+        return;
+    }
+    let Some(map) = entity.as_object_mut() else {
+        return;
+    };
+    let current = map
+        .get("note_id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    if current.is_empty() {
+        map.insert(
+            "note_id".into(),
+            Value::String(fallback_note_id.to_string()),
+        );
+    }
+}
+
+fn image_manifest_entry(
+    note_id: &str,
+    image: &Value,
+    fallback_index: i64,
+    run_dir: &Path,
+) -> Value {
+    let index = integer_field(image, "index").unwrap_or(fallback_index);
+    let source_url = string_field_value(image, "url");
+    let local_path = string_field_value(image, "local_path");
+    let download_error = first_string_field(image, &["download_error", "save_error"]);
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), image);
+
+    json!({
+        "note_id": note_id,
+        "type": "image",
+        "role": "image",
+        "index": index,
+        "local_path": string_or_null(&local_path),
+        "size_bytes": file_size_or_null(local_file.as_deref()),
+        "width": option_i64_or_null(width),
+        "height": option_i64_or_null(height),
+        "duration_s": Value::Null,
+        "codec": Value::Null,
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": direct_resolution_status(&source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    })
+}
+
+fn video_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Value {
+    let source_url = video_source_url(video);
+    let local_path = string_field_value(video, "local_path");
+    let download_error = first_string_field(video, &["download_error", "save_error"]);
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let size_bytes = file_size(local_file.as_deref());
+
+    json!({
+        "note_id": note_id,
+        "type": "video",
+        "role": "video",
+        "index": Value::Null,
+        "local_path": string_or_null(&local_path),
+        "size_bytes": option_u64_or_null(size_bytes),
+        "width": option_i64_or_null(integer_field(video, "width")),
+        "height": option_i64_or_null(integer_field(video, "height")),
+        "duration_s": option_f64_or_null(f64_field(video, "duration_s")),
+        "codec": string_or_null(&string_field_value(video, "codec")),
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": video_resolution_status(video, &source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    })
+}
+
+fn poster_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Option<Value> {
+    let source_url = string_field_value(video, "poster_url");
+    let local_path = string_field_value(video, "poster_local_path");
+    let download_error = first_string_field(video, &["poster_download_error", "poster_save_error"]);
+    if source_url.is_empty() && local_path.is_empty() && download_error.is_none() {
+        return None;
+    }
+    let local_file = local_path_buf(run_dir, &local_path);
+    let (status, error) = download_status_and_error(
+        &local_path,
+        local_file.as_deref(),
+        &source_url,
+        download_error,
+    );
+    let (width, height) = image_dimensions_or_fields(local_file.as_deref(), &Value::Null);
+
+    Some(json!({
+        "note_id": note_id,
+        "type": "image",
+        "index": Value::Null,
+        "role": "video_poster",
+        "local_path": string_or_null(&local_path),
+        "size_bytes": file_size_or_null(local_file.as_deref()),
+        "width": option_i64_or_null(width),
+        "height": option_i64_or_null(height),
+        "duration_s": Value::Null,
+        "codec": Value::Null,
+        "source_url": string_or_null(&source_url),
+        "resolved_url_status": direct_resolution_status(&source_url),
+        "download_status": status,
+        "download_error": option_string_or_null(error.as_deref()),
+    }))
+}
+
+fn is_video_manifest_candidate(video: &Value, note_type: &str) -> bool {
+    note_type == "video"
+        || !string_field_value(video, "local_path").is_empty()
+        || first_string_field(video, &["download_error", "save_error"]).is_some()
+        || has_video_source_candidate(video)
+}
+
+fn download_status_and_error(
+    local_path: &str,
+    local_file: Option<&Path>,
+    source_url: &str,
+    download_error: Option<String>,
+) -> (&'static str, Option<String>) {
+    if local_file.is_some_and(Path::is_file) {
+        return ("downloaded", None);
+    }
+    if !local_path.trim().is_empty() {
+        return (
+            "failed",
+            Some(format!("local file is missing or unreadable: {local_path}")),
+        );
+    }
+    if let Some(error) = download_error.filter(|s| !s.trim().is_empty()) {
+        return ("failed", Some(error));
+    }
+    if source_url.trim().is_empty() {
+        return ("failed", Some("source URL is empty".to_string()));
+    }
+    (
+        "failed",
+        Some("download did not produce local_path".to_string()),
+    )
+}
+
+fn image_dimensions_or_fields(
+    local_file: Option<&Path>,
+    source: &Value,
+) -> (Option<i64>, Option<i64>) {
+    if let Some(path) = local_file {
+        if let Ok((width, height)) = image::image_dimensions(path) {
+            return (Some(i64::from(width)), Some(i64::from(height)));
+        }
+    }
+    (
+        integer_field(source, "width"),
+        integer_field(source, "height"),
+    )
+}
+
+fn file_size(local_file: Option<&Path>) -> Option<u64> {
+    local_file
+        .and_then(|path| std::fs::metadata(path).ok())
+        .map(|metadata| metadata.len())
+}
+
+fn file_size_or_null(local_file: Option<&Path>) -> Value {
+    option_u64_or_null(file_size(local_file))
+}
+
+fn local_path_buf(run_dir: &Path, local_path: &str) -> Option<PathBuf> {
+    let trimmed = local_path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    Some(if path.is_absolute() || path.exists() {
+        path
+    } else {
+        run_dir.join(path)
+    })
+}
+
+fn string_field_value(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn first_string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        let candidate = string_field_value(value, key);
+        (!candidate.is_empty()).then_some(candidate)
+    })
+}
+
+fn integer_field(value: &Value, key: &str) -> Option<i64> {
+    let value = value.get(key)?;
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| {
+            value
+                .as_f64()
+                .filter(|n| n.is_finite())
+                .map(|n| n.round() as i64)
+        })
+}
+
+fn f64_field(value: &Value, key: &str) -> Option<f64> {
+    value
+        .get(key)
+        .and_then(Value::as_f64)
+        .filter(|n| n.is_finite())
+}
+
+fn string_or_null(value: &str) -> Value {
+    if value.trim().is_empty() {
+        Value::Null
+    } else {
+        json!(value)
+    }
+}
+
+fn option_string_or_null(value: Option<&str>) -> Value {
+    value.map(string_or_null).unwrap_or(Value::Null)
+}
+
+fn option_i64_or_null(value: Option<i64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn option_u64_or_null(value: Option<u64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn option_f64_or_null(value: Option<f64>) -> Value {
+    value.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn direct_resolution_status(source_url: &str) -> &'static str {
+    if source_url.trim().is_empty() {
+        "missing"
+    } else {
+        "resolved"
+    }
+}
+
+fn video_resolution_status(video: &Value, source_url: &str) -> &'static str {
+    if !source_url.trim().is_empty() {
+        "resolved"
+    } else if has_video_source_candidate(video) {
+        "unresolved"
+    } else {
+        "missing"
+    }
+}
+
+fn video_source_url(video: &Value) -> String {
+    for key in ["resolved_url", "master_url", "url"] {
+        if let Some(url) = video
+            .get(key)
+            .and_then(Value::as_str)
+            .and_then(clean_media_url)
+        {
+            return url;
+        }
+    }
+
+    for key in ["source_urls", "backup_urls"] {
+        if let Some(arr) = video.get(key).and_then(Value::as_array) {
+            for item in arr {
+                if let Some(url) = item.as_str().and_then(clean_media_url) {
+                    return url;
+                }
+            }
+        }
+    }
+
+    if let Some(candidates) = video.get("candidates").and_then(Value::as_array) {
+        for item in candidates {
+            if let Some(url) = item
+                .get("url")
+                .and_then(Value::as_str)
+                .and_then(clean_media_url)
+            {
+                return url;
+            }
+        }
+    }
+
+    String::new()
+}
+
+fn clean_media_url(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if (trimmed.starts_with("http://") || trimmed.starts_with("https://"))
+        && !trimmed.starts_with("blob:")
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+fn has_video_source_candidate(video: &Value) -> bool {
+    for key in ["resolved_url", "master_url", "url"] {
+        if !string_field_value(video, key).is_empty() {
+            return true;
+        }
+    }
+    for key in ["source_urls", "backup_urls"] {
+        if video
+            .get(key)
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item.as_str().is_some_and(|s| !s.trim().is_empty()))
+            })
+        {
+            return true;
+        }
+    }
+    video
+        .get("candidates")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.iter().any(|item| {
+                item.get("url")
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.trim().is_empty())
+            })
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1418,5 +1845,127 @@ mod tests {
 
         assert!(options.include_media);
         assert!(!options.download_media);
+    }
+
+    #[test]
+    fn ensure_entity_note_id_uses_card_fallback_when_missing() {
+        let mut missing = json!({ "note_id": "", "images": [] });
+        ensure_entity_note_id(&mut missing, "card-note");
+        assert_eq!(missing["note_id"], "card-note");
+
+        let mut existing = json!({ "note_id": "entity-note", "images": [] });
+        ensure_entity_note_id(&mut existing, "card-note");
+        assert_eq!(existing["note_id"], "entity-note");
+    }
+
+    #[test]
+    fn local_path_buf_prefers_existing_relative_path_as_recorded() {
+        let cwd = std::env::current_dir().unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("media-manifest-relative-")
+            .tempdir_in(&cwd)
+            .unwrap();
+        let file_path = dir.path().join("asset.bin");
+        std::fs::write(&file_path, b"asset").unwrap();
+        let recorded_path = file_path.strip_prefix(&cwd).unwrap();
+        let unrelated_run_dir = tempfile::tempdir().unwrap();
+
+        let resolved = local_path_buf(unrelated_run_dir.path(), &recorded_path.to_string_lossy())
+            .expect("path");
+
+        assert_eq!(resolved, recorded_path);
+        assert_eq!(file_size(Some(&resolved)), Some(5));
+    }
+
+    #[test]
+    fn media_manifest_records_downloaded_image_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("image.png");
+        let image = image::RgbImage::from_pixel(2, 3, image::Rgb([1, 2, 3]));
+        image.save(&image_path).unwrap();
+        let size = std::fs::metadata(&image_path).unwrap().len();
+        let notes = vec![json!({
+            "entity": {
+                "note_id": "note-image",
+                "type": "image",
+                "images": [{
+                    "url": "https://img.example/1.jpg",
+                    "index": 0,
+                    "local_path": image_path.to_string_lossy(),
+                }],
+                "video": {},
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["note_id"], "note-image");
+        assert_eq!(assets[0]["type"], "image");
+        assert_eq!(assets[0]["index"], 0);
+        assert_eq!(
+            assets[0]["local_path"],
+            image_path.to_string_lossy().as_ref()
+        );
+        assert_eq!(assets[0]["size_bytes"], size);
+        assert_eq!(assets[0]["width"], 2);
+        assert_eq!(assets[0]["height"], 3);
+        assert_eq!(assets[0]["source_url"], "https://img.example/1.jpg");
+        assert_eq!(assets[0]["resolved_url_status"], "resolved");
+        assert_eq!(assets[0]["download_status"], "downloaded");
+        assert!(assets[0]["download_error"].is_null());
+    }
+
+    #[test]
+    fn media_manifest_records_video_failure_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = vec![json!({
+            "entity": {
+                "note_id": "note-video",
+                "type": "video",
+                "video": {
+                    "url": "blob:https://www.xiaohongshu.com/not-downloadable",
+                    "duration_s": 42.5,
+                    "width": 1080,
+                    "height": 1920,
+                    "codec": "h264",
+                    "download_error": "downloadable video URL not found (blob: URLs cannot be downloaded)",
+                }
+            }
+        })];
+
+        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let assets = manifest.as_array().unwrap();
+
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["note_id"], "note-video");
+        assert_eq!(assets[0]["type"], "video");
+        assert!(assets[0]["local_path"].is_null());
+        assert!(assets[0]["source_url"].is_null());
+        assert_eq!(assets[0]["resolved_url_status"], "unresolved");
+        assert_eq!(assets[0]["download_status"], "failed");
+        assert_eq!(
+            assets[0]["download_error"],
+            "downloadable video URL not found (blob: URLs cannot be downloaded)"
+        );
+        assert_eq!(assets[0]["duration_s"], 42.5);
+        assert_eq!(assets[0]["width"], 1080);
+        assert_eq!(assets[0]["height"], 1920);
+        assert_eq!(assets[0]["codec"], "h264");
+    }
+
+    #[test]
+    fn media_manifest_writes_stable_run_dir_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::new("run", dir.path());
+        let manifest = json!([{ "note_id": "note-1", "type": "image" }]);
+
+        let path = write_media_manifest_file(&ctx, &manifest).unwrap();
+        let expected = dir.path().join("media_manifest.json");
+        let saved: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+
+        assert_eq!(Path::new(&path), expected.as_path());
+        assert_eq!(saved, manifest);
     }
 }


### PR DESCRIPTION
## Summary
- write a stable `<run_dir>/media_manifest.json` when `topic_scan --download-media` is used
- keep stdout lean: emit `media_manifest_path` and `media_manifest_count`, not the full manifest array
- include per-asset status/error, local path, source URL, dimensions, video duration/codec, and size metadata in the manifest file
- move manifest generation into `core/src/sites/xhs/media_manifest.rs` so `tools.rs` stays focused on tool orchestration
- add focused unit coverage for image success, video failure, manifest file writing, note-id fallback, note filtering, URL parsing, relative paths, and zero-byte files

Closes #109.

## Before vs after

Command:

```bash
socai topic_scan "攀岩技巧" --download-media --num-notes 2
```

### Before

The CLI printed the topic-scan JSON payload, and downloaded media paths were only embedded inside each note entity. Callers had to infer assets by walking `notes[].entity.images[]` and `notes[].entity.video` themselves.

Example stdout shape before this PR:

```json
{
  "query": "攀岩技巧",
  "notes": [
    {
      "ok": true,
      "entity": {
        "note_id": "note-123",
        "type": "image",
        "images": [
          {
            "url": "https://img.example/1.jpg",
            "index": 0,
            "local_path": "/Users/me/.socai/runs/agent_20260612_153012_topic_scan/site_media/note-123/note-123_abcd1234.jpg"
          }
        ],
        "video": {}
      }
    }
  ],
  "sampling": {
    "download_media": true
  }
}
```

There was no stable run-level manifest and no standalone manifest file path.

### After

The same command still returns notes in the same place, but stdout stays small. It now adds only:

- `media_manifest_path`: where the full flat manifest was written
- `media_manifest_count`: number of asset rows in that file
- `media_manifest_error`: only present if writing the manifest file fails

Example stderr/stdout shape after this PR:

```text
stderr:
run_dir: /Users/me/.socai/runs/agent_20260612_153012_topic_scan
```

```json
{
  "query": "攀岩技巧",
  "notes": [
    {
      "ok": true,
      "entity": {
        "note_id": "note-123",
        "type": "video",
        "video": {
          "local_path": "/Users/me/.socai/runs/agent_20260612_153012_topic_scan/site_media/note-123/note-123_abcd1234.mp4"
        }
      }
    }
  ],
  "media_manifest_path": "/Users/me/.socai/runs/agent_20260612_153012_topic_scan/media_manifest.json",
  "media_manifest_count": 2,
  "sampling": {
    "download_media": true
  }
}
```

For `topic_scan` calls without `--download-media`, these manifest fields are omitted.

## What `media_manifest_path` points to

`media_manifest_path` is the manifest file in the same command run directory:

```text
<run_dir>/media_manifest.json
```

With the example above, that is:

```text
/Users/me/.socai/runs/agent_20260612_153012_topic_scan/media_manifest.json
```

The file contains the full flat `media_manifest` array, pretty-printed as JSON.

## Is the manifest flat? What about multi-image notes?

Yes. The file is a flat array: one row per media asset attempt, not nested by note. The note-to-asset relationship is carried by `note_id`; carousel ordering is carried by `index` for image assets.

For a note with multiple images, the manifest file has multiple rows with the same `note_id` and increasing `index` values:

```json
[
  {
    "note_id": "note-789",
    "type": "image",
    "role": "image",
    "index": 0,
    "local_path": "/Users/me/.socai/runs/agent_20260612_153012_topic_scan/site_media/note-789/note-789_img1.jpg",
    "size_bytes": 234567,
    "width": 1080,
    "height": 1440,
    "duration_s": null,
    "codec": null,
    "source_url": "https://img.example/1.jpg",
    "resolved_url_status": "resolved",
    "download_status": "downloaded",
    "download_error": null
  },
  {
    "note_id": "note-789",
    "type": "image",
    "role": "image",
    "index": 1,
    "local_path": "/Users/me/.socai/runs/agent_20260612_153012_topic_scan/site_media/note-789/note-789_img2.jpg",
    "size_bytes": 345678,
    "width": 1080,
    "height": 1440,
    "duration_s": null,
    "codec": null,
    "source_url": "https://img.example/2.jpg",
    "resolved_url_status": "resolved",
    "download_status": "downloaded",
    "download_error": null
  }
]
```

A video poster is represented as its own row with `type: "image"` and `role: "video_poster"`, so callers can distinguish it from carousel images.

## Why a run-level manifest file instead of adding metadata files per media folder?

The manifest is intentionally centralized because the caller needs a stable registry for the whole topic-scan run:

- **Keeps stdout/LLM context compact:** stdout gets a path and count; the full per-asset array lives on disk.
- **Covers failures:** failed downloads often have no local file or media folder metadata to attach to. A manifest row can still record `note_id`, `source_url`, `download_status: "failed"`, and `download_error`.
- **Avoids filesystem inference:** beta-agent should not need to walk `site_media/`, parse folder names, or infer note IDs from paths. The manifest file is the source of truth for note-to-asset mapping.
- **Keeps folder layout flexible:** media folders can remain implementation details. Changing path layout later should not break consumers as long as the manifest file stays stable.
- **Makes registration easy:** autonomous jobs can read one flat array and register each media artifact exactly once, including failed assets.

Per-folder metadata could be added later as a convenience, but it would not replace the run-level manifest because it cannot describe missing/failed assets as reliably and would force callers back into path traversal.

## Validation
- `cargo test -p socai-core media_manifest`
- `cargo test -p socai-core`
- `cargo test -p socai-cli`
