### PR TITLE
feat(telemetry): capture tool args (query_text, metadata) on desktop socai_tool_call

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use crate::tasks::{now_ms, AgentTaskRegistry, AgentTaskSnapshot};
 use crate::telemetry::{duration_ms, short_error, DesktopTelemetry};
 use crate::timeline::{agent_event_to_timeline, AgentTaskEventKind, AgentTaskEventPayload};
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use socai_core::agent::{
     catalog_models_for, configured_default_model_for, configured_default_provider, make_run_dir,
     provider_credential_kind, resolve_provider, save_default_model, AgentEvent, CredentialKind,
@@ -833,23 +833,26 @@ fn pump_agent_task_events(
                     name,
                     turn,
                     sequence,
+                    input,
                     duration_ms: tool_duration_ms,
                     error,
                     ..
                 } => {
-                    telemetry.capture(
-                        "socai_tool_call",
-                        json!({
-                            "task_id": task_id.clone(),
-                            "run_id": run_id.clone(),
-                            "tool_name": name,
-                            "turn": turn,
-                            "sequence": sequence,
-                            "duration_ms": tool_duration_ms,
-                            "ok": error.is_none(),
-                            "error": error.as_deref().map(short_error),
-                        }),
-                    );
+                    let mut props = Map::new();
+                    props.insert("task_id".into(), json!(task_id.clone()));
+                    props.insert("run_id".into(), json!(run_id.clone()));
+                    props.insert("tool_name".into(), json!(name));
+                    props.insert("turn".into(), json!(turn));
+                    props.insert("sequence".into(), json!(sequence));
+                    props.insert("duration_ms".into(), json!(tool_duration_ms));
+                    props.insert("ok".into(), json!(error.is_none()));
+                    props.insert("error".into(), json!(error.as_deref().map(short_error)));
+                    // Mirror the CLI tool trace: lift the search query into
+                    // query_text/query_len and fold the rest of the args into
+                    // metadata (note_id reduced to a presence flag). Tool OUTPUT
+                    // (note bodies) is never included.
+                    merge_tool_input(&mut props, input);
+                    telemetry.capture("socai_tool_call", Value::Object(props));
                 }
                 _ => {}
             }
@@ -857,6 +860,46 @@ fn pump_agent_task_events(
             emit_timeline_payload(&app, registry.as_ref(), &task_id, payload, None).await;
         }
     })
+}
+
+/// Summarize a tool call's input arguments the way the CLI tool trace does: the
+/// search `query` becomes `query_text` + `query_len`, a `note_id` collapses to a
+/// `note_id_present` flag, and any other scalar args go under `metadata`. Only
+/// the arguments are summarized — tool output (note bodies) is never included.
+fn merge_tool_input(props: &mut Map<String, Value>, input: &Value) {
+    let Some(args) = input.as_object() else {
+        return;
+    };
+    let mut metadata = Map::new();
+    for (key, value) in args {
+        match key.as_str() {
+            "query" => {
+                if let Some(query) = value.as_str() {
+                    let query = query.trim();
+                    if !query.is_empty() {
+                        props.insert("query_len".into(), json!(query.chars().count()));
+                        props.insert("query_text".into(), json!(query));
+                    }
+                }
+            }
+            "note_id" => {
+                let present = value
+                    .as_str()
+                    .map(|id| !id.trim().is_empty())
+                    .unwrap_or(!value.is_null());
+                if present {
+                    props.insert("note_id_present".into(), json!(true));
+                }
+            }
+            _ if value.is_string() || value.is_number() || value.is_boolean() => {
+                metadata.insert(key.clone(), value.clone());
+            }
+            _ => {}
+        }
+    }
+    if !metadata.is_empty() {
+        props.insert("metadata".into(), Value::Object(metadata));
+    }
 }
 
 pub(crate) async fn emit_task_event(

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -891,10 +891,28 @@ fn merge_tool_input(props: &mut Map<String, Value>, input: &Value) {
                     props.insert("note_id_present".into(), json!(true));
                 }
             }
-            _ if value.is_string() || value.is_number() || value.is_boolean() => {
-                metadata.insert(key.clone(), value.clone());
+            // Other scalar args go under metadata, mirroring the CLI summarizer:
+            // `tab_label` is renamed to `tab`, and string values are trimmed with
+            // empty/whitespace-only ones dropped. Non-scalar values are skipped.
+            _ => {
+                let meta_key = if key.as_str() == "tab_label" {
+                    "tab"
+                } else {
+                    key.as_str()
+                };
+                match value {
+                    Value::String(text) => {
+                        let text = text.trim();
+                        if !text.is_empty() {
+                            metadata.insert(meta_key.to_string(), json!(text));
+                        }
+                    }
+                    Value::Number(_) | Value::Bool(_) => {
+                        metadata.insert(meta_key.to_string(), value.clone());
+                    }
+                    _ => {}
+                }
             }
-            _ => {}
         }
     }
     if !metadata.is_empty() {

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -181,7 +181,8 @@ Desktop field semantics:
 `socai_tool_call` mirrors the CLI tool trace's argument summary: the tool's
 `query` argument is lifted to `query_text` + `query_len`, a `note_id` argument
 collapses to a `note_id_present` boolean (the raw id is not sent), and any other
-scalar arguments go under `metadata`. The tool's **output** (note bodies,
+scalar arguments go under `metadata` — with the `tab_label` arg renamed to `tab`
+and empty strings dropped, matching the CLI. The tool's **output** (note bodies,
 comments, scraped content) is never included — only the arguments.
 
 Unlike the CLI's `query_text`, **the desktop has no opt-out for `task_text`**: it

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -161,7 +161,7 @@ and model in use are captured on `socai_agent_task_start`.
 | `socai_browser_connect` | User connects Chrome | — |
 | `socai_agent_task_start` | A task begins running | `task_id`, `provider`, `model`, `task_len`, `task_text` |
 | `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `turns`, `input_tokens`, `output_tokens`, `duration_ms`, `error` |
-| `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error` |
+| `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, `query_text`, `query_len`, `metadata`, `note_id_present` |
 
 Desktop field semantics:
 
@@ -177,6 +177,12 @@ Desktop field semantics:
 | `task_len` | number | Agent prompt length in Unicode scalar values. |
 | `task_text` | string | Full agent prompt. Always sent on desktop; see privacy boundaries. |
 | `turn` / `sequence` | number | Position of a tool call within the run. |
+
+`socai_tool_call` mirrors the CLI tool trace's argument summary: the tool's
+`query` argument is lifted to `query_text` + `query_len`, a `note_id` argument
+collapses to a `note_id_present` boolean (the raw id is not sent), and any other
+scalar arguments go under `metadata`. The tool's **output** (note bodies,
+comments, scraped content) is never included — only the arguments.
 
 Unlike the CLI's `query_text`, **the desktop has no opt-out for `task_text`**: it
 is sent whenever desktop telemetry is enabled. `SOCAI_TELEMETRY=off` is the only


### PR DESCRIPTION
## What & why

Follow-up to #119 (desktop telemetry). When comparing the unified `socai_tool_call` event across surfaces, the **desktop** version was much thinner than the **CLI** one — most notably it carried no `query_text`, so you couldn't see what the agent actually searched for.

Cause: the CLI emits a purpose-built trace that parses command args, while the desktop rides the generic `AgentEvent::ToolResult` stream, from which I'd only forwarded `tool_name` / `turn` / `sequence` / `duration_ms` / `ok` / `error`.

## Change

In `pump_agent_task_events` ([app/src-tauri/src/commands.rs](app/src-tauri/src/commands.rs)), summarize each tool call's **input arguments** the same way the CLI tool trace does:

- the tool's `query` argument → `query_text` + `query_len`
- a `note_id` argument → `note_id_present` boolean (the raw id is **not** sent)
- any other scalar args → `metadata`

So a desktop `socai_tool_call` for `topic_scan` now looks like its CLI counterpart, split by `source` as intended.

## Privacy

Only the tool **arguments** are summarized. The tool **output** (note bodies, comments, scraped content — and #121 now always returns comments) is still **never** included. `note_id` stays a presence flag, matching the CLI's minimization.

## Scope

- **Client-only.** The proxy is already passthrough (allowlist removed in #119, live in prod), so the new fields flow to Axiom with **no site redeploy**.
- No new dependencies. Builds green against current main (`cargo check -p socai_app`).
- Docs: `docs/telemetry-schema.md` desktop `socai_tool_call` row + field notes updated.

## Validate

Rebuild the desktop app, run an agent task, then:

```bash
axiom query "['socai-cli-prod'] | where event == 'socai_tool_call' and source == 'desktop' | sort by _time desc | limit 10" --start-time=-15m --format=json --no-spinner
```

`query_text` / `query_len` / `metadata` should now be populated on search tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
