### PR TITLE
fix(cli): accurate xhs run-dir names for author and search

### DIFF
--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -41,14 +41,18 @@ pub async fn run_tool_command(
     input: Value,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
-    // Run-dir label: site + command, plus the query when the command has one,
-    // so runs are tellable apart at a glance (…_xhs_search_notes_咖啡).
+    // Run-dir label: site + command, plus the command's identifying input when
+    // it has one, so runs are tellable apart at a glance
+    // (…_xhs_search_notes_咖啡, …_xhs_author_<author_id>).
     let mut label = format!("{}_{}", cmd.site_id, cmd.command_name);
-    if let Some(query) = input.get("query").and_then(Value::as_str) {
-        let query = query.trim();
-        if !query.is_empty() {
-            label.push('_');
-            label.push_str(query);
+    for key in ["query", "author_id"] {
+        if let Some(value) = input.get(key).and_then(Value::as_str) {
+            let value = value.trim();
+            if !value.is_empty() {
+                label.push('_');
+                label.push_str(value);
+                break;
+            }
         }
     }
     let (run_dir, ctx) = command_context_for_label(cmd.site_id, &label);

--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -118,7 +118,8 @@ pub async fn call_site_tool(
 
 /// Allocate a run dir for a one-shot command and build its ToolContext with
 /// the site enabled (so site-gated tools resolve). The site id is part of the
-/// run-dir name (`<ts>_<site>_<command>[_<query>]`).
+/// run-dir name (`<ts>_<site>_<command>[_<identifier>]`, where the optional
+/// identifier is the command's first non-empty `query`/`author_id` input).
 pub fn command_context(site_id: &str, label: &str) -> (String, ToolContext) {
     command_context_for_label(site_id, &format!("{site_id}_{label}"))
 }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -322,7 +322,15 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             .unwrap_or(false);
         if preview {
             // Cards only — download_media doesn't apply to a card-only read.
-            search_notes_command(page, &query, filters.as_ref(), num_notes, debug_snapshot).await
+            search_notes_command(
+                page,
+                "search",
+                &query,
+                filters.as_ref(),
+                num_notes,
+                debug_snapshot,
+            )
+            .await
         } else {
             let download_media = args
                 .get("download_media")
@@ -330,6 +338,7 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
                 .unwrap_or(false);
             topic_scan_command(
                 page,
+                "search",
                 &query,
                 filters.as_ref(),
                 num_notes,
@@ -369,8 +378,15 @@ fn run_search_notes_deprecated(
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
-        let envelope =
-            search_notes_command(page, &query, filters.as_ref(), num_notes, debug_snapshot).await?;
+        let envelope = search_notes_command(
+            page,
+            "search_notes",
+            &query,
+            filters.as_ref(),
+            num_notes,
+            debug_snapshot,
+        )
+        .await?;
         Ok(with_deprecation(
             envelope,
             "`search_notes` is deprecated and will be removed in a future release. \
@@ -399,6 +415,7 @@ fn run_topic_scan_deprecated(
             .unwrap_or(false);
         let envelope = topic_scan_command(
             page,
+            "topic_scan",
             &query,
             filters.as_ref(),
             num_notes,
@@ -488,14 +505,22 @@ const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
 
 pub async fn search_notes_command(
     page: Arc<PageSession>,
+    command_name: &'static str,
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
+    // `command_name` decouples the user-facing command (e.g. `search --preview`)
+    // from the underlying tool, so the run-dir label and envelope show what was
+    // actually invoked rather than the internal `search_notes` op.
+    let spec = XhsCommandSpec {
+        command_name,
+        ..SEARCH_NOTES_COMMAND
+    };
     run_xhs_tool_command(
         page,
-        SEARCH_NOTES_COMMAND,
+        spec,
         search_notes_input(query, filters, num_notes)?,
         debug_snapshot,
     )
@@ -504,15 +529,23 @@ pub async fn search_notes_command(
 
 pub async fn topic_scan_command(
     page: Arc<PageSession>,
+    command_name: &'static str,
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
     download_media: bool,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
+    // The user-facing `search` command shares this operation with the
+    // deprecated `topic_scan` alias; record whichever name the caller invoked
+    // so the run-dir label and envelope reflect the actual command.
+    let spec = XhsCommandSpec {
+        command_name,
+        ..TOPIC_SCAN_COMMAND
+    };
     run_xhs_tool_command(
         page,
-        TOPIC_SCAN_COMMAND,
+        spec,
         topic_scan_input(query, filters, num_notes, download_media)?,
         debug_snapshot,
     )


### PR DESCRIPTION
## What

Two fixes so XHS one-shot command run directories are named after what the user actually ran, making consecutive runs easy to tell apart in the runs folder.

### 1. `xhs author` — include the author id in the folder name
Author scans were producing a bare `<timestamp>_xhs_author` folder, so scans of different authors were indistinguishable at a glance.

**Cause:** the shared run-dir labeler in `core/src/sites/runner.rs` only appended `input["query"]`, which `search`/`topic_scan` carry. The `author` command's identifying field is `author_id`, not `query`, so it fell through.

**Fix:** generalized the single `query` check into an ordered key list `["query", "author_id"]`, appending the first non-empty match → `<timestamp>_xhs_author_<author_id>`. Since downloaded media nests under the run dir, media gets the author-keyed folder too. Also updated the `command_context` doc comment to match.

### 2. `xhs search` — label the folder `search`, not the internal op
`xhs search` produced `<timestamp>_xhs_topic_scan_<query>` instead of `xhs_search_<query>`.

**Cause:** `xhs search` delegates to an internal op (`topic_scan` by default, `search_notes` with `--preview`) in `core/src/sites/xhs/tools.rs`, and the run-dir label was pulled from that internal op's name — leaking an implementation detail.

**Fix:** thread the user-facing command name through `topic_scan_command` / `search_notes_command` via a `command_name` parameter, so `search` records `search` (folder + envelope `command` field). The deprecated `topic_scan` / `search_notes` aliases keep their own names for script/telemetry stability. `tool_name` is unchanged, so the same underlying tool still runs.

## Test

- `cargo fmt`, `cargo build -p socai-core`, `cargo clippy -p socai-core` (no new warnings)
- `cargo test -p socai-core` — 32 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)