### PR TITLE
Use runs.dir config for topic_scan artifacts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,10 @@ pnpm exec tauri build --bundles app   # → target/release/bundle/macos/socai.ap
 ```
 
 `dev:desktop:local` points `SOCAI_HOME` / `SOCAI_RUNS_DIR` at the repo's
-`.socai/` directory, so runs and the task index land alongside the checkout:
+`.socai/` directory, so runs and the task index land alongside the checkout.
+For normal CLI usage, the equivalent persistent run-artifact setting is
+`socai config set runs.dir <path>`; the environment variable remains the highest
+precedence override for local/dev scripts:
 
 ```text
 .socai/app/tasks.json

--- a/README.md
+++ b/README.md
@@ -72,22 +72,34 @@ Options:
 - `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socia会自动往下翻页，获取更多帖子。
 - `--preview` — 只拿帖子概要（标题、封面等等），不逐个打开帖子拿详情。
 - `--download-media` — 打开每篇帖子的时候 (不加`--preview`时): 把图像和视频下载到 `run_dir`
-  (`site_media/`), 并创建列表 `<run_dir>/media_manifest.json`.
+  (`site_media/`), 输出 top-level `run` (`id`, `dir`, `media_dir`), 并创建列表
+  `<run_dir>/media_manifest.json`.
 - `--pretty` — 输出JSON按换行格式.
 - `--debug-snapshot` — 把网页 DOM + a11y tree + screenshots 写入文件，用于开发调试
-
 
 **新增了抖音支持**：
 ```bash
 socai dy search "咖啡" --num 30         # 搜索关键词并拿n条视频的信息
 ```
 
+### 配置 (`socai config`)
 
-### 控制浏览器profile:
+Config lives in `~/.socai/config.json`. 常用配置项：
 
-- `chrome.profile` values: `existing`, `managed`, `auto`.
-- Default: `existing` — attach to your existing browser/profile with CDP enabled.
-- To opt into socai's isolated profile persistently:
+- `runs.dir` — generated run/artifact root. By default, runs are written under
+  `~/.socai/runs/<timestamp>_<slug>/`. Set it when another system needs to own
+  or clean up socai artifacts:
+
+  ```bash
+  socai config set runs.dir "$(pwd)/.data/beta-agent/runs"
+  ```
+
+  Relative paths passed to `socai config set runs.dir` are stored as absolute
+  paths from the current directory. `SOCAI_RUNS_DIR` still takes precedence when
+  set.
+- `chrome.profile` — browser profile mode: `existing`, `managed`, or `auto`.
+  Default is `existing`, which attaches to your existing browser/profile with
+  CDP enabled. To opt into socai's isolated profile persistently:
 
   ```bash
   socai config set chrome.profile managed # 以后默认使用 socai 独立 chrome 资料目录
@@ -96,20 +108,19 @@ socai dy search "咖啡" --num 30         # 搜索关键词并拿n条视频的�
 
   The default managed profile path is `~/.socai/chrome-profile`; sign in to
   xiaohongshu once there and future sessions reuse that login/cookies.
-- To use a custom managed profile directory:
+- `chrome.profile_dir` — custom managed chrome user-data-dir:
 
   ```bash
   socai config set chrome.profile_dir ~/.socai/profiles/xhs-test
   ```
 
-- To switch back to your existing browser profile:
+To switch back to your existing browser profile:
 
-  ```bash
-  socai config set chrome.profile existing
-  ```
+```bash
+socai config set chrome.profile existing
+```
 
-- Config lives in `~/.socai/config.json`. Advanced endpoint overrides still use
-  `SOCAI_CDP_WS` / `SOCAI_CDP_URL`.
+Advanced endpoint overrides still use `SOCAI_CDP_WS` / `SOCAI_CDP_URL`.
 
 ## 2. TUI
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,7 +45,7 @@ fn build_cli() -> clap::Command {
                 .subcommand(
                     clap::Command::new("get")
                         .about("Print the full config, or a single config key.")
-                        .arg(Arg::new("key").help("Key to read, e.g. chrome.profile.")),
+                        .arg(Arg::new("key").help("Key to read, e.g. runs.dir or chrome.profile.")),
                 )
                 .subcommand(clap::Command::new("list").about("Print the full config as JSON."))
                 .subcommand(
@@ -54,7 +54,7 @@ fn build_cli() -> clap::Command {
                         .arg(
                             Arg::new("key")
                                 .required(true)
-                                .help("Key to set, e.g. chrome.profile."),
+                                .help("Key to set, e.g. runs.dir or chrome.profile."),
                         )
                         .arg(Arg::new("value").required(true).help("Value to store.")),
                 )
@@ -64,7 +64,7 @@ fn build_cli() -> clap::Command {
                         .arg(
                             Arg::new("key")
                                 .required(true)
-                                .help("Key to remove, e.g. chrome.profile."),
+                                .help("Key to remove, e.g. runs.dir or chrome.profile."),
                         ),
                 ),
         )

--- a/core/src/agent/run_logging.rs
+++ b/core/src/agent/run_logging.rs
@@ -11,7 +11,10 @@
 // args match the persisted debug payload directly.
 #![allow(clippy::too_many_arguments)]
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use chrono::Local;
 use serde_json::{json, Map, Value};
@@ -44,11 +47,44 @@ fn safe_slug(text: &str, max_chars: usize) -> String {
     final_slug.chars().take(max_chars).collect()
 }
 
+/// Root for generated run directories. Precedence: `SOCAI_RUNS_DIR`, then
+/// `socai config set runs.dir <path>`, then `~/.socai/runs`.
 pub fn default_runs_root() -> PathBuf {
-    if let Ok(env) = std::env::var("SOCAI_RUNS_DIR") {
-        return PathBuf::from(env);
+    if let Some(root) = env_runs_root(std::env::var_os("SOCAI_RUNS_DIR")) {
+        return root;
     }
-    if let Some(home) = dirs::home_dir() {
+    let config_root = match crate::config::load_config() {
+        Ok(config) => config.runs_root(),
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to load socai config for runs.dir; using default runs root");
+            None
+        }
+    };
+    default_runs_root_from_parts(None, config_root, dirs::home_dir())
+}
+
+fn env_runs_root(value: Option<OsString>) -> Option<PathBuf> {
+    let value = value?;
+    let trimmed = value.to_string_lossy().trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+fn default_runs_root_from_parts(
+    env_root: Option<OsString>,
+    config_root: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(root) = env_runs_root(env_root) {
+        return root;
+    }
+    if let Some(root) = config_root {
+        return root;
+    }
+    if let Some(home) = home {
         return home.join(".socai/runs");
     }
     PathBuf::from(".socai/runs")
@@ -59,9 +95,13 @@ pub fn default_runs_root() -> PathBuf {
 /// exists. The timestamp is local time, matching the per-frame snapshot
 /// folder names.
 pub fn make_run_dir(task: &str) -> PathBuf {
+    make_run_dir_in_root(default_runs_root(), task)
+}
+
+fn make_run_dir_in_root(root: impl AsRef<Path>, task: &str) -> PathBuf {
     let ts = Local::now().format("%Y%m%d_%H%M%S").to_string();
     let slug = safe_slug(task, 48);
-    let base = default_runs_root().join(format!("{ts}_{slug}"));
+    let base = root.as_ref().join(format!("{ts}_{slug}"));
     if !base.exists() {
         return base;
     }
@@ -273,5 +313,53 @@ mod tests {
         let v = json!({"type": "image", "source": {"data": "aGVsbG8="}});
         let safe = json_safe_for_log(&v, 1000);
         assert_eq!(safe.get("omitted"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn default_runs_root_uses_configured_runs_dir() {
+        let home = PathBuf::from("/tmp/socai-home");
+        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
+
+        assert_eq!(
+            default_runs_root_from_parts(None, Some(configured_runs_dir.clone()), Some(home)),
+            configured_runs_dir
+        );
+        let run_dir = make_run_dir_in_root(&configured_runs_dir, "topic scan");
+        assert!(run_dir.starts_with(&configured_runs_dir));
+        let file_name = run_dir.file_name().and_then(|name| name.to_str()).unwrap();
+        assert!(file_name.ends_with("topic_scan"));
+    }
+
+    #[test]
+    fn default_runs_root_prefers_env_over_configured_runs_dir() {
+        let home = PathBuf::from("/tmp/socai-home");
+        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
+        let env_runs_dir = PathBuf::from("/tmp/socai-env-runs");
+
+        assert_eq!(
+            default_runs_root_from_parts(
+                Some(OsString::from(env_runs_dir.to_string_lossy().to_string())),
+                Some(configured_runs_dir),
+                Some(home),
+            ),
+            env_runs_dir
+        );
+        let run_dir = make_run_dir_in_root(&env_runs_dir, "topic scan");
+        assert!(run_dir.starts_with(&env_runs_dir));
+    }
+
+    #[test]
+    fn default_runs_root_ignores_empty_env_override() {
+        let home = PathBuf::from("/tmp/socai-home");
+        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
+
+        assert_eq!(
+            default_runs_root_from_parts(
+                Some(OsString::from("  \t  ")),
+                Some(configured_runs_dir.clone()),
+                Some(home),
+            ),
+            configured_runs_dir
+        );
     }
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -11,6 +11,8 @@ use crate::cdp::{ChromeConnectOptions, ChromeProfile};
 pub struct SocaiConfig {
     #[serde(default)]
     pub chrome: ChromeConfig,
+    #[serde(default)]
+    pub runs: RunsConfig,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -23,6 +25,15 @@ pub struct ChromeConfig {
     /// `managed` or `auto`.
     #[serde(default)]
     pub profile_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunsConfig {
+    /// Root directory where socai creates per-run artifact directories. Missing
+    /// means the product default: `~/.socai/runs` (or `SOCAI_RUNS_DIR` when the
+    /// environment override is set).
+    #[serde(default)]
+    pub dir: Option<String>,
 }
 
 impl SocaiConfig {
@@ -43,12 +54,22 @@ impl SocaiConfig {
             managed_user_data_dir,
         }
     }
+
+    pub fn runs_root(&self) -> Option<PathBuf> {
+        self.runs
+            .dir
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_tilde_path)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 enum ConfigKey {
     ChromeProfile,
     ChromeProfileDir,
+    RunsDir,
 }
 
 impl ConfigKey {
@@ -56,8 +77,10 @@ impl ConfigKey {
         match key.trim() {
             "chrome.profile" => Ok(Self::ChromeProfile),
             "chrome.profile_dir" | "chrome.profile-dir" => Ok(Self::ChromeProfileDir),
+            "runs.dir" | "runs_dir" | "runs-dir" | "output.dir" | "output_dir"
+            | "output-dir" => Ok(Self::RunsDir),
             other => anyhow::bail!(
-                "unknown config key {other:?}; supported keys: chrome.profile, chrome.profile_dir"
+                "unknown config key {other:?}; supported keys: chrome.profile, chrome.profile_dir, runs.dir"
             ),
         }
     }
@@ -66,6 +89,7 @@ impl ConfigKey {
         match self {
             Self::ChromeProfile => &["chrome", "profile"],
             Self::ChromeProfileDir => &["chrome", "profile_dir"],
+            Self::RunsDir => &["runs", "dir"],
         }
     }
 
@@ -73,6 +97,7 @@ impl ConfigKey {
         match self {
             Self::ChromeProfile => "chrome.profile",
             Self::ChromeProfileDir => "chrome.profile_dir",
+            Self::RunsDir => "runs.dir",
         }
     }
 }
@@ -156,6 +181,7 @@ fn parse_key_value(key: ConfigKey, raw_value: &str) -> Result<Value> {
     match key {
         ConfigKey::ChromeProfile => Ok(Value::String(ChromeProfile::parse(value)?.as_str().into())),
         ConfigKey::ChromeProfileDir => Ok(Value::String(value.to_string())),
+        ConfigKey::RunsDir => Ok(Value::String(normalized_path_value(value)?)),
     }
 }
 
@@ -217,6 +243,16 @@ fn prune_empty_objects(value: &mut Value) -> bool {
     object.is_empty()
 }
 
+fn normalized_path_value(value: &str) -> Result<String> {
+    let path = expand_tilde_path(value);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    Ok(path.to_string_lossy().to_string())
+}
+
 fn expand_tilde_path(value: &str) -> PathBuf {
     if value == "~" {
         if let Some(home) = dirs::home_dir() {
@@ -264,5 +300,21 @@ mod tests {
     fn parse_chrome_profile_config_is_strict() {
         assert!(parse_key_value(ConfigKey::ChromeProfile, "managed").is_ok());
         assert!(parse_key_value(ConfigKey::ChromeProfile, "isolated").is_err());
+    }
+
+    #[test]
+    fn runs_root_uses_configured_dir() {
+        let mut config = SocaiConfig::default();
+        config.runs.dir = Some("/tmp/socai-runs".into());
+        assert_eq!(config.runs_root(), Some(PathBuf::from("/tmp/socai-runs")));
+    }
+
+    #[test]
+    fn runs_dir_config_accepts_output_dir_alias_and_normalizes_relative_path() {
+        let parsed = parse_key_value(ConfigKey::RunsDir, "relative-runs").unwrap();
+        let value = parsed.as_str().expect("runs dir string");
+        assert!(PathBuf::from(value).is_absolute());
+        assert!(value.ends_with("relative-runs"));
+        assert_eq!(canonical_config_key("output-dir").unwrap(), "runs.dir");
     }
 }

--- a/core/src/sites/dy/tools.rs
+++ b/core/src/sites/dy/tools.rs
@@ -116,6 +116,7 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
                 tool_name: "search",
                 before: None,
                 after: None,
+                include_run_metadata: false,
             },
             page.clone(),
             &dy_tools(page),
@@ -143,6 +144,7 @@ fn run_page_state(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> 
                     })
                 })),
                 after: None,
+                include_run_metadata: false,
             },
             page.clone(),
             &dy_tools(page),

--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -7,7 +7,7 @@
 //! modules supply only the tool set and optional page-state hooks — do not
 //! copy this scaffolding into a site folder.
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use serde_json::{json, Value};
 
@@ -28,6 +28,10 @@ pub struct ToolCommand<'a> {
     pub tool_name: &'a str,
     pub before: Option<PageHook>,
     pub after: Option<PageHook>,
+    /// Include run metadata in the command envelope and data payload. Keep this
+    /// opt-in so existing command stdout shapes stay stable unless a command
+    /// explicitly promises run metadata.
+    pub include_run_metadata: bool,
 }
 
 pub async fn run_tool_command(
@@ -76,12 +80,19 @@ pub async fn run_tool_command(
     })
     .await?;
 
-    Ok(json!({
+    let mut response = json!({
         "command": cmd.command_name,
         "run_dir": run_dir,
         "input": invocation.get("input").cloned().unwrap_or(Value::Null),
         "data": data,
-    }))
+    });
+    if cmd.include_run_metadata {
+        let run = run_metadata(&ctx, input_downloads_media(&invocation["input"]));
+        response["run"] = run.clone();
+        response["data"] = attach_run_metadata(response["data"].take(), &run);
+    }
+
+    Ok(response)
 }
 
 /// Invoke one tool by name and parse its text reply as JSON (falling back to
@@ -106,6 +117,35 @@ pub async fn call_site_tool(
 /// run-dir name (`<ts>_<site>_<command>[_<query>]`).
 pub fn command_context(site_id: &str, label: &str) -> (String, ToolContext) {
     command_context_for_label(site_id, &format!("{site_id}_{label}"))
+}
+
+pub fn run_metadata(ctx: &ToolContext, include_media_dir: bool) -> Value {
+    let mut run = json!({
+        "id": ctx.run_id.clone(),
+        "dir": path_string(&ctx.run_dir),
+    });
+    if include_media_dir {
+        run["media_dir"] = json!(path_string(&ctx.run_dir.join("site_media")));
+    }
+    run
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
+fn input_downloads_media(input: &Value) -> bool {
+    input
+        .get("download_media")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub(crate) fn attach_run_metadata(mut data: Value, run: &Value) -> Value {
+    if let Some(map) = data.as_object_mut() {
+        map.entry("run").or_insert_with(|| run.clone());
+    }
+    data
 }
 
 fn command_context_for_label(site_id: &str, label: &str) -> (String, ToolContext) {

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -17,7 +17,7 @@ use crate::sites::registry::{
     required_string, ArgKind, BoxFuture, CommandArg, SiteCommand, SiteSpec, SlowWhen,
 };
 use crate::sites::runner::{
-    get_bool, get_f64, get_i64, get_str, json_result, run_tool_command,
+    get_bool, get_f64, get_i64, get_str, json_result, run_metadata, run_tool_command,
     trimmed_required, PageHook, ToolCommand,
 };
 use crate::sites::xhs::media_manifest::{
@@ -316,7 +316,10 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
-        let preview = args.get("preview").and_then(Value::as_bool).unwrap_or(false);
+        let preview = args
+            .get("preview")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         if preview {
             // Cards only — download_media doesn't apply to a card-only read.
             search_notes_command(page, &query, filters.as_ref(), num_notes, debug_snapshot).await
@@ -421,7 +424,10 @@ fn run_author_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) ->
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
         // Default reads each note; --preview returns cards only.
-        let preview = args.get("preview").and_then(Value::as_bool).unwrap_or(false);
+        let preview = args
+            .get("preview")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let download_media = args
             .get("download_media")
             .and_then(Value::as_bool)
@@ -451,6 +457,7 @@ struct XhsCommandSpec {
     tool_name: &'static str,
     before: CommandPageAction,
     after: CommandPageAction,
+    include_run_metadata: bool,
 }
 
 const SEARCH_NOTES_COMMAND: XhsCommandSpec = XhsCommandSpec {
@@ -458,6 +465,7 @@ const SEARCH_NOTES_COMMAND: XhsCommandSpec = XhsCommandSpec {
     tool_name: "search_notes",
     before: CommandPageAction::SearchReady,
     after: CommandPageAction::None,
+    include_run_metadata: false,
 };
 
 const TOPIC_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
@@ -465,6 +473,7 @@ const TOPIC_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
     tool_name: "topic_scan",
     before: CommandPageAction::SearchReady,
     after: CommandPageAction::None,
+    include_run_metadata: true,
 };
 
 const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
@@ -474,6 +483,7 @@ const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
     // note modal is left open before/after.
     before: CommandPageAction::CloseOpenNote,
     after: CommandPageAction::CloseOpenNote,
+    include_run_metadata: false,
 };
 
 pub async fn search_notes_command(
@@ -600,6 +610,7 @@ async fn run_xhs_tool_command(
             tool_name: spec.tool_name,
             before: page_action_hook(spec.before),
             after: page_action_hook(spec.after),
+            include_run_metadata: spec.include_run_metadata,
         },
         page,
         &tools,
@@ -1643,6 +1654,7 @@ impl Tool for TopicScanTool {
         let mut payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
             "query": query,
+            "run": run_metadata(ctx, download_media),
             "filters": filter_result,
             "search": search,
             "selected_cards": selected_cards,
@@ -1978,5 +1990,32 @@ mod tests {
 
         assert!(options.include_media);
         assert!(!options.download_media);
+    }
+
+    #[test]
+    fn run_metadata_includes_media_dir_only_when_requested() {
+        let ctx = ToolContext::new("run-1", "/tmp/socai-run");
+
+        let without_media = run_metadata(&ctx, false);
+        assert_eq!(without_media["id"], json!("run-1"));
+        assert_eq!(without_media["dir"], json!("/tmp/socai-run"));
+        assert!(without_media.get("media_dir").is_none());
+
+        let with_media = run_metadata(&ctx, true);
+        assert_eq!(with_media["media_dir"], json!("/tmp/socai-run/site_media"));
+    }
+
+    #[test]
+    fn attach_run_metadata_preserves_existing_run_object() {
+        let run = json!({"id": "outer", "dir": "/tmp/outer"});
+        let data = crate::sites::runner::attach_run_metadata(json!({"run": {"id": "inner"}}), &run);
+        assert_eq!(data["run"]["id"], json!("inner"));
+    }
+
+    #[test]
+    fn standalone_run_metadata_is_topic_scan_only() {
+        assert!(!SEARCH_NOTES_COMMAND.include_run_metadata);
+        assert!(TOPIC_SCAN_COMMAND.include_run_metadata);
+        assert!(!AUTHOR_SCAN_COMMAND.include_run_metadata);
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -6,7 +6,8 @@ history replay.
 
 ## Guiding rule
 
-`~/.socai/runs/...` is the source of truth for task results.
+`~/.socai/runs/...` (or the root configured by `runs.dir` / `SOCAI_RUNS_DIR`)
+is the source of truth for task results.
 
 The desktop app may keep an index in `~/.socai/app/tasks.json`, but it should not
 persist duplicate task result payloads such as final answers or event timelines.
@@ -16,7 +17,7 @@ The app can hydrate those fields from the run directory when serving the UI.
 
 | Data | Default path | Override | Owner |
 | --- | --- | --- | --- |
-| Core run artifacts | `~/.socai/runs/agent_<timestamp>_<task-slug>/` | `SOCAI_RUNS_DIR` | `socai-core` |
+| Core run artifacts | `~/.socai/runs/<timestamp>_<task-slug>/` | `SOCAI_RUNS_DIR`, else `socai config set runs.dir <path>` | `socai-core` |
 | Desktop task index | `~/.socai/app/tasks.json` | `SOCAI_HOME` (`$SOCAI_HOME/app/tasks.json`) | Tauri app |
 
 Do not add a second persistent task-result store under `~/.socai/app/`. If the
@@ -57,7 +58,7 @@ Created before starting the core run and passed into `socai-core`.
 Example:
 
 ```txt
-~/.socai/runs/agent_20260518_142233_find_xhs_coffee_notes
+~/.socai/runs/20260518_142233_find_xhs_coffee_notes
 ```
 
 This directory is the source of truth for final answer and timeline replay.
@@ -115,7 +116,7 @@ snapshots with fields like:
   "started_at": 1790000000200,
   "finished_at": 1790000060000,
   "run_id": "20260518-142233-123456",
-  "run_dir": "/Users/alice/.socai/runs/agent_20260518_142233_find_popular_xhs_coffee_notes",
+  "run_dir": "/Users/alice/.socai/runs/20260518_142233_find_popular_xhs_coffee_notes",
   "target_id": null,
   "error": null,
   "turns": 4,


### PR DESCRIPTION
## Summary
- add persistent `socai config set runs.dir <path>` support for generated run/artifact directories, with `SOCAI_RUNS_DIR` remaining the highest-precedence override
- use the configured runs root for standalone XHS tool run directories, including `topic_scan --download-media` artifacts/media
- include `run` metadata in `topic_scan` JSON (`id`, `dir`, and `media_dir` when media downloads are requested) without widening `search_notes` / `extract_note` stdout shape
- update CLI help and docs for the config-based workflow

Fixes #107

## Validation
- `rustfmt --edition 2021 --check --config skip_children=true core/src/config.rs core/src/sites/xhs/tools.rs core/src/agent/run_logging.rs cli/src/main.rs`
- `cargo test -p socai-core default_runs_root -- --test-threads=1`
- `cargo test -p socai-core standalone_run_metadata_is_topic_scan_only`
- `cargo test`
- `git diff --check`
- temp-`HOME` CLI smoke: `target/debug/socai config set runs.dir relative-runs` + `target/debug/socai config get runs.dir`
