### PR TITLE
Fix topic_scan cached result skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ cargo install --path cli --force
 ```bash
 socai topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
 socai topic_scan "运营爆款思路" --num-notes 10 --download-media       # 同时下载帖子图片/视频到 run_dir/site_media/
+socai topic_scan "运营爆款思路" --num-notes 5 --force-reread         # 忽略已分析历史，重新打开并分析帖子
 socai search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
 socai extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
@@ -78,6 +79,11 @@ Options:
   for the first page only (~19).
 - `--download-media` — `topic_scan` only: download note images/videos into the
   printed `run_dir` (`site_media/`) and add `local_path` fields to the JSON.
+- Repeated `topic_scan` runs return cached analyzed note entities when available;
+  metadata-only old history is re-read once and cached so repeated JSON stays
+  evidence-complete.
+- `--force-reread` — `topic_scan` only: bypass already-analyzed history and
+  re-open/re-analyze notes.
 - `--pretty` — indented JSON (any tool command).
 - `--debug-snapshot` — record DOM + a11y tree + screenshots per page change.
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use socai_core::runtime::{
 };
 use socai_core::sites::xhs::{
     search_notes_command, topic_scan_command, xhs_agent_instructions, xhs_agent_tools,
-    XhsPageRuntime, XHS_HOME_URL,
+    TopicScanCommandOptions, XhsPageRuntime, XHS_HOME_URL,
 };
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
@@ -76,17 +76,21 @@ pub async fn tool_topic_scan(
     query: String,
     num_notes: Option<i64>,
     download_media: Option<bool>,
+    force_reread: Option<bool>,
 ) -> Result<Value, String> {
     require_connected(&runtime).await?;
     let page = temporary_page(&runtime, XHS_HOME_URL, "tool · topic_scan").await?;
     let result = topic_scan_command(
         page.clone(),
-        &query,
-        None,
-        None,
-        num_notes,
-        download_media.unwrap_or(false),
-        false,
+        TopicScanCommandOptions {
+            query: &query,
+            tab_label: None,
+            filters: None,
+            num_notes,
+            download_media: download_media.unwrap_or(false),
+            force_reread: force_reread.unwrap_or(false),
+            debug_snapshot: false,
+        },
     )
     .await;
     close_page(page).await;

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use socai_core::runtime::SocaiRuntime;
 use socai_core::sites::xhs::{
-    extract_note_command, search_notes_command, topic_scan_command, XHS_HOME_URL,
+    extract_note_command, search_notes_command, topic_scan_command, TopicScanCommandOptions,
+    XHS_HOME_URL,
 };
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -318,16 +319,23 @@ impl DaemonState {
                 .get("download_media")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
+            let force_reread = args
+                .get("force_reread")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             let debug_snapshot = debug_snapshot_flag(&args);
             let page = self.runtime.ensure_site_page("xhs", XHS_HOME_URL).await?;
             topic_scan_command(
                 page,
-                &query,
-                tab_label,
-                filters,
-                num_notes,
-                download_media,
-                debug_snapshot,
+                TopicScanCommandOptions {
+                    query: &query,
+                    tab_label,
+                    filters,
+                    num_notes,
+                    download_media,
+                    force_reread,
+                    debug_snapshot,
+                },
             )
             .await
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,6 +58,9 @@ enum Command {
         /// local_path fields in the JSON output.
         #[arg(long = "download-media")]
         download_media: bool,
+        /// Bypass already-analyzed history and re-open/re-analyze notes.
+        #[arg(long = "force-reread")]
+        force_reread: bool,
         #[arg(long)]
         pretty: bool,
         /// Record DOM + a11y tree + screenshot bundles to <run_dir>/snapshots/
@@ -143,6 +146,7 @@ async fn main() -> Result<()> {
             filter,
             num_notes,
             download_media,
+            force_reread,
             pretty,
             debug_snapshot,
         } => {
@@ -158,6 +162,9 @@ async fn main() -> Result<()> {
             }
             if download_media {
                 input["download_media"] = serde_json::json!(true);
+            }
+            if force_reread {
+                input["force_reread"] = serde_json::json!(true);
             }
 
             let result =

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -4,10 +4,10 @@
 //!
 //! - In-run dedup still lives on `ToolContext::processed_notes`; this store
 //!   only handles cross-run persistence.
-//! - Schema is intentionally smaller — we keep `note_id`, `title`, `author`,
-//!   `url`, `level`, `include_media`, `analysis_count`, `first_seen_at`,
-//!   `last_seen_at`. Run dirs and artifact paths are dropped — they live in
-//!   the per-run logs and would mostly point at stale paths anyway.
+//! - Schema keeps note metadata plus a small local cache of successful note
+//!   entities keyed by read level/media settings. Run dirs and artifact-local
+//!   paths are dropped — they live in per-run logs and would mostly point at
+//!   stale paths anyway.
 //! - File at `~/.socai/xhs/history.json` (overridable via `SOCAI_HOME`).
 
 use std::collections::BTreeMap;
@@ -18,6 +18,20 @@ use std::sync::Mutex;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CachedAnalysis {
+    #[serde(default)]
+    pub cache_key: String,
+    #[serde(default)]
+    pub level: String,
+    #[serde(default)]
+    pub include_media: bool,
+    #[serde(default)]
+    pub analyzed_at: String,
+    #[serde(default)]
+    pub entity: Value,
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HistoryEntry {
@@ -40,6 +54,11 @@ pub struct HistoryEntry {
     pub first_seen_at: String,
     #[serde(default)]
     pub last_seen_at: String,
+    /// Cached successful entities by level/media cache key. Kept out of CLI
+    /// skip metadata, but persisted so repeated scans can return deep evidence
+    /// without reopening notes.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub cached_results: BTreeMap<String, CachedAnalysis>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -88,6 +107,33 @@ impl XhsHistoryStore {
         guard.notes.get(id).cloned()
     }
 
+    pub fn cache_key_for(note_id: &str, level: &str, include_media: bool) -> String {
+        format!(
+            "xhs:note:{}:level={}:include_media={}",
+            note_id.trim(),
+            normalize_level(level),
+            include_media
+        )
+    }
+
+    /// Return the best cached entity that covers the requested level/media.
+    /// A deeper cached result can satisfy a shallower request, and media is
+    /// only required when the caller requested media.
+    pub fn cached_result(
+        &self,
+        note_id: &str,
+        level: &str,
+        include_media: bool,
+    ) -> Option<CachedAnalysis> {
+        let id = note_id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let guard = self.inner.lock().ok()?;
+        let entry = guard.notes.get(id)?;
+        best_cached_analysis(entry, level, include_media)
+    }
+
     /// True when a prior analysis already covers what's being requested:
     /// recorded level is >= requested AND, if media was requested, media
     /// was included previously.
@@ -95,6 +141,9 @@ impl XhsHistoryStore {
         let Some(prev) = self.get(note_id) else {
             return false;
         };
+        if best_cached_analysis(&prev, level, include_media).is_some() {
+            return true;
+        }
         if level_value(&prev.level) < level_value(level) {
             return false;
         }
@@ -144,18 +193,22 @@ impl XhsHistoryStore {
         let title = string_field(entity, "title");
         let author = string_field(entity, "author");
         let url = string_field(entity, "url");
+        let cache_key = Self::cache_key_for(&note_id, level, include_media);
+        let cached_entity = sanitize_cached_entity(entity);
 
         let snapshot = {
             let Ok(mut guard) = self.inner.lock() else {
                 return;
             };
-            let entry = guard.notes.entry(note_id.clone()).or_insert_with(|| {
-                let mut e = HistoryEntry::default();
-                e.note_id = note_id.clone();
-                e.first_seen_at = now.clone();
-                e
-            });
-            entry.note_id = note_id;
+            let entry = guard
+                .notes
+                .entry(note_id.clone())
+                .or_insert_with(|| HistoryEntry {
+                    note_id: note_id.clone(),
+                    first_seen_at: now.clone(),
+                    ..Default::default()
+                });
+            entry.note_id = note_id.clone();
             if !title.is_empty() {
                 entry.title = title;
             }
@@ -166,11 +219,21 @@ impl XhsHistoryStore {
                 entry.url = url;
             }
             if level_value(level) > level_value(&entry.level) {
-                entry.level = level.to_string();
+                entry.level = normalize_level(level);
             }
             if include_media {
                 entry.include_media = true;
             }
+            entry.cached_results.insert(
+                cache_key.clone(),
+                CachedAnalysis {
+                    cache_key,
+                    level: normalize_level(level),
+                    include_media,
+                    analyzed_at: now.clone(),
+                    entity: cached_entity,
+                },
+            );
             entry.analysis_count = entry.analysis_count.saturating_add(1);
             entry.last_seen_at = now;
             guard.clone()
@@ -217,6 +280,75 @@ fn annotate_cards_from(entries: &BTreeMap<String, HistoryEntry>, cards: &mut Val
     }
 }
 
+fn best_cached_analysis(
+    entry: &HistoryEntry,
+    level: &str,
+    include_media: bool,
+) -> Option<CachedAnalysis> {
+    let mut best: Option<&CachedAnalysis> = None;
+    for cached in entry.cached_results.values() {
+        if level_value(&cached.level) < level_value(level) {
+            continue;
+        }
+        if include_media && !cached.include_media {
+            continue;
+        }
+        if best
+            .map(|current| cached_analysis_is_better(cached, current))
+            .unwrap_or(true)
+        {
+            best = Some(cached);
+        }
+    }
+    best.cloned()
+}
+
+fn cached_analysis_is_better(candidate: &CachedAnalysis, current: &CachedAnalysis) -> bool {
+    let candidate_level = level_value(&candidate.level);
+    let current_level = level_value(&current.level);
+    if candidate_level != current_level {
+        return candidate_level > current_level;
+    }
+    if candidate.include_media != current.include_media {
+        return candidate.include_media;
+    }
+    candidate.analyzed_at > current.analyzed_at
+}
+
+fn sanitize_cached_entity(entity: &Value) -> Value {
+    let mut value = entity.clone();
+    remove_artifact_local_paths(&mut value);
+    value
+}
+
+fn remove_artifact_local_paths(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.remove("local_path");
+            map.remove("poster_local_path");
+            map.remove("frame_paths");
+            for child in map.values_mut() {
+                remove_artifact_local_paths(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                remove_artifact_local_paths(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_level(level: &str) -> String {
+    match level.trim().to_ascii_lowercase().as_str() {
+        "deep" => "deep".to_string(),
+        "lite" => "lite".to_string(),
+        "card" => "card".to_string(),
+        other => other.to_string(),
+    }
+}
+
 fn level_value(level: &str) -> i32 {
     match level.trim().to_ascii_lowercase().as_str() {
         "deep" => 3,
@@ -243,8 +375,7 @@ fn save_file(path: &Path, data: &HistoryFile) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let bytes = serde_json::to_vec_pretty(data)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let bytes = serde_json::to_vec_pretty(data).map_err(std::io::Error::other)?;
     let tmp = path.with_extension("json.tmp");
     fs::write(&tmp, &bytes)?;
     fs::rename(&tmp, path)?;
@@ -273,10 +404,16 @@ mod tests {
         assert_eq!(entry.level, "lite");
         assert_eq!(entry.analysis_count, 1);
         assert!(!entry.first_seen_at.is_empty());
+        assert!(entry
+            .cached_results
+            .contains_key(&XhsHistoryStore::cache_key_for("abc", "lite", false)));
 
-        // Reopen from disk — entries persist.
+        // Reopen from disk — entries and cached entities persist.
         let store2 = XhsHistoryStore::open(&path);
-        assert!(store2.get("abc").is_some());
+        let cached = store2
+            .cached_result("abc", "lite", false)
+            .expect("cached result present");
+        assert_eq!(cached.entity["title"], json!("T"));
     }
 
     #[test]
@@ -303,6 +440,119 @@ mod tests {
         assert!(!store.is_satisfied_by("n1", "deep", false));
         assert!(!store.is_satisfied_by("n1", "lite", true));
         assert!(!store.is_satisfied_by("unknown", "card", false));
+    }
+
+    #[test]
+    fn cached_result_returns_deepest_satisfying_entity() {
+        let dir = tempdir().unwrap();
+        let store = XhsHistoryStore::open(dir.path().join("h.json"));
+        store.record(
+            &json!({"note_id": "n1", "title": "lite", "content": "short"}),
+            "lite",
+            false,
+        );
+        store.record(
+            &json!({"note_id": "n1", "title": "deep", "content": "full", "top_comments": ["c"]}),
+            "deep",
+            false,
+        );
+
+        let cached = store
+            .cached_result("n1", "lite", false)
+            .expect("deeper cache satisfies lite request");
+        assert_eq!(cached.level, "deep");
+        assert_eq!(cached.entity["content"], json!("full"));
+        assert_eq!(cached.entity["top_comments"], json!(["c"]));
+    }
+
+    #[test]
+    fn cached_result_respects_media_requirement() {
+        let dir = tempdir().unwrap();
+        let store = XhsHistoryStore::open(dir.path().join("h.json"));
+        store.record(&json!({"note_id": "n1", "title": "deep"}), "deep", false);
+
+        assert!(store.cached_result("n1", "deep", true).is_none());
+        assert!(!store.is_satisfied_by("n1", "deep", true));
+    }
+
+    #[test]
+    fn metadata_only_history_from_old_versions_still_satisfies_requests() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("history.json");
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "notes": {
+                    "n1": {
+                        "note_id": "n1",
+                        "level": "deep",
+                        "include_media": false,
+                        "last_seen_at": "2026-01-01T00:00:00Z"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let store = XhsHistoryStore::open(&path);
+        assert!(store.is_satisfied_by("n1", "deep", false));
+        assert!(store.cached_result("n1", "deep", false).is_none());
+    }
+
+    #[test]
+    fn partial_cache_history_falls_back_to_top_level_metadata() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("history.json");
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "notes": {
+                    "n1": {
+                        "note_id": "n1",
+                        "level": "deep",
+                        "include_media": false,
+                        "last_seen_at": "2026-01-01T00:00:00Z",
+                        "cached_results": {
+                            "xhs:note:n1:level=lite:include_media=false": {
+                                "cache_key": "xhs:note:n1:level=lite:include_media=false",
+                                "level": "lite",
+                                "include_media": false,
+                                "analyzed_at": "2026-01-01T00:00:00Z",
+                                "entity": {"note_id": "n1", "content": "lite"}
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let store = XhsHistoryStore::open(&path);
+        assert!(store.is_satisfied_by("n1", "deep", false));
+        assert!(store.cached_result("n1", "deep", false).is_none());
+    }
+
+    #[test]
+    fn cached_result_strips_artifact_local_paths() {
+        let dir = tempdir().unwrap();
+        let store = XhsHistoryStore::open(dir.path().join("h.json"));
+        store.record(
+            &json!({
+                "note_id": "n1",
+                "images": [{"url": "https://example.test/i.jpg", "local_path": "/tmp/run/i.jpg"}],
+                "video": {"local_path": "/tmp/run/v.mp4", "poster_local_path": "/tmp/run/p.jpg", "frame_paths": ["/tmp/run/f.jpg"]}
+            }),
+            "deep",
+            false,
+        );
+
+        let cached = store.cached_result("n1", "deep", false).unwrap();
+        assert!(cached.entity["images"][0].get("local_path").is_none());
+        assert!(cached.entity["video"].get("local_path").is_none());
+        assert!(cached.entity["video"].get("poster_local_path").is_none());
+        assert!(cached.entity["video"].get("frame_paths").is_none());
     }
 
     #[test]

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -121,10 +121,14 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
 - Cards carry `already_analyzed` / `history_level` / `history_include_media`
   flags when a prior run already read them. `read_note` and `topic_scan`
   short-circuit notes already covered at the requested level and media
-  setting — the returned payload has `skipped: true` plus the prior
-  `history` entry. To deepen prior analysis, request a higher `level` (e.g.
-  `deep` after a `lite`) or set `include_media: true`. Media downloads are not
-  cache-skipped because fresh local files are expected in the current run dir.
+  setting. Skipped payloads include `status: "skipped"`, `skip_reason`,
+  `cached_result_returned`, `cache_key`, `analyzed_at`, a summary of the prior
+  `history` entry, and the cached note entity in `entity` when available. If
+  metadata-only history has no cached entity yet, the note is re-read and the
+  cache is populated. Use `force_reread` to bypass history and re-analyze. To
+  deepen prior analysis, request a higher `level` (e.g. `deep` after a `lite`)
+  or set `include_media: true`. Media downloads are not cache-skipped because
+  fresh local files are expected in the current run dir.
 - Keep DOM text, comment evidence, image OCR/vision, and video transcript/frame
   evidence labeled separately in final answers.
 - If a read returns a stale-note warning or note-id mismatch, close the current

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -4,10 +4,10 @@ pub mod page;
 pub mod tools;
 
 pub use self::entities::{parse_count_text, XhsAuthorProfile, XhsNote, XhsNoteCard};
-pub use self::history::{HistoryEntry, HistorySnapshot, XhsHistoryStore};
+pub use self::history::{CachedAnalysis, HistoryEntry, HistorySnapshot, XhsHistoryStore};
 pub use self::page::{ReadNoteOptions, XhsPageRuntime, XHS_HOME_URL};
 pub use self::tools::{
     close_open_note, ensure_search_ready, extract_note_command, search_notes_command,
     topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_tools,
-    xhs_tools_with_llm_provider, XHS_KNOWLEDGE,
+    xhs_tools_with_llm_provider, TopicScanCommandOptions, XHS_KNOWLEDGE,
 };

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -14,7 +14,9 @@ use async_trait::async_trait;
 use serde_json::{json, Map, Value};
 
 use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
-use crate::sites::xhs::{ReadNoteOptions, XhsHistoryStore, XhsNoteCard, XhsPageRuntime};
+use crate::sites::xhs::{
+    HistoryEntry, ReadNoteOptions, XhsHistoryStore, XhsNoteCard, XhsPageRuntime,
+};
 
 /// Default number of notes `topic_scan` reads when the caller doesn't specify.
 const DEFAULT_NUM_NOTES: i64 = 10;
@@ -144,20 +146,32 @@ pub async fn search_notes_command(
     .await
 }
 
+pub struct TopicScanCommandOptions<'a> {
+    pub query: &'a str,
+    pub tab_label: Option<&'a str>,
+    pub filters: Option<&'a Value>,
+    pub num_notes: Option<i64>,
+    pub download_media: bool,
+    pub force_reread: bool,
+    pub debug_snapshot: bool,
+}
+
 pub async fn topic_scan_command(
     page: Arc<PageSession>,
-    query: &str,
-    tab_label: Option<&str>,
-    filters: Option<&Value>,
-    num_notes: Option<i64>,
-    download_media: bool,
-    debug_snapshot: bool,
+    options: TopicScanCommandOptions<'_>,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         TOPIC_SCAN_COMMAND,
-        topic_scan_input(query, tab_label, filters, num_notes, download_media)?,
-        debug_snapshot,
+        topic_scan_input(
+            options.query,
+            options.tab_label,
+            options.filters,
+            options.num_notes,
+            options.download_media,
+            options.force_reread,
+        )?,
+        options.debug_snapshot,
     )
     .await
 }
@@ -200,6 +214,7 @@ fn topic_scan_input(
     filters: Option<&Value>,
     num_notes: Option<i64>,
     download_media: bool,
+    force_reread: bool,
 ) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
@@ -213,6 +228,9 @@ fn topic_scan_input(
     }
     if download_media {
         input["download_media"] = json!(true);
+    }
+    if force_reread {
+        input["force_reread"] = json!(true);
     }
     Ok(input)
 }
@@ -376,6 +394,31 @@ fn get_str<'a>(input: &'a Value, key: &str) -> Option<&'a str> {
 
 fn get_bool(input: &Value, key: &str, default: bool) -> bool {
     input.get(key).and_then(Value::as_bool).unwrap_or(default)
+}
+
+fn force_reread(input: &Value) -> bool {
+    get_bool(input, "force_reread", false)
+}
+
+fn history_summary(entry: &HistoryEntry) -> Value {
+    json!({
+        "note_id": &entry.note_id,
+        "title": &entry.title,
+        "author": &entry.author,
+        "url": &entry.url,
+        "level": &entry.level,
+        "include_media": entry.include_media,
+        "analysis_count": entry.analysis_count,
+        "first_seen_at": &entry.first_seen_at,
+        "last_seen_at": &entry.last_seen_at,
+    })
+}
+
+fn topic_scan_cached_entity_is_complete(entity: &Value, level: &str, comment_count: i64) -> bool {
+    if level == "deep" && comment_count > 0 {
+        return entity.get("top_comments").is_some();
+    }
+    true
 }
 
 fn read_note_options(input: &Value) -> ReadNoteOptions {
@@ -579,6 +622,11 @@ impl Tool for ReadNoteTool {
                 "level": { "type": "string", "enum": ["card", "lite", "deep"], "default": "lite" },
                 "include_media": { "type": "boolean", "default": false },
                 "download_media": { "type": "boolean", "default": false },
+                "force_reread": {
+                    "type": "boolean",
+                    "description": "Bypass already-analyzed history and reopen/re-extract the note.",
+                    "default": false
+                },
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 },
                 "max_video_frames": { "type": "integer", "default": 4, "minimum": 1 }
             }
@@ -593,28 +641,44 @@ impl Tool for ReadNoteTool {
             .and_then(|i| usize::try_from(i).ok());
         let wait_seconds = get_f64(&input, "wait_seconds", 6.0);
         let options = read_note_options(&input);
+        let force_reread_requested = force_reread(&input);
 
         // Cross-run dedup: short-circuit when a previous run already covers
         // this note at the requested level + media. Only fires when note_id
         // is known up front. Downloads are intentionally never skipped because
         // the caller expects fresh local files in the current run dir.
         if let Some(id) = note_id.as_deref().filter(|s| !s.trim().is_empty()) {
-            if !options.download_media
+            if !force_reread_requested
+                && !options.download_media
                 && self
                     .history
                     .is_satisfied_by(id, &options.level, options.include_media)
             {
-                let entry = self.history.get(id).unwrap_or_default();
-                return Ok(json_result(&json!({
-                    "ok": true,
-                    "skipped": true,
-                    "reason": "already_analyzed",
-                    "note_id": id,
-                    "requested_level": options.level,
-                    "requested_include_media": options.include_media,
-                    "requested_download_media": options.download_media,
-                    "history": entry,
-                })));
+                if let Some(cached) =
+                    self.history
+                        .cached_result(id, &options.level, options.include_media)
+                {
+                    let entry = self.history.get(id).unwrap_or_default();
+                    return Ok(json_result(&json!({
+                        "ok": true,
+                        "status": "skipped",
+                        "skip_reason": "already_analyzed",
+                        "skipped": true,
+                        "reason": "already_analyzed",
+                        "note_id": id,
+                        "requested_level": &options.level,
+                        "requested_include_media": options.include_media,
+                        "requested_download_media": options.download_media,
+                        "cached_result_returned": true,
+                        "cache_key": cached.cache_key,
+                        "analyzed_at": cached.analyzed_at,
+                        "history": history_summary(&entry),
+                        "entity": cached.entity,
+                    })));
+                }
+                // Metadata-only history from older socai versions has no
+                // cached entity to return. Re-read once so future skips are
+                // evidence-complete without requiring a second flag.
             }
         }
 
@@ -1063,12 +1127,15 @@ impl Tool for TopicScanTool {
          collect up to `num_notes` cards in page order (scrolling only if the \
          first page is too small) → open each note and read its body + top \
          comments → return one compact bundle (search results + selected cards \
-         + note bodies + comments). Pass `download_media=true` to download \
-         note images/videos into the run dir and include local paths. Defaults \
-         to 10 notes; pass a larger `num_notes` to scan more (each note is \
-         opened, so latency scales with it). Prefer this for XHS topic \
-         research. Do not repeat the same scan unless the previous one was \
-         clearly insufficient."
+         + note bodies + comments). Already-analyzed notes return cached note \
+         entities when available; metadata-only old history is re-read once to \
+         populate the cache. Pass `force_reread=true` to bypass history and \
+         re-open notes. Pass `download_media=true` to download note \
+         images/videos into the run dir and include local paths. Defaults to 10 \
+         notes; pass a larger `num_notes` to scan more (each note is opened, \
+         so latency scales with it). Prefer this for XHS topic research. Do \
+         not repeat the same scan unless the previous one was clearly \
+         insufficient."
     }
 
     fn input_schema(&self) -> Value {
@@ -1091,6 +1158,11 @@ impl Tool for TopicScanTool {
                     "type": "boolean",
                     "description": "Download note images/videos into the command run_dir and include local_path fields in returned notes.",
                     "default": false
+                },
+                "force_reread": {
+                    "type": "boolean",
+                    "description": "Bypass already-analyzed history and reopen/re-analyze notes.",
+                    "default": false
                 }
             },
             "required": ["query"]
@@ -1112,6 +1184,7 @@ impl Tool for TopicScanTool {
         // genuinely expensive enrichment and not needed for topic research).
         let include_media = false;
         let download_media = get_bool(&input, "download_media", false);
+        let force_reread_requested = force_reread(&input);
 
         let media = media_for(
             ctx,
@@ -1148,7 +1221,7 @@ impl Tool for TopicScanTool {
         let level = "deep";
         let comment_count = TOPIC_SCAN_COMMENTS;
         let requested_media = include_media;
-        let can_use_cached_reads = !download_media;
+        let can_use_cached_reads = !download_media && !force_reread_requested;
         let want = num_notes.max(1) as usize;
 
         // Read top-to-bottom: pull cards from the results state (which only
@@ -1202,6 +1275,11 @@ impl Tool for TopicScanTool {
                 notes.push(json!({
                     "scan_level": level,
                     "source_position": card.position,
+                    "ok": true,
+                    "status": "skipped",
+                    "skip_reason": "already_processed",
+                    "note_id": &card.note_id,
+                    "cached_result_returned": false,
                     "skipped": {"reason": "already_processed"},
                     "entity": &card,
                 }));
@@ -1213,15 +1291,43 @@ impl Tool for TopicScanTool {
                     .history
                     .is_satisfied_by(&card.note_id, level, requested_media)
             {
-                let entry = self.history.get(&card.note_id).unwrap_or_default();
-                notes.push(json!({
-                    "scan_level": level,
-                    "source_position": card.position,
-                    "skipped": {"reason": "already_analyzed", "history": entry},
-                    "entity": &card,
-                }));
-                ctx.mark_processed_note(&card.note_id, level, requested_media);
-                continue;
+                let cached = self
+                    .history
+                    .cached_result(&card.note_id, level, requested_media)
+                    .filter(|cached| {
+                        topic_scan_cached_entity_is_complete(&cached.entity, level, comment_count)
+                    });
+                if let Some(cached) = cached {
+                    let history_entry = self.history.get(&card.note_id).unwrap_or_default();
+                    let history = history_summary(&history_entry);
+                    let cache_key = cached.cache_key;
+                    let analyzed_at = cached.analyzed_at;
+                    notes.push(json!({
+                        "scan_level": level,
+                        "source_position": card.position,
+                        "ok": true,
+                        "status": "skipped",
+                        "skip_reason": "already_analyzed",
+                        "note_id": &card.note_id,
+                        "cached_result_returned": true,
+                        "cache_key": &cache_key,
+                        "analyzed_at": &analyzed_at,
+                        "history": history.clone(),
+                        "skipped": {
+                            "reason": "already_analyzed",
+                            "history": history,
+                            "cached_result_returned": true,
+                            "cache_key": cache_key,
+                            "analyzed_at": analyzed_at,
+                        },
+                        "entity": cached.entity,
+                    }));
+                    ctx.mark_processed_note(&card.note_id, level, requested_media);
+                    continue;
+                }
+                // Metadata-only history (or deep topic-scan cache without
+                // comments) cannot satisfy downstream evidence needs. Re-read
+                // once so the returned note and future cache are deep.
             }
             let read_result = xhs
                 .read_note_with_options(
@@ -1329,6 +1435,7 @@ impl Tool for TopicScanTool {
                 "comments_per_note": TOPIC_SCAN_COMMENTS,
                 "include_media": include_media,
                 "download_media": download_media,
+                "force_reread": force_reread_requested,
             },
             "timing": {
                 "media": media_timing,
@@ -1418,5 +1525,39 @@ mod tests {
 
         assert!(options.include_media);
         assert!(!options.download_media);
+    }
+
+    #[test]
+    fn force_reread_uses_single_flag() {
+        assert!(force_reread(&json!({"force_reread": true})));
+        assert!(!force_reread(&json!({"no_cache": true})));
+    }
+
+    #[test]
+    fn topic_scan_input_includes_only_force_reread_cache_flag() {
+        let input = topic_scan_input("攀岩", None, None, Some(2), false, true).unwrap();
+
+        assert_eq!(input["force_reread"], json!(true));
+        assert!(input.get("include_cached_results").is_none());
+        assert!(input.get("no_cache").is_none());
+    }
+
+    #[test]
+    fn topic_scan_cached_entity_requires_comments_for_deep_cache() {
+        assert!(topic_scan_cached_entity_is_complete(
+            &json!({"top_comments": []}),
+            "deep",
+            12,
+        ));
+        assert!(!topic_scan_cached_entity_is_complete(
+            &json!({"content": "cached without comments"}),
+            "deep",
+            12,
+        ));
+        assert!(topic_scan_cached_entity_is_complete(
+            &json!({"content": "lite cache"}),
+            "lite",
+            12,
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Return cached deep note evidence by default when `topic_scan` skips an already-analyzed note.
- Add one cache-control flag only: `--force-reread` / `force_reread`, which bypasses already-analyzed history and reopens/reanalyzes notes.
- Persist sanitized cached note entities in XHS history so repeated scans can return note bodies/comments instead of only card metadata.
- Re-read metadata-only or incomplete old history once so the returned scan and future cache are evidence-complete.
- Update CLI, daemon, Tauri command plumbing, tool schemas, README, and XHS agent knowledge docs.

Closes #108.

## Public flag behavior
Only one user-facing cache flag is supported:

```bash
socai topic_scan "攀岩训练" --num-notes 5 --force-reread
```

There is no `--include-cached-results` flag and no `--no-cache` alias. Cached results are returned by default when available; `--force-reread` is only for deliberately bypassing history.


## Terminology: `already_analyzed` vs same-scan duplicates

In this PR, `already_analyzed` means the note is covered by persisted XHS history from an earlier successful analysis. That history lives in `~/.socai/xhs/history.json` (or `$SOCAI_HOME/xhs/history.json`) and can come from a previous `topic_scan`, `read_note`, or `extract_note` call. It is not meant to describe a duplicate card inside the same `topic_scan` loop.

Same-run/same-scan duplication is handled separately:

- `topic_scan` keeps a local `seen` set keyed by `note_id` / link / position, so duplicate search cards in one scan are normally not selected twice.
- `ToolContext::processed_notes` catches notes already processed earlier in the same agent run and labels them `skip_reason: "already_processed"`, not `already_analyzed`.

So the main repeat-scan scenario is: run `topic_scan` once, then run another `topic_scan` later that finds the same note. The second run can now return the cached deep `entity` instead of only the shallow search card.

## When do we re-read the same note?

A note is re-opened/re-analyzed in these cases:

1. `--force-reread` / `force_reread: true` is set. This deliberately bypasses persisted history and in-run processed-note skips.
2. Persisted history says the note was analyzed, but it came from an older socai version and has no cached entity. We re-read once to return deep evidence now and populate `cached_results` for future runs.
3. `topic_scan` needs deep topic-scan evidence, but the cached entity is incomplete for this macro (for example it lacks `top_comments`). We re-read once so `data.notes[].entity` has body + top comments.
4. `download_media` is true. Media downloads are never cache-skipped because the caller expects fresh `local_path` files under the current command `run_dir`.
5. The request asks for a higher level or media coverage than history can satisfy (for example previous `lite`, current `deep`; or previous no-media, current `include_media`).

Normal duplicate cards within a single `topic_scan` should not cause a second read of the same note; they are deduped or marked `already_processed`.

## JSON before / after

### 1. `topic_scan` skipped note entry: `data.notes[]`

Before this PR, an already-analyzed note in `topic_scan` returned skip metadata plus only the shallow search card in `entity`:

```json
{
  "scan_level": "deep",
  "source_position": 2,
  "skipped": {
    "reason": "already_analyzed",
    "history": {
      "note_id": "abc123",
      "title": "...",
      "author": "...",
      "url": "...",
      "level": "deep",
      "include_media": false,
      "analysis_count": 1,
      "first_seen_at": "...",
      "last_seen_at": "..."
    }
  },
  "entity": {
    "note_id": "abc123",
    "title": "...",
    "author": "...",
    "likes": "...",
    "link": "...",
    "cover_url": "...",
    "type": "normal",
    "position": 2,
    "xsec_token": "..."
  }
}
```

After this PR, when a cached deep result exists, the same `data.notes[]` entry includes explicit skipped fields and `entity` is the cached deep note result, including body fields and `top_comments`:

```json
{
  "scan_level": "deep",
  "source_position": 2,
  "ok": true,
  "status": "skipped",
  "skip_reason": "already_analyzed",
  "note_id": "abc123",
  "cached_result_returned": true,
  "cache_key": "xhs:note:abc123:level=deep:include_media=false",
  "analyzed_at": "2026-06-12T00:00:00Z",
  "history": {
    "note_id": "abc123",
    "title": "...",
    "author": "...",
    "url": "...",
    "level": "deep",
    "include_media": false,
    "analysis_count": 1,
    "first_seen_at": "...",
    "last_seen_at": "..."
  },
  "skipped": {
    "reason": "already_analyzed",
    "history": { "note_id": "abc123", "level": "deep" },
    "cached_result_returned": true,
    "cache_key": "xhs:note:abc123:level=deep:include_media=false",
    "analyzed_at": "2026-06-12T00:00:00Z"
  },
  "entity": {
    "note_id": "abc123",
    "url": "https://www.xiaohongshu.com/explore/abc123?...",
    "type": "normal",
    "title": "...",
    "author": "...",
    "content": "full note body...",
    "hashtags": ["..."],
    "date": "...",
    "location": "...",
    "likes": "...",
    "favorites": "...",
    "comments_count": "...",
    "images": [{ "url": "..." }],
    "video": {},
    "extraction_level": "deep",
    "top_comments": [{ "author": "...", "content": "..." }],
    "top_comments_wait": { "ready": true, "reason": "..." }
  }
}
```

If history says the note was analyzed but the history row is from an older socai version and has no cached entity (or the cached topic-scan entity is missing `top_comments`), `topic_scan` no longer returns a shallow skipped card. It falls through to re-open the note and returns the normal fresh-read shape:

```json
{
  "scan_level": "deep",
  "source_position": 2,
  "ok": true,
  "entity": {
    "note_id": "abc123",
    "content": "full note body...",
    "top_comments": [{ "content": "..." }]
  }
}
```

### 2. `topic_scan` top-level sampling object: `data.sampling`

Before:

```json
{
  "num_notes": 5,
  "selected": 5,
  "comments_per_note": 12,
  "include_media": false,
  "download_media": false
}
```

After:

```json
{
  "num_notes": 5,
  "selected": 5,
  "comments_per_note": 12,
  "include_media": false,
  "download_media": false,
  "force_reread": false
}
```

When `--force-reread` is passed, `force_reread` is `true` and history skipping is bypassed.

### 3. `read_note` skipped JSON

Before, `read_note` history skips returned only skip metadata/history:

```json
{
  "ok": true,
  "skipped": true,
  "reason": "already_analyzed",
  "note_id": "abc123",
  "requested_level": "lite",
  "requested_include_media": false,
  "requested_download_media": false,
  "history": { "note_id": "abc123", "level": "lite" }
}
```

After, if a cached entity exists, it returns explicit skip fields plus the cached entity:

```json
{
  "ok": true,
  "status": "skipped",
  "skip_reason": "already_analyzed",
  "skipped": true,
  "reason": "already_analyzed",
  "note_id": "abc123",
  "requested_level": "lite",
  "requested_include_media": false,
  "requested_download_media": false,
  "cached_result_returned": true,
  "cache_key": "xhs:note:abc123:level=lite:include_media=false",
  "analyzed_at": "2026-06-12T00:00:00Z",
  "history": { "note_id": "abc123", "level": "lite" },
  "entity": { "note_id": "abc123", "content": "cached note body..." }
}
```

### 4. History file: `~/.socai/xhs/history.json`

Before, each history row only stored summary metadata:

```json
{
  "notes": {
    "abc123": {
      "note_id": "abc123",
      "title": "...",
      "author": "...",
      "url": "...",
      "level": "deep",
      "include_media": false,
      "analysis_count": 1,
      "first_seen_at": "...",
      "last_seen_at": "..."
    }
  }
}
```

After, successful reads add `cached_results` keyed by read level/media:

```json
{
  "notes": {
    "abc123": {
      "note_id": "abc123",
      "title": "...",
      "author": "...",
      "url": "...",
      "level": "deep",
      "include_media": false,
      "analysis_count": 1,
      "first_seen_at": "...",
      "last_seen_at": "...",
      "cached_results": {
        "xhs:note:abc123:level=deep:include_media=false": {
          "cache_key": "xhs:note:abc123:level=deep:include_media=false",
          "level": "deep",
          "include_media": false,
          "analyzed_at": "2026-06-12T00:00:00Z",
          "entity": {
            "note_id": "abc123",
            "content": "full note body...",
            "top_comments": [{ "content": "..." }]
          }
        }
      }
    }
  }
}
```

Artifact-local fields such as `local_path`, `poster_local_path`, and `frame_paths` are stripped before caching so old run directories are not leaked into future output.

## Tests / validation
- `git diff --check`
- `cargo test -p socai-core -p socai-cli -p socai_app`
- `cargo run -p socai-cli -- topic_scan --help`

## Notes
- Independent reviewer subagent found no blockers before this follow-up.
- `cargo fmt --check` currently reports unrelated formatting diffs in unchanged files.


