### PR TITLE
refactor(xhs): trim search/author output, cache full notes for reuse

### DIFF
--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -20,15 +20,17 @@ pub struct XhsNote {
     pub content_source: String,
     pub hashtags: Vec<String>,
     pub date: String,
+    /// Note POI / geo-tag label (the place the author tagged on the note).
+    /// Distinct from the author's IP territory, which only appears on the
+    /// profile header — notes never expose it — so there is no note-level
+    /// `ip_location`.
     pub location: String,
-    pub ip_location: String,
     pub likes: String,
     pub favorites: String,
     pub comments_count: String,
     pub image_count: i64,
     pub images: Vec<Value>,
     pub video: Value,
-    pub extraction_level: String,
 
     /// Serialized as `"wait"` to keep the public note shape compact.
     #[serde(rename = "wait", skip_serializing_if = "Option::is_none", default)]
@@ -69,23 +71,13 @@ impl XhsAuthorProfile {
         map.insert("url".into(), json!(normalize_url(&self.profile_url)));
         map.insert("bio".into(), json!(self.bio));
         map.insert("ip_location".into(), json!(self.ip_location));
+        // Counts are kept as the raw displayed strings ("1.2万"); the parsed
+        // `*_value` integers were redundant, so they're no longer emitted.
         map.insert("followers".into(), json!(self.followers));
-        map.insert(
-            "followers_value".into(),
-            json!(parse_count_text(&self.followers)),
-        );
         map.insert("following".into(), json!(self.following));
-        map.insert(
-            "following_value".into(),
-            json!(parse_count_text(&self.following)),
-        );
         map.insert(
             "likes_and_collections".into(),
             json!(self.likes_and_collections),
-        );
-        map.insert(
-            "likes_and_collections_value".into(),
-            json!(parse_count_text(&self.likes_and_collections)),
         );
         map.insert("note_count".into(), json!(self.note_cards.len()));
         let cards: Vec<Value> = self
@@ -171,7 +163,6 @@ impl Default for XhsNote {
             hashtags: Vec::new(),
             date: String::new(),
             location: String::new(),
-            ip_location: String::new(),
             likes: String::new(),
             favorites: String::new(),
             comments_count: String::new(),
@@ -180,7 +171,6 @@ impl Default for XhsNote {
             // Keep video as {}, not null, so the wire shape stays consistent
             // for video-less notes.
             video: Value::Object(Default::default()),
-            extraction_level: "lite".into(),
             wait_meta: None,
             stale_warning: None,
         }

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -4,10 +4,12 @@
 //!
 //! - In-run dedup still lives on `ToolContext::processed_notes`; this store
 //!   only handles cross-run persistence.
-//! - Schema is intentionally smaller — we keep `note_id`, `title`, `author`,
-//!   `url`, `level`, `include_media`, `analysis_count`, `first_seen_at`,
-//!   `last_seen_at`. Run dirs and artifact paths are dropped — they live in
-//!   the per-run logs and would mostly point at stale paths anyway.
+//! - Besides the lookup metadata (`note_id`, `title`, `author`, `url`, `level`,
+//!   `include_media`, `analysis_count`, `first_seen_at`, `last_seen_at`) we also
+//!   cache the full last-read `entity` (body + comments + images + location), so
+//!   a reused note returns its complete data instead of degrading to the bare
+//!   search card. Run dirs and artifact paths are dropped — they live in the
+//!   per-run logs and would mostly point at stale paths anyway.
 //! - File at `~/.socai/xhs/history.json` (overridable via `SOCAI_HOME`).
 
 use std::collections::BTreeMap;
@@ -40,6 +42,11 @@ pub struct HistoryEntry {
     pub first_seen_at: String,
     #[serde(default)]
     pub last_seen_at: String,
+    /// Full last-read entity (body, comments, images, location, …) so a reused
+    /// note can be returned complete without re-opening it. `None` for entries
+    /// written before this field existed or recorded from a card only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -86,6 +93,24 @@ impl XhsHistoryStore {
         }
         let guard = self.inner.lock().ok()?;
         guard.notes.get(id).cloned()
+    }
+
+    /// True when we have the full cached entity for a note (so a reuse can
+    /// return complete data). False for pre-upgrade entries that only stored
+    /// lookup metadata — those should be re-read to backfill the cache.
+    /// Cheap: checks presence without cloning the entity.
+    pub fn has_cached_entity(&self, note_id: &str) -> bool {
+        let id = note_id.trim();
+        if id.is_empty() {
+            return false;
+        }
+        let Ok(guard) = self.inner.lock() else {
+            return false;
+        };
+        guard
+            .notes
+            .get(id)
+            .is_some_and(|entry| entry.entity.is_some())
     }
 
     /// True when a prior analysis already covers what's being requested:
@@ -171,6 +196,8 @@ impl XhsHistoryStore {
             if include_media {
                 entry.include_media = true;
             }
+            // Cache the full entity so a later reuse returns complete data.
+            entry.entity = Some(entity.clone());
             entry.analysis_count = entry.analysis_count.saturating_add(1);
             entry.last_seen_at = now;
             guard.clone()

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -61,16 +61,21 @@ searching again.
 ## Entity Fields
 
 Note fields: `note_id`, `url`, `type`, `title`, `author`, `author_id`,
-`author_url`, `content`, `hashtags`, `date`, `location`, `ip_location`,
-`likes`, `favorites`, `comments_count`, `shares`, `image_count`, `images`,
-`video`, `top_comments`.
+`author_url`, `content`, `hashtags`, `date`, `location` (the note's POI/geo-tag;
+notes carry no `ip_location` — that is profile-only), `likes`, `favorites`,
+`comments_count`, `image_count`, `images`, `video`, `top_comments`. (Search /
+profile result *cards* — not opened notes — instead carry `link`/`xsec_token`
+for the tokenized URL.)
 
-Comment fields: `username`, `text`, `likes`, `like_count`, `time`,
-`is_author_reply`, `is_pinned`, `reply_count`, `sub_comments`.
+`top_comments` is a plain array of comment text strings. The full comment
+objects (`username`, `text`, `likes`, `like_count`, `time`, `is_author_reply`,
+`is_pinned`, `reply_count`, `sub_comments`) are kept in the run artifact
+(`<run_dir>/artifacts/…json`), which holds the complete untrimmed bundle.
 
 Author fields: `display_name`, `xhs_id`, `profile_url`, `bio`, `ip_location`,
-`followers`, `following`, `likes_and_collections` (each `*_value` is the parsed
-integer, e.g. `5.6万` → `56000`), `note_count`, `note_cards`.
+`followers`, `following`, `likes_and_collections` (raw displayed strings, e.g.
+`5.6万`), `note_count`, `note_cards` (only when notes weren't opened; once read,
+the listing lives in `notes`).
 
 Image fields: `url`, `index`, `is_cover`, optional `ocr_text`,
 `vision_description`, `local_path`.

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -1085,7 +1085,7 @@ impl<'a> XhsPageRuntime<'a> {
             .filter(Value::is_object)
             .unwrap_or_else(|| Value::Object(Map::new()));
 
-        let mut note = parse_note(&body, &options.level);
+        let mut note = parse_note(&body);
 
         if note.note_id.is_empty() && !options.note_id_fallback.trim().is_empty() {
             note.note_id = options.note_id_fallback.trim().to_string();
@@ -1377,7 +1377,7 @@ fn canonical_filter_state(raw: &Value) -> Value {
 
 /// Parse the JS-side `body` payload into a wire-ready XhsNote. Performs all
 /// normalization up front so serde Serialize alone produces stable output.
-fn parse_note(body: &Value, level: &str) -> XhsNote {
+fn parse_note(body: &Value) -> XhsNote {
     let s = |k: &str| {
         body.get(k)
             .and_then(Value::as_str)
@@ -1443,14 +1443,12 @@ fn parse_note(body: &Value, level: &str) -> XhsNote {
         hashtags,
         date: s("date"),
         location: s("location"),
-        ip_location: s("ip_location"),
         likes: s("likes"),
         favorites: s("favorites"),
         comments_count: s("comments_count"),
         image_count,
         images,
         video,
-        extraction_level: level.to_string(),
         wait_meta: None,
         stale_warning: None,
     }
@@ -1644,11 +1642,10 @@ mod tests {
 
     #[test]
     fn parse_empty_body_yields_defaults() {
-        let note = parse_note(&Value::Object(Map::new()), "lite");
+        let note = parse_note(&Value::Object(Map::new()));
         assert_eq!(note.note_id, "");
         assert_eq!(note.image_count, 0);
         assert!(note.images.is_empty());
-        assert_eq!(note.extraction_level, "lite");
     }
 
     #[test]
@@ -1660,7 +1657,7 @@ mod tests {
             "image_urls": ["https://img.example/1.jpg", "https://img.example/2.jpg"],
             "hashtags": ["#tag1", "#tag2"],
         });
-        let note = parse_note(&body, "lite");
+        let note = parse_note(&body);
         assert_eq!(note.note_id, "abc123");
         assert_eq!(note.title, "测试笔记");
         assert_eq!(note.author, "张三");
@@ -1675,20 +1672,20 @@ mod tests {
     fn hashtags_clipped_to_12() {
         let tags: Vec<String> = (0..20).map(|i| format!("#t{i}")).collect();
         let body = json!({ "hashtags": tags });
-        let note = parse_note(&body, "lite");
+        let note = parse_note(&body);
         assert_eq!(note.hashtags.len(), 12);
     }
 
     #[test]
     fn image_count_prefers_explicit_then_images_len() {
         let body = json!({ "image_count": 5, "image_urls": ["a", "b"] });
-        assert_eq!(parse_note(&body, "lite").image_count, 5);
+        assert_eq!(parse_note(&body).image_count, 5);
 
         let body = json!({ "image_urls": ["a", "b", "c"] });
-        assert_eq!(parse_note(&body, "lite").image_count, 3);
+        assert_eq!(parse_note(&body).image_count, 3);
 
         let body = json!({});
-        assert_eq!(parse_note(&body, "lite").image_count, 0);
+        assert_eq!(parse_note(&body).image_count, 0);
     }
 
     #[test]

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -815,9 +815,17 @@ const SocaiXhsPageScripts = (() => {
     );
     const hashtags = $$('.hash-tag a, a[href*="/page/topics/"], #detail-desc a.tag', root)
       .filter(isVisible).map(text).filter(Boolean);
-    const rootText = norm(text(root));
-    const date = (rootText.match(/\b\d{4}-\d{1,2}-\d{1,2}\b|\b\d{1,2}-\d{1,2}\b/) || [''])[0];
-    const ipLocation = (rootText.match(/IP属地[:：]?\s*([\u4e00-\u9fffA-Za-z0-9_-]+)/) || [])[1] || '';
+    // Publish date lives in the note's bottom bar (`.bottom-container .date`),
+    // e.g. "编辑于 03-28" or "2024-03-28 北京". Scope to that element and pull the
+    // date token out of its short text — regexing the whole note body would
+    // grab things like "13-15" from the content. Comments also use `.date`,
+    // hence excludeComments.
+    const dateText = firstVisibleText(
+      ['.bottom-container .date', '.note-content .date', '.note-scroller .date', '.date'],
+      root,
+      { excludeComments: true },
+    );
+    const date = (dateText.match(/\d{4}-\d{1,2}-\d{1,2}|\d{1,2}-\d{1,2}/) || [''])[0];
     const locationText = cleanLocationText(
       firstVisibleText(['.location, .poi, [class*="location"], [class*="poi"]'], root, { excludeComments: true })
     );
@@ -838,7 +846,6 @@ const SocaiXhsPageScripts = (() => {
       content_source: contentSource,
       date,
       location: locationText,
-      ip_location: ipLocation,
       likes,
       favorites,
       comments_count: commentsCount,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -322,15 +322,8 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             .unwrap_or(false);
         if preview {
             // Cards only — download_media doesn't apply to a card-only read.
-            search_notes_command(
-                page,
-                "search",
-                &query,
-                filters.as_ref(),
-                num_notes,
-                debug_snapshot,
-            )
-            .await
+            search_notes_command(page, "search", &query, filters.as_ref(), num_notes, debug_snapshot)
+                .await
         } else {
             let download_media = args
                 .get("download_media")
@@ -708,7 +701,7 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
     ReadNoteOptions {
         // `level` is no longer a user-facing knob (body content is identical
         // across tiers; media is gated by include_media/download_media). It now
-        // only feeds the cosmetic extraction_level label + cross-run dedup.
+        // only feeds the cross-run history dedup key.
         level: "lite".to_string(),
         include_media: get_bool(input, "include_media", false),
         download_media: get_bool(input, "download_media", false),
@@ -756,6 +749,32 @@ async fn attach_top_comments(xhs: &XhsPageRuntime<'_>, note: &mut Value) {
     }
 }
 
+/// Build a skipped-note entry. We return the full entity cached in history
+/// (body + comments + images + location) so a reused note keeps its data
+/// instead of degrading to the bare search card; the `skipped` block carries a
+/// compact provenance summary (no title/author/url repeat — those are in
+/// `entity`). Falls back to the card when history has no cached entity (e.g. a
+/// pre-upgrade entry, or one only ever seen as a card).
+fn skipped_note_entry(card: &XhsNoteCard, reason: &str, history: &XhsHistoryStore) -> Value {
+    let entry = history.get(&card.note_id);
+    let entity = entry
+        .as_ref()
+        .and_then(|e| e.entity.clone())
+        .unwrap_or_else(|| serde_json::to_value(card).unwrap_or(Value::Null));
+    let mut skipped = json!({ "reason": reason });
+    if let (Some(entry), Some(map)) = (entry.as_ref(), skipped.as_object_mut()) {
+        map.insert("level".into(), json!(entry.level));
+        map.insert("analysis_count".into(), json!(entry.analysis_count));
+        map.insert("first_seen_at".into(), json!(entry.first_seen_at));
+        map.insert("last_seen_at".into(), json!(entry.last_seen_at));
+    }
+    json!({
+        "source_position": card.position,
+        "skipped": skipped,
+        "entity": entity,
+    })
+}
+
 /// Open one already-selected card, read its body at `level`, attach top
 /// comments, and record it in run + cross-run history. Shared by `topic_scan`
 /// (cards from search) and `author_scan` (cards from a profile page) — the only
@@ -783,25 +802,18 @@ async fn scan_card_note(
         && !card.note_id.is_empty()
         && ctx.has_processed_note(&card.note_id, level, requested_media)
     {
-        return json!({
-            "scan_level": level,
-            "source_position": card.position,
-            "skipped": {"reason": "already_processed"},
-            "entity": card,
-        });
+        return skipped_note_entry(card, "already_processed", history);
     }
     if can_use_cached_reads
         && !card.note_id.is_empty()
         && history.is_satisfied_by(&card.note_id, level, requested_media)
+        // Only short-circuit when we actually have the cached entity to return;
+        // a pre-upgrade entry without one is re-read so it backfills the cache
+        // instead of degrading to a bare card.
+        && history.has_cached_entity(&card.note_id)
     {
-        let entry = history.get(&card.note_id).unwrap_or_default();
         ctx.mark_processed_note(&card.note_id, level, requested_media);
-        return json!({
-            "scan_level": level,
-            "source_position": card.position,
-            "skipped": {"reason": "already_analyzed", "history": entry},
-            "entity": card,
-        });
+        return skipped_note_entry(card, "already_analyzed", history);
     }
 
     let read_result = xhs
@@ -834,7 +846,6 @@ async fn scan_card_note(
                 entity = serde_json::to_value(card).unwrap_or(Value::Null);
             }
             let mut entry = json!({
-                "scan_level": level,
                 "source_position": card.position,
                 "ok": ok,
                 "entity": entity,
@@ -852,7 +863,6 @@ async fn scan_card_note(
             entry
         }
         Err(e) => json!({
-            "scan_level": level,
             "source_position": card.position,
             "ok": false,
             "entity": card,
@@ -896,6 +906,65 @@ async fn scan_card_note(
     }
 
     entry
+}
+
+/// Trim a topic_scan / author_scan bundle to the shape we hand back to the
+/// agent/CLI so it doesn't dominate an LLM context window. The full payload is
+/// still written to the run artifact (`<run_dir>/artifacts/…json`), which is the
+/// place to look for everything dropped here. Diagnostic blocks (`sampling`,
+/// `timing`) and the `search` result block are dropped; the opened `notes`
+/// (each trimmed by [`lean_scan_note`]) carry the per-note listing, so
+/// `author_scan`'s `profile.note_cards` — a duplicate of that listing — is
+/// dropped too once notes were read.
+fn lean_scan_payload(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.remove("search");
+    obj.remove("sampling");
+    obj.remove("timing");
+    let notes_read = obj
+        .get("notes")
+        .and_then(Value::as_array)
+        .is_some_and(|notes| !notes.is_empty());
+    // author_scan only: `profile.note_cards` repeats the note listing now
+    // carried by `notes`. Keep it only when no notes were opened (preview),
+    // where it's the sole listing.
+    if notes_read {
+        if let Some(profile) = obj.get_mut("profile").and_then(Value::as_object_mut) {
+            profile.remove("note_cards");
+        }
+    }
+    if let Some(notes) = obj.get_mut("notes").and_then(Value::as_array_mut) {
+        for note in notes.iter_mut() {
+            lean_scan_note(note);
+        }
+    }
+}
+
+/// Trim one scanned-note entry to the lean shape: drop the body-source marker
+/// (`content_source`) and the per-extract wait diagnostics (`wait`,
+/// `top_comments_wait`), and collapse `top_comments` to a plain array of comment
+/// texts. Applies to both freshly-read and reused (cached) entities; the full
+/// objects stay in the run artifact.
+fn lean_scan_note(note: &mut Value) {
+    let Some(entry) = note.as_object_mut() else {
+        return;
+    };
+    let Some(entity) = entry.get_mut("entity").and_then(Value::as_object_mut) else {
+        return;
+    };
+    entity.remove("content_source");
+    entity.remove("wait");
+    entity.remove("top_comments_wait");
+    if let Some(comments) = entity.get_mut("top_comments").and_then(Value::as_array_mut) {
+        let texts: Vec<Value> = comments
+            .iter()
+            .filter_map(|comment| comment.get("text").cloned())
+            .filter(|text| text.as_str().is_some_and(|s| !s.is_empty()))
+            .collect();
+        entity.insert("top_comments".into(), Value::Array(texts));
+    }
 }
 
 /// search_notes(query, wait_seconds) -> {query, cards: [...]}
@@ -963,6 +1032,15 @@ impl Tool for SearchNotesTool {
             .await?;
         if let Some(cards) = value.get_mut("cards") {
             self.history.annotate_cards(cards);
+        }
+        // `submit` is the search-submission diagnostic (strategy + page-state
+        // echo). The preview path writes no artifact, so keep it only when the
+        // search failed (where it explains why) and drop it on success.
+        let failed = value.get("ok").and_then(Value::as_bool) == Some(false);
+        if !failed {
+            if let Some(obj) = value.as_object_mut() {
+                obj.remove("submit");
+            }
         }
         Ok(json_result(&value))
     }
@@ -1567,11 +1645,10 @@ impl Tool for TopicScanTool {
                 .filter(|reason| !reason.is_empty())
                 .unwrap_or("search_failed")
                 .to_string();
-            let payload = json!({
+            let mut payload = json!({
                 "ok": false,
                 "query": query,
                 "search": search,
-                "selected_cards": [],
                 "notes": [],
                 "reason": reason,
                 "sampling": {
@@ -1582,6 +1659,9 @@ impl Tool for TopicScanTool {
                     "download_media": download_media,
                 },
             });
+            // `reason` already summarizes the failure; keep the failed scan
+            // compact too.
+            lean_scan_payload(&mut payload);
             return Ok(json_result(&payload));
         }
 
@@ -1657,15 +1737,14 @@ impl Tool for TopicScanTool {
             _ => json!({}),
         };
 
-        // Annotate cards in the search payload and selected_cards against
-        // the pre-call snapshot so flags reflect "known before this scan"
-        // rather than "known after this scan's own writes".
+        // Annotate cards in the search payload against the pre-call snapshot so
+        // flags reflect "known before this scan" rather than "known after this
+        // scan's own writes". (Only kept in the artifact; the opened notes are
+        // the returned listing.)
         let mut search = search;
         if let Some(cards) = search.get_mut("cards") {
             history_snapshot.annotate_cards(cards);
         }
-        let mut selected_cards = serde_json::to_value(&selected)?;
-        history_snapshot.annotate_cards(&mut selected_cards);
 
         let media_manifest_metadata = if download_media {
             let media_manifest = topic_scan_media_manifest(&notes, &ctx.run_dir);
@@ -1690,7 +1769,6 @@ impl Tool for TopicScanTool {
             "run": run_metadata(ctx, download_media),
             "filters": filter_result,
             "search": search,
-            "selected_cards": selected_cards,
             "notes": notes,
             "sampling": {
                 "num_notes": num_notes,
@@ -1735,6 +1813,9 @@ impl Tool for TopicScanTool {
             json!({"site": "xhs", "category": "topic_scan"}),
         );
 
+        // Artifact above keeps the full bundle; trim what we return so the
+        // agent/CLI output stays small.
+        lean_scan_payload(&mut payload);
         Ok(json_result(&payload))
     }
 }
@@ -1958,6 +2039,9 @@ impl Tool for AuthorScanTool {
             json!({"site": "xhs", "category": "author_scan"}),
         );
 
+        // Artifact above keeps the full bundle; trim what we return so the
+        // agent/CLI output stays small.
+        lean_scan_payload(&mut payload);
         Ok(json_result(&payload))
     }
 }


### PR DESCRIPTION
## What

Trims the `xhs search` / `xhs author` JSON down to a useful shape so it stops dominating agent/LLM context, caches full notes so reuse returns complete data, and fixes a date-extraction bug. The complete untrimmed bundle is still written to `<run_dir>/artifacts/…json`.

## Output size before/after (`--pretty`)

| command | before | after | top-level keys dropped |
|---|---|---|---|
| `search` (topic scan) | 114.2 KiB | 58.5 KiB (**−49%**) | `sampling`, `search`, `selected_cards`, `timing` |
| `author` | 57.5 KiB | 38.7 KiB (**−33%**) | `sampling`, `timing` (+ `profile.note_cards`) |
| `search --preview` | 8.4 KiB | 8.7 KiB | `submit` (success only) |

Per-note `entity`: removed `content_source`, `extraction_level`, `ip_location`, `wait`, `top_comments_wait`; `top_comments` changed from `list[object]` → `list[string]` (text only).

## Changes

- **Lean output**: drop derivable/diagnostic blocks (`sampling`, `timing`, `search`, `selected_cards`); collapse `top_comments` to text; drop `author`'s duplicated `profile.note_cards` (once notes read) and redundant `*_value` count integers.
- **`--preview` `submit`**: kept only on failure (preview writes no artifact, so it's the only failure detail), dropped on success.
- **Removed fields**: `extraction_level` / per-note `scan_level` (retired `level` knob; history dedup still uses `level` internally); note-level `ip_location` (IP territory is profile-only — notes keep `location`).
- **History reuse**: cache the full last-read `entity` so an already-analyzed note returns complete body/comments/images instead of the bare card. Pre-upgrade entries without a cached entity are re-read once to backfill.
- **Bug fix**: date extraction scoped to `.bottom-container .date` instead of regexing the whole note body (which grabbed fragments like `"13-15"`).

## Notes

- Reviewers don't need raw dumps — the table above + the run_dir artifact cover the full data.

## Test

- `cargo test -p socai-core` → 93 passed
- `cargo build -p socai-cli` + `cargo check` (app) clean; clippy no new warnings
- Verified live: lean stdout, full artifact, preview submit-on-failure, history reuse + pre-upgrade backfill, date fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)