### PR TITLE
fix: download xhs video poster covers

### DIFF
--- a/core/src/media/common.rs
+++ b/core/src/media/common.rs
@@ -81,6 +81,20 @@ pub(crate) fn save_bytes(
     Ok(path)
 }
 
+pub(crate) fn save_named_bytes(
+    base_dir: &Path,
+    payload: &[u8],
+    label: &str,
+    filename: &str,
+) -> Result<PathBuf> {
+    let safe_label = sanitize_label(label, "media");
+    let safe_filename = sanitize_filename(filename, "asset.bin");
+    let dir = ensure_dir(&base_dir.join(&safe_label))?;
+    let path = dir.join(safe_filename);
+    std::fs::write(&path, payload)?;
+    Ok(path)
+}
+
 pub(crate) fn url_suffix(url: &str, fallback: &str) -> String {
     let without_query = url.split('?').next().unwrap_or("");
     let suffix = Path::new(without_query)
@@ -187,6 +201,52 @@ fn sanitize_label(label: &str, fallback: &str) -> String {
     }
 }
 
+fn sanitize_filename(filename: &str, fallback: &str) -> String {
+    let raw_name = Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    let cleaned: String = raw_name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches(['.', '_', '-']);
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 pub(crate) fn empty_object() -> Value {
     Value::Object(Map::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_named_bytes_writes_fixed_file_inside_label_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = save_named_bytes(dir.path(), b"poster", "note/one", "post.jpg").unwrap();
+
+        assert_eq!(path, dir.path().join("note_one").join("post.jpg"));
+        assert_eq!(std::fs::read(path).unwrap(), b"poster");
+    }
+
+    #[test]
+    fn save_named_bytes_strips_path_components_from_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = save_named_bytes(dir.path(), b"poster", "note", "../post.jpg").unwrap();
+
+        assert_eq!(path, dir.path().join("note").join("post.jpg"));
+        assert_eq!(std::fs::read(path).unwrap(), b"poster");
+    }
 }

--- a/core/src/media/processor.rs
+++ b/core/src/media/processor.rs
@@ -6,7 +6,9 @@ use crate::agent::Backend as LlmProvider;
 use anyhow::Result;
 use serde_json::{json, Value};
 
-use crate::media::common::{ensure_dir, find_in_path, save_bytes, MediaConfig, USER_AGENT};
+use crate::media::common::{
+    ensure_dir, find_in_path, save_bytes, save_named_bytes, MediaConfig, USER_AGENT,
+};
 use crate::media::timing::TimingRecord;
 
 #[derive(Clone)]
@@ -91,6 +93,10 @@ impl MediaProcessor {
         save_bytes(&self.config.base_dir, payload, label, suffix)
     }
 
+    pub fn save_named_bytes(&self, payload: &[u8], label: &str, filename: &str) -> Result<PathBuf> {
+        save_named_bytes(&self.config.base_dir, payload, label, filename)
+    }
+
     pub async fn download_file(
         &self,
         url: &str,
@@ -100,6 +106,17 @@ impl MediaProcessor {
     ) -> Result<PathBuf> {
         let payload = self.download_bytes(url, referer).await?;
         self.save_bytes(&payload, label, suffix)
+    }
+
+    pub async fn download_named_file(
+        &self,
+        url: &str,
+        referer: &str,
+        label: &str,
+        filename: &str,
+    ) -> Result<PathBuf> {
+        let payload = self.download_bytes(url, referer).await?;
+        self.save_named_bytes(&payload, label, filename)
     }
 
     pub async fn download_file_with_timeout(

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -16,7 +16,8 @@ impl MediaProcessor {
     /// Download the playable video (and poster, when present) to the run's
     /// media directory without transcription, frame extraction, OCR, or vision.
     /// The returned video object preserves the input shape and adds
-    /// `local_path` / `poster_local_path` where downloads succeed.
+    /// `local_path` / `poster_local_path` where downloads succeed. Posters are
+    /// saved at the stable note-local path `site_media/<note>/post.jpg`.
     pub async fn download_video(
         &self,
         video: &Value,
@@ -43,12 +44,7 @@ impl MediaProcessor {
             .to_string();
         if !poster_url.is_empty() {
             match self
-                .download_file(
-                    &poster_url,
-                    referer,
-                    label,
-                    &url_suffix(&poster_url, ".jpg"),
-                )
+                .download_named_file(&poster_url, referer, label, "post.jpg")
                 .await
             {
                 Ok(path) => insert_string(&mut result, "poster_local_path", path.to_string_lossy()),
@@ -153,7 +149,7 @@ impl MediaProcessor {
     ) {
         match self.download_bytes(poster_url, referer).await {
             Ok(poster) if !poster.is_empty() => {
-                match self.save_bytes(&poster, label, &url_suffix(poster_url, ".jpg")) {
+                match self.save_named_bytes(&poster, label, "post.jpg") {
                     Ok(path) => insert_string(result, "poster_local_path", path.to_string_lossy()),
                     Err(err) => insert_string(result, "poster_save_error", format!("{err:#}")),
                 }

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -75,6 +75,8 @@ pub struct ReadNoteOptions {
     pub download_media: bool,
     pub max_images: usize,
     pub max_video_frames: usize,
+    pub poster_url_fallback: String,
+    pub note_id_fallback: String,
 }
 
 impl Default for ReadNoteOptions {
@@ -85,6 +87,8 @@ impl Default for ReadNoteOptions {
             download_media: false,
             max_images: 12,
             max_video_frames: 4,
+            poster_url_fallback: String::new(),
+            note_id_fallback: String::new(),
         }
     }
 }
@@ -582,15 +586,38 @@ impl<'a> XhsPageRuntime<'a> {
         note_id: &str,
         index: Option<usize>,
         wait_seconds: f64,
-        options: ReadNoteOptions,
+        mut options: ReadNoteOptions,
     ) -> Result<Value> {
         let mut open = None;
+        if options.note_id_fallback.trim().is_empty() && !note_id.trim().is_empty() {
+            options.note_id_fallback = note_id.trim().to_string();
+        }
         if !note_id.is_empty() || index.is_some() {
             let opened = self.open_note(note_id, index, wait_seconds).await?;
             if !script_ok(&opened) {
                 return Ok(
                     json!({ "ok": false, "open": opened, "error": opened.get("error").and_then(Value::as_str).unwrap_or("open_failed") }),
                 );
+            }
+            if options.poster_url_fallback.trim().is_empty() {
+                if let Some(cover_url) = opened
+                    .get("target")
+                    .and_then(|target| target.get("cover_url"))
+                    .and_then(Value::as_str)
+                    .filter(|url| !url.trim().is_empty())
+                {
+                    options.poster_url_fallback = cover_url.to_string();
+                }
+            }
+            if options.note_id_fallback.trim().is_empty() {
+                if let Some(target_note_id) = opened
+                    .get("target")
+                    .and_then(|target| target.get("note_id"))
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.trim().is_empty())
+                {
+                    options.note_id_fallback = target_note_id.to_string();
+                }
             }
             open = Some(opened);
         }
@@ -1016,6 +1043,10 @@ impl<'a> XhsPageRuntime<'a> {
 
         let mut note = parse_note(&body, &options.level);
 
+        if note.note_id.is_empty() && !options.note_id_fallback.trim().is_empty() {
+            note.note_id = options.note_id_fallback.trim().to_string();
+        }
+
         // Fall back to the live page URL when the JS payload didn't populate
         // body.url. One extra evaluate is cheap and keeps extraction stable
         // across navigation styles.
@@ -1044,6 +1075,10 @@ impl<'a> XhsPageRuntime<'a> {
             "waited_ms": raw.get("waited_ms").and_then(Value::as_i64).unwrap_or(0),
             "attempts": raw.get("attempts").and_then(Value::as_i64).unwrap_or(0),
         }));
+
+        if note.r#type == "video" && !options.poster_url_fallback.trim().is_empty() {
+            apply_video_poster_fallback(&mut note.video, &options.poster_url_fallback);
+        }
 
         if options.include_media {
             self.enrich_note_media(&mut note, options.max_images, options.max_video_frames)
@@ -1440,6 +1475,20 @@ fn insert_value_string(value: &mut Value, key: &str, text: &str) {
     }
 }
 
+fn apply_video_poster_fallback(video: &mut Value, fallback_url: &str) {
+    let fallback_url = fallback_url.trim();
+    if fallback_url.is_empty() {
+        return;
+    }
+    let has_poster = video
+        .get("poster_url")
+        .and_then(Value::as_str)
+        .is_some_and(|url| !url.trim().is_empty());
+    if !has_poster {
+        insert_value_string(video, "poster_url", fallback_url);
+    }
+}
+
 fn search_transition_ok(state: &Value, query: &str) -> bool {
     if state
         .get("page_state")
@@ -1596,5 +1645,23 @@ mod tests {
 
         let body = json!({});
         assert_eq!(parse_note(&body, "lite").image_count, 0);
+    }
+
+    #[test]
+    fn video_poster_fallback_fills_missing_url() {
+        let mut video = json!({});
+
+        apply_video_poster_fallback(&mut video, " https://img.example/cover.jpg ");
+
+        assert_eq!(video["poster_url"], "https://img.example/cover.jpg");
+    }
+
+    #[test]
+    fn video_poster_fallback_preserves_existing_url() {
+        let mut video = json!({ "poster_url": "https://img.example/poster.jpg" });
+
+        apply_video_poster_fallback(&mut video, "https://img.example/cover.jpg");
+
+        assert_eq!(video["poster_url"], "https://img.example/poster.jpg");
     }
 }

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -231,7 +231,7 @@ const SocaiXhsPageScripts = (() => {
           author_id: card.user?.userId || card.user?.id || '',
           author_url: card.user?.userId ? `https://www.xiaohongshu.com/user/profile/${card.user.userId}` : '',
           likes: String(card.interactInfo?.likedCount || card.interactInfo?.likes || ''),
-          cover_url: card.cover?.urlDefault || card.cover?.urlPre || '',
+          cover_url: cleanImageUrl(card.cover?.urlDefault || card.cover?.urlPre || ''),
           type: card.type || '',
           position: i,
           xsec_token: token,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -388,6 +388,10 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
         download_media: get_bool(input, "download_media", false),
         max_images: get_i64(input, "max_images", 12).max(1) as usize,
         max_video_frames: get_i64(input, "max_video_frames", 4).max(1) as usize,
+        poster_url_fallback: get_str(input, "poster_url_fallback")
+            .unwrap_or("")
+            .to_string(),
+        note_id_fallback: get_str(input, "note_id_fallback").unwrap_or("").to_string(),
     }
 }
 
@@ -1241,6 +1245,8 @@ impl Tool for TopicScanTool {
                         // enrichment-oriented default.
                         max_images: if download_media { 100 } else { 12 },
                         max_video_frames: 4,
+                        poster_url_fallback: card.cover_url.clone(),
+                        note_id_fallback: card.note_id.clone(),
                     },
                 )
                 .await;


### PR DESCRIPTION
## Summary
- save video poster downloads to a stable note-local `site_media/<note_id>/post.jpg` path
- use search-card cover URL as a fallback when note-detail `poster_url` is missing
- preserve `media_manifest` compatibility for `video_poster` entries and add path-safety tests

## Validation
- `cargo test -p socai-core`
- `cargo test -p socai-cli`
- reviewer pass: no blockers