### PR TITLE
fix(xhs): repair search/topic_scan when XHS rotates the search placeholder

### DIFF
--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -71,7 +71,18 @@ const SocaiXhsPageScripts = (() => {
   // (a chat-style composer with an AI helper "问点点" below). The
   // legacy <input> selectors are kept as fallback in case XHS rolls
   // the old UI back to some users.
+  //
+  // 2026-06: the composer placeholder now rotates trending hot-search
+  // phrases (e.g. "世界杯L组7点直播") instead of containing "搜索", so
+  // `placeholder*="搜索"` matches nothing and search silently no-ops.
+  // Anchor on the textarea's stable structural role instead:
+  // `.search-input textarea` works on both the home feed and the
+  // /search_result page; `#search-input-in-feeds textarea` is the
+  // explicit home-feed container. The placeholder match is demoted to
+  // a fallback.
   const SEARCH_INPUT_SELECTORS = [
+    '.search-input textarea',
+    '#search-input-in-feeds textarea',
     'textarea[placeholder*="搜索"]',
     'input#search-input',
     'input[type="search"]',

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1139,6 +1139,36 @@ impl Tool for TopicScanTool {
         // re-runs the search and would drop them), so don't pass them here.
         let search = xhs.search_notes(&query, None, 2.0, None).await?;
 
+        // If the search never landed on a results page (search box not found,
+        // login required, …) bail before the browse loop. Otherwise
+        // extract_search_cards would read whatever feed is on screen — the
+        // /explore recommendations — and silently return notes unrelated to the
+        // query. Surface the failure so callers see why instead of bad data.
+        if !search.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            let reason = search
+                .get("reason")
+                .and_then(Value::as_str)
+                .filter(|reason| !reason.is_empty())
+                .unwrap_or("search_failed")
+                .to_string();
+            let payload = json!({
+                "ok": false,
+                "query": query,
+                "search": search,
+                "selected_cards": [],
+                "notes": [],
+                "reason": reason,
+                "sampling": {
+                    "num_notes": num_notes,
+                    "selected": 0,
+                    "comments_per_note": TOPIC_SCAN_COMMENTS,
+                    "include_media": include_media,
+                    "download_media": download_media,
+                },
+            });
+            return Ok(json_result(&payload));
+        }
+
         // Optional tab switch (re-runs the search under the chosen tab), then
         // optional filter application.
         let mut tab_result = Value::Object(serde_json::Map::new());


### PR DESCRIPTION
## Problem

`topic_scan` (and `search_notes`) stopped applying the search query — it would browse posts unrelated to the query.

**Root cause:** XHS's homepage search box is a chat-style `<textarea>`, and its placeholder now **rotates trending hot-search phrases** (observed live: `世界杯L组7点直播`) instead of containing `搜索`. Every selector in `findSearchInput()` was keyed on `placeholder*="搜索"`, so it matched **nothing** → `findSearchInput()` returned `undefined` → search silently no-oped:

```
search_notes "露营"  →  ok:false, reason:"search_input_not_found", url:".../explore"
```

Worse, `topic_scan` ignored `search.ok` and called `extract_search_cards()` anyway, which on `/explore` falls back to scraping the **recommended feed** — so it returned real posts, just not the searched ones.

## Fix

1. **Anchor selectors on structural role, not volatile content.** `SEARCH_INPUT_SELECTORS` now leads with `.search-input textarea` (works on both the home feed and `/search_result*`) and `#search-input-in-feeds textarea` (home container). The placeholder match is demoted to a fallback.
2. **Fail loudly.** `topic_scan` now bails with the failure reason when `search.ok` is false, instead of silently returning explore-feed notes.

## Verification (live XHS, rebuilt daemon)

- `search_notes "露营"` → real camping posts, `xsec_source=pc_search`.
- `topic_scan "露营装备" --num-notes 2` → `ok:true`, landed on `/search_result_ai?keyword=…`, notes: *"solo露营装备清单（附收纳过程）"*, *"新手露营👏有哪些好用建议？"* — query-relevant.

## Note / follow-up

The new `/search_result_ai` layout double-encodes the URL keyword (`keyword=%25E9…`), so `searchParams.get('keyword')` won't decode to the query. Validation survives because `search_transition_ok` falls back to the input-field value (`input_keyword`), but it would break if XHS ever stops pre-filling that textarea. Not broken today — flagging as fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)