### PR TITLE
fix: scope CDP control to socai tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -107,167 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,11 +123,13 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
 dependencies = [
- "async-std",
  "futures-io",
  "futures-util",
  "log",
+ "native-tls",
  "pin-project-lite",
+ "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -385,19 +226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -580,73 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "chromiumoxide"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
-dependencies = [
- "async-std",
- "async-tungstenite",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "chromiumoxide_cdp",
- "chromiumoxide_types",
- "dunce",
- "fnv",
- "futures",
- "futures-timer",
- "pin-project-lite",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
- "url",
- "which",
- "winreg 0.52.0",
-]
-
-[[package]]
-name = "chromiumoxide_cdp"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
-dependencies = [
- "chromiumoxide_pdl",
- "chromiumoxide_types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chromiumoxide_pdl"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
-dependencies = [
- "chromiumoxide_types",
- "either",
- "heck 0.4.1",
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chromiumoxide_types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,15 +484,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1043,7 +795,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1159,12 +911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +921,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1223,7 +969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1231,33 +977,6 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
 
 [[package]]
 name = "fastrand"
@@ -1272,7 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1439,19 +1158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,12 +1179,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1746,18 +1446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,12 +1559,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2404,15 +2086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,12 +2157,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2514,9 +2181,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "markup5ever"
@@ -2626,7 +2290,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2712,7 +2376,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3061,12 +2725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,23 +2813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,20 +2855,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3613,19 +3240,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3633,8 +3247,8 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3690,7 +3304,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4173,8 +3787,8 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "async-tungstenite",
  "base64 0.22.1",
- "chromiumoxide",
  "chrono",
  "dirs 5.0.1",
  "futures",
@@ -4213,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4324,7 +3938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -4740,10 +4353,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5167,7 +4780,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5188,6 +4801,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha1",
  "thiserror 1.0.69",
@@ -5337,12 +4951,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -5652,18 +5260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5685,7 +5281,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6200,16 +5796,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6217,12 +5803,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -6396,7 +5976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/socai-io/socai"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 futures = "0.3"
-tokio-tungstenite = "0.23"
+async-tungstenite = { version = "0.27", default-features = false, features = ["tokio-native-tls"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -36,8 +36,6 @@ libc = "0.2"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-chromiumoxide = "0.7"
 
 socai-core = { path = "core" }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -201,7 +201,9 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,chromiumoxide=off,hyper=off,reqwest=off".into()),
+                .unwrap_or_else(|_| {
+                    "info,async_tungstenite=off,tungstenite=off,hyper=off,reqwest=off".into()
+                }),
         )
         .init();
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,12 +10,12 @@ serde_json.workspace = true
 async-trait.workspace = true
 tokio = { workspace = true }
 futures.workspace = true
+async-tungstenite.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 reqwest.workspace = true
 base64.workspace = true
-chromiumoxide.workspace = true
 dirs = "5"
 libc.workspace = true
 uuid = { version = "1", features = ["v4"] }

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -1,12 +1,13 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chromiumoxide::Browser;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, Mutex};
 
 use crate::cdp::endpoint::Endpoint;
+use crate::cdp::launch::ChromeProcess;
+use crate::cdp::raw_client::RawCdpClient;
 
 const EVENT_CHANNEL_CAPACITY: usize = 64;
 
@@ -97,16 +98,22 @@ pub enum CdpState {
         attempt: u8,
     },
     Connected {
-        #[allow(dead_code)] // held to tie WS lifetime to the variant
-        browser: Arc<Browser>,
-        /// Abort handle for the spawned WS pump task. On user disconnect we
-        /// must abort it so the underlying WebSocket actually closes — Chrome
-        /// keeps the "controlled by automated software" banner up until every
-        /// CDP client disconnects.
-        handler_task: tokio::task::AbortHandle,
+        /// Remote-debugging endpoint. When Chrome exposes the HTTP debugging
+        /// API, status/tab inventory uses that passive control plane. When it
+        /// only exposes the browser websocket, `browser_client` is used for raw
+        /// `Target.*` commands without chromiumoxide's global auto-init.
         endpoint: Endpoint,
+        browser_client: Option<RawCdpClient>,
         browser_version: String,
         targets: HashMap<String, TargetInfo>,
+        monitor_task: tokio::task::AbortHandle,
+        /// Managed chrome process socai launched, if any. Held here so it is
+        /// killed on drop — disconnect, reconnect, or daemon shutdown all
+        /// replace this state and tear the browser down, mirroring the old
+        /// chromiumoxide `Browser` drop semantics. `None` when we attached to an
+        /// already-running browser (the user's existing profile, or a managed
+        /// profile a prior socai entrypoint launched and we merely reused).
+        chrome_process: Option<ChromeProcess>,
     },
 }
 
@@ -182,6 +189,7 @@ pub enum BrowserEvent {
 pub struct Cdp {
     state: Arc<Mutex<CdpState>>,
     events: broadcast::Sender<BrowserEvent>,
+    owned_targets: Arc<Mutex<HashSet<String>>>,
 }
 
 impl Cdp {
@@ -190,6 +198,7 @@ impl Cdp {
         Self {
             state: Arc::new(Mutex::new(CdpState::initial())),
             events,
+            owned_targets: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -206,6 +215,32 @@ impl Cdp {
             CdpState::Connected { targets, .. } => page_list_from(targets),
             _ => Vec::new(),
         }
+    }
+
+    pub(crate) async fn endpoint(&self) -> anyhow::Result<Endpoint> {
+        match &*self.state.lock().await {
+            CdpState::Connected { endpoint, .. } => Ok(endpoint.clone()),
+            _ => Err(anyhow::anyhow!("CDP not connected")),
+        }
+    }
+
+    pub(crate) async fn browser_client(&self) -> Option<RawCdpClient> {
+        match &*self.state.lock().await {
+            CdpState::Connected { browser_client, .. } => browser_client.clone(),
+            _ => None,
+        }
+    }
+
+    pub(crate) async fn register_owned_target(&self, target_id: impl Into<String>) {
+        self.owned_targets.lock().await.insert(target_id.into());
+    }
+
+    pub(crate) async fn unregister_owned_target(&self, target_id: &str) {
+        self.owned_targets.lock().await.remove(target_id);
+    }
+
+    pub(crate) async fn take_owned_targets(&self) -> Vec<String> {
+        self.owned_targets.lock().await.drain().collect()
     }
 
     /// Block until status transitions to Connected, or surface Disconnected

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -98,12 +98,12 @@ pub enum CdpState {
         attempt: u8,
     },
     Connected {
-        /// Remote-debugging endpoint. When Chrome exposes the HTTP debugging
-        /// API, status/tab inventory uses that passive control plane. When it
-        /// only exposes the browser websocket, `browser_client` is used for raw
-        /// `Target.*` commands without chromiumoxide's global auto-init.
+        /// Remote-debugging endpoint. The endpoint may be discovered through
+        /// HTTP (`/json/version`) or `DevToolsActivePort`, but active target
+        /// inventory/lifecycle always uses `browser_client` and raw `Target.*`
+        /// commands without chromiumoxide's global auto-init.
         endpoint: Endpoint,
-        browser_client: Option<RawCdpClient>,
+        browser_client: RawCdpClient,
         browser_version: String,
         targets: HashMap<String, TargetInfo>,
         monitor_task: tokio::task::AbortHandle,
@@ -217,16 +217,9 @@ impl Cdp {
         }
     }
 
-    pub(crate) async fn endpoint(&self) -> anyhow::Result<Endpoint> {
-        match &*self.state.lock().await {
-            CdpState::Connected { endpoint, .. } => Ok(endpoint.clone()),
-            _ => Err(anyhow::anyhow!("CDP not connected")),
-        }
-    }
-
     pub(crate) async fn browser_client(&self) -> Option<RawCdpClient> {
         match &*self.state.lock().await {
-            CdpState::Connected { browser_client, .. } => browser_client.clone(),
+            CdpState::Connected { browser_client, .. } => Some(browser_client.clone()),
             _ => None,
         }
     }

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -33,6 +34,20 @@ pub struct VersionInfo {
     pub user_agent: Option<String>,
     #[serde(rename = "V8-Version", default)]
     pub v8_version: Option<String>,
+    #[serde(rename = "webSocketDebuggerUrl", default)]
+    pub web_socket_debugger_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DebugTarget {
+    #[serde(rename = "id", default)]
+    pub target_id: String,
+    #[serde(rename = "type", default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub url: String,
     #[serde(rename = "webSocketDebuggerUrl", default)]
     pub web_socket_debugger_url: Option<String>,
 }
@@ -121,6 +136,79 @@ pub async fn wait_for_existing_chrome_endpoint(
     }
 }
 
+pub async fn list_debug_targets(endpoint: &Endpoint) -> anyhow::Result<Vec<DebugTarget>> {
+    let url = endpoint_url(endpoint, "json/list")?;
+    get_json(url.as_str()).await
+}
+
+/// Best-effort fetch of the browser product/revision string via the HTTP debug
+/// API (`/json/version`). Used to populate the connected status when the
+/// endpoint was discovered without a cached version (e.g. `SOCAI_CDP_WS`),
+/// where we would otherwise show "unknown browser". Returns `None` if the HTTP
+/// debug API is unavailable.
+pub async fn fetch_browser_version(endpoint: &Endpoint) -> Option<String> {
+    let url = endpoint_url(endpoint, "json/version").ok()?;
+    let version: VersionInfo = get_json(url.as_str()).await.ok()?;
+    version.browser.or(version.user_agent)
+}
+
+pub async fn create_debug_page(
+    endpoint: &Endpoint,
+    start_url: &str,
+) -> anyhow::Result<DebugTarget> {
+    let mut url = endpoint_url(endpoint, "json/new")?;
+    let start_url = start_url.trim();
+    if !start_url.is_empty() {
+        url.set_query(Some(start_url));
+    }
+    let resp = debug_http_client()?
+        .put(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(resp.json().await?)
+}
+
+pub async fn close_debug_target(endpoint: &Endpoint, target_id: &str) -> anyhow::Result<bool> {
+    let target_id = target_id.trim();
+    if target_id.is_empty() {
+        return Ok(false);
+    }
+    let url = endpoint_url(endpoint, &format!("json/close/{target_id}"))?;
+    debug_http_client()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(true)
+}
+
+pub fn http_base_url(endpoint: &Endpoint) -> anyhow::Result<String> {
+    if let Some(version_url) = endpoint.http_version_url.as_deref() {
+        let mut url = reqwest::Url::parse(version_url)?;
+        url.set_path("");
+        url.set_query(None);
+        url.set_fragment(None);
+        return Ok(url.as_str().trim_end_matches('/').to_string());
+    }
+
+    let mut url = reqwest::Url::parse(&endpoint.browser_ws_url)?;
+    match url.scheme() {
+        "ws" => url
+            .set_scheme("http")
+            .map_err(|_| anyhow::anyhow!("failed to convert ws endpoint to http"))?,
+        "wss" => url
+            .set_scheme("https")
+            .map_err(|_| anyhow::anyhow!("failed to convert wss endpoint to https"))?,
+        "http" | "https" => {}
+        scheme => anyhow::bail!("unsupported CDP endpoint scheme: {scheme}"),
+    }
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
 /// Open the chrome://inspect remote-debugging page in the user's default
 /// chrome for the existing-browser attach flow. Best-effort; failures
 /// are swallowed so setup UX still degrades gracefully to printed instructions.
@@ -169,9 +257,11 @@ pub(crate) async fn endpoint_from_active_port(profile: &Path) -> Option<Endpoint
     let port: u16 = lines.next()?.trim().parse().ok()?;
     let ws_path = lines.next().map(str::trim).unwrap_or("").to_string();
 
-    // Prefer richer info via HTTP /json/version. Fall back to constructing the
-    // ws URL ourselves if the HTTP endpoint refuses but DevToolsActivePort
-    // gave us the path.
+    // Prefer richer info via HTTP /json/version. If the HTTP debugging API is
+    // unavailable (some user Chrome launches expose only the websocket path),
+    // keep the browser websocket fallback. The scoped-CDP runtime can use that
+    // websocket with raw `Target.getTargets`/`Target.createTarget` without
+    // chromiumoxide's global discovery/auto-init behavior.
     let http_url = format!("http://127.0.0.1:{port}");
     let source = format!("active_port:{}", marker.display());
     if let Ok(endpoint) = endpoint_from_http_url(&http_url, &source).await {
@@ -180,9 +270,10 @@ pub(crate) async fn endpoint_from_active_port(profile: &Path) -> Option<Endpoint
     if ws_path.is_empty() {
         return None;
     }
+    let browser_ws_url = format!("ws://127.0.0.1:{port}{ws_path}");
     Some(Endpoint {
         source,
-        browser_ws_url: format!("ws://127.0.0.1:{port}{ws_path}"),
+        browser_ws_url,
         http_version_url: None,
         version: None,
         managed: false,
@@ -275,13 +366,38 @@ fn shellexpand(s: &str) -> String {
     s.to_string()
 }
 
+fn endpoint_url(endpoint: &Endpoint, path: &str) -> anyhow::Result<reqwest::Url> {
+    let mut url = reqwest::Url::parse(&http_base_url(endpoint)?)?;
+    url.set_path(path.trim_start_matches('/'));
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
 async fn get_json<T: for<'de> serde::Deserialize<'de>>(url: &str) -> anyhow::Result<T> {
-    let resp = reqwest::Client::builder()
-        .timeout(HTTP_TIMEOUT)
-        .build()?
+    let resp = debug_http_client()?
         .get(url)
         .send()
         .await?
         .error_for_status()?;
     Ok(resp.json().await?)
+}
+
+fn debug_http_client() -> anyhow::Result<reqwest::Client> {
+    // Built once and cloned thereafter (clone is a cheap Arc bump that shares the
+    // connection pool). The connected-state poller calls this every ~2s, so
+    // rebuilding the client + pool each time would be needless CPU/latency.
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    if let Some(client) = CLIENT.get() {
+        return Ok(client.clone());
+    }
+    let client = reqwest::Client::builder()
+        // Chrome's remote-debugging HTTP API is always a local control plane
+        // endpoint (`127.0.0.1:<port>`). Do not honor HTTP(S)_PROXY / ALL_PROXY
+        // here: proxy tools such as Clash can otherwise intercept `/json/list`
+        // and return 502 even though Chrome is healthy.
+        .no_proxy()
+        .timeout(HTTP_TIMEOUT)
+        .build()?;
+    Ok(CLIENT.get_or_init(|| client).clone())
 }

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -38,20 +38,6 @@ pub struct VersionInfo {
     pub web_socket_debugger_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct DebugTarget {
-    #[serde(rename = "id", default)]
-    pub target_id: String,
-    #[serde(rename = "type", default)]
-    pub r#type: String,
-    #[serde(default)]
-    pub title: String,
-    #[serde(default)]
-    pub url: String,
-    #[serde(rename = "webSocketDebuggerUrl", default)]
-    pub web_socket_debugger_url: Option<String>,
-}
-
 /// Resolve only explicitly supplied endpoints (args + env vars). Returns None
 /// when nothing explicit was set; the caller decides whether to fall back to
 /// profile-scan discovery.
@@ -88,8 +74,9 @@ pub async fn resolve_explicit_endpoint(
     Ok(None)
 }
 
-/// One-shot discovery: explicit endpoints first, then `DevToolsActivePort` /
-/// `/json/version` probes on the standard Chrome profile roots and ports.
+/// One-shot discovery: explicit endpoints first, then `DevToolsActivePort`
+/// browser websocket markers, then `/json/version` probes on standard debug
+/// ports when no websocket marker is available.
 pub async fn discover_existing_chrome_endpoint() -> anyhow::Result<Option<Endpoint>> {
     if let Some(endpoint) = resolve_explicit_endpoint(None, None).await? {
         return Ok(Some(endpoint));
@@ -134,79 +121,6 @@ pub async fn wait_for_existing_chrome_endpoint(
         }
         tokio::time::sleep(step).await;
     }
-}
-
-pub async fn list_debug_targets(endpoint: &Endpoint) -> anyhow::Result<Vec<DebugTarget>> {
-    let url = endpoint_url(endpoint, "json/list")?;
-    get_json(url.as_str()).await
-}
-
-/// Best-effort fetch of the browser product/revision string via the HTTP debug
-/// API (`/json/version`). Used to populate the connected status when the
-/// endpoint was discovered without a cached version (e.g. `SOCAI_CDP_WS`),
-/// where we would otherwise show "unknown browser". Returns `None` if the HTTP
-/// debug API is unavailable.
-pub async fn fetch_browser_version(endpoint: &Endpoint) -> Option<String> {
-    let url = endpoint_url(endpoint, "json/version").ok()?;
-    let version: VersionInfo = get_json(url.as_str()).await.ok()?;
-    version.browser.or(version.user_agent)
-}
-
-pub async fn create_debug_page(
-    endpoint: &Endpoint,
-    start_url: &str,
-) -> anyhow::Result<DebugTarget> {
-    let mut url = endpoint_url(endpoint, "json/new")?;
-    let start_url = start_url.trim();
-    if !start_url.is_empty() {
-        url.set_query(Some(start_url));
-    }
-    let resp = debug_http_client()?
-        .put(url)
-        .send()
-        .await?
-        .error_for_status()?;
-    Ok(resp.json().await?)
-}
-
-pub async fn close_debug_target(endpoint: &Endpoint, target_id: &str) -> anyhow::Result<bool> {
-    let target_id = target_id.trim();
-    if target_id.is_empty() {
-        return Ok(false);
-    }
-    let url = endpoint_url(endpoint, &format!("json/close/{target_id}"))?;
-    debug_http_client()?
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?;
-    Ok(true)
-}
-
-pub fn http_base_url(endpoint: &Endpoint) -> anyhow::Result<String> {
-    if let Some(version_url) = endpoint.http_version_url.as_deref() {
-        let mut url = reqwest::Url::parse(version_url)?;
-        url.set_path("");
-        url.set_query(None);
-        url.set_fragment(None);
-        return Ok(url.as_str().trim_end_matches('/').to_string());
-    }
-
-    let mut url = reqwest::Url::parse(&endpoint.browser_ws_url)?;
-    match url.scheme() {
-        "ws" => url
-            .set_scheme("http")
-            .map_err(|_| anyhow::anyhow!("failed to convert ws endpoint to http"))?,
-        "wss" => url
-            .set_scheme("https")
-            .map_err(|_| anyhow::anyhow!("failed to convert wss endpoint to https"))?,
-        "http" | "https" => {}
-        scheme => anyhow::bail!("unsupported CDP endpoint scheme: {scheme}"),
-    }
-    url.set_path("");
-    url.set_query(None);
-    url.set_fragment(None);
-    Ok(url.as_str().trim_end_matches('/').to_string())
 }
 
 /// Open the chrome://inspect remote-debugging page in the user's default
@@ -257,19 +171,15 @@ pub(crate) async fn endpoint_from_active_port(profile: &Path) -> Option<Endpoint
     let port: u16 = lines.next()?.trim().parse().ok()?;
     let ws_path = lines.next().map(str::trim).unwrap_or("").to_string();
 
-    // Prefer richer info via HTTP /json/version. If the HTTP debugging API is
-    // unavailable (some user Chrome launches expose only the websocket path),
-    // keep the browser websocket fallback. The scoped-CDP runtime can use that
-    // websocket with raw `Target.getTargets`/`Target.createTarget` without
-    // chromiumoxide's global discovery/auto-init behavior.
-    let http_url = format!("http://127.0.0.1:{port}");
-    let source = format!("active_port:{}", marker.display());
-    if let Ok(endpoint) = endpoint_from_http_url(&http_url, &source).await {
-        return Some(endpoint);
-    }
+    // `DevToolsActivePort` already contains the browser websocket path. Use it
+    // directly instead of probing `/json/version`: some user Chrome profiles
+    // expose the websocket while returning 404 from the HTTP discovery API, and
+    // the runtime's target inventory/lifecycle now uses raw browser-websocket
+    // `Target.*` commands for both existing and managed Chrome.
     if ws_path.is_empty() {
         return None;
     }
+    let source = format!("active_port:{}", marker.display());
     let browser_ws_url = format!("ws://127.0.0.1:{port}{ws_path}");
     Some(Endpoint {
         source,
@@ -366,14 +276,6 @@ fn shellexpand(s: &str) -> String {
     s.to_string()
 }
 
-fn endpoint_url(endpoint: &Endpoint, path: &str) -> anyhow::Result<reqwest::Url> {
-    let mut url = reqwest::Url::parse(&http_base_url(endpoint)?)?;
-    url.set_path(path.trim_start_matches('/'));
-    url.set_query(None);
-    url.set_fragment(None);
-    Ok(url)
-}
-
 async fn get_json<T: for<'de> serde::Deserialize<'de>>(url: &str) -> anyhow::Result<T> {
     let resp = debug_http_client()?
         .get(url)
@@ -384,9 +286,10 @@ async fn get_json<T: for<'de> serde::Deserialize<'de>>(url: &str) -> anyhow::Res
 }
 
 fn debug_http_client() -> anyhow::Result<reqwest::Client> {
-    // Built once and cloned thereafter (clone is a cheap Arc bump that shares the
-    // connection pool). The connected-state poller calls this every ~2s, so
-    // rebuilding the client + pool each time would be needless CPU/latency.
+    // Built once and cloned thereafter (clone is a cheap Arc bump that shares
+    // the connection pool). HTTP is no longer used for active target
+    // lifecycle, but explicit `SOCAI_CDP_URL` / conventional-port discovery may
+    // still need `/json/version`.
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     if let Some(client) = CLIENT.get() {
         return Ok(client.clone());
@@ -394,8 +297,8 @@ fn debug_http_client() -> anyhow::Result<reqwest::Client> {
     let client = reqwest::Client::builder()
         // Chrome's remote-debugging HTTP API is always a local control plane
         // endpoint (`127.0.0.1:<port>`). Do not honor HTTP(S)_PROXY / ALL_PROXY
-        // here: proxy tools such as Clash can otherwise intercept `/json/list`
-        // and return 502 even though Chrome is healthy.
+        // here: proxy tools such as Clash can otherwise intercept `/json/*`
+        // discovery calls and return 502 even though Chrome is healthy.
         .no_proxy()
         .timeout(HTTP_TIMEOUT)
         .build()?;

--- a/core/src/cdp/launch.rs
+++ b/core/src/cdp/launch.rs
@@ -1,0 +1,214 @@
+//! Raw managed-chrome launcher.
+//!
+//! socai's managed profile launches its own isolated Chrome rather than
+//! attaching to the user's daily browser. Previously that used
+//! `chromiumoxide::Browser::launch`, but the scoped-CDP runtime no longer
+//! depends on chromiumoxide at all (see [`crate::cdp::raw_client`]). We only
+//! need chrome's *process* spawned with a remote-debugging port — control then
+//! goes through the same scoped raw client used for the existing-browser path.
+//!
+//! Chrome is started with `--remote-debugging-port=0` so it picks a free port
+//! and writes it (plus the browser websocket path) to
+//! `<user_data_dir>/DevToolsActivePort`, which
+//! [`crate::cdp::endpoint::endpoint_from_active_port`] already knows how to
+//! read.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context};
+use tokio::process::{Child, Command};
+use tokio::time::Instant;
+use tracing::info;
+
+use crate::cdp::endpoint::{self, Endpoint};
+
+const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(150);
+
+/// Owns a managed Chrome child process. Killed on drop, so a disconnect,
+/// reconnect, or daemon shutdown tears down the socai-launched browser —
+/// mirroring the previous chromiumoxide `Browser` drop semantics. Chrome we
+/// merely *reused* (already running, discovered via `DevToolsActivePort`) is
+/// never wrapped in this; we don't own those processes and must not kill them.
+pub struct ChromeProcess {
+    child: Child,
+}
+
+impl Drop for ChromeProcess {
+    fn drop(&mut self) {
+        // `start_kill` is non-blocking; the tokio reaper collects the zombie.
+        // Best-effort: if the process already exited this is a harmless no-op.
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Launch socai's managed Chrome against `user_data_dir` and wait for its
+/// remote-debugging endpoint to come up. Returns the (managed-marked) endpoint
+/// and a process guard the caller must keep alive for the connection's
+/// lifetime.
+pub(crate) async fn launch_managed_chrome(
+    user_data_dir: &Path,
+) -> anyhow::Result<(Endpoint, ChromeProcess)> {
+    let executable = find_chrome_executable().ok_or_else(|| {
+        anyhow!(
+            "no chrome/chromium executable found. install Google Chrome, or set \
+             SOCAI_CHROME_EXECUTABLE / CHROME to its path."
+        )
+    })?;
+
+    // Remove any stale DevToolsActivePort before launching. We kill managed
+    // chrome with SIGKILL (see `ChromeProcess::drop`), which leaves the marker
+    // behind, so a stale one pointing at a dead/recycled port is the *normal*
+    // state on the persistent managed profile. Deleting it first guarantees
+    // `wait_for_active_port` only observes the port THIS process writes —
+    // otherwise the first poll races and may return the stale endpoint, after
+    // which we'd connect to nothing (or a foreign browser) while killing the
+    // chrome we just launched.
+    let marker = user_data_dir.join("DevToolsActivePort");
+    let _ = tokio::fs::remove_file(&marker).await;
+
+    let mut command = Command::new(&executable);
+    command
+        .arg(format!("--user-data-dir={}", user_data_dir.display()))
+        .arg("--remote-debugging-port=0")
+        .arg("--no-first-run")
+        .arg("--no-default-browser-check")
+        .arg("--disable-blink-features=AutomationControlled")
+        .arg("--window-size=1280,900")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    info!(
+        executable = %executable.display(),
+        profile = %user_data_dir.display(),
+        "launching managed chrome"
+    );
+    let child = command
+        .spawn()
+        .with_context(|| format!("failed to launch chrome at {}", executable.display()))?;
+    let process = ChromeProcess { child };
+
+    let endpoint = wait_for_active_port(user_data_dir, LAUNCH_TIMEOUT).await?;
+    Ok((
+        endpoint::mark_managed_endpoint(endpoint, user_data_dir),
+        process,
+    ))
+}
+
+/// Poll `<user_data_dir>/DevToolsActivePort` until chrome has written its
+/// chosen port, or `timeout` elapses.
+async fn wait_for_active_port(user_data_dir: &Path, timeout: Duration) -> anyhow::Result<Endpoint> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(endpoint) = endpoint::endpoint_from_active_port(user_data_dir).await {
+            return Ok(endpoint);
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "managed chrome did not expose a debugging endpoint within {}s",
+                timeout.as_secs()
+            ));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Resolve the chrome/chromium executable: explicit env override first
+/// (`SOCAI_CHROME_EXECUTABLE`, then `CHROME`), then well-known per-OS install
+/// locations.
+pub(crate) fn find_chrome_executable() -> Option<PathBuf> {
+    if let Some(path) = chrome_executable_override() {
+        return Some(path);
+    }
+    if let Some(found) = default_chrome_executables()
+        .into_iter()
+        .find(|path| path.exists())
+    {
+        return Some(found);
+    }
+    // Last resort: a PATH-resolvable command name, left for `Command` to
+    // resolve at spawn time. Only set on platforms where launching by bare
+    // name is conventional (Linux); `None` elsewhere.
+    fallback_chrome_command()
+}
+
+fn chrome_executable_override() -> Option<PathBuf> {
+    for key in ["SOCAI_CHROME_EXECUTABLE", "CHROME"] {
+        if let Ok(value) = std::env::var(key) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn default_chrome_executables() -> Vec<PathBuf> {
+    [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn default_chrome_executables() -> Vec<PathBuf> {
+    let names = [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "microsoft-edge",
+        "brave-browser",
+    ];
+    let roots = ["/usr/bin", "/usr/local/bin", "/snap/bin", "/opt/google/chrome"];
+    let mut out = Vec::new();
+    for root in roots {
+        for name in names {
+            out.push(PathBuf::from(root).join(name));
+        }
+    }
+    out
+}
+
+#[cfg(target_os = "windows")]
+fn default_chrome_executables() -> Vec<PathBuf> {
+    let suffixes = [
+        r"Google\Chrome\Application\chrome.exe",
+        r"Chromium\Application\chrome.exe",
+        r"Microsoft\Edge\Application\msedge.exe",
+        r"BraveSoftware\Brave-Browser\Application\brave.exe",
+    ];
+    let mut out = Vec::new();
+    for key in ["PROGRAMFILES", "PROGRAMFILES(X86)", "LOCALAPPDATA"] {
+        if let Ok(base) = std::env::var(key) {
+            if !base.trim().is_empty() {
+                for suffix in suffixes {
+                    out.push(PathBuf::from(&base).join(suffix));
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(target_os = "linux")]
+fn fallback_chrome_command() -> Option<PathBuf> {
+    Some(PathBuf::from("google-chrome"))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn fallback_chrome_command() -> Option<PathBuf> {
+    None
+}

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -5,10 +5,10 @@ use serde_json::{json, Value};
 use tracing::{debug, warn};
 
 use crate::cdp::connection::{
-    page_list_from, BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile, StatusPayload,
-    TargetInfo,
+    page_list_from, BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile,
+    StatusPayload, TargetInfo,
 };
-use crate::cdp::endpoint::{self, DebugTarget, Endpoint};
+use crate::cdp::endpoint::{self, Endpoint};
 use crate::cdp::launch::{self, ChromeProcess};
 use crate::cdp::raw_client::RawCdpClient;
 
@@ -17,18 +17,10 @@ const ATTEMPT_DELAY: Duration = Duration::from_millis(500);
 const TARGET_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const TARGET_POLL_FAILURES: u8 = 3;
 
-#[derive(Clone)]
-#[allow(clippy::large_enum_variant)] // only one poller exists per connection
-enum TargetPoller {
-    Http(Endpoint),
-    BrowserWs(RawCdpClient),
-}
-
 struct ConnectInventory {
     targets: HashMap<String, TargetInfo>,
     browser_version: String,
-    browser_client: Option<RawCdpClient>,
-    poller: TargetPoller,
+    browser_client: RawCdpClient,
 }
 
 /// A resolved remote-debugging endpoint plus, for managed mode, the chrome
@@ -61,16 +53,13 @@ impl Cdp {
     }
 
     pub async fn disconnect(&self) {
-        // Close socai-owned page targets before dropping endpoint state. Page
-        // sessions may use independent target websockets or a browser websocket
-        // session, so browser-status disconnect must explicitly tear them down.
-        let endpoint = self.endpoint().await.ok();
+        // Close socai-owned page targets before dropping endpoint state. All
+        // target lifecycle is routed through the browser websocket so existing
+        // and managed Chrome share the same cleanup path.
         let browser_client = self.browser_client().await;
         for target_id in self.take_owned_targets().await {
             if let Some(client) = browser_client.as_ref() {
                 let _ = close_target_via_browser_ws(client, &target_id).await;
-            } else if let Some(endpoint) = endpoint.as_ref() {
-                let _ = endpoint::close_debug_target(endpoint, &target_id).await;
             }
         }
         transition_unconditional(
@@ -123,7 +112,7 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
     } = open_endpoint(options).await?;
 
     let inventory = connect_inventory(&endpoint).await?;
-    let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.poller.clone());
+    let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.browser_client.clone());
 
     {
         let state = cdp.state();
@@ -147,9 +136,9 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
     }
 
     // Initial targets emit so subscribers can hydrate. Future updates come from
-    // lightweight polling: HTTP `/json/list` where available, otherwise raw
-    // `Target.getTargets` over the browser websocket. Neither path enables
-    // Target discovery nor attaches to user-owned tabs.
+    // lightweight raw `Target.getTargets` polling over the browser websocket.
+    // This does not enable target discovery and does not attach to user-owned
+    // tabs.
     let initial_pages = cdp.pages().await;
     cdp.emit(BrowserEvent::TargetsChanged(initial_pages));
 
@@ -240,35 +229,17 @@ async fn open_managed_endpoint(options: &ChromeConnectOptions) -> anyhow::Result
 }
 
 /// Quick liveness probe for a discovered endpoint: a `DevToolsActivePort`
-/// marker can outlive the chrome that wrote it (crash / kill). Prefer the
-/// passive HTTP debug API; fall back to confirming the browser websocket still
-/// accepts a connection.
+/// marker can outlive the chrome that wrote it (crash / kill). Probe the same
+/// browser-websocket `Target.*` path the runtime will use for target inventory
+/// and lifecycle.
 async fn reachable(endpoint: &Endpoint) -> bool {
-    if endpoint::list_debug_targets(endpoint).await.is_ok() {
-        return true;
+    match RawCdpClient::connect(&endpoint.browser_ws_url).await {
+        Ok(client) => browser_ws_targets(&client).await.is_ok(),
+        Err(_) => false,
     }
-    RawCdpClient::connect(&endpoint.browser_ws_url).await.is_ok()
 }
 
 async fn connect_inventory(endpoint: &Endpoint) -> anyhow::Result<ConnectInventory> {
-    if let Ok(debug_targets) = endpoint::list_debug_targets(endpoint).await {
-        let browser_version = match browser_version_opt(endpoint) {
-            Some(version) => version,
-            // Endpoint had no cached version (e.g. SOCAI_CDP_WS). Fetch it
-            // passively over the HTTP debug API rather than reporting
-            // "unknown browser", matching the pre-merge live-version behavior.
-            None => endpoint::fetch_browser_version(endpoint)
-                .await
-                .unwrap_or_else(|| "unknown browser".into()),
-        };
-        return Ok(ConnectInventory {
-            targets: targets_map(debug_targets),
-            browser_version,
-            browser_client: None,
-            poller: TargetPoller::Http(endpoint.clone()),
-        });
-    }
-
     let client = RawCdpClient::connect(&endpoint.browser_ws_url).await?;
     let targets = browser_ws_targets(&client).await?;
     let browser_version = browser_ws_version(&client)
@@ -279,8 +250,7 @@ async fn connect_inventory(endpoint: &Endpoint) -> anyhow::Result<ConnectInvento
     Ok(ConnectInventory {
         targets,
         browser_version,
-        browser_client: Some(client.clone()),
-        poller: TargetPoller::BrowserWs(client),
+        browser_client: client,
     })
 }
 
@@ -332,12 +302,12 @@ fn abort_monitor_if_connected(state: &CdpState) {
     }
 }
 
-fn spawn_target_poll_loop(cdp: Cdp, poller: TargetPoller) -> tokio::task::AbortHandle {
+fn spawn_target_poll_loop(cdp: Cdp, browser_client: RawCdpClient) -> tokio::task::AbortHandle {
     let join = tokio::spawn(async move {
         let mut failures = 0u8;
         loop {
             tokio::time::sleep(TARGET_POLL_INTERVAL).await;
-            match poll_targets(&poller).await {
+            match browser_ws_targets(&browser_client).await {
                 Ok(targets) => {
                     failures = 0;
                     if let Some(pages) = replace_targets(&cdp, targets).await {
@@ -358,16 +328,6 @@ fn spawn_target_poll_loop(cdp: Cdp, poller: TargetPoller) -> tokio::task::AbortH
     join.abort_handle()
 }
 
-async fn poll_targets(poller: &TargetPoller) -> anyhow::Result<HashMap<String, TargetInfo>> {
-    match poller {
-        TargetPoller::Http(endpoint) => {
-            let debug_targets = endpoint::list_debug_targets(endpoint).await?;
-            Ok(targets_map(debug_targets))
-        }
-        TargetPoller::BrowserWs(client) => browser_ws_targets(client).await,
-    }
-}
-
 /// Replace cached targets. Returns the new visible page list when it changed;
 /// `None` means either no visible page change or the connection is inactive.
 async fn replace_targets(
@@ -383,25 +343,6 @@ async fn replace_targets(
     let after = page_list_from(&next_targets);
     *targets = next_targets;
     (before != after).then_some(after)
-}
-
-fn targets_map(debug_targets: Vec<DebugTarget>) -> HashMap<String, TargetInfo> {
-    debug_targets
-        .into_iter()
-        .map(|target| {
-            let info = target_info_from_debug(target);
-            (info.target_id.clone(), info)
-        })
-        .collect()
-}
-
-fn target_info_from_debug(target: DebugTarget) -> TargetInfo {
-    TargetInfo {
-        target_id: target.target_id,
-        r#type: target.r#type,
-        title: target.title,
-        url: target.url,
-    }
 }
 
 async fn browser_ws_targets(client: &RawCdpClient) -> anyhow::Result<HashMap<String, TargetInfo>> {
@@ -473,8 +414,10 @@ async fn close_target_via_browser_ws(client: &RawCdpClient, target_id: &str) -> 
 /// `None` for endpoints discovered without a `/json/version` round-trip (e.g.
 /// an explicit `SOCAI_CDP_WS`), in which case callers fetch it actively.
 fn browser_version_opt(endpoint: &Endpoint) -> Option<String> {
-    endpoint
-        .version
-        .as_ref()
-        .and_then(|version| version.browser.clone().or_else(|| version.user_agent.clone()))
+    endpoint.version.as_ref().and_then(|version| {
+        version
+            .browser
+            .clone()
+            .or_else(|| version.user_agent.clone())
+    })
 }

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -1,30 +1,42 @@
 use std::collections::HashMap;
-use std::env;
-use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 
-use chromiumoxide::cdp::browser_protocol::target::{
-    EventTargetCreated, EventTargetDestroyed, EventTargetInfoChanged, GetTargetsParams,
-    SetDiscoverTargetsParams,
-};
-use chromiumoxide::{Browser, BrowserConfig, Handler};
-use futures::StreamExt;
-use tracing::{debug, info, warn};
+use serde_json::{json, Value};
+use tracing::{debug, warn};
 
 use crate::cdp::connection::{
-    BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile, StatusPayload, TargetInfo,
+    page_list_from, BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile, StatusPayload,
+    TargetInfo,
 };
-use crate::cdp::endpoint::{self, Endpoint};
+use crate::cdp::endpoint::{self, DebugTarget, Endpoint};
+use crate::cdp::launch::{self, ChromeProcess};
+use crate::cdp::raw_client::RawCdpClient;
 
 const MAX_ATTEMPTS: u8 = 3;
 const ATTEMPT_DELAY: Duration = Duration::from_millis(500);
-const MANAGED_LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
+const TARGET_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const TARGET_POLL_FAILURES: u8 = 3;
 
-struct OpenBrowser {
+#[derive(Clone)]
+#[allow(clippy::large_enum_variant)] // only one poller exists per connection
+enum TargetPoller {
+    Http(Endpoint),
+    BrowserWs(RawCdpClient),
+}
+
+struct ConnectInventory {
+    targets: HashMap<String, TargetInfo>,
+    browser_version: String,
+    browser_client: Option<RawCdpClient>,
+    poller: TargetPoller,
+}
+
+/// A resolved remote-debugging endpoint plus, for managed mode, the chrome
+/// process socai launched. The process guard is threaded into the `Connected`
+/// state so it lives exactly as long as the connection.
+struct OpenEndpoint {
     endpoint: Endpoint,
-    browser: Browser,
-    handler: Handler,
+    chrome_process: Option<ChromeProcess>,
 }
 
 impl Cdp {
@@ -49,6 +61,18 @@ impl Cdp {
     }
 
     pub async fn disconnect(&self) {
+        // Close socai-owned page targets before dropping endpoint state. Page
+        // sessions may use independent target websockets or a browser websocket
+        // session, so browser-status disconnect must explicitly tear them down.
+        let endpoint = self.endpoint().await.ok();
+        let browser_client = self.browser_client().await;
+        for target_id in self.take_owned_targets().await {
+            if let Some(client) = browser_client.as_ref() {
+                let _ = close_target_via_browser_ws(client, &target_id).await;
+            } else if let Some(endpoint) = endpoint.as_ref() {
+                let _ = endpoint::close_debug_target(endpoint, &target_id).await;
+            }
+        }
         transition_unconditional(
             self,
             CdpState::Disconnected {
@@ -93,72 +117,49 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
 }
 
 async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> anyhow::Result<()> {
-    let OpenBrowser {
+    let OpenEndpoint {
         endpoint,
-        browser,
-        mut handler,
-    } = open_browser(options).await?;
+        chrome_process,
+    } = open_endpoint(options).await?;
 
-    let cdp_for_pump = cdp.clone();
-    let pump = tokio::spawn(async move {
-        // Handler stream yields Result<_, CdpError>. Individual decode errors
-        // are non-fatal — only stream exhaustion (None) means the WS closed.
-        while let Some(event) = handler.next().await {
-            if let Err(e) = event {
-                debug!(error = ?e, "cdp handler non-fatal error");
-            }
-        }
-        on_connection_dropped(cdp_for_pump).await;
-    });
-    let handler_task = pump.abort_handle();
-
-    let version = browser.version().await?;
-    let browser_version = format!("{} v{}", version.product, version.revision);
-
-    browser
-        .execute(SetDiscoverTargetsParams {
-            discover: true,
-            filter: None,
-        })
-        .await?;
-
-    let initial = browser.execute(GetTargetsParams::default()).await?;
-    let targets: HashMap<String, TargetInfo> = initial
-        .result
-        .target_infos
-        .iter()
-        .map(target_info_to_pair)
-        .collect();
-
-    let browser = Arc::new(browser);
+    let inventory = connect_inventory(&endpoint).await?;
+    let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.poller.clone());
 
     {
         let state = cdp.state();
         let mut guard = state.lock().await;
         if !guard.is_connecting() {
+            monitor_task.abort();
+            // Dropping `chrome_process` here kills a just-launched managed chrome
+            // if the connect was cancelled mid-flight.
             return Err(anyhow::anyhow!("connect cancelled"));
         }
         *guard = CdpState::Connected {
-            browser: Arc::clone(&browser),
-            handler_task,
             endpoint,
-            browser_version,
-            targets,
+            browser_client: inventory.browser_client,
+            browser_version: inventory.browser_version,
+            targets: inventory.targets,
+            monitor_task,
+            chrome_process,
         };
         let payload: StatusPayload = (&*guard).into();
         cdp.emit(BrowserEvent::StatusChanged(payload));
     }
 
-    // initial targets emit so subscribers can hydrate
+    // Initial targets emit so subscribers can hydrate. Future updates come from
+    // lightweight polling: HTTP `/json/list` where available, otherwise raw
+    // `Target.getTargets` over the browser websocket. Neither path enables
+    // Target discovery nor attaches to user-owned tabs.
     let initial_pages = cdp.pages().await;
     cdp.emit(BrowserEvent::TargetsChanged(initial_pages));
-
-    spawn_target_event_loop(Arc::clone(&browser), cdp.clone());
 
     Ok(())
 }
 
-async fn open_browser(options: Option<ChromeConnectOptions>) -> anyhow::Result<OpenBrowser> {
+/// Resolve the remote-debugging endpoint for this connect attempt, honoring the
+/// chrome profile preference. Explicit `SOCAI_CDP_*` / argument endpoints win
+/// for non-managed modes; managed mode launches (or reuses) socai's own chrome.
+async fn open_endpoint(options: Option<ChromeConnectOptions>) -> anyhow::Result<OpenEndpoint> {
     let options = match options {
         Some(options) => options,
         None => ChromeConnectOptions::from_config()?,
@@ -166,18 +167,21 @@ async fn open_browser(options: Option<ChromeConnectOptions>) -> anyhow::Result<O
 
     if !matches!(options.profile, ChromeProfile::Managed) {
         if let Some(endpoint) = endpoint::resolve_explicit_endpoint(None, None).await? {
-            return connect_to_endpoint(endpoint).await;
+            return Ok(OpenEndpoint {
+                endpoint,
+                chrome_process: None,
+            });
         }
     }
 
     match options.profile {
-        ChromeProfile::Managed => open_managed_browser(&options).await,
-        ChromeProfile::Existing => open_existing_browser().await,
-        ChromeProfile::Auto => match open_managed_browser(&options).await {
-            Ok(connection) => Ok(connection),
+        ChromeProfile::Managed => open_managed_endpoint(&options).await,
+        ChromeProfile::Existing => open_existing_endpoint().await,
+        ChromeProfile::Auto => match open_managed_endpoint(&options).await {
+            Ok(open) => Ok(open),
             Err(managed_err) => {
                 warn!(error = %managed_err, "managed chrome launch failed; falling back to existing browser discovery");
-                open_existing_browser().await.map_err(|existing_err| {
+                open_existing_endpoint().await.map_err(|existing_err| {
                     anyhow::anyhow!(
                         "managed chrome launch failed: {managed_err:#}; existing-browser fallback failed: {existing_err:#}"
                     )
@@ -187,17 +191,8 @@ async fn open_browser(options: Option<ChromeConnectOptions>) -> anyhow::Result<O
     }
 }
 
-async fn connect_to_endpoint(endpoint: Endpoint) -> anyhow::Result<OpenBrowser> {
-    let (browser, handler) = Browser::connect(&endpoint.browser_ws_url).await?;
-    Ok(OpenBrowser {
-        endpoint,
-        browser,
-        handler,
-    })
-}
-
-async fn open_existing_browser() -> anyhow::Result<OpenBrowser> {
-    let endpoint: Endpoint = endpoint::discover_running_chrome_endpoint()
+async fn open_existing_endpoint() -> anyhow::Result<OpenEndpoint> {
+    let endpoint = endpoint::discover_running_chrome_endpoint()
         .await?
         .ok_or_else(|| {
             anyhow::anyhow!(
@@ -206,79 +201,98 @@ async fn open_existing_browser() -> anyhow::Result<OpenBrowser> {
                  or run `socai config set chrome.profile managed` to use socai's managed chrome profile."
             )
         })?;
-    connect_to_endpoint(endpoint).await
+    Ok(OpenEndpoint {
+        endpoint,
+        chrome_process: None,
+    })
 }
 
-async fn open_managed_browser(options: &ChromeConnectOptions) -> anyhow::Result<OpenBrowser> {
+async fn open_managed_endpoint(options: &ChromeConnectOptions) -> anyhow::Result<OpenEndpoint> {
     let user_data_dir = match &options.managed_user_data_dir {
         Some(path) => path.clone(),
         None => endpoint::managed_chrome_user_data_dir()?,
     };
     tokio::fs::create_dir_all(&user_data_dir).await?;
 
-    // if another socai entrypoint already launched the isolated profile, reuse
-    // it instead of attempting a second chrome process with the same profile.
+    // If a prior socai entrypoint already launched this isolated profile, reuse
+    // it rather than spawning a second chrome against the same profile dir. We
+    // didn't launch that process, so it gets no `ChromeProcess` guard — we must
+    // not kill a browser we don't own.
     if let Some(endpoint) = endpoint::endpoint_from_active_port(&user_data_dir).await {
-        match connect_to_endpoint(endpoint::mark_managed_endpoint(endpoint, &user_data_dir)).await {
-            Ok(connection) => return Ok(connection),
-            Err(err) => {
-                warn!(profile = %user_data_dir.display(), error = %err, "managed chrome active-port marker was stale");
-            }
+        let endpoint = endpoint::mark_managed_endpoint(endpoint, &user_data_dir);
+        if reachable(&endpoint).await {
+            return Ok(OpenEndpoint {
+                endpoint,
+                chrome_process: None,
+            });
         }
+        warn!(
+            profile = %user_data_dir.display(),
+            "managed chrome active-port marker was stale; relaunching"
+        );
     }
 
-    let mut builder = BrowserConfig::builder()
-        .with_head()
-        .user_data_dir(&user_data_dir)
-        .launch_timeout(MANAGED_LAUNCH_TIMEOUT)
-        .viewport(None)
-        .window_size(1280, 900)
-        .arg("--disable-blink-features=AutomationControlled")
-        .arg("--no-default-browser-check")
-        .arg("--no-first-run");
-
-    if let Some(executable) = chrome_executable_override() {
-        builder = builder.chrome_executable(executable);
-    }
-
-    info!(profile = %user_data_dir.display(), "launching managed chrome profile");
-    let (browser, handler) = Browser::launch(builder.build().map_err(anyhow::Error::msg)?).await?;
-    let endpoint = Endpoint {
-        source: format!("managed_profile:{}", user_data_dir.display()),
-        browser_ws_url: browser.websocket_address().clone(),
-        http_version_url: None,
-        version: None,
-        managed: true,
-        user_data_dir: Some(user_data_dir.display().to_string()),
-    };
-    Ok(OpenBrowser {
+    let (endpoint, chrome_process) = launch::launch_managed_chrome(&user_data_dir).await?;
+    Ok(OpenEndpoint {
         endpoint,
-        browser,
-        handler,
+        chrome_process: Some(chrome_process),
     })
 }
 
-fn chrome_executable_override() -> Option<PathBuf> {
-    env::var("SOCAI_CHROME_EXECUTABLE")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            env::var("CHROME")
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-        })
-        .map(PathBuf::from)
+/// Quick liveness probe for a discovered endpoint: a `DevToolsActivePort`
+/// marker can outlive the chrome that wrote it (crash / kill). Prefer the
+/// passive HTTP debug API; fall back to confirming the browser websocket still
+/// accepts a connection.
+async fn reachable(endpoint: &Endpoint) -> bool {
+    if endpoint::list_debug_targets(endpoint).await.is_ok() {
+        return true;
+    }
+    RawCdpClient::connect(&endpoint.browser_ws_url).await.is_ok()
 }
 
-async fn on_connection_dropped(cdp: Cdp) {
+async fn connect_inventory(endpoint: &Endpoint) -> anyhow::Result<ConnectInventory> {
+    if let Ok(debug_targets) = endpoint::list_debug_targets(endpoint).await {
+        let browser_version = match browser_version_opt(endpoint) {
+            Some(version) => version,
+            // Endpoint had no cached version (e.g. SOCAI_CDP_WS). Fetch it
+            // passively over the HTTP debug API rather than reporting
+            // "unknown browser", matching the pre-merge live-version behavior.
+            None => endpoint::fetch_browser_version(endpoint)
+                .await
+                .unwrap_or_else(|| "unknown browser".into()),
+        };
+        return Ok(ConnectInventory {
+            targets: targets_map(debug_targets),
+            browser_version,
+            browser_client: None,
+            poller: TargetPoller::Http(endpoint.clone()),
+        });
+    }
+
+    let client = RawCdpClient::connect(&endpoint.browser_ws_url).await?;
+    let targets = browser_ws_targets(&client).await?;
+    let browser_version = browser_ws_version(&client)
+        .await
+        .ok()
+        .or_else(|| browser_version_opt(endpoint))
+        .unwrap_or_else(|| "unknown browser".into());
+    Ok(ConnectInventory {
+        targets,
+        browser_version,
+        browser_client: Some(client.clone()),
+        poller: TargetPoller::BrowserWs(client),
+    })
+}
+
+async fn on_connection_lost(cdp: Cdp, reason: String) {
+    let _ = cdp.take_owned_targets().await;
     let state = cdp.state();
     let mut guard = state.lock().await;
     if matches!(*guard, CdpState::Connected { .. }) {
-        *guard = CdpState::Disconnected {
-            reason: "connection_lost".into(),
-        };
+        *guard = CdpState::Disconnected { reason };
         let payload: StatusPayload = (&*guard).into();
         cdp.emit(BrowserEvent::StatusChanged(payload));
+        cdp.emit(BrowserEvent::TargetsChanged(Vec::new()));
     }
 }
 
@@ -301,115 +315,166 @@ async fn transition_if_eligible(cdp: &Cdp, new: CdpState) -> bool {
 async fn transition_unconditional(cdp: &Cdp, new: CdpState) {
     let state = cdp.state();
     let mut guard = state.lock().await;
-    abort_pump_if_connected(&guard);
+    let clear_targets = matches!(*guard, CdpState::Connected { .. })
+        && matches!(new, CdpState::Disconnected { .. });
+    abort_monitor_if_connected(&guard);
     *guard = new;
     let payload: StatusPayload = (&*guard).into();
     cdp.emit(BrowserEvent::StatusChanged(payload));
-}
-
-/// On user-initiated disconnect we have to terminate the WS pump task — its
-/// `Handler` owns the WebSocket, so dropping the `Arc<Browser>` alone won't
-/// close the socket. Aborting causes the task to be dropped, which drops the
-/// `Handler`, which closes the WS — only then does Chrome remove the
-/// "controlled by automated software" banner.
-fn abort_pump_if_connected(state: &CdpState) {
-    if let CdpState::Connected { handler_task, .. } = state {
-        handler_task.abort();
+    if clear_targets {
+        cdp.emit(BrowserEvent::TargetsChanged(Vec::new()));
     }
 }
 
-/// Subscribe to Target.* events from chromiumoxide; fold them into the cached
-/// targets map and emit `BrowserEvent::TargetsChanged` whenever the visible
-/// page list actually changes. Replaces the previous 100ms `Target.getTargets`
-/// polling loop.
-fn spawn_target_event_loop(browser: Arc<Browser>, cdp: Cdp) {
-    tokio::spawn(async move {
-        let (created, destroyed, changed) = match try_join_listeners(&browser).await {
-            Ok(streams) => streams,
-            Err(e) => {
-                warn!(error = %e, "failed to subscribe to target events");
-                return;
-            }
-        };
-        let mut created = Box::pin(created);
-        let mut destroyed = Box::pin(destroyed);
-        let mut changed = Box::pin(changed);
+fn abort_monitor_if_connected(state: &CdpState) {
+    if let CdpState::Connected { monitor_task, .. } = state {
+        monitor_task.abort();
+    }
+}
 
-        let mut last_emitted = cdp.pages().await;
-
+fn spawn_target_poll_loop(cdp: Cdp, poller: TargetPoller) -> tokio::task::AbortHandle {
+    let join = tokio::spawn(async move {
+        let mut failures = 0u8;
         loop {
-            let dirty = tokio::select! {
-                Some(ev) = created.next() => {
-                    apply_target_change(&cdp, |targets| {
-                        targets.insert(ev.target_info.target_id.inner().clone(), to_target_info(&ev.target_info));
-                    }).await
+            tokio::time::sleep(TARGET_POLL_INTERVAL).await;
+            match poll_targets(&poller).await {
+                Ok(targets) => {
+                    failures = 0;
+                    if let Some(pages) = replace_targets(&cdp, targets).await {
+                        cdp.emit(BrowserEvent::TargetsChanged(pages));
+                    }
                 }
-                Some(ev) = destroyed.next() => {
-                    apply_target_change(&cdp, |targets| {
-                        targets.remove(ev.target_id.inner().as_str());
-                    }).await
+                Err(err) => {
+                    failures = failures.saturating_add(1);
+                    debug!(failures, error = %err, "target poll failed");
+                    if failures >= TARGET_POLL_FAILURES {
+                        on_connection_lost(cdp.clone(), format!("connection_lost: {err}")).await;
+                        break;
+                    }
                 }
-                Some(ev) = changed.next() => {
-                    apply_target_change(&cdp, |targets| {
-                        targets.insert(ev.target_info.target_id.inner().clone(), to_target_info(&ev.target_info));
-                    }).await
-                }
-                else => break,
-            };
-            if !dirty {
-                break;
-            }
-            let pages = cdp.pages().await;
-            if pages != last_emitted {
-                last_emitted = pages.clone();
-                cdp.emit(BrowserEvent::TargetsChanged(pages));
             }
         }
     });
+    join.abort_handle()
 }
 
-async fn try_join_listeners(
-    browser: &Browser,
-) -> anyhow::Result<(
-    impl futures::Stream<Item = Arc<EventTargetCreated>>,
-    impl futures::Stream<Item = Arc<EventTargetDestroyed>>,
-    impl futures::Stream<Item = Arc<EventTargetInfoChanged>>,
-)> {
-    let created = browser.event_listener::<EventTargetCreated>().await?;
-    let destroyed = browser.event_listener::<EventTargetDestroyed>().await?;
-    let changed = browser.event_listener::<EventTargetInfoChanged>().await?;
-    Ok((created, destroyed, changed))
+async fn poll_targets(poller: &TargetPoller) -> anyhow::Result<HashMap<String, TargetInfo>> {
+    match poller {
+        TargetPoller::Http(endpoint) => {
+            let debug_targets = endpoint::list_debug_targets(endpoint).await?;
+            Ok(targets_map(debug_targets))
+        }
+        TargetPoller::BrowserWs(client) => browser_ws_targets(client).await,
+    }
 }
 
-/// Apply a closure under the state lock. Returns false if state moved out of
-/// Connected (loop should exit).
-async fn apply_target_change<F>(cdp: &Cdp, f: F) -> bool
-where
-    F: FnOnce(&mut HashMap<String, TargetInfo>),
-{
+/// Replace cached targets. Returns the new visible page list when it changed;
+/// `None` means either no visible page change or the connection is inactive.
+async fn replace_targets(
+    cdp: &Cdp,
+    next_targets: HashMap<String, TargetInfo>,
+) -> Option<Vec<TargetInfo>> {
     let state = cdp.state();
     let mut guard = state.lock().await;
-    match &mut *guard {
-        CdpState::Connected { targets, .. } => {
-            f(targets);
-            true
-        }
-        _ => false,
-    }
+    let CdpState::Connected { targets, .. } = &mut *guard else {
+        return None;
+    };
+    let before = page_list_from(targets);
+    let after = page_list_from(&next_targets);
+    *targets = next_targets;
+    (before != after).then_some(after)
 }
 
-fn target_info_to_pair(
-    info: &chromiumoxide::cdp::browser_protocol::target::TargetInfo,
-) -> (String, TargetInfo) {
-    let ti = to_target_info(info);
-    (ti.target_id.clone(), ti)
+fn targets_map(debug_targets: Vec<DebugTarget>) -> HashMap<String, TargetInfo> {
+    debug_targets
+        .into_iter()
+        .map(|target| {
+            let info = target_info_from_debug(target);
+            (info.target_id.clone(), info)
+        })
+        .collect()
 }
 
-fn to_target_info(info: &chromiumoxide::cdp::browser_protocol::target::TargetInfo) -> TargetInfo {
+fn target_info_from_debug(target: DebugTarget) -> TargetInfo {
     TargetInfo {
-        target_id: info.target_id.inner().clone(),
-        r#type: info.r#type.clone(),
-        title: info.title.clone(),
-        url: info.url.clone(),
+        target_id: target.target_id,
+        r#type: target.r#type,
+        title: target.title,
+        url: target.url,
     }
+}
+
+async fn browser_ws_targets(client: &RawCdpClient) -> anyhow::Result<HashMap<String, TargetInfo>> {
+    let value = client.execute("Target.getTargets", json!({})).await?;
+    let infos = value
+        .get("targetInfos")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Target.getTargets missing targetInfos"))?;
+    let mut targets = HashMap::new();
+    for info in infos {
+        let target = target_info_from_protocol(info);
+        if !target.target_id.is_empty() {
+            targets.insert(target.target_id.clone(), target);
+        }
+    }
+    Ok(targets)
+}
+
+fn target_info_from_protocol(info: &Value) -> TargetInfo {
+    TargetInfo {
+        target_id: info
+            .get("targetId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        r#type: info
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        title: info
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        url: info
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+async fn browser_ws_version(client: &RawCdpClient) -> anyhow::Result<String> {
+    let value = client.execute("Browser.getVersion", json!({})).await?;
+    let product = value
+        .get("product")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown browser");
+    let revision = value
+        .get("revision")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if revision.is_empty() {
+        Ok(product.to_string())
+    } else {
+        Ok(format!("{product} v{revision}"))
+    }
+}
+
+async fn close_target_via_browser_ws(client: &RawCdpClient, target_id: &str) -> anyhow::Result<()> {
+    client
+        .execute("Target.closeTarget", json!({ "targetId": target_id }))
+        .await?;
+    Ok(())
+}
+
+/// Browser version string from the cached endpoint metadata, if present.
+/// `None` for endpoints discovered without a `/json/version` round-trip (e.g.
+/// an explicit `SOCAI_CDP_WS`), in which case callers fetch it actively.
+fn browser_version_opt(endpoint: &Endpoint) -> Option<String> {
+    endpoint
+        .version
+        .as_ref()
+        .and_then(|version| version.browser.clone().or_else(|| version.user_agent.clone()))
 }

--- a/core/src/cdp/mod.rs
+++ b/core/src/cdp/mod.rs
@@ -1,7 +1,9 @@
 pub mod connection;
 pub mod endpoint;
+pub(crate) mod launch;
 pub mod lifecycle;
 pub mod pages;
+pub(crate) mod raw_client;
 pub mod session;
 pub mod snapshot;
 

--- a/core/src/cdp/pages.rs
+++ b/core/src/cdp/pages.rs
@@ -1,14 +1,12 @@
-use std::sync::Arc;
+use serde_json::{json, Value};
 
-use chromiumoxide::cdp::browser_protocol::target::CloseTargetParams;
-use chromiumoxide::Browser;
-
-use crate::cdp::connection::{Cdp, CdpState};
+use crate::cdp::connection::Cdp;
+use crate::cdp::endpoint;
 use crate::cdp::session::PageSession;
 
-/// Thin page factory over one CDP connection. Higher-level runtime code can
-/// decide whether a page belongs to a tool session, an agent run, or a debug
-/// command.
+/// Thin page factory over one remote-debugging endpoint. Higher-level runtime
+/// code decides whether a page belongs to a tool session, an agent run, or a
+/// debug command.
 pub struct PageSessionManager {
     cdp: Cdp,
 }
@@ -18,12 +16,79 @@ impl PageSessionManager {
         Self { cdp }
     }
 
-    /// Open a new tab navigated to `start_url`. Errors if the CDP connection
-    /// is not in `Connected` state.
+    /// Open a new socai-owned tab and control only that target. This
+    /// deliberately avoids browser-wide CDP target discovery/auto-attach, so
+    /// unrelated user tabs are not instrumented.
     pub async fn create_page(&self, start_url: &str) -> anyhow::Result<PageSession> {
-        let browser = self.browser().await?;
-        let page = browser.new_page(start_url).await?;
-        Ok(PageSession::new(page))
+        if let Some(browser_client) = self.cdp.browser_client().await {
+            return self
+                .create_page_via_browser_ws(browser_client, start_url)
+                .await;
+        }
+
+        let endpoint = self.cdp.endpoint().await?;
+        let target = endpoint::create_debug_page(&endpoint, start_url).await?;
+        let target_id = target.target_id.clone();
+        let Some(ws) = target.web_socket_debugger_url else {
+            let _ = endpoint::close_debug_target(&endpoint, &target_id).await;
+            anyhow::bail!("created target missing webSocketDebuggerUrl: {target_id}");
+        };
+        let page = match PageSession::connect(target_id.clone(), &ws, self.cdp.clone()).await {
+            Ok(page) => page,
+            Err(err) => {
+                let _ = endpoint::close_debug_target(&endpoint, &target_id).await;
+                return Err(err);
+            }
+        };
+        self.cdp.register_owned_target(target_id).await;
+        Ok(page)
+    }
+
+    async fn create_page_via_browser_ws(
+        &self,
+        browser_client: crate::cdp::raw_client::RawCdpClient,
+        start_url: &str,
+    ) -> anyhow::Result<PageSession> {
+        let created = browser_client
+            .execute(
+                "Target.createTarget",
+                json!({ "url": blank_or_start_url(start_url) }),
+            )
+            .await?;
+        let target_id = created
+            .get("targetId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("Target.createTarget missing targetId"))?
+            .to_string();
+
+        let attached = match browser_client
+            .execute(
+                "Target.attachToTarget",
+                json!({ "targetId": target_id, "flatten": true }),
+            )
+            .await
+        {
+            Ok(attached) => attached,
+            Err(err) => {
+                let _ = browser_client
+                    .execute("Target.closeTarget", json!({ "targetId": target_id }))
+                    .await;
+                return Err(err);
+            }
+        };
+        let session_id = attached
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("Target.attachToTarget missing sessionId"))?
+            .to_string();
+
+        self.cdp.register_owned_target(target_id.clone()).await;
+        Ok(PageSession::attached(
+            target_id,
+            browser_client,
+            session_id,
+            self.cdp.clone(),
+        ))
     }
 
     /// Close a page target by target id. This is stronger than consuming a
@@ -34,19 +99,25 @@ impl PageSessionManager {
         if target_id.is_empty() {
             return Ok(false);
         }
-        let browser = self.browser().await?;
-        browser
-            .execute(CloseTargetParams::new(target_id.to_string()))
-            .await?;
-        Ok(true)
-    }
-
-    async fn browser(&self) -> anyhow::Result<Arc<Browser>> {
-        let state = self.cdp.state();
-        let guard = state.lock().await;
-        match &*guard {
-            CdpState::Connected { browser, .. } => Ok(Arc::clone(browser)),
-            _ => Err(anyhow::anyhow!("CDP not connected")),
+        if let Some(browser_client) = self.cdp.browser_client().await {
+            browser_client
+                .execute("Target.closeTarget", json!({ "targetId": target_id }))
+                .await?;
+            self.cdp.unregister_owned_target(target_id).await;
+            return Ok(true);
         }
+        let endpoint = self.cdp.endpoint().await?;
+        let result = endpoint::close_debug_target(&endpoint, target_id).await;
+        self.cdp.unregister_owned_target(target_id).await;
+        result
+    }
+}
+
+fn blank_or_start_url(start_url: &str) -> &str {
+    let start_url = start_url.trim();
+    if start_url.is_empty() {
+        "about:blank"
+    } else {
+        start_url
     }
 }

--- a/core/src/cdp/pages.rs
+++ b/core/src/cdp/pages.rs
@@ -1,7 +1,6 @@
 use serde_json::{json, Value};
 
 use crate::cdp::connection::Cdp;
-use crate::cdp::endpoint;
 use crate::cdp::session::PageSession;
 
 /// Thin page factory over one remote-debugging endpoint. Higher-level runtime
@@ -16,32 +15,19 @@ impl PageSessionManager {
         Self { cdp }
     }
 
-    /// Open a new socai-owned tab and control only that target. This
-    /// deliberately avoids browser-wide CDP target discovery/auto-attach, so
-    /// unrelated user tabs are not instrumented.
+    /// Open a new socai-owned tab and control only that target. All target
+    /// lifecycle is routed through the browser websocket (`Target.*`) so
+    /// existing and managed Chrome share one code path. This deliberately
+    /// avoids browser-wide CDP target discovery/auto-attach, so unrelated user
+    /// tabs are not instrumented.
     pub async fn create_page(&self, start_url: &str) -> anyhow::Result<PageSession> {
-        if let Some(browser_client) = self.cdp.browser_client().await {
-            return self
-                .create_page_via_browser_ws(browser_client, start_url)
-                .await;
-        }
-
-        let endpoint = self.cdp.endpoint().await?;
-        let target = endpoint::create_debug_page(&endpoint, start_url).await?;
-        let target_id = target.target_id.clone();
-        let Some(ws) = target.web_socket_debugger_url else {
-            let _ = endpoint::close_debug_target(&endpoint, &target_id).await;
-            anyhow::bail!("created target missing webSocketDebuggerUrl: {target_id}");
-        };
-        let page = match PageSession::connect(target_id.clone(), &ws, self.cdp.clone()).await {
-            Ok(page) => page,
-            Err(err) => {
-                let _ = endpoint::close_debug_target(&endpoint, &target_id).await;
-                return Err(err);
-            }
-        };
-        self.cdp.register_owned_target(target_id).await;
-        Ok(page)
+        let browser_client = self
+            .cdp
+            .browser_client()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("CDP browser websocket is not connected"))?;
+        self.create_page_via_browser_ws(browser_client, start_url)
+            .await
     }
 
     async fn create_page_via_browser_ws(
@@ -99,19 +85,16 @@ impl PageSessionManager {
         if target_id.is_empty() {
             return Ok(false);
         }
-        if let Some(browser_client) = self.cdp.browser_client().await {
-            browser_client
-                .execute("Target.closeTarget", json!({ "targetId": target_id }))
-                .await?;
-            self.cdp.unregister_owned_target(target_id).await;
-            return Ok(true);
-        }
-        let endpoint = self.cdp.endpoint().await?;
-        let result = endpoint::close_debug_target(&endpoint, target_id).await;
-        if matches!(result, Ok(true)) {
-            self.cdp.unregister_owned_target(target_id).await;
-        }
-        result
+        let browser_client = self
+            .cdp
+            .browser_client()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("CDP browser websocket is not connected"))?;
+        browser_client
+            .execute("Target.closeTarget", json!({ "targetId": target_id }))
+            .await?;
+        self.cdp.unregister_owned_target(target_id).await;
+        Ok(true)
     }
 }
 

--- a/core/src/cdp/pages.rs
+++ b/core/src/cdp/pages.rs
@@ -108,7 +108,9 @@ impl PageSessionManager {
         }
         let endpoint = self.cdp.endpoint().await?;
         let result = endpoint::close_debug_target(&endpoint, target_id).await;
-        self.cdp.unregister_owned_target(target_id).await;
+        if matches!(result, Ok(true)) {
+            self.cdp.unregister_owned_target(target_id).await;
+        }
         result
     }
 }

--- a/core/src/cdp/raw_client.rs
+++ b/core/src/cdp/raw_client.rs
@@ -17,9 +17,9 @@ const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// This intentionally avoids `chromiumoxide::Handler`: we send only explicit
 /// commands socai needs. Events are ignored, and no browser-wide target
-/// discovery/auto-attach/domain enabling is performed. The same transport is
-/// used for direct page-target websockets and for a browser websocket with an
-/// explicit `sessionId` attached to one socai-owned target.
+/// discovery/auto-attach/domain enabling is performed. The runtime uses a
+/// browser websocket for target inventory/lifecycle and routes page commands
+/// with an explicit `sessionId` attached to one socai-owned target.
 #[derive(Clone)]
 pub struct RawCdpClient {
     tx: mpsc::Sender<CommandRequest>,

--- a/core/src/cdp/raw_client.rs
+++ b/core/src/cdp/raw_client.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_tungstenite::tokio::connect_async_with_config;
+use async_tungstenite::tungstenite::protocol::WebSocketConfig;
+use async_tungstenite::tungstenite::Message as WsMessage;
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::{mpsc, oneshot};
+
+const COMMAND_CHANNEL_CAPACITY: usize = 64;
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Minimal CDP websocket client.
+///
+/// This intentionally avoids `chromiumoxide::Handler`: we send only explicit
+/// commands socai needs. Events are ignored, and no browser-wide target
+/// discovery/auto-attach/domain enabling is performed. The same transport is
+/// used for direct page-target websockets and for a browser websocket with an
+/// explicit `sessionId` attached to one socai-owned target.
+#[derive(Clone)]
+pub struct RawCdpClient {
+    tx: mpsc::Sender<CommandRequest>,
+}
+
+struct CommandRequest {
+    method: String,
+    params: Value,
+    session_id: Option<String>,
+    resp: oneshot::Sender<std::result::Result<Value, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IncomingMessage {
+    id: Option<u64>,
+    result: Option<Value>,
+    error: Option<CdpErrorPayload>,
+    #[allow(dead_code)]
+    method: Option<String>,
+    #[allow(dead_code)]
+    params: Option<Value>,
+    #[serde(rename = "sessionId")]
+    #[allow(dead_code)]
+    session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CdpErrorPayload {
+    code: i64,
+    message: String,
+}
+
+impl RawCdpClient {
+    pub async fn connect(ws_url: &str) -> Result<Self> {
+        let config = WebSocketConfig {
+            max_message_size: None,
+            max_frame_size: None,
+            ..Default::default()
+        };
+        let (ws, _) = connect_async_with_config(ws_url, Some(config))
+            .await
+            .with_context(|| format!("failed to connect CDP websocket: {ws_url}"))?;
+        let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        tokio::spawn(run_connection(ws, rx));
+        Ok(Self { tx })
+    }
+
+    pub async fn execute(&self, method: impl Into<String>, params: Value) -> Result<Value> {
+        self.execute_for_session(None, method, params).await
+    }
+
+    pub async fn execute_for_session(
+        &self,
+        session_id: Option<&str>,
+        method: impl Into<String>,
+        params: Value,
+    ) -> Result<Value> {
+        let method = method.into();
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(CommandRequest {
+                method: method.clone(),
+                params,
+                session_id: session_id.map(ToOwned::to_owned),
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| anyhow!("CDP session is closed"))?;
+
+        let response = tokio::time::timeout(COMMAND_TIMEOUT, resp_rx)
+            .await
+            .map_err(|_| anyhow!("CDP command timed out: {method}"))?
+            .map_err(|_| anyhow!("CDP session closed while waiting for: {method}"))?;
+        response.map_err(|err| anyhow!("CDP command failed ({method}): {err}"))
+    }
+}
+
+async fn run_connection<S>(
+    ws: async_tungstenite::WebSocketStream<S>,
+    mut rx: mpsc::Receiver<CommandRequest>,
+) where
+    S: futures::AsyncRead + futures::AsyncWrite + Unpin,
+{
+    let (mut write, mut read) = ws.split();
+    let mut next_id: u64 = 1;
+    let mut pending: HashMap<u64, oneshot::Sender<std::result::Result<Value, String>>> =
+        HashMap::new();
+
+    // Periodically drop entries whose caller already gave up — `execute_*` times
+    // out after COMMAND_TIMEOUT and drops its receiver, which marks the sender
+    // closed. Without this, a target that stops answering (but keeps the socket
+    // open) would leak one `pending` entry per timed-out command for the life of
+    // the connection.
+    let mut prune = tokio::time::interval(COMMAND_TIMEOUT);
+    prune.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = prune.tick() => {
+                pending.retain(|_, resp| !resp.is_closed());
+            }
+            command = rx.recv() => {
+                let Some(command) = command else {
+                    fail_all(&mut pending, "command channel closed");
+                    break;
+                };
+                let id = next_id;
+                next_id = next_id.wrapping_add(1).max(1);
+                let mut payload = serde_json::json!({
+                    "id": id,
+                    "method": command.method,
+                    "params": command.params,
+                });
+                if let Some(session_id) = command.session_id {
+                    payload["sessionId"] = Value::String(session_id);
+                }
+                let text = match serde_json::to_string(&payload) {
+                    Ok(text) => text,
+                    Err(err) => {
+                        let _ = command.resp.send(Err(format!("failed to serialize CDP command: {err}")));
+                        continue;
+                    }
+                };
+                pending.insert(id, command.resp);
+                if let Err(err) = write.send(WsMessage::Text(text)).await {
+                    fail_one(&mut pending, id, format!("websocket send failed: {err}"));
+                    fail_all(&mut pending, "websocket send failed");
+                    break;
+                }
+            }
+            message = read.next() => {
+                match message {
+                    Some(Ok(WsMessage::Text(text))) => handle_text_message(&mut pending, &text),
+                    Some(Ok(WsMessage::Binary(bytes))) => {
+                        if let Ok(text) = std::str::from_utf8(&bytes) {
+                            handle_text_message(&mut pending, text);
+                        }
+                    }
+                    Some(Ok(WsMessage::Close(_))) | None => {
+                        fail_all(&mut pending, "websocket closed");
+                        break;
+                    }
+                    Some(Ok(WsMessage::Ping(_))) | Some(Ok(WsMessage::Pong(_))) => {}
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        fail_all(&mut pending, &format!("websocket receive failed: {err}"));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn handle_text_message(
+    pending: &mut HashMap<u64, oneshot::Sender<std::result::Result<Value, String>>>,
+    text: &str,
+) {
+    let Ok(message) = serde_json::from_str::<IncomingMessage>(text) else {
+        tracing::debug!(target: "socai::cdp::raw", msg = text, "failed to parse CDP message");
+        return;
+    };
+    let Some(id) = message.id else {
+        // Target-scoped events are intentionally ignored. We do not enable noisy
+        // domains, but Chrome may still emit a few lifecycle/runtime messages in
+        // response to commands.
+        return;
+    };
+    let Some(resp) = pending.remove(&id) else {
+        return;
+    };
+    let result = if let Some(err) = message.error {
+        Err(format!("{} ({})", err.message, err.code))
+    } else {
+        Ok(message.result.unwrap_or_else(|| serde_json::json!({})))
+    };
+    let _ = resp.send(result);
+}
+
+fn fail_one(
+    pending: &mut HashMap<u64, oneshot::Sender<std::result::Result<Value, String>>>,
+    id: u64,
+    reason: String,
+) {
+    if let Some(resp) = pending.remove(&id) {
+        let _ = resp.send(Err(reason));
+    }
+}
+
+fn fail_all(
+    pending: &mut HashMap<u64, oneshot::Sender<std::result::Result<Value, String>>>,
+    reason: &str,
+) {
+    for (_, resp) in pending.drain() {
+        let _ = resp.send(Err(reason.to_string()));
+    }
+}

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -8,6 +8,7 @@ use base64::Engine as _;
 use serde_json::{json, Value};
 
 use super::connection::Cdp;
+use super::endpoint;
 use super::raw_client::RawCdpClient;
 use super::snapshot::SnapshotRecorder;
 
@@ -350,12 +351,25 @@ impl PageSession {
     /// Close the underlying tab. Consumes the session.
     pub async fn close(self) -> anyhow::Result<()> {
         // `Page.close` often closes the target websocket before Chrome sends a
-        // command response. Treat that as success; cancellation paths that need
-        // a stronger close use `Target.closeTarget` via the HTTP endpoint.
+        // command response. Treat that as success, but if the command errors
+        // before Chrome closes the target, best-effort fall back to the stronger
+        // target-level close so owned tabs do not become untracked leftovers.
         let target_id = self.target_id.clone();
-        let _ = self.execute("Page.close", json!({})).await;
+        if self.execute("Page.close", json!({})).await.is_err() {
+            self.close_target_fallback(&target_id).await;
+        }
         self.owner.unregister_owned_target(&target_id).await;
         Ok(())
+    }
+
+    async fn close_target_fallback(&self, target_id: &str) {
+        if let Some(client) = self.owner.browser_client().await {
+            let _ = client
+                .execute("Target.closeTarget", json!({ "targetId": target_id }))
+                .await;
+        } else if let Ok(endpoint) = self.owner.endpoint().await {
+            let _ = endpoint::close_debug_target(&endpoint, target_id).await;
+        }
     }
 }
 

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -2,49 +2,29 @@ use std::path::Path;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
-use chromiumoxide::cdp::browser_protocol::accessibility::EnableParams;
-use chromiumoxide::cdp::browser_protocol::input::{
-    DispatchKeyEventParams, DispatchKeyEventType, InsertTextParams,
-};
-use chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat;
-use chromiumoxide::layout::Point;
-use chromiumoxide::page::ScreenshotParams;
-use chromiumoxide::types::{Command, Method, MethodId};
-use chromiumoxide::Page;
-use serde::Serialize;
-use serde_json::Value;
+use anyhow::{anyhow, Context};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use serde_json::{json, Value};
 
-/// Raw `Accessibility.getFullAXTree` command whose response is left as
-/// untyped JSON. chromiumoxide's generated `GetFullAxTreeParams` deserializes
-/// the reply into its own `AxNode` structs, which lag the live Chrome AX
-/// schema and fail (the historical `uninteresting` serde error). We only want
-/// the JSON for the debug snapshot, so we skip the typed round-trip entirely.
-#[derive(Debug, Serialize)]
-struct GetFullAxTreeRaw {}
-
-impl Method for GetFullAxTreeRaw {
-    fn identifier(&self) -> MethodId {
-        "Accessibility.getFullAXTree".into()
-    }
-}
-
-impl Command for GetFullAxTreeRaw {
-    type Response = Value;
-}
-
+use super::connection::Cdp;
+use super::raw_client::RawCdpClient;
 use super::snapshot::SnapshotRecorder;
 
-/// A tab-scoped session. Wraps a chromiumoxide `Page` with the small set of
-/// primitives the agent layer needs: `evaluate_json` (the JS-extractor entry
-/// point), `navigate`, and `page_info`. Higher-level tools (selector waits,
-/// click-by-selector, fill, etc.) live in the sites module.
+/// A tab-scoped session. Unlike the previous chromiumoxide-backed
+/// implementation, this sends only the commands socai needs to one owned page
+/// target. It does not enable Network/Page/Runtime event domains globally and
+/// does not auto-attach to unrelated browser tabs.
 ///
 /// `recorder` is an optional debug hook: when set (via `--debug-snapshot`),
 /// every `evaluate_json` — the universal perception point for the tools —
 /// first lets the recorder capture a DOM/a11y/screenshot bundle if the page
 /// changed since the last capture. See [`SnapshotRecorder`].
 pub struct PageSession {
-    page: Page,
+    target_id: String,
+    owner: Cdp,
+    client: RawCdpClient,
+    session_id: Option<String>,
     recorder: StdMutex<Option<Arc<SnapshotRecorder>>>,
 }
 
@@ -63,15 +43,38 @@ return {
 "#;
 
 impl PageSession {
-    pub(crate) fn new(page: Page) -> Self {
+    pub(crate) async fn connect(
+        target_id: String,
+        ws_url: &str,
+        owner: Cdp,
+    ) -> anyhow::Result<Self> {
+        let client = RawCdpClient::connect(ws_url).await?;
+        Ok(Self {
+            target_id,
+            owner,
+            client,
+            session_id: None,
+            recorder: StdMutex::new(None),
+        })
+    }
+
+    pub(crate) fn attached(
+        target_id: String,
+        client: RawCdpClient,
+        session_id: String,
+        owner: Cdp,
+    ) -> Self {
         Self {
-            page,
+            target_id,
+            owner,
+            client,
+            session_id: Some(session_id),
             recorder: StdMutex::new(None),
         }
     }
 
     pub fn target_id(&self) -> &str {
-        self.page.target_id().inner()
+        &self.target_id
     }
 
     /// Attach a debug snapshot recorder. Captures begin on the next
@@ -92,11 +95,13 @@ impl PageSession {
         self.recorder.lock().ok().and_then(|guard| guard.clone())
     }
 
+    async fn execute(&self, method: &str, params: Value) -> anyhow::Result<Value> {
+        self.client
+            .execute_for_session(self.session_id.as_deref(), method, params)
+            .await
+    }
+
     /// Let an attached recorder capture the page *before* an operation runs.
-    /// Called at the top of every action (`navigate`, `click`, `type_text`,
-    /// `press_key`) and every `evaluate_json`, so the snapshot timeline has a
-    /// frame for each tool operation, showing the state it acted on. Cheap and
-    /// a no-op when no recorder is attached; content-deduped downstream.
     async fn snapshot_before(&self) {
         if let Some(recorder) = self.recorder() {
             recorder.before_operation(self).await;
@@ -115,7 +120,18 @@ impl PageSession {
     ) -> anyhow::Result<()> {
         self.snapshot_before().await;
         let timeout = seconds(timeout_seconds);
-        tokio::time::timeout(timeout, self.page.goto(url)).await??;
+        let resp = tokio::time::timeout(
+            timeout,
+            self.execute("Page.navigate", json!({ "url": url })),
+        )
+        .await
+        .map_err(|_| anyhow!("Page.navigate timed out after {timeout_seconds}s"))??;
+        // `Page.navigate` reports navigation failures (DNS, net::ERR_*, blocked)
+        // in an `errorText` field rather than as a CDP error — chromiumoxide's
+        // `goto` surfaced these, so check it to preserve that behavior.
+        if let Some(err) = resp.get("errorText").and_then(Value::as_str) {
+            anyhow::bail!("navigation to {url} failed: {err}");
+        }
         self.wait_for_load_state("domcontentloaded", timeout_seconds)
             .await?;
         Ok(())
@@ -152,14 +168,6 @@ impl PageSession {
     /// `serde_json::Value`. The expression is wrapped in an IIFE when it
     /// contains a top-level `return`, so callers can pass function-body style
     /// snippets.
-    ///
-    /// This is the tools' universal perception point. Before running the
-    /// caller's snippet, it lets an attached [`SnapshotRecorder`] capture the
-    /// *current* DOM — i.e. the state the tool is about to read or act on —
-    /// gated on whether the page changed since the last capture. Capturing
-    /// *before* (not after) means the snapshot reflects exactly what the tool
-    /// saw going into this operation; any change the operation causes is
-    /// captured before the next one.
     pub async fn evaluate_json(&self, expression: &str) -> anyhow::Result<Value> {
         self.snapshot_before().await;
         self.evaluate_json_raw(expression).await
@@ -169,26 +177,36 @@ impl PageSession {
     /// so its own DOM reads don't recurse back into capture.
     pub(crate) async fn evaluate_json_raw(&self, expression: &str) -> anyhow::Result<Value> {
         let wrapped = wrap_expression(expression);
-        let result = self.page.evaluate(wrapped.as_str()).await?;
-        let value: Value = result.into_value()?;
-        Ok(value)
+        let resp = self
+            .execute(
+                "Runtime.evaluate",
+                json!({
+                    "expression": wrapped,
+                    "awaitPromise": true,
+                    "returnByValue": true,
+                }),
+            )
+            .await?;
+        if let Some(exception) = resp.get("exceptionDetails") {
+            anyhow::bail!("javascript exception: {}", summarize_exception(exception));
+        }
+        let result = resp
+            .get("result")
+            .ok_or_else(|| anyhow!("Runtime.evaluate missing result"))?;
+        remote_object_value(result)
     }
 
-    /// Turn on the CDP Accessibility domain. Not required for `getFullAXTree`
-    /// to return data, but it keeps `AXNodeId`s stable across calls, which makes
-    /// the per-node a11y dumps comparable between snapshots. The recorder calls
-    /// it once. Idempotent; persists across navigations within the target.
+    /// Turn on the CDP Accessibility domain. The recorder calls it once when
+    /// debug snapshots are enabled. This is intentionally opt-in because AX tree
+    /// collection can be expensive on large pages.
     pub(crate) async fn enable_accessibility(&self) -> anyhow::Result<()> {
-        self.page.execute(EnableParams::default()).await?;
+        self.execute("Accessibility.enable", json!({})).await?;
         Ok(())
     }
 
     /// Full accessibility tree for the document as JSON (`{ "nodes": [...] }`).
-    /// Used by the snapshot recorder; backed by CDP `Accessibility.getFullAXTree`
-    /// with an untyped response (see [`GetFullAxTreeRaw`]).
     pub(crate) async fn ax_tree_json(&self) -> anyhow::Result<Value> {
-        let resp = self.page.execute(GetFullAxTreeRaw {}).await?;
-        Ok(resp.result)
+        self.execute("Accessibility.getFullAXTree", json!({})).await
     }
 
     pub async fn page_info(&self) -> anyhow::Result<Value> {
@@ -197,42 +215,66 @@ impl PageSession {
 
     pub async fn click(&self, x: f64, y: f64) -> anyhow::Result<()> {
         self.snapshot_before().await;
-        self.page.click(Point::new(x, y)).await?;
+        self.dispatch_mouse("mouseMoved", x, y, "none", 0).await?;
+        self.dispatch_mouse("mousePressed", x, y, "left", 1).await?;
+        self.dispatch_mouse("mouseReleased", x, y, "left", 1)
+            .await?;
         Ok(())
     }
 
     pub async fn mouse_move(&self, x: f64, y: f64) -> anyhow::Result<()> {
         self.snapshot_before().await;
-        self.page.move_mouse(Point::new(x, y)).await?;
+        self.dispatch_mouse("mouseMoved", x, y, "none", 0).await
+    }
+
+    async fn dispatch_mouse(
+        &self,
+        event_type: &str,
+        x: f64,
+        y: f64,
+        button: &str,
+        click_count: i64,
+    ) -> anyhow::Result<()> {
+        self.execute(
+            "Input.dispatchMouseEvent",
+            json!({
+                "type": event_type,
+                "x": x,
+                "y": y,
+                "button": button,
+                "clickCount": click_count,
+            }),
+        )
+        .await?;
         Ok(())
     }
 
     pub async fn type_text(&self, text: &str) -> anyhow::Result<()> {
         self.snapshot_before().await;
-        self.page.execute(InsertTextParams::new(text)).await?;
+        self.execute("Input.insertText", json!({ "text": text }))
+            .await?;
         Ok(())
     }
 
     pub async fn press_key(&self, key: &str) -> anyhow::Result<()> {
         self.snapshot_before().await;
         let (vk, code, text) = key_definition(key);
-        let base = |event_type| {
-            let mut builder = DispatchKeyEventParams::builder()
-                .r#type(event_type)
-                .key(key)
-                .code(code)
-                .windows_virtual_key_code(vk)
-                .native_virtual_key_code(vk);
-            if !text.is_empty() {
-                builder = builder.text(text);
+        let base = |event_type: &str| {
+            let mut params = json!({
+                "type": event_type,
+                "key": key,
+                "code": code,
+                "windowsVirtualKeyCode": vk,
+                "nativeVirtualKeyCode": vk,
+            });
+            if event_type == "keyDown" && !text.is_empty() {
+                params["text"] = Value::String(text.to_string());
             }
-            builder.build().map_err(anyhow::Error::msg)
+            params
         };
-        self.page
-            .execute(base(DispatchKeyEventType::KeyDown)?)
+        self.execute("Input.dispatchKeyEvent", base("keyDown"))
             .await?;
-        self.page
-            .execute(base(DispatchKeyEventType::KeyUp)?)
+        self.execute("Input.dispatchKeyEvent", base("keyUp"))
             .await?;
         Ok(())
     }
@@ -249,22 +291,51 @@ impl PageSession {
     /// JPEG screenshot (quality 0-100). Web-page captures compress far
     /// better as JPEG than PNG at no practical loss for review purposes.
     pub async fn screenshot_jpeg(&self, full: bool, quality: u32) -> anyhow::Result<Vec<u8>> {
-        let params = ScreenshotParams::builder()
-            .format(CaptureScreenshotFormat::Jpeg)
-            .quality(i64::from(quality))
-            .full_page(full)
-            .capture_beyond_viewport(full)
-            .build();
-        Ok(self.page.screenshot(params).await?)
+        self.capture_screenshot("jpeg", full, Some(quality)).await
     }
 
     pub async fn screenshot_png(&self, full: bool) -> anyhow::Result<Vec<u8>> {
-        let params = ScreenshotParams::builder()
-            .format(CaptureScreenshotFormat::Png)
-            .full_page(full)
-            .capture_beyond_viewport(full)
-            .build();
-        Ok(self.page.screenshot(params).await?)
+        self.capture_screenshot("png", full, None).await
+    }
+
+    /// Raw `Page.captureScreenshot`. For full-page captures we clip to the
+    /// document's content size (CDP otherwise only returns the viewport). The
+    /// reply is base64 PNG/JPEG bytes regardless of format.
+    async fn capture_screenshot(
+        &self,
+        format: &str,
+        full: bool,
+        quality: Option<u32>,
+    ) -> anyhow::Result<Vec<u8>> {
+        let mut params = json!({
+            "format": format,
+            "captureBeyondViewport": full,
+            "fromSurface": true,
+        });
+        if let Some(quality) = quality {
+            params["quality"] = json!(quality);
+        }
+        if full {
+            let metrics = self.execute("Page.getLayoutMetrics", json!({})).await?;
+            let content = metrics
+                .get("contentSize")
+                .ok_or_else(|| anyhow!("Page.getLayoutMetrics missing contentSize"))?;
+            let width = content.get("width").and_then(Value::as_f64).unwrap_or(1.0);
+            let height = content.get("height").and_then(Value::as_f64).unwrap_or(1.0);
+            params["clip"] = json!({
+                "x": content.get("x").and_then(Value::as_f64).unwrap_or(0.0),
+                "y": content.get("y").and_then(Value::as_f64).unwrap_or(0.0),
+                "width": width.max(1.0),
+                "height": height.max(1.0),
+                "scale": 1.0,
+            });
+        }
+        let resp = self.execute("Page.captureScreenshot", params).await?;
+        let data = resp
+            .get("data")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("Page.captureScreenshot missing data"))?;
+        BASE64.decode(data).context("failed to decode screenshot")
     }
 
     pub async fn save_screenshot(&self, path: impl AsRef<Path>, full: bool) -> anyhow::Result<()> {
@@ -276,12 +347,42 @@ impl PageSession {
         Ok(())
     }
 
-    /// Close the underlying tab. Consumes the session — the chromiumoxide
-    /// page handle is dropped on success.
+    /// Close the underlying tab. Consumes the session.
     pub async fn close(self) -> anyhow::Result<()> {
-        self.page.close().await?;
+        // `Page.close` often closes the target websocket before Chrome sends a
+        // command response. Treat that as success; cancellation paths that need
+        // a stronger close use `Target.closeTarget` via the HTTP endpoint.
+        let target_id = self.target_id.clone();
+        let _ = self.execute("Page.close", json!({})).await;
+        self.owner.unregister_owned_target(&target_id).await;
         Ok(())
     }
+}
+
+fn remote_object_value(object: &Value) -> anyhow::Result<Value> {
+    if let Some(value) = object.get("value") {
+        return Ok(value.clone());
+    }
+    if object.get("subtype").and_then(Value::as_str) == Some("null") {
+        return Ok(Value::Null);
+    }
+    if object.get("type").and_then(Value::as_str) == Some("undefined") {
+        return Ok(Value::Null);
+    }
+    if let Some(unserializable) = object.get("unserializableValue").and_then(Value::as_str) {
+        return Ok(Value::String(unserializable.to_string()));
+    }
+    Ok(Value::Null)
+}
+
+fn summarize_exception(exception: &Value) -> String {
+    exception
+        .get("exception")
+        .and_then(|value| value.get("description").or_else(|| value.get("value")))
+        .and_then(Value::as_str)
+        .or_else(|| exception.get("text").and_then(Value::as_str))
+        .unwrap_or("unknown exception")
+        .to_string()
 }
 
 fn seconds(value: f64) -> Duration {

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -8,7 +8,6 @@ use base64::Engine as _;
 use serde_json::{json, Value};
 
 use super::connection::Cdp;
-use super::endpoint;
 use super::raw_client::RawCdpClient;
 use super::snapshot::SnapshotRecorder;
 
@@ -44,21 +43,6 @@ return {
 "#;
 
 impl PageSession {
-    pub(crate) async fn connect(
-        target_id: String,
-        ws_url: &str,
-        owner: Cdp,
-    ) -> anyhow::Result<Self> {
-        let client = RawCdpClient::connect(ws_url).await?;
-        Ok(Self {
-            target_id,
-            owner,
-            client,
-            session_id: None,
-            recorder: StdMutex::new(None),
-        })
-    }
-
     pub(crate) fn attached(
         target_id: String,
         client: RawCdpClient,
@@ -350,26 +334,17 @@ impl PageSession {
 
     /// Close the underlying tab. Consumes the session.
     pub async fn close(self) -> anyhow::Result<()> {
-        // `Page.close` often closes the target websocket before Chrome sends a
-        // command response. Treat that as success, but if the command errors
-        // before Chrome closes the target, best-effort fall back to the stronger
-        // target-level close so owned tabs do not become untracked leftovers.
         let target_id = self.target_id.clone();
-        if self.execute("Page.close", json!({})).await.is_err() {
-            self.close_target_fallback(&target_id).await;
-        }
+        let client = self
+            .owner
+            .browser_client()
+            .await
+            .ok_or_else(|| anyhow!("CDP browser websocket is not connected"))?;
+        client
+            .execute("Target.closeTarget", json!({ "targetId": target_id }))
+            .await?;
         self.owner.unregister_owned_target(&target_id).await;
         Ok(())
-    }
-
-    async fn close_target_fallback(&self, target_id: &str) {
-        if let Some(client) = self.owner.browser_client().await {
-            let _ = client
-                .execute("Target.closeTarget", json!({ "targetId": target_id }))
-                .await;
-        } else if let Ok(endpoint) = self.owner.endpoint().await {
-            let _ = endpoint::close_debug_target(&endpoint, target_id).await;
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the Chrome slowdown caused by socai's previous browser-wide CDP connection behavior.

- Replaces the persistent `chromiumoxide::Browser::connect` runtime path with a scoped raw CDP runtime.
- Uses the browser WebSocket as the single active target-management path in both existing and managed Chrome:
  - `Target.getTargets` for passive tab inventory
  - `Target.createTarget` for socai-owned tabs
  - `Target.attachToTarget` only for the created/owned target
  - `Target.closeTarget` for cleanup
- Avoids Chrome's HTTP `/json/list`, `/json/new`, and `/json/close` APIs for active runtime behavior. HTTP is now only an endpoint-discovery fallback when a browser WebSocket URL is not already available from `DevToolsActivePort` / `SOCAI_CDP_WS`.
- Sends page commands only through the owned target/session.
- Removes unintended broad instrumentation of user tabs:
  - no browser-wide `Target.setDiscoverTargets`
  - no auto-initialization of discovered page targets
  - no `Network.enable`, `Performance.enable`, `Log.enable`, etc. on unrelated tabs
- Bypasses local proxy/VPN tooling for the remaining Chrome debug HTTP discovery calls with `reqwest::ClientBuilder::no_proxy()`.
- Tracks socai-owned targets and closes/unregisters them on page close, task cancel, and browser disconnect.

## Issue analysis

### User-visible problem

After socai connected to Chrome CDP, opening unrelated sites such as GitHub or YouTube became extremely slow. Lightweight pages such as Google Search were much less affected.

The symptom initially looked like a browser-cache or VPN/proxy problem, but the underlying issue was broader: socai's CDP connection caused Chrome automation instrumentation to be applied to tabs socai did not own.

### Root cause

socai previously used `chromiumoxide::Browser::connect` as the shared browser connection. That is a good fit for owning/automating a browser instance, but a poor fit for passively connecting to a user's daily browser profile.

In `chromiumoxide`, the browser handler enables target discovery and treats discovered page targets as targets it should initialize. That means pages unrelated to socai can be driven through an automation initialization path.

Observed `chromiumoxide` behavior includes:

- browser-wide target discovery
- building `Target` state for discovered pages
- attaching to page targets
- enabling page/runtime/network-related instrumentation during target init, including domains such as:
  - `Page`
  - `Runtime`
  - `Network`
  - `Performance`
  - `Log`
- recursive target auto-attach behavior for related targets/workers/frames

For simple pages, this overhead may not be noticeable. For GitHub/YouTube-style pages, the extra CDP event and target/session machinery can become expensive because those sites create many requests, iframes, workers, execution contexts, and background events.

Important nuance: this was not primarily because HTTP disk cache was directly disabled. The problem was that unrelated tabs were effectively being treated like inspected/automated targets.

### Why upgrading `chromiumoxide` was not enough

I checked the latest published `chromiumoxide` (`0.9.1`). The same design pattern still appears to exist: handler creation enables target discovery, discovered pages are attached/initialized, and page initialization still includes auto-attach/performance/log behavior.

So a version bump would likely not fix the architectural mismatch. We need owned-target-only behavior, not whole-browser automation behavior.

## Fix design

The core invariant after this PR is:

> socai may observe browser/tab inventory passively, but may only attach/control tabs it created or explicitly owns.

### Browser/status path

The connected-state path no longer opens a `chromiumoxide` browser handler.

It first resolves a browser WebSocket URL:

1. Prefer explicit / already-known browser WebSocket sources:
   - `SOCAI_CDP_WS`
   - `DevToolsActivePort` from an existing or managed Chrome profile
2. Use Chrome's HTTP `/json/version` only as an endpoint-discovery fallback when a browser WebSocket URL is not otherwise known, e.g. `SOCAI_CDP_URL` or probing a conventional debug port.

Once connected, tab inventory always uses raw browser-WebSocket CDP:

- `Browser.getVersion`
- `Target.getTargets`

This path intentionally does **not** send:

- `Target.setDiscoverTargets`
- `Target.setAutoAttach`
- `Network.enable`
- `Performance.enable`
- `Log.enable`

### Page control path

When socai needs to run a tool/task, it always creates and controls one owned tab through the browser WebSocket:

- `Target.createTarget`
- `Target.attachToTarget` for that created target only
- page commands routed with that `sessionId`
- `Target.closeTarget` for cleanup

The active runtime no longer uses Chrome's HTTP `/json/list`, `/json/new`, or `/json/close` APIs, so existing and managed Chrome share the same target-management implementation.

The raw page session sends only explicit commands socai needs:

- `Runtime.evaluate`
- `Page.navigate`
- `Input.dispatchMouseEvent`
- `Input.dispatchKeyEvent`
- `Input.insertText`
- `Page.captureScreenshot`
- `Accessibility.*` only when debug snapshots are enabled
- `Target.closeTarget`

## CLI tab/session behavior

The CLI daemon keeps one reusable page session per site in memory. This is independent of whether the browser is an existing Chrome profile or socai's managed Chrome profile; active target lifecycle uses browser-WebSocket `Target.*` in both cases.

| Situation | Existing Chrome | Managed Chrome |
|---|---|---|
| CLI tab reuse | One tab per site | One tab per site |
| XHS search then another XHS search | Same `xhs` tab reused | Same `xhs` tab reused |
| XHS + DY commands | Separate tabs, one per site | Separate tabs, one per site |
| `socai stop` closes socai-owned tabs | Yes | Yes |
| `socai stop` kills Chrome | No | Yes, if this socai daemon launched that managed Chrome process |
| Depends on `/json` HTTP working? | No | No |
| User manually closes the socai tab | Next command detects the stale page session and creates a new tab | Next command detects the stale page session and creates a new tab |

Implementation notes:

- CLI state is keyed by site, not by command: `site_pages["xhs"]`, `site_pages["dy"]`, etc.
- There is also an in-memory `owned_targets` set used for cleanup on page close, cancellation, disconnect, and daemon shutdown.
- Existing profile mode never owns the user's Chrome process, so shutdown only closes socai-owned tabs and disconnects CDP.
- Managed profile mode uses socai's isolated Chrome profile; if socai launched that Chrome process, dropping the process guard during `socai stop` closes the managed browser. This is process ownership behavior, not a consequence of whether `/json/version` or `/json/list` is available.

## Follow-up bugs found while testing

### 502 from Chrome debug HTTP discovery

Error seen during earlier testing:

```text
HTTP status server error (502 Bad Gateway) for url (http://127.0.0.1:9222/json/list)
```

Cause: local debug HTTP requests were going through proxy/VPN tooling such as ClashVerge because `reqwest` honored proxy environment/system config.

Fix: the remaining Chrome debug HTTP discovery calls now use `.no_proxy()` because `127.0.0.1:<debug-port>` is a local control-plane endpoint and must never go through an HTTP proxy.

### 404 from `/json/list`

Error:

```text
HTTP status client error (404 Not Found) for url (http://127.0.0.1:9222/json/list)
```

Cause: some Chrome setups expose a usable browser WebSocket through `DevToolsActivePort` while the HTTP debug API is unavailable or stale for `/json/list`.

Fix: the active runtime no longer requires `/json/list` at all. `DevToolsActivePort` is used directly to get the browser WebSocket, then raw CDP `Target.getTargets` / `Target.createTarget` / `Target.attachToTarget` handles target inventory and owned-tab creation.

### Chrome approval dialog appeared twice

Cause: the first browser-WebSocket fallback attempted to validate `DevToolsActivePort` with a probe WebSocket, then opened another WebSocket for the real runtime. Chrome showed approval once per client connection.

Fix: remove the extra existing-browser probe. The runtime now opens one browser WebSocket for the active connection and uses it for both target polling and owned-tab sessions.

## Validation

Automated validation:

```bash
cargo check --locked
cargo test --workspace --locked
git diff --check
```

Live smoke tests on the unified browser-WebSocket target-management path:

```bash
# Existing profile: forced discovery through the real Chrome profile's DevToolsActivePort.
SOCAI_CHROME_USER_DATA_DIR="$HOME/Library/Application Support/Google/Chrome" \
  ./target/debug/socai xhs search AI --preview --num-notes 1 --pretty

# Managed profile: temporary isolated SOCAI_HOME / chrome-profile.
./target/debug/socai xhs search AI --preview --num-notes 1 --pretty
```

Results:

- Existing Chrome profile: connected through `DevToolsActivePort` + browser WebSocket, created an owned tab with `Target.createTarget`, and returned one XHS result.
- Managed Chrome profile: launched isolated Chrome, connected through `DevToolsActivePort` + browser WebSocket, created an owned tab with `Target.createTarget`, and reached XHS. The temporary fresh profile returned `login_required`, which is expected without XHS cookies.

## Risk / notes

- This replaces a high-level automation library path with a smaller raw CDP client, so behavior should be watched closely in real Chrome profiles.
- The raw client intentionally ignores events and does not enable noisy domains unless explicitly needed.
- If future socai features need more browser automation semantics, consider either extending the raw client carefully or forking `chromiumoxide` with explicit owned-target-only configuration knobs.


