### PR TITLE
feat(xhs): author profile scan command + always return note comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ cargo install --path cli --force
 socai xhs topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
 socai xhs topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest_path
 socai xhs search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
+socai xhs author <作者id> --num-notes 30                                       # 打开作者主页，拿作者简介 + 帖子概要
+socai xhs author <作者id> --num-notes 10 --read-notes                          # 再逐个打开帖子读正文 + 评论
 socai xhs extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
 socai stop                                                                 # 停止 daemon（关闭工具标签页）
 ```
@@ -74,8 +76,10 @@ Options:
 - `--tab <TAB>` — search tab to switch to, `topic_scan` only (`全部` / `图文` / `视频` / `用户`).
 - `--num-notes <N>` — `topic_scan`: notes to read (opens each, body + comments).
   `search_notes`: cards to collect by auto-scrolling (titles/likes/covers only,
-  no bodies — stays fast). Both scroll only if the first page holds fewer; omit
-  for the first page only (~19).
+  no bodies — stays fast). `author`: note cards to collect from the profile grid.
+  Scrolls only if the first page holds fewer; omit for the first page only (~19).
+- `--read-notes` — `author` only: after collecting cards, open each note and read
+  its body + top comments (like `topic_scan`; latency scales with the card count).
 - `--download-media` — `topic_scan` only: download note images/videos into the
   printed `run_dir` (`site_media/`), add `local_path` fields, emit top-level
   `media_manifest_path` / `media_manifest_count`, and write `<run_dir>/media_manifest.json`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socai
 
-[![release](https://img.shields.io/github/v/release/socai-io/socai?style=flat-square&color=blue&label=release)](https://github.com/socai-io/socai/releases/latest)
 [![website](https://img.shields.io/badge/website-socai.io-blue?style=flat-square)](https://socai.io)
+[![release](https://img.shields.io/github/v/release/socai-io/socai?style=flat-square&color=blue&label=release)](https://github.com/socai-io/socai/releases/latest)
 
 专为小红书优化的 web use agent，执行小红书调研、内容抽取和自定义 agent 任务。
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,11 @@ cargo install --path cli --force
 小红书常用命令：
 
 ```bash
-socai xhs topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内   # 搜索并逐个打开帖子，获取内容
-socai xhs topic_scan "运营爆款思路" --num-notes 10 --download-media       # 下载图片/视频并输出 media_manifest_path
-socai xhs search_notes "运营爆款思路" --num-notes 100 --filter sort=最新          # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
-socai xhs author <作者id> --num-notes 30                                       # 打开作者主页，拿作者简介 + 帖子概要
-socai xhs author <作者id> --num-notes 10 --read-notes                          # 再逐个打开帖子读正文 + 评论
-socai xhs extract_note --note-id <id>                                          # 从当前结果页抽取某个帖子
-socai stop                                                                 # 停止 daemon（关闭工具标签页）
+socai xhs topic_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内 --download-media  # 搜索并逐个打开帖子，获取内容，并下载图片/视频
+socai xhs search_notes "运营爆款思路" --num-notes 100 --filter sort=最新  # 只打开搜索结果页，拿帖子标题/点赞/封面，不读正文
+socai xhs author <作者id> --num-notes 10 --read-notes                   # 打开作者主页，拿作者简介 + 帖子信息，加了--read-notes会逐个打开帖子读正文和评论，不加则是拿帖子概要
+socai xhs extract_note --note-id <id>                                  # 从当前结果页抽取某个帖子，必须从瀑布流页发起
+socai stop                                                             # 停止 daemon（关闭工具标签页）
 ```
 
 Options:
@@ -135,7 +133,7 @@ socai   # 不带子命令即打开 TUI
 
 ## 3. Desktop App (GUI)
 
-[Download .dmg for Mac](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg).
+[下载Mac版 .dmg](https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg).
 
 ## 添加自定义功能和网站
 socai具有自我迭代能力，如果你是AI（Claude Code, Codex, Cursor等），遵循`core/src/sites/creation/SKILL.md`中的步骤，和你的用户详细确认需求，并按照skill一步步新增代码，从而增加新功能或新网站。

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -419,10 +419,13 @@ impl DaemonState {
             // daemon restarts. Falls back to a direct connect when the bridge
             // can't start.
             crate::bridge::ensure_bridge_env().await;
-            let page = self
-                .runtime
-                .ensure_site_page(site.id, site.home_url)
-                .await?;
+            // Create the session tab blank and let the command navigate itself:
+            // every site command either opens its own entry URL (e.g. `author`
+            // opens the profile directly) or has a `before` hook that reaches
+            // the right page (search/topic_scan via ensure_search_ready). Passing
+            // home_url here would force an extra `/explore` load before the
+            // command then navigates again — wasted time for no benefit.
+            let page = self.runtime.ensure_site_page(site.id, "").await?;
             (spec.run)(page, args.clone(), debug_snapshot).await
         }
         .await;

--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -48,6 +48,7 @@ pub struct XhsAuthorProfile {
     pub xhs_id: String,
     pub profile_url: String,
     pub bio: String,
+    pub ip_location: String,
     pub followers: String,
     pub following: String,
     pub likes_and_collections: String,
@@ -67,6 +68,7 @@ impl XhsAuthorProfile {
         );
         map.insert("url".into(), json!(normalize_url(&self.profile_url)));
         map.insert("bio".into(), json!(self.bio));
+        map.insert("ip_location".into(), json!(self.ip_location));
         map.insert("followers".into(), json!(self.followers));
         map.insert(
             "followers_value".into(),

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -19,7 +19,8 @@ user's task and ground your answer in tool output.
 `search_notes`, `extract_search_cards`, `list_search_tabs`,
 `click_search_tab`, `reset_search_filters`, `apply_search_filters`,
 `open_note`, `close_note`, `read_note`, `extract_note`, `extract_comments`, `scroll_in_note`,
-`collect_carousel_images`, `extract_profile`, `topic_scan`, `page_state`.
+`collect_carousel_images`, `extract_profile`, `author_scan`, `topic_scan`,
+`page_state`.
 
 Prefer `topic_scan` for any "research a topic" task — it bundles search,
 sample, and read in one call. `topic_scan` is equivalent to calling
@@ -51,8 +52,12 @@ searching again.
   note cards with cover, title, author, likes, and type.
 - `note_detail`: modal or full detail. Left side is carousel/video, right side
   is author, title/body, hashtags, comments, and engagement bar.
-- `profile_page`: author avatar/name/XHS ID/bio/stats and note-card grid. Use
-  `extract_profile`; scroll loads more cards.
+- `profile_page`: author avatar/name/XHS ID/bio/IP location/stats and note-card
+  grid. Use `author_scan` (opens the profile by id) when you have the author id,
+  or `extract_profile` when already on the page; scroll loads more cards. The
+  grid renders many cards at once (often dozens), so a small `num_notes` returns
+  the first render without scrolling. Profile note cards open the same note
+  detail (modal/full) as search cards, so `read_note`/`open_note` work on them.
 
 ## Entity Fields
 
@@ -64,8 +69,9 @@ Note fields: `note_id`, `url`, `type`, `title`, `author`, `author_id`,
 Comment fields: `username`, `text`, `likes`, `like_count`, `time`,
 `is_author_reply`, `is_pinned`, `reply_count`, `sub_comments`.
 
-Author fields: `display_name`, `xhs_id`, `profile_url`, `bio`, `followers`,
-`following`, `likes_and_collections`, `note_cards`.
+Author fields: `display_name`, `xhs_id`, `profile_url`, `bio`, `ip_location`,
+`followers`, `following`, `likes_and_collections` (each `*_value` is the parsed
+integer, e.g. `5.6万` → `56000`), `note_count`, `note_cards`.
 
 Image fields: `url`, `index`, `is_cover`, optional `ocr_text`,
 `vision_description`, `local_path`.
@@ -89,42 +95,37 @@ Video fields: `url`, `resolved_url`, `poster_url`, optional `transcript`,
   reading note bodies. Or use `extract_search_cards` to inspect already-loaded
   cards without opening notes.
 - Manual note read: use `read_note(index=N)` or `read_note(note_id=...)`.
-  Use `level="card"` for metadata only, `level="lite"` for body/comments, and
-  `level="deep"` plus `include_media=true` only when images, OCR, video, or
-  visual evidence materially matters. Use `download_media=true` when the user
-  explicitly wants local image/video files rather than OCR/vision enrichment.
-- Creator analysis: navigate/open a profile, then use `extract_profile`.
+  Pass `include_media=true` only when images, OCR, video, or visual evidence
+  materially matters. Use `download_media=true` when the user explicitly wants
+  local image/video files rather than OCR/vision enrichment.
+- Creator analysis: call `author_scan(author_id=..., num_notes=N)`. It opens
+  the author's profile, reads the header (bio, xhs id, IP location,
+  follower/following/liked-&-collected counts), and collects their note summary
+  cards in page order (scrolling for `num_notes`; omit for the first render).
+  Pass `read_notes=true` to also open each note and read its body + top
+  comments — that makes it the profile-scoped analog of `topic_scan` (latency
+  scales with the card count, so keep `num_notes` modest when combining with
+  details). Use `extract_profile` instead only when already on the profile page.
   Keep creator inventory/style analysis separate from keyword/topic sampling
   unless the user explicitly asks for both.
-- Comment sentiment: use lite/deep note reads first; call `scroll_in_note`
-  then `extract_comments` when more visible comments are needed.
-- Media-heavy tasks: use deep reads sparingly. OCR, vision, transcription, and
-  frame extraction depend on optional local/cloud capabilities and can be slow.
-  `download_media=true` only downloads files into the run dir and avoids those
-  expensive enrichment steps.
-
-## Reading Levels
-
-- `card`: note metadata and engagement only. Low latency; no comments/media.
-- `lite`: title, author, body, hashtags, publish metadata, engagement, and a
-  small hot-comment sample. Best default for most search/research tasks.
-- `deep`: lite fields plus optional image OCR/vision, video transcript, sampled
-  frame descriptions, and a larger comment sample. Use only when the user asks
-  for media evidence, screenshots/OCR, video narration, or high-confidence
-  evidence.
+- Comment sentiment: a note read already returns top comments; call
+  `scroll_in_note` then `extract_comments` when more visible comments are needed.
+- Media-heavy tasks: enable `include_media` sparingly. OCR, vision,
+  transcription, and frame extraction depend on optional local/cloud
+  capabilities and can be slow. `download_media=true` only downloads files into
+  the run dir and avoids those expensive enrichment steps.
 
 ## Evidence Rules
 
 - Preserve real XHS post links from cards when available, including
   `xsec_token` query parameters. Fall back to bare `/explore/<note_id>` only
   when no real tokenized URL exists.
-- Cards carry `already_analyzed` / `history_level` / `history_include_media`
-  flags when a prior run already read them. `read_note` and `topic_scan`
-  short-circuit notes already covered at the requested level and media
-  setting — the returned payload has `skipped: true` plus the prior
-  `history` entry. To deepen prior analysis, request a higher `level` (e.g.
-  `deep` after a `lite`) or set `include_media: true`. Media downloads are not
-  cache-skipped because fresh local files are expected in the current run dir.
+- Cards carry `already_analyzed` / `history_include_media` flags when a prior
+  run already read them. `read_note` and `topic_scan` short-circuit notes
+  already covered at the same media setting — the returned payload has
+  `skipped: true` plus the prior `history` entry. To deepen prior analysis, set
+  `include_media: true`. Media downloads are not cache-skipped because fresh
+  local files are expected in the current run dir.
 - Keep DOM text, comment evidence, image OCR/vision, and video transcript/frame
   evidence labeled separately in final answers.
 - If a read returns a stale-note warning or note-id mismatch, close the current

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -8,7 +8,7 @@ pub use self::entities::{parse_count_text, XhsAuthorProfile, XhsNote, XhsNoteCar
 pub use self::history::{HistoryEntry, HistorySnapshot, XhsHistoryStore};
 pub use self::page::{ReadNoteOptions, XhsPageRuntime, XHS_HOME_URL};
 pub use self::tools::{
-    close_open_note, ensure_search_ready, extract_note_command, search_notes_command,
-    topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_tools,
+    author_scan_command, close_open_note, ensure_search_ready, extract_note_command,
+    search_notes_command, topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_tools,
     xhs_tools_with_llm_provider, XHS_KNOWLEDGE, XHS_SITE,
 };

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -949,6 +949,7 @@ impl<'a> XhsPageRuntime<'a> {
                 }
             },
             bio: string_field(&info, "bio"),
+            ip_location: string_field(&info, "ip_location"),
             followers: string_field(&info, "followers"),
             following: string_field(&info, "following"),
             likes_and_collections: string_field(&info, "likes_and_collections"),
@@ -1014,6 +1015,111 @@ impl<'a> XhsPageRuntime<'a> {
         }
         cards.truncate(limit);
         Ok(cards)
+    }
+
+    /// Navigate directly to an author's profile page by id and wait for the
+    /// page to settle on a `profile_page` state. This is the single allowed
+    /// direct-URL navigation — it's the entry point of an author scan; every
+    /// subsequent action (scrolling, opening notes) is DOM-driven like the
+    /// rest of the site. Stops early if a login wall appears.
+    pub async fn open_profile(&self, author_id: &str, wait_seconds: f64) -> Result<Value> {
+        let id = author_id.trim();
+        if id.is_empty() {
+            anyhow::bail!("author id is required");
+        }
+        let url = format!("https://www.xiaohongshu.com/user/profile/{id}");
+        self.page.navigate_with_timeout(&url, 60.0).await?;
+
+        let deadline = Instant::now() + Duration::from_secs_f64(wait_seconds.max(1.0));
+        let mut state = self.expect_object("pageState", None).await?;
+        loop {
+            let kind = state.get("state").and_then(Value::as_str).unwrap_or("");
+            let login = state
+                .get("login_required")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if kind == "profile_page" || login || Instant::now() >= deadline {
+                break;
+            }
+            sleep_ms(300).await;
+            state = self.expect_object("pageState", None).await?;
+        }
+
+        let kind = state.get("state").and_then(Value::as_str).unwrap_or("");
+        let login = state
+            .get("login_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        Ok(json!({
+            "ok": kind == "profile_page",
+            "author_id": id,
+            "url": self.current_url().await?,
+            "login_required": login,
+            "state": state,
+            "reason": if kind == "profile_page" {
+                ""
+            } else if login {
+                "login_required"
+            } else {
+                "not_profile_page"
+            },
+        }))
+    }
+
+    /// Collect note cards from the current profile page, scrolling the window
+    /// to lazy-load more until `target` unique cards are gathered or the feed
+    /// stops growing across a few consecutive scrolls (real end of the grid).
+    /// Returns at most `target` cards in feed order.
+    pub async fn collect_profile_cards(&self, target: usize) -> Result<Vec<XhsNoteCard>> {
+        const MAX_STALLS: usize = 3;
+        let limit = target.max(1);
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut cards: Vec<XhsNoteCard> = Vec::new();
+        let mut stalls = 0usize;
+        loop {
+            let raw = self.expect_array("profileCards", None).await?;
+            let before = cards.len();
+            for card in parse_cards(&raw) {
+                let key = if !card.note_id.is_empty() {
+                    card.note_id.clone()
+                } else if !card.link.is_empty() {
+                    card.link.clone()
+                } else {
+                    format!("pos:{}", card.position)
+                };
+                if key.is_empty() || !seen.insert(key) {
+                    continue;
+                }
+                cards.push(card);
+                if cards.len() >= limit {
+                    return Ok(cards);
+                }
+            }
+            if cards.len() <= before {
+                stalls += 1;
+                if stalls >= MAX_STALLS {
+                    break;
+                }
+            } else {
+                stalls = 0;
+            }
+            self.page.scroll(900).await?;
+            sleep_ms(900).await;
+        }
+        Ok(cards)
+    }
+
+    /// Read the note cards currently rendered on the profile page without
+    /// scrolling (the cheap first-page-only path).
+    pub async fn extract_profile_cards_once(&self) -> Result<Vec<XhsNoteCard>> {
+        let raw = self.expect_array("profileCards", None).await?;
+        Ok(parse_cards(&raw))
+    }
+
+    /// Extract just the author header (display name, xhs id, bio, IP location,
+    /// follower/following/like counts) from the current profile page.
+    pub async fn profile_info(&self) -> Result<Value> {
+        self.expect_object("profileInfo", None).await
     }
 
     /// Extract the currently open note. Caller is responsible for having

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -903,6 +903,7 @@ const SocaiXhsPageScripts = (() => {
     const bio = firstVisibleText(['.user-desc', '.profile-desc', '.desc', '.bio'], document);
     const body = norm(text(document.body));
     const xhsId = (body.match(/小红书号[:：]?\s*([A-Za-z0-9_.-]+)/) || [])[1] || profileIdFromUrl();
+    const ipLocation = (body.match(/IP属地[:：]?\s*([^\s,，。]+)/i) || [])[1] || '';
     const statText = (label) => {
       const re = new RegExp(`([0-9.,万wWkK+]+)\\s*(?:${label})`);
       return (body.match(re) || [])[1] || '';
@@ -913,6 +914,7 @@ const SocaiXhsPageScripts = (() => {
       xhs_id: xhsId,
       profile_url: location.href,
       bio,
+      ip_location: ipLocation,
       followers: statText('粉丝'),
       following: statText('关注'),
       likes_and_collections: statText('获赞与收藏|获赞|赞与收藏'),

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -25,11 +25,16 @@ use crate::sites::xhs::media_manifest::{
 };
 use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
 use crate::sites::xhs::{
-    ReadNoteOptions, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
+    ReadNoteOptions, XhsAuthorProfile, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
 };
 
 /// Default number of notes `topic_scan` reads when the caller doesn't specify.
 const DEFAULT_NUM_NOTES: i64 = 10;
+
+/// Top comments attached to every note read (read_note, extract_note,
+/// topic_scan, author_scan). Comments are read from the already-open note's DOM
+/// (one extra JS read, no extra navigation), so every note read includes them.
+const TOP_COMMENTS_PER_NOTE: i64 = 12;
 
 /// XHS agent playbook: browser-lock rule, tool inventory, anti-bot rules,
 /// page states, entity fields, workflows, reading levels, evidence rules,
@@ -80,6 +85,10 @@ pub fn xhs_tools_with_llm_provider(
         Arc::new(TopicScanTool {
             page: page.clone(),
             llm_provider,
+            history: history.clone(),
+        }),
+        Arc::new(AuthorScanTool {
+            page: page.clone(),
             history,
         }),
         Arc::new(PageStateTool { page }),
@@ -206,6 +215,44 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
             run: run_topic_scan,
         },
         SiteCommand {
+            name: "author",
+            tool_name: "author_scan",
+            about: "Open a Xiaohongshu author's profile and print their header (bio, xhs id, \
+                    IP location, follower/following/like counts) plus their note cards as JSON.",
+            args: &[
+                CommandArg {
+                    key: "author_id",
+                    long: None,
+                    value_name: "AUTHOR_ID",
+                    help: "Author id — the trailing segment of /user/profile/<id>.",
+                    required: true,
+                    kind: ArgKind::Str,
+                },
+                CommandArg {
+                    key: "num_notes",
+                    long: Some("num-notes"),
+                    value_name: "N",
+                    help: "Scroll the profile grid to collect at least this many note cards \
+                           (titles/likes/covers only). Omit for the first screen.",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+                CommandArg {
+                    key: "read_notes",
+                    long: Some("read-notes"),
+                    value_name: "READ_NOTES",
+                    help: "Open each collected note and read its body + top comments \
+                           (like topic_scan; latency scales with the card count).",
+                    required: false,
+                    kind: ArgKind::Flag,
+                },
+            ],
+            // Scrolling for a large num_notes or opening each note for details
+            // can take a while; give it the longer budget.
+            slow: SlowWhen::Always,
+            run: run_author_scan,
+        },
+        SiteCommand {
             name: "extract_note",
             tool_name: "read_note",
             about: "Open a note from the current search/topic page and print the parsed note.",
@@ -258,6 +305,18 @@ fn run_topic_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> 
     })
 }
 
+fn run_author_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+    Box::pin(async move {
+        let author_id = required_string(&args, "author_id")?;
+        let num_notes = args.get("num_notes").and_then(Value::as_i64);
+        let read_notes = args
+            .get("read_notes")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        author_scan_command(page, &author_id, num_notes, read_notes, debug_snapshot).await
+    })
+}
+
 fn run_extract_note(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
     Box::pin(async move {
         let note_id = required_string(&args, "note_id")?;
@@ -292,6 +351,15 @@ const TOPIC_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
     tool_name: "topic_scan",
     before: CommandPageAction::SearchReady,
     after: CommandPageAction::None,
+};
+
+const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
+    command_name: "author",
+    tool_name: "author_scan",
+    // The tool navigates to the profile URL itself; just make sure no stale
+    // note modal is left open before/after.
+    before: CommandPageAction::CloseOpenNote,
+    after: CommandPageAction::CloseOpenNote,
 };
 
 const EXTRACT_NOTE_COMMAND: XhsCommandSpec = XhsCommandSpec {
@@ -330,6 +398,22 @@ pub async fn topic_scan_command(
         page,
         TOPIC_SCAN_COMMAND,
         topic_scan_input(query, tab_label, filters, num_notes, download_media)?,
+        debug_snapshot,
+    )
+    .await
+}
+
+pub async fn author_scan_command(
+    page: Arc<PageSession>,
+    author_id: &str,
+    num_notes: Option<i64>,
+    read_notes: bool,
+    debug_snapshot: bool,
+) -> anyhow::Result<Value> {
+    run_xhs_tool_command(
+        page,
+        AUTHOR_SCAN_COMMAND,
+        author_scan_input(author_id, num_notes, read_notes)?,
         debug_snapshot,
     )
     .await
@@ -386,6 +470,23 @@ fn topic_scan_input(
     }
     if download_media {
         input["download_media"] = json!(true);
+    }
+    Ok(input)
+}
+
+fn author_scan_input(
+    author_id: &str,
+    num_notes: Option<i64>,
+    read_notes: bool,
+) -> anyhow::Result<Value> {
+    let mut input = json!({
+        "author_id": trimmed_required(author_id, "author_id")?,
+    });
+    if let Some(n) = num_notes {
+        input["num_notes"] = json!(n.max(1));
+    }
+    if read_notes {
+        input["read_notes"] = json!(true);
     }
     Ok(input)
 }
@@ -473,7 +574,10 @@ pub async fn close_open_note(page: &PageSession) {
 
 fn read_note_options(input: &Value) -> ReadNoteOptions {
     ReadNoteOptions {
-        level: get_str(input, "level").unwrap_or("lite").to_string(),
+        // `level` is no longer a user-facing knob (body content is identical
+        // across tiers; media is gated by include_media/download_media). It now
+        // only feeds the cosmetic extraction_level label + cross-run dedup.
+        level: "lite".to_string(),
         include_media: get_bool(input, "include_media", false),
         download_media: get_bool(input, "download_media", false),
         max_images: get_i64(input, "max_images", 12).max(1) as usize,
@@ -498,6 +602,168 @@ fn media_for(
     } else {
         Ok(None)
     }
+}
+
+/// Read up to `TOP_COMMENTS_PER_NOTE` top comments from the currently open note
+/// and insert them under `note["top_comments"]`. Best-effort: on failure the
+/// note is left without the field. Shared by `read_note` and `extract_note`.
+async fn attach_top_comments(xhs: &XhsPageRuntime<'_>, note: &mut Value) {
+    let Ok(payload) = xhs
+        .extract_comments_with_wait(TOP_COMMENTS_PER_NOTE, 5.0)
+        .await
+    else {
+        return;
+    };
+    let comments = payload
+        .get("comments")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(map) = note.as_object_mut() {
+        map.insert("top_comments".into(), Value::Array(comments));
+    }
+}
+
+/// Open one already-selected card, read its body at `level`, attach top
+/// comments, and record it in run + cross-run history. Shared by `topic_scan`
+/// (cards from search) and `author_scan` (cards from a profile page) — the only
+/// difference between those macros is where the cards come from, not how each
+/// note is read. Returns the per-note entry; the caller pushes it and closes
+/// the modal.
+#[allow(clippy::too_many_arguments)]
+async fn scan_card_note(
+    xhs: &XhsPageRuntime<'_>,
+    history: &XhsHistoryStore,
+    ctx: &ToolContext,
+    card: &XhsNoteCard,
+    level: &str,
+    comment_count: i64,
+    include_media: bool,
+    download_media: bool,
+) -> Value {
+    let requested_media = include_media;
+    let can_use_cached_reads = !download_media;
+
+    // Dedup: skip notes already processed at this level or deeper within the
+    // same run OR in a previous run (cross-run history). Media downloads are
+    // never cache-skipped: the caller expects fresh files under the run_dir.
+    if can_use_cached_reads
+        && !card.note_id.is_empty()
+        && ctx.has_processed_note(&card.note_id, level, requested_media)
+    {
+        return json!({
+            "scan_level": level,
+            "source_position": card.position,
+            "skipped": {"reason": "already_processed"},
+            "entity": card,
+        });
+    }
+    if can_use_cached_reads
+        && !card.note_id.is_empty()
+        && history.is_satisfied_by(&card.note_id, level, requested_media)
+    {
+        let entry = history.get(&card.note_id).unwrap_or_default();
+        ctx.mark_processed_note(&card.note_id, level, requested_media);
+        return json!({
+            "scan_level": level,
+            "source_position": card.position,
+            "skipped": {"reason": "already_analyzed", "history": entry},
+            "entity": card,
+        });
+    }
+
+    let read_result = xhs
+        .read_note_with_options(
+            &card.note_id,
+            None,
+            6.0,
+            ReadNoteOptions {
+                level: level.to_string(),
+                include_media,
+                download_media,
+                // Pure downloads are cheap compared with OCR/vision, so allow
+                // full XHS carousels instead of the enrichment-oriented default.
+                max_images: if download_media { 100 } else { 12 },
+                max_video_frames: 4,
+                poster_url_fallback: card.cover_url.clone(),
+                note_id_fallback: card.note_id.clone(),
+            },
+        )
+        .await;
+    let mut entry = match read_result {
+        Ok(payload) => {
+            let ok = payload.get("ok").and_then(Value::as_bool).unwrap_or(false);
+            let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
+            ensure_entity_note_id(&mut entity, card);
+            // When the read failed (modal never opened, stale note, …), fall
+            // back to the card so the entry still carries note_id/title, and
+            // surface the failure reason for debugging.
+            if entity.is_null() {
+                entity = serde_json::to_value(card).unwrap_or(Value::Null);
+            }
+            let mut entry = json!({
+                "scan_level": level,
+                "source_position": card.position,
+                "ok": ok,
+                "entity": entity,
+            });
+            if !ok {
+                if let Some(map) = entry.as_object_mut() {
+                    if let Some(err) = payload.get("error") {
+                        map.insert("error".into(), err.clone());
+                    }
+                    if let Some(open) = payload.get("open") {
+                        map.insert("open".into(), open.clone());
+                    }
+                }
+            }
+            entry
+        }
+        Err(e) => json!({
+            "scan_level": level,
+            "source_position": card.position,
+            "ok": false,
+            "entity": card,
+            "error": format!("{e:#}"),
+        }),
+    };
+
+    // Pull comments separately after waiting for the slower comment list to
+    // hydrate. Body content often appears before comments. Scans always include
+    // comments — there is no longer a level gate.
+    if comment_count > 0 {
+        if let Ok(comments_payload) = xhs.extract_comments_with_wait(comment_count, 5.0).await {
+            let comments = comments_payload
+                .get("comments")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(map) = entry.get_mut("entity").and_then(|v| v.as_object_mut()) {
+                map.insert("top_comments".into(), Value::Array(comments));
+                map.insert(
+                    "top_comments_wait".into(),
+                    json!({
+                        "ready": comments_payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
+                        "reason": comments_payload.get("reason").and_then(Value::as_str).unwrap_or(""),
+                        "waited_ms": comments_payload.get("waited_ms").and_then(Value::as_i64).unwrap_or(0),
+                        "attempts": comments_payload.get("attempts").and_then(Value::as_i64).unwrap_or(0),
+                    }),
+                );
+            }
+        }
+    }
+
+    // Mark processed in-run + record in cross-run history.
+    if !card.note_id.is_empty() {
+        ctx.mark_processed_note(&card.note_id, level, requested_media);
+    }
+    if entry.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        if let Some(entity) = entry.get("entity") {
+            history.record(entity, level, requested_media);
+        }
+    }
+
+    entry
 }
 
 /// search_notes(query, wait_seconds) -> {query, cards: [...]}
@@ -673,7 +939,6 @@ impl Tool for ReadNoteTool {
                 "note_id": { "type": "string" },
                 "index": { "type": "integer", "minimum": 0 },
                 "wait_seconds": { "type": "number", "default": 6.0 },
-                "level": { "type": "string", "enum": ["card", "lite", "deep"], "default": "lite" },
                 "include_media": { "type": "boolean", "default": false },
                 "download_media": { "type": "boolean", "default": false },
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 },
@@ -723,7 +988,7 @@ impl Tool for ReadNoteTool {
                 options.include_media || options.download_media,
             )?,
         );
-        let value = xhs
+        let mut value = xhs
             .read_note_with_options(
                 note_id.as_deref().unwrap_or(""),
                 index,
@@ -732,6 +997,11 @@ impl Tool for ReadNoteTool {
             )
             .await?;
         if value.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            // The note modal is still open here (the command's `after` hook
+            // closes it), so always attach top comments before recording.
+            if let Some(entity) = value.get_mut("entity") {
+                attach_top_comments(&xhs, entity).await;
+            }
             if let Some(entity) = value.get("entity") {
                 self.history
                     .record(entity, &options.level, options.include_media);
@@ -755,8 +1025,9 @@ impl Tool for ExtractNoteTool {
     }
 
     fn description(&self) -> &str {
-        "Extract the currently visible note body from the page. Assumes the \
-         user already navigated to a note URL or has the detail modal open."
+        "Extract the currently visible note from the page (body + top comments). \
+         Assumes the user already navigated to a note URL or has the detail \
+         modal open."
     }
 
     fn input_schema(&self) -> Value {
@@ -764,7 +1035,6 @@ impl Tool for ExtractNoteTool {
             "type": "object",
             "properties": {
                 "wait_seconds": { "type": "number", "default": 8.0 },
-                "level": { "type": "string", "enum": ["card", "lite", "deep"], "default": "lite" },
                 "include_media": { "type": "boolean", "default": false },
                 "download_media": { "type": "boolean", "default": false },
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 },
@@ -787,7 +1057,10 @@ impl Tool for ExtractNoteTool {
         let note = xhs
             .extract_note_with_options(wait_seconds, options.clone())
             .await?;
-        let value = serde_json::to_value(&note)?;
+        let mut value = serde_json::to_value(&note)?;
+        // Always attach top comments — the note is already open, so reading them
+        // is one extra DOM read with no extra navigation.
+        attach_top_comments(&xhs, &mut value).await;
         self.history
             .record(&value, &options.level, options.include_media);
         Ok(json_result(&value))
@@ -1143,11 +1416,6 @@ pub struct TopicScanTool {
     history: Arc<XhsHistoryStore>,
 }
 
-/// Number of top comments pulled per scanned note. Comments are read for free
-/// from the already-open note modal's DOM (one extra JS read, no extra
-/// navigation), so every scan includes them.
-const TOPIC_SCAN_COMMENTS: i64 = 12;
-
 #[async_trait]
 impl Tool for TopicScanTool {
     fn name(&self) -> &str {
@@ -1251,7 +1519,7 @@ impl Tool for TopicScanTool {
                 "sampling": {
                     "num_notes": num_notes,
                     "selected": 0,
-                    "comments_per_note": TOPIC_SCAN_COMMENTS,
+                    "comments_per_note": TOP_COMMENTS_PER_NOTE,
                     "include_media": include_media,
                     "download_media": download_media,
                 },
@@ -1274,9 +1542,7 @@ impl Tool for TopicScanTool {
         // Every sampled note is read with the same extraction level (body +
         // top comments).
         let level = "deep";
-        let comment_count = TOPIC_SCAN_COMMENTS;
-        let requested_media = include_media;
-        let can_use_cached_reads = !download_media;
+        let comment_count = TOP_COMMENTS_PER_NOTE;
         let want = num_notes.max(1) as usize;
 
         // Read top-to-bottom: pull cards from the results state (which only
@@ -1319,114 +1585,17 @@ impl Tool for TopicScanTool {
             }
             selected.push(card.clone());
 
-            // Dedup: skip notes already processed at this level or deeper
-            // within the same run OR in a previous run (cross-run history).
-            // Media downloads are never cache-skipped: the caller expects
-            // fresh files under this command's run_dir.
-            if can_use_cached_reads
-                && !card.note_id.is_empty()
-                && ctx.has_processed_note(&card.note_id, level, requested_media)
-            {
-                notes.push(json!({
-                    "scan_level": level,
-                    "source_position": card.position,
-                    "skipped": {"reason": "already_processed"},
-                    "entity": &card,
-                }));
-                continue;
-            }
-            if can_use_cached_reads
-                && !card.note_id.is_empty()
-                && self
-                    .history
-                    .is_satisfied_by(&card.note_id, level, requested_media)
-            {
-                let entry = self.history.get(&card.note_id).unwrap_or_default();
-                notes.push(json!({
-                    "scan_level": level,
-                    "source_position": card.position,
-                    "skipped": {"reason": "already_analyzed", "history": entry},
-                    "entity": &card,
-                }));
-                ctx.mark_processed_note(&card.note_id, level, requested_media);
-                continue;
-            }
-            let read_result = xhs
-                .read_note_with_options(
-                    &card.note_id,
-                    None,
-                    6.0,
-                    ReadNoteOptions {
-                        level: level.to_string(),
-                        include_media,
-                        download_media,
-                        // Pure downloads are cheap compared with OCR/vision,
-                        // so allow full XHS carousels instead of the smaller
-                        // enrichment-oriented default.
-                        max_images: if download_media { 100 } else { 12 },
-                        max_video_frames: 4,
-                        poster_url_fallback: card.cover_url.clone(),
-                        note_id_fallback: card.note_id.clone(),
-                    },
-                )
-                .await;
-            let mut entry = match read_result {
-                Ok(payload) => {
-                    let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
-                    ensure_entity_note_id(&mut entity, &card);
-                    json!({
-                        "scan_level": level,
-                        "source_position": card.position,
-                        "ok": payload.get("ok").and_then(Value::as_bool).unwrap_or(false),
-                        "entity": entity,
-                    })
-                }
-                Err(e) => json!({
-                    "scan_level": level,
-                    "source_position": card.position,
-                    "ok": false,
-                    "entity": &card,
-                    "error": format!("{e:#}"),
-                }),
-            };
-
-            // Pull comments separately after waiting for the slower comment
-            // list to hydrate. Body content often appears before comments.
-            if level == "deep" && comment_count > 0 {
-                if let Ok(comments_payload) =
-                    xhs.extract_comments_with_wait(comment_count, 5.0).await
-                {
-                    let comments = comments_payload
-                        .get("comments")
-                        .and_then(Value::as_array)
-                        .cloned()
-                        .unwrap_or_default();
-                    let entity_map = entry.get_mut("entity").and_then(|v| v.as_object_mut());
-                    if let Some(map) = entity_map {
-                        map.insert("top_comments".into(), Value::Array(comments));
-                        map.insert(
-                            "top_comments_wait".into(),
-                            json!({
-                                "ready": comments_payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
-                                "reason": comments_payload.get("reason").and_then(Value::as_str).unwrap_or(""),
-                                "waited_ms": comments_payload.get("waited_ms").and_then(Value::as_i64).unwrap_or(0),
-                                "attempts": comments_payload.get("attempts").and_then(Value::as_i64).unwrap_or(0),
-                            }),
-                        );
-                    }
-                }
-            }
-
-            // Mark processed in-run + record in cross-run history.
-            if !card.note_id.is_empty() {
-                ctx.mark_processed_note(&card.note_id, level, requested_media);
-            }
-            if entry.get("ok").and_then(Value::as_bool).unwrap_or(false) {
-                if let Some(entity) = entry.get("entity") {
-                    self.history.record(entity, level, requested_media);
-                }
-            }
-
+            let entry = scan_card_note(
+                &xhs,
+                &self.history,
+                ctx,
+                &card,
+                level,
+                comment_count,
+                include_media,
+                download_media,
+            )
+            .await;
             notes.push(entry);
             let _ = xhs.close_note(0.6).await;
         }
@@ -1474,7 +1643,7 @@ impl Tool for TopicScanTool {
             "sampling": {
                 "num_notes": num_notes,
                 "selected": selected.len(),
-                "comments_per_note": TOPIC_SCAN_COMMENTS,
+                "comments_per_note": TOP_COMMENTS_PER_NOTE,
                 "include_media": include_media,
                 "download_media": download_media,
             },
@@ -1512,6 +1681,187 @@ impl Tool for TopicScanTool {
                     .unwrap_or(0)
             ),
             json!({"site": "xhs", "category": "topic_scan"}),
+        );
+
+        Ok(json_result(&payload))
+    }
+}
+
+/// author_scan(author_id, num_notes?, read_notes?) -> author profile bundle
+///
+/// Composite macro mirroring `topic_scan`, but entered from an author's profile
+/// page instead of a search query: open `…/user/profile/<id>` → read the author
+/// header (bio, xhs id, IP location, follower/following/like counts) → collect
+/// note summary cards in page order (scrolling to reach `num_notes`) → when
+/// `read_notes` is set, open each note and read its body + top comments.
+pub struct AuthorScanTool {
+    page: Arc<PageSession>,
+    history: Arc<XhsHistoryStore>,
+}
+
+#[async_trait]
+impl Tool for AuthorScanTool {
+    fn name(&self) -> &str {
+        "author_scan"
+    }
+
+    fn description(&self) -> &str {
+        "Xiaohongshu author/creator scan: open an author's profile page by id → \
+         read the author header (display name, xhs id, bio, IP location, \
+         follower/following/liked-&-collected counts) → collect their note \
+         summary cards in page order (titles/likes/covers only; pass `num_notes` \
+         to scroll the grid for more, omit for just the first screen). Pass \
+         `read_notes=true` to also open each collected note and read its body \
+         + top comments (like topic_scan; latency scales with the card count). \
+         Use this for creator research — it's search_notes + topic_scan but \
+         scoped to one author instead of a query."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "string",
+                    "description": "Xiaohongshu user id — the trailing segment of /user/profile/<id>."
+                },
+                "num_notes": {
+                    "type": "integer",
+                    "description": "Collect at least this many note cards, scrolling the profile grid (lazy-loaded). Omit for the first screen only.",
+                    "minimum": 1
+                },
+                "read_notes": {
+                    "type": "boolean",
+                    "description": "Open each collected note and read its body + top comments. Off by default (summaries only).",
+                    "default": false
+                }
+            },
+            "required": ["author_id"]
+        })
+    }
+
+    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let author_id = get_str(&input, "author_id")
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("missing author_id"))?
+            .to_string();
+        let read_notes = get_bool(&input, "read_notes", false);
+        let num_notes = input
+            .get("num_notes")
+            .and_then(Value::as_i64)
+            .filter(|n| *n > 0)
+            .map(|n| n as usize);
+
+        let xhs = XhsPageRuntime::new(&self.page);
+        // Snapshot history before reading so card annotations reflect "known
+        // before this scan" rather than this scan's own writes.
+        let history_snapshot = self.history.snapshot();
+
+        let open = xhs.open_profile(&author_id, 8.0).await?;
+        if !open.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            let reason = open
+                .get("reason")
+                .and_then(Value::as_str)
+                .filter(|reason| !reason.is_empty())
+                .unwrap_or("open_profile_failed")
+                .to_string();
+            return Ok(json_result(&json!({
+                "ok": false,
+                "author_id": author_id,
+                "open": open,
+                "profile": Value::Null,
+                "notes": [],
+                "reason": reason,
+            })));
+        }
+
+        let info = xhs.profile_info().await?;
+        let cards = match num_notes {
+            Some(target) => xhs.collect_profile_cards(target).await?,
+            None => xhs.extract_profile_cards_once().await?,
+        };
+
+        let profile_url = {
+            let candidate = get_str(&info, "profile_url").unwrap_or("");
+            if candidate.is_empty() {
+                open.get("url")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string()
+            } else {
+                candidate.to_string()
+            }
+        };
+        let display_name = get_str(&info, "display_name").unwrap_or("").to_string();
+        let profile = XhsAuthorProfile {
+            display_name: display_name.clone(),
+            xhs_id: get_str(&info, "xhs_id").unwrap_or("").to_string(),
+            profile_url,
+            bio: get_str(&info, "bio").unwrap_or("").to_string(),
+            ip_location: get_str(&info, "ip_location").unwrap_or("").to_string(),
+            followers: get_str(&info, "followers").unwrap_or("").to_string(),
+            following: get_str(&info, "following").unwrap_or("").to_string(),
+            likes_and_collections: get_str(&info, "likes_and_collections")
+                .unwrap_or("")
+                .to_string(),
+            note_cards: cards.clone(),
+        };
+        let mut profile_value = profile.to_value();
+        if let Some(cards_value) = profile_value.get_mut("note_cards") {
+            history_snapshot.annotate_cards(cards_value);
+        }
+
+        // Optionally open each collected note and read body + top comments.
+        let mut notes: Vec<Value> = Vec::new();
+        if read_notes {
+            for card in &cards {
+                if !card.note_id.is_empty() {
+                    ctx.add_topic_scan_note_ids(std::slice::from_ref(&card.note_id));
+                }
+                let entry = scan_card_note(
+                    &xhs,
+                    &self.history,
+                    ctx,
+                    card,
+                    "deep",
+                    TOP_COMMENTS_PER_NOTE,
+                    false,
+                    false,
+                )
+                .await;
+                notes.push(entry);
+                let _ = xhs.close_note(0.6).await;
+            }
+        }
+
+        let payload = json!({
+            "ok": true,
+            "author_id": author_id,
+            "profile": profile_value,
+            "notes": notes,
+            "sampling": {
+                "num_notes": num_notes,
+                "collected": cards.len(),
+                "read_notes": read_notes,
+                "comments_per_note": if read_notes { TOP_COMMENTS_PER_NOTE } else { 0 },
+            },
+        });
+
+        // Persist as artifact so it shows up in the run dir + working memory.
+        let label = if display_name.is_empty() {
+            author_id.clone()
+        } else {
+            display_name
+        };
+        let _ = ctx.write_json_artifact(
+            &format!("xhs_author_scan_{}", sanitize_for_filename(&author_id)),
+            &payload,
+            "artifacts",
+            "author_scan",
+            "json",
+            &format!("Author scan: {label} ({} notes)", cards.len()),
+            json!({"site": "xhs", "category": "author_scan"}),
         );
 
         Ok(json_result(&payload))


### PR DESCRIPTION
## What

Adds an `author` command/tool for Xiaohongshu creator research, plus makes note reads always return comments.

### `socai xhs author <id>`
Opens an author's profile **by id** (key-free) and returns:
- **Header**: display name, xhs id, bio, **IP location**, follower / following / liked-&-collected counts (with parsed integer `*_value`s).
- **Note cards**: title / likes / cover / id in page order. `--num-notes N` scrolls the grid for more; omit for the first screen.
- `--read-notes`: also opens each collected note and reads its body + top comments (profile-scoped analog of `topic_scan`).

The composite `author_scan` tool auto-registers for CLI / daemon / TUI / desktop; `author_scan_command` is exported for direct desktop use.

### Note reads always return comments
- `read_note` / `extract_note` now attach `top_comments` (shared `attach_top_comments` helper); the scan macros' comment extraction is unconditional.
- The vestigial `card`/`lite`/`deep` `level` param is removed from `read_note`/`extract_note` — it only set a cosmetic label (body content was identical across tiers; media is gated separately by `include_media`/`download_media`).

### Cleanups
- Per-note open→read→comments extracted into a shared `scan_card_note` helper used by `topic_scan` and `author_scan`; comment-count constant consolidated.
- Daemon one-shot dispatch creates the session tab blank and lets the command navigate itself, dropping a wasted `/explore` load before profile navigation.
- README restructured (CLI/TUI/GUI sections) + `author` examples.

## Test
- `cargo build` (core + cli) clean; `cargo test sites::` green (31 tests).
- Verified against two real accounts: profile header + cards extraction, `--num-notes` scroll-to-target (80 cards), `--read-notes` (bodies + 12 comments/note), and `extract_note` returning comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)