### PR TITLE
feat(telemetry): unify socai_tool_call summarization across CLI + desktop

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -17,6 +17,8 @@ use socai_core::sites::xhs::{
     search_notes_command, topic_scan_command, XhsPageRuntime, XHS_HOME_URL,
 };
 use socai_core::sites::{find_site, SiteSpec};
+use socai_core::telemetry::query_text_enabled;
+use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_result};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -833,6 +835,7 @@ fn pump_agent_task_events(
                     turn,
                     sequence,
                     input,
+                    content,
                     duration_ms: tool_duration_ms,
                     error,
                     ..
@@ -846,11 +849,13 @@ fn pump_agent_task_events(
                     props.insert("duration_ms".into(), json!(tool_duration_ms));
                     props.insert("ok".into(), json!(error.is_none()));
                     props.insert("error".into(), json!(error.as_deref().map(short_error)));
-                    // Mirror the CLI tool trace: lift the search query into
-                    // query_text/query_len and fold the rest of the args into
-                    // metadata (note_id reduced to a presence flag). Tool OUTPUT
-                    // (note bodies) is never included.
-                    merge_tool_input(&mut props, input);
+                    // Same shared summarizer the CLI daemon uses: the search
+                    // query is lifted into query_text/query_len (gated by
+                    // query_text_enabled) and every other arg folds into
+                    // metadata; result counts are extracted from the output.
+                    // Tool OUTPUT text (note bodies) is never included.
+                    props.extend(summarize_tool_args(input, query_text_enabled()));
+                    props.extend(summarize_tool_result(content));
                     telemetry.capture("socai_tool_call", Value::Object(props));
                 }
                 _ => {}
@@ -859,64 +864,6 @@ fn pump_agent_task_events(
             emit_timeline_payload(&app, registry.as_ref(), &task_id, payload, None).await;
         }
     })
-}
-
-/// Summarize a tool call's input arguments the way the CLI tool trace does: the
-/// search `query` becomes `query_text` + `query_len`, a `note_id` collapses to a
-/// `note_id_present` flag, and any other scalar args go under `metadata`. Only
-/// the arguments are summarized — tool output (note bodies) is never included.
-fn merge_tool_input(props: &mut Map<String, Value>, input: &Value) {
-    let Some(args) = input.as_object() else {
-        return;
-    };
-    let mut metadata = Map::new();
-    for (key, value) in args {
-        match key.as_str() {
-            "query" => {
-                if let Some(query) = value.as_str() {
-                    let query = query.trim();
-                    if !query.is_empty() {
-                        props.insert("query_len".into(), json!(query.chars().count()));
-                        props.insert("query_text".into(), json!(query));
-                    }
-                }
-            }
-            "note_id" => {
-                let present = value
-                    .as_str()
-                    .map(|id| !id.trim().is_empty())
-                    .unwrap_or(!value.is_null());
-                if present {
-                    props.insert("note_id_present".into(), json!(true));
-                }
-            }
-            // Other scalar args go under metadata, mirroring the CLI summarizer:
-            // `tab_label` is renamed to `tab`, and string values are trimmed with
-            // empty/whitespace-only ones dropped. Non-scalar values are skipped.
-            _ => {
-                let meta_key = if key.as_str() == "tab_label" {
-                    "tab"
-                } else {
-                    key.as_str()
-                };
-                match value {
-                    Value::String(text) => {
-                        let text = text.trim();
-                        if !text.is_empty() {
-                            metadata.insert(meta_key.to_string(), json!(text));
-                        }
-                    }
-                    Value::Number(_) | Value::Bool(_) => {
-                        metadata.insert(meta_key.to_string(), value.clone());
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-    if !metadata.is_empty() {
-        props.insert("metadata".into(), Value::Object(metadata));
-    }
 }
 
 pub(crate) async fn emit_task_event(

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1,3 +1,4 @@
+use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_result};
 use socai_core::telemetry::{query_text_enabled, telemetry_enabled, Telemetry, TelemetrySource};
 
 use anyhow::{anyhow, Context, Result};
@@ -463,11 +464,14 @@ impl DaemonState {
             "duration_ms".into(),
             json!(started.elapsed().as_millis() as u64),
         );
-        merge_object(&mut props, command_arg_summary(telemetry, input));
+        merge_object(
+            &mut props,
+            Value::Object(summarize_tool_args(input, telemetry.include_query_text)),
+        );
         match result {
             Ok(value) => {
                 props.insert("ok".into(), json!(true));
-                merge_object(&mut props, result_metrics(value));
+                merge_object(&mut props, Value::Object(summarize_tool_result(value)));
             }
             Err(err) => {
                 props.insert("ok".into(), json!(false));
@@ -500,83 +504,6 @@ fn base_trace_props(
     props
 }
 
-fn command_arg_summary(telemetry: &DaemonTelemetry, args: &Value) -> Value {
-    let mut props = Map::new();
-    if let Some(query) = args.get("query").and_then(Value::as_str) {
-        insert_query_props(&mut props, telemetry, query);
-    }
-    if let Some(metadata) = explicit_param_metadata(args) {
-        props.insert("metadata".into(), Value::Object(metadata));
-    }
-    if args.get("note_id").and_then(Value::as_str).is_some() {
-        props.insert("note_id_present".into(), json!(true));
-    }
-    Value::Object(props)
-}
-
-fn explicit_param_metadata(args: &Value) -> Option<Map<String, Value>> {
-    let mut metadata = Map::new();
-    insert_optional_str_metadata(&mut metadata, args, "tab_label", "tab");
-    insert_optional_i64_metadata(&mut metadata, args, "num_notes", "num_notes");
-    insert_true_bool_metadata(&mut metadata, args, "debug_snapshot", "debug_snapshot");
-    if metadata.is_empty() {
-        None
-    } else {
-        Some(metadata)
-    }
-}
-
-fn insert_query_props(props: &mut Map<String, Value>, telemetry: &DaemonTelemetry, query: &str) {
-    props.insert("query_len".into(), json!(query.chars().count()));
-    props.insert(
-        "query_text_enabled".into(),
-        json!(telemetry.include_query_text),
-    );
-    if telemetry.include_query_text {
-        props.insert("query_text".into(), json!(query));
-    }
-}
-
-fn insert_optional_str_metadata(
-    metadata: &mut Map<String, Value>,
-    args: &Value,
-    arg_key: &str,
-    metadata_key: &str,
-) {
-    let Some(value) = args
-        .get(arg_key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
-        return;
-    };
-    metadata.insert(metadata_key.to_string(), json!(value));
-}
-
-fn insert_optional_i64_metadata(
-    metadata: &mut Map<String, Value>,
-    args: &Value,
-    arg_key: &str,
-    metadata_key: &str,
-) {
-    let Some(value) = args.get(arg_key).and_then(Value::as_i64) else {
-        return;
-    };
-    metadata.insert(metadata_key.to_string(), json!(value));
-}
-
-fn insert_true_bool_metadata(
-    metadata: &mut Map<String, Value>,
-    args: &Value,
-    arg_key: &str,
-    metadata_key: &str,
-) {
-    if args.get(arg_key).and_then(Value::as_bool) == Some(true) {
-        metadata.insert(metadata_key.to_string(), json!(true));
-    }
-}
-
 fn merge_object(target: &mut Map<String, Value>, value: Value) {
     let Value::Object(map) = value else {
         return;
@@ -586,134 +513,10 @@ fn merge_object(target: &mut Map<String, Value>, value: Value) {
     }
 }
 
-fn result_metrics(value: &Value) -> Value {
-    let mut props = Map::new();
-    let data = value.get("data").unwrap_or(value);
-    if let Some(ok) = data.get("ok").and_then(Value::as_bool) {
-        props.insert("result_ok".into(), json!(ok));
-    }
-    if let Some(cards) = data.get("cards").and_then(Value::as_array) {
-        props.insert("cards_count".into(), json!(cards.len()));
-    }
-    if let Some(cards) = data
-        .get("search")
-        .and_then(|search| search.get("cards"))
-        .and_then(Value::as_array)
-    {
-        props.insert("search_cards_count".into(), json!(cards.len()));
-    }
-    if let Some(cards) = data.get("selected_cards").and_then(Value::as_array) {
-        props.insert("selected_cards_count".into(), json!(cards.len()));
-    }
-    if let Some(notes) = data.get("notes").and_then(Value::as_array) {
-        props.insert("notes_count".into(), json!(notes.len()));
-        let skipped = notes
-            .iter()
-            .filter(|note| note.get("skipped").is_some())
-            .count();
-        props.insert("notes_skipped_count".into(), json!(skipped));
-    }
-    if value.get("run_dir").is_some() {
-        props.insert("has_run_dir".into(), json!(true));
-    }
-    Value::Object(props)
-}
-
 fn error_summary(err: &anyhow::Error) -> String {
     let rendered = format!("{err:#}");
     let first = rendered.lines().next().unwrap_or("command failed").trim();
     first.chars().take(240).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn command_summary_includes_query_text_by_default() {
-        let summary = command_arg_summary(
-            &DaemonTelemetry::default(),
-            &json!({ "query": "运营爆款思路" }),
-        );
-        let object = summary.as_object().expect("summary is an object");
-        assert_eq!(object.get("query_text"), Some(&json!("运营爆款思路")));
-        assert_eq!(object.get("query_text_enabled"), Some(&json!(true)));
-        assert_eq!(object.get("query_len"), Some(&json!(6)));
-    }
-
-    #[test]
-    fn command_summary_redacts_query_text_when_disabled() {
-        let telemetry = DaemonTelemetry {
-            enabled: true,
-            include_query_text: false,
-        };
-        let summary = command_arg_summary(&telemetry, &json!({ "query": "运营爆款思路" }));
-        let object = summary.as_object().expect("summary is an object");
-        assert!(!object.contains_key("query_text"));
-        assert_eq!(object.get("query_text_enabled"), Some(&json!(false)));
-        assert_eq!(object.get("query_len"), Some(&json!(6)));
-    }
-
-    #[test]
-    fn command_summary_omits_defaulted_optional_params() {
-        let summary = command_arg_summary(
-            &DaemonTelemetry::default(),
-            &json!({ "query": "x", "debug_snapshot": false }),
-        );
-        let object = summary.as_object().expect("summary is an object");
-        assert!(!object.contains_key("metadata"));
-    }
-
-    #[test]
-    fn command_summary_tracks_explicit_optional_params_as_metadata() {
-        let summary = command_arg_summary(
-            &DaemonTelemetry::default(),
-            &json!({
-                "query": "x",
-                "tab_label": "latest",
-                "num_notes": 12,
-                "debug_snapshot": true
-            }),
-        );
-        let object = summary.as_object().expect("summary is an object");
-        let metadata = object
-            .get("metadata")
-            .and_then(Value::as_object)
-            .expect("metadata object");
-        assert_eq!(metadata.get("tab"), Some(&json!("latest")));
-        assert_eq!(metadata.get("num_notes"), Some(&json!(12)));
-        assert_eq!(metadata.get("debug_snapshot"), Some(&json!(true)));
-        assert!(!object.contains_key("tab_label"));
-        assert!(!object.contains_key("num_notes"));
-    }
-
-    #[test]
-    fn result_metrics_extracts_safe_counts() {
-        let metrics = result_metrics(&json!({
-            "run_dir": "/tmp/socai-run",
-            "data": {
-                "ok": true,
-                "cards": [{}, {}],
-                "search": { "cards": [{}, {}, {}] },
-                "selected_cards": [{}],
-                "notes": [
-                    { "id": "1", "body": "must not be copied" },
-                    { "skipped": "missing note" },
-                    { "skipped": true, "comments": ["must not be copied"] }
-                ]
-            }
-        }));
-        let object = metrics.as_object().expect("metrics is an object");
-        assert_eq!(object.get("result_ok"), Some(&json!(true)));
-        assert_eq!(object.get("cards_count"), Some(&json!(2)));
-        assert_eq!(object.get("search_cards_count"), Some(&json!(3)));
-        assert_eq!(object.get("selected_cards_count"), Some(&json!(1)));
-        assert_eq!(object.get("notes_count"), Some(&json!(3)));
-        assert_eq!(object.get("notes_skipped_count"), Some(&json!(2)));
-        assert_eq!(object.get("has_run_dir"), Some(&json!(true)));
-        assert!(!object.contains_key("body"));
-        assert!(!object.contains_key("comments"));
-    }
 }
 
 async fn send_request(

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -9,6 +9,8 @@ use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
+pub mod tool_call;
+
 const EVENT_SCHEMA_VERSION: u32 = 1;
 const TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
 const CHANNEL_CAPACITY: usize = 512;

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -1,0 +1,213 @@
+//! Shared summarization of a site tool call for the `socai_tool_call` telemetry
+//! event. Both the CLI daemon and the desktop app feed their tool invocations
+//! through here, so every site (xhs, dy, and any future site) is reported
+//! through one code path — there is no per-site or per-arg whitelist to keep in
+//! sync, and newly-added commands/params are captured automatically.
+
+use serde_json::{json, Map, Value};
+
+/// Summarize a tool call's input arguments. The search `query` is the one gated
+/// arg: its character length is always reported, but the raw text only when
+/// `include_query_text` is on. Every other arg flows into a nested `metadata`
+/// object as-is, so newly-added params/commands/sites are captured
+/// automatically. Only the arguments are summarized here — tool OUTPUT (note
+/// bodies, comments) is never included; see [`summarize_tool_result`] for the
+/// safe, count-only output summary.
+pub fn summarize_tool_args(args: &Value, include_query_text: bool) -> Map<String, Value> {
+    let mut props = Map::new();
+    let Some(obj) = args.as_object() else {
+        return props;
+    };
+    let mut metadata = Map::new();
+    for (key, value) in obj {
+        if key == "query" {
+            if let Some(query) = value.as_str() {
+                let query = query.trim();
+                if !query.is_empty() {
+                    props.insert("query_len".into(), json!(query.chars().count()));
+                    props.insert("query_text_enabled".into(), json!(include_query_text));
+                    if include_query_text {
+                        props.insert("query_text".into(), json!(query));
+                    }
+                }
+            }
+            continue;
+        }
+        if let Some(value) = meaningful_metadata_value(value) {
+            metadata.insert(key.clone(), value);
+        }
+    }
+    if !metadata.is_empty() {
+        props.insert("metadata".into(), Value::Object(metadata));
+    }
+    props
+}
+
+/// Normalize an arg value for `metadata`, returning `None` for the
+/// "unset"/default shapes that shouldn't be reported: `null`, `false`,
+/// empty/whitespace-only strings, and empty arrays/objects. Strings are trimmed;
+/// every other value is reported verbatim.
+fn meaningful_metadata_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Null | Value::Bool(false) => None,
+        Value::String(text) => {
+            let text = text.trim();
+            if text.is_empty() {
+                None
+            } else {
+                Some(json!(text))
+            }
+        }
+        Value::Array(items) if items.is_empty() => None,
+        Value::Object(map) if map.is_empty() => None,
+        other => Some(other.clone()),
+    }
+}
+
+/// Extract safe, count-only metrics from a tool call's output. Reports the size
+/// of well-known result collections plus a couple of presence flags — never the
+/// note bodies, comments, or any free text. The value may be the raw tool result
+/// or wrapped in a `data` envelope (CLI daemon); both shapes are handled.
+pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
+    let mut props = Map::new();
+    let data = value.get("data").unwrap_or(value);
+    if let Some(ok) = data.get("ok").and_then(Value::as_bool) {
+        props.insert("result_ok".into(), json!(ok));
+    }
+    if let Some(cards) = data.get("cards").and_then(Value::as_array) {
+        props.insert("cards_count".into(), json!(cards.len()));
+    }
+    if let Some(cards) = data
+        .get("search")
+        .and_then(|search| search.get("cards"))
+        .and_then(Value::as_array)
+    {
+        props.insert("search_cards_count".into(), json!(cards.len()));
+    }
+    if let Some(cards) = data.get("selected_cards").and_then(Value::as_array) {
+        props.insert("selected_cards_count".into(), json!(cards.len()));
+    }
+    if let Some(notes) = data.get("notes").and_then(Value::as_array) {
+        props.insert("notes_count".into(), json!(notes.len()));
+        let skipped = notes
+            .iter()
+            .filter(|note| note.get("skipped").is_some())
+            .count();
+        props.insert("notes_skipped_count".into(), json!(skipped));
+    }
+    if value.get("run_dir").is_some() {
+        props.insert("has_run_dir".into(), json!(true));
+    }
+    props
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn includes_query_text_when_enabled() {
+        let props = summarize_tool_args(&json!({ "query": "运营爆款思路" }), true);
+        assert_eq!(props.get("query_text"), Some(&json!("运营爆款思路")));
+        assert_eq!(props.get("query_text_enabled"), Some(&json!(true)));
+        assert_eq!(props.get("query_len"), Some(&json!(6)));
+    }
+
+    #[test]
+    fn redacts_query_text_when_disabled() {
+        let props = summarize_tool_args(&json!({ "query": "运营爆款思路" }), false);
+        assert!(!props.contains_key("query_text"));
+        assert_eq!(props.get("query_text_enabled"), Some(&json!(false)));
+        assert_eq!(props.get("query_len"), Some(&json!(6)));
+    }
+
+    #[test]
+    fn omits_defaulted_optional_params() {
+        let props = summarize_tool_args(&json!({ "query": "x", "debug_snapshot": false }), true);
+        assert!(!props.contains_key("metadata"));
+    }
+
+    #[test]
+    fn keeps_query_out_of_metadata_and_nests_other_params() {
+        let props = summarize_tool_args(
+            &json!({
+                "query": "x",
+                "author_id": "abc",
+                "num_notes": 12,
+                "debug_snapshot": true
+            }),
+            true,
+        );
+        assert!(props.contains_key("query_len"));
+        let metadata = props
+            .get("metadata")
+            .and_then(Value::as_object)
+            .expect("metadata object");
+        assert!(!metadata.contains_key("query"));
+        assert_eq!(metadata.get("author_id"), Some(&json!("abc")));
+        assert_eq!(metadata.get("num_notes"), Some(&json!(12)));
+        assert_eq!(metadata.get("debug_snapshot"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn reports_arbitrary_params_without_a_whitelist() {
+        // `author_id` (xhs) and any future site's params flow through generically;
+        // defaulted flags (`preview: false`) stay out of the payload.
+        let props = summarize_tool_args(
+            &json!({
+                "author_id": "5ff00000000000000000abcd",
+                "num_notes": 8,
+                "preview": false,
+                "download_media": true
+            }),
+            true,
+        );
+        let metadata = props
+            .get("metadata")
+            .and_then(Value::as_object)
+            .expect("metadata object");
+        assert_eq!(
+            metadata.get("author_id"),
+            Some(&json!("5ff00000000000000000abcd"))
+        );
+        assert_eq!(metadata.get("num_notes"), Some(&json!(8)));
+        assert_eq!(metadata.get("download_media"), Some(&json!(true)));
+        assert!(!metadata.contains_key("preview"), "defaulted false dropped");
+    }
+
+    #[test]
+    fn result_summary_reports_dy_and_xhs_card_counts() {
+        // dy search returns top-level `cards`; the same path covers any site that
+        // returns a `cards` array.
+        let props = summarize_tool_result(&json!({ "ok": true, "cards": [{}, {}, {}] }));
+        assert_eq!(props.get("result_ok"), Some(&json!(true)));
+        assert_eq!(props.get("cards_count"), Some(&json!(3)));
+    }
+
+    #[test]
+    fn result_summary_extracts_safe_counts_without_copying_text() {
+        let props = summarize_tool_result(&json!({
+            "run_dir": "/tmp/socai-run",
+            "data": {
+                "ok": true,
+                "cards": [{}, {}],
+                "search": { "cards": [{}, {}, {}] },
+                "selected_cards": [{}],
+                "notes": [
+                    { "id": "1", "body": "must not be copied" },
+                    { "skipped": "missing note" },
+                    { "skipped": true, "comments": ["must not be copied"] }
+                ]
+            }
+        }));
+        assert_eq!(props.get("result_ok"), Some(&json!(true)));
+        assert_eq!(props.get("cards_count"), Some(&json!(2)));
+        assert_eq!(props.get("search_cards_count"), Some(&json!(3)));
+        assert_eq!(props.get("selected_cards_count"), Some(&json!(1)));
+        assert_eq!(props.get("notes_count"), Some(&json!(3)));
+        assert_eq!(props.get("notes_skipped_count"), Some(&json!(2)));
+        assert_eq!(props.get("has_run_dir"), Some(&json!(true)));
+        assert!(!props.contains_key("body"));
+        assert!(!props.contains_key("comments"));
+    }
+}


### PR DESCRIPTION
## What

Unifies the `socai_tool_call` telemetry summarization into one shared module so the CLI daemon and the desktop app report through identical, site-agnostic logic. xhs, dy, and any future site are covered automatically — no per-site or per-arg whitelist to maintain.

## Changes
- **New `core/src/telemetry/tool_call.rs`** (single source of truth):
  - `summarize_tool_args(args, include_query_text)` — `query` stays gated (length always; raw text only when enabled), every other arg flows into `metadata` as-is, dropping unset/default values. Fixes the new `author` command's `author_id` (and any future param) being silently dropped by the old CLI whitelist.
  - `summarize_tool_result(value)` — safe, count-only output metrics.
- **CLI daemon** (`cli/src/daemon.rs`): calls the shared functions; removes duplicated `command_arg_summary` / `result_metrics` / helpers + their tests (moved to core).
- **Desktop app** (`app/src-tauri/src/commands.rs`): calls the shared functions; removes duplicated `merge_tool_input`. Now reports `note_id` raw under `metadata` (was a presence flag), honors `query_text_enabled`, and drops the dead `tab_label`→`tab` rename.

## Tests
- 7 unit tests in `core/src/telemetry/tool_call.rs` (query gate, generic params, dy/xhs result counts).
- `cargo build -p socai-cli` and `cargo check` (app) pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)