### PR TITLE
feat(app): UI updates — status capsule, settings menu, silent updater

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -807,6 +807,93 @@ async fn emit_timeline_payload(
     let _ = app.emit("agent_task:event", event);
 }
 
+// ── App configuration (~/.socai/config.json) ───────────────────────────────
+// The desktop settings menu reads and writes the same config file the CLI
+// manages via `socai config set`. Only the keys the menu surfaces are exposed.
+// Persistence, validation, and key parsing all live in `socai_core::config`;
+// these commands are thin pass-throughs plus the resolved defaults the menu
+// shows as placeholders.
+
+#[derive(serde::Serialize)]
+pub struct DesktopConfig {
+    /// Chrome profile mode: "managed" | "existing" | "auto". Falls back to the
+    /// product default ("existing") when the config key is unset.
+    chrome_source: String,
+    /// Configured managed-profile directory, or "" when unset.
+    chrome_profile_dir: String,
+    /// Resolved default managed-profile directory (shown as the input placeholder).
+    chrome_profile_dir_default: String,
+    /// Configured run-artifact root, or "" when unset.
+    output_dir: String,
+    /// Resolved default run-artifact root (shown as the input placeholder).
+    output_dir_default: String,
+}
+
+#[tauri::command]
+pub fn config_get() -> Result<DesktopConfig, String> {
+    let config = socai_core::config::load_config().map_err(|err| format!("{err:#}"))?;
+    Ok(DesktopConfig {
+        chrome_source: config.chrome.profile.unwrap_or_default().as_str().to_string(),
+        chrome_profile_dir: config.chrome.profile_dir.unwrap_or_default(),
+        chrome_profile_dir_default: default_managed_profile_dir(),
+        output_dir: config.runs.dir.unwrap_or_default(),
+        output_dir_default: default_runs_root_display(),
+    })
+}
+
+#[tauri::command]
+pub fn config_set(key: String, value: String) -> Result<(), String> {
+    socai_core::config::set_config_key(&key, &value)
+        .map(|_| ())
+        .map_err(|err| format!("{err:#}"))
+}
+
+#[tauri::command]
+pub fn config_unset(key: String) -> Result<(), String> {
+    socai_core::config::unset_config_key(&key)
+        .map(|_| ())
+        .map_err(|err| format!("{err:#}"))
+}
+
+/// Default run-artifact root when `runs.dir` is unset. Mirrors
+/// `socai_core::agent::run_logging::default_runs_root` for the no-config case:
+/// `SOCAI_RUNS_DIR`, then `~/.socai/runs`.
+fn default_runs_root_display() -> String {
+    if let Some(dir) = non_empty_env("SOCAI_RUNS_DIR") {
+        return dir;
+    }
+    join_home(".socai/runs")
+}
+
+/// Default managed chrome user-data-dir when `chrome.profile_dir` is unset.
+/// Mirrors `socai_core::cdp` endpoint resolution: `SOCAI_HOME/chrome-profile`,
+/// then `~/.socai/chrome-profile`.
+fn default_managed_profile_dir() -> String {
+    if let Some(home) = non_empty_env("SOCAI_HOME") {
+        return PathBuf::from(home)
+            .join("chrome-profile")
+            .to_string_lossy()
+            .into_owned();
+    }
+    join_home(".socai/chrome-profile")
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var_os(key)
+        .map(|value| value.to_string_lossy().trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn join_home(relative: &str) -> String {
+    match std::env::var_os("HOME").filter(|home| !home.is_empty()) {
+        Some(home) => PathBuf::from(home)
+            .join(relative)
+            .to_string_lossy()
+            .into_owned(),
+        None => relative.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -866,16 +866,14 @@ fn default_runs_root_display() -> String {
 }
 
 /// Default managed chrome user-data-dir when `chrome.profile_dir` is unset.
-/// Mirrors `socai_core::cdp` endpoint resolution: `SOCAI_HOME/chrome-profile`,
-/// then `~/.socai/chrome-profile`.
+/// Delegates to the core resolver (`SOCAI_HOME/chrome-profile`, then
+/// `~/.socai/chrome-profile`) so the placeholder matches what chrome would
+/// actually launch with — including `~` expansion of a tilde-prefixed
+/// `SOCAI_HOME`, which a local reimplementation tends to drift on.
 fn default_managed_profile_dir() -> String {
-    if let Some(home) = non_empty_env("SOCAI_HOME") {
-        return PathBuf::from(home)
-            .join("chrome-profile")
-            .to_string_lossy()
-            .into_owned();
-    }
-    join_home(".socai/chrome-profile")
+    socai_core::cdp::managed_chrome_user_data_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default()
 }
 
 fn non_empty_env(key: &str) -> Option<String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -92,6 +92,9 @@ pub fn run() {
             commands::agent_task_get,
             commands::agent_task_events,
             commands::agent_task_cancel,
+            commands::config_get,
+            commands::config_set,
+            commands::config_unset,
         ])
         .run(tauri::generate_context!())
         .expect("error while running socai");

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -3,7 +3,13 @@ export type TaskStatusKey = "queued" | "running" | "completed" | "failed" | "can
 
 const DEFAULT_LANGUAGE: Language = "zh";
 const STORAGE_KEY = "socai-language";
+const TIMEZONE_STORAGE_KEY = "socai-timezone";
 const supportedLanguages: Language[] = ["zh", "en"];
+
+// Active IANA timezone for displaying task timestamps. `undefined` follows the
+// system local zone. This is a display-only preference (no backend field) — it
+// is persisted to localStorage and threaded into the timestamp formatters.
+let activeTimezone: string | undefined = readInitialTimezone();
 
 const messages = {
   "language.switcherAria": { en: "language", zh: "语言" },
@@ -25,7 +31,7 @@ const messages = {
   "chrome.browser": { en: "browser", zh: "浏览器" },
   "chrome.endpoint": { en: "endpoint", zh: "端点" },
   "chrome.source": { en: "source", zh: "来源" },
-  "chrome.sourceManaged": { en: "isolated profile", zh: "独立资料目录" },
+  "chrome.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
   "chrome.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
   "chrome.profile": { en: "profile", zh: "资料目录" },
   "chrome.disconnect": { en: "disconnect", zh: "断开连接" },
@@ -38,20 +44,45 @@ const messages = {
     zh: "如何启用远程调试？↗",
   },
 
-  "update.available": { en: "update available", zh: "有可用更新" },
-  "update.toggleAria": { en: "show update status", zh: "显示更新状态" },
-  "update.dialogAria": { en: "app update", zh: "应用更新" },
-  "update.title": { en: "update", zh: "更新" },
-  "update.newVersion": { en: "new version", zh: "新版本" },
-  "update.upgradeAndRestart": { en: "upgrade & restart", zh: "升级并重启" },
-  "update.downloading": { en: "downloading…", zh: "下载中…" },
-  "update.readyTitle": { en: "update ready", zh: "更新就绪" },
-  "update.readyHint": { en: "restart to finish the update.", zh: "重启以完成更新。" },
-  "update.restartToFinish": { en: "restart to finish", zh: "待重启" },
-  "update.restartNow": { en: "restart now", zh: "立即重启" },
-  "update.failed": { en: "update failed", zh: "更新失败" },
-  "update.retry": { en: "try again", zh: "重试" },
-  "update.viewOnGithub": { en: "view on github ↗", zh: "在 github 查看 ↗" },
+  "update.restartToUpdate": { en: "restart to update", zh: "重启更新" },
+  "update.taskRunningWarn": {
+    en: "a task is running — restarting will interrupt it.",
+    zh: "有任务正在运行 — 重启会中断它。",
+  },
+  "update.restartAnyway": { en: "restart anyway", zh: "仍然重启" },
+  "update.later": { en: "later", zh: "稍后" },
+
+  "settings.aria": { en: "settings", zh: "设置" },
+  "settings.title": { en: "settings", zh: "设置" },
+  "settings.general": { en: "general", zh: "通用" },
+  "settings.language": { en: "language", zh: "语言" },
+  "settings.timezone": { en: "timezone", zh: "时区" },
+  "settings.timezoneSystem": { en: "system (local)", zh: "系统（本地）" },
+  "settings.output": { en: "output", zh: "输出" },
+  "settings.outputDir": { en: "output directory", zh: "输出目录" },
+  "settings.outputHint": {
+    en: "where run reports, traces, and screenshots are saved.",
+    zh: "运行报告、轨迹和截图的保存位置。",
+  },
+  "settings.browse": { en: "browse…", zh: "浏览…" },
+  "settings.chrome": { en: "chrome", zh: "chrome" },
+  "settings.source": { en: "source", zh: "来源" },
+  "settings.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
+  "settings.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
+  "settings.profileDir": { en: "profile directory", zh: "资料目录" },
+  "settings.profileHint": {
+    en: "socai launches a throwaway chrome with this profile.",
+    zh: "socai 会用此资料目录启动临时 chrome。",
+  },
+  "settings.endpoint": { en: "debugging endpoint", zh: "调试端点" },
+  "settings.endpointHint": {
+    en: "socai auto-detects a chrome started with --remote-debugging-port.",
+    zh: "socai 会自动检测使用 --remote-debugging-port 启动的 chrome。",
+  },
+  "settings.endpointDisconnected": { en: "not connected", zh: "未连接" },
+  "settings.saved": { en: "saved", zh: "已保存" },
+  "settings.saveFailed": { en: "could not save settings.", zh: "无法保存设置。" },
+  "settings.autosaveHint": { en: "changes are saved automatically.", zh: "更改会自动保存。" },
 
   "agent.label": { en: "model", zh: "模型" },
   "agent.configurationAria": { en: "agent configuration", zh: "智能体设置" },
@@ -159,6 +190,25 @@ export function getLocale(): string {
   return toHtmlLanguage(currentLanguage);
 }
 
+// Timezone preference. "system" (or empty) clears the override and follows the
+// local zone; any other value is treated as an IANA id.
+export function getTimezone(): string {
+  return activeTimezone ?? "system";
+}
+
+export function setTimezone(timezone: string): void {
+  activeTimezone = timezone && timezone !== "system" ? timezone : undefined;
+  try {
+    if (activeTimezone) {
+      window.localStorage.setItem(TIMEZONE_STORAGE_KEY, activeTimezone);
+    } else {
+      window.localStorage.removeItem(TIMEZONE_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures; the active session still uses the chosen zone.
+  }
+}
+
 export function taskStatusLabel(status: TaskStatusKey): string {
   return taskStatusLabels[status][currentLanguage];
 }
@@ -194,10 +244,18 @@ export function formatTokenUsage(inputTokens: number, outputTokens: number): str
 export function formatTaskTimestamp(ms: number): string {
   if (!ms) return "";
   const date = new Date(ms);
-  const time = date.toLocaleTimeString(getLocale(), { hour: "2-digit", minute: "2-digit" });
+  const time = date.toLocaleTimeString(getLocale(), {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: activeTimezone,
+  });
   return `${relativeDayLabel(date)} ${time}`;
 }
 
+// The today/yesterday bucket is computed in the system-local zone; the timezone
+// preference only re-anchors the clock time and the fallback date string. The
+// two can disagree within a few hours of midnight across distant zones, which
+// is an acceptable tradeoff for a display-only preference.
 function relativeDayLabel(date: Date): string {
   const now = new Date();
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
@@ -209,6 +267,7 @@ function relativeDayLabel(date: Date): string {
   return date.toLocaleDateString(getLocale(), {
     month: "short",
     day: "numeric",
+    timeZone: activeTimezone,
     ...(sameYear ? {} : { year: "numeric" }),
   });
 }
@@ -222,6 +281,16 @@ function readInitialLanguage(): Language {
   }
 
   return DEFAULT_LANGUAGE;
+}
+
+function readInitialTimezone(): string | undefined {
+  try {
+    const stored = window.localStorage.getItem(TIMEZONE_STORAGE_KEY);
+    if (stored && stored !== "system") return stored;
+  } catch {
+    // Ignore storage errors and follow the system local zone.
+  }
+  return undefined;
 }
 
 function toHtmlLanguage(language: Language): string {

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -44,6 +44,8 @@ const messages = {
     zh: "如何启用远程调试？↗",
   },
 
+  "status.capsuleAria": { en: "chrome and agent status", zh: "chrome 与智能体状态" },
+
   "update.restartToUpdate": { en: "restart to update", zh: "重启更新" },
   "update.taskRunningWarn": {
     en: "a task is running — restarting will interrupt it.",
@@ -82,6 +84,7 @@ const messages = {
   "settings.endpointDisconnected": { en: "not connected", zh: "未连接" },
   "settings.saved": { en: "saved", zh: "已保存" },
   "settings.saveFailed": { en: "could not save settings.", zh: "无法保存设置。" },
+  "settings.loadFailed": { en: "could not load settings.", zh: "无法加载设置。" },
   "settings.autosaveHint": { en: "changes are saved automatically.", zh: "更改会自动保存。" },
 
   "agent.label": { en: "model", zh: "模型" },

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,12 +1,14 @@
 //! Tauri desktop entry — header status/configuration plus tools / agent panels.
 
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 
-import { applyLanguageToDocument, formatTabs, getLanguage, isSupportedLanguage, setLanguage, t } from "./lib/i18n";
+import { applyLanguageToDocument, formatTabs, t } from "./lib/i18n";
 import { agentPanel } from "./panels/tasks";
+import { settingsMenu } from "./panels/settings";
 
 export type Status =
   | { state: "disconnected"; reason: string }
@@ -149,42 +151,24 @@ function render(): void {
     <div class="shell">
       <header class="topbar">
         <div class="brand">${MARK_SVG}<span class="brand-name">socai</span></div>
+        ${renderUpdateChip()}
         <div class="topbar-controls">
-          ${updateStatusBar()}
-          ${renderLanguageSwitch()}
-          ${connectionStatusBar()}
-          ${agentPanel.renderHeader()}
+          <div class="status-capsule" role="group" aria-label="${htmlEsc(t("chrome.dialogAria"))}">
+            ${connectionStatusBar()}
+            <span class="status-capsule__divider" aria-hidden="true"></span>
+            ${agentPanel.renderHeader()}
+          </div>
+          ${settingsMenu.render(state)}
         </div>
       </header>
       <main class="stack">${sections}</main>
     </div>
   `;
-  bindLanguageSwitch();
   bindConnectionStatusBar();
-  bindUpdateStatusBar();
+  bindUpdateChip();
   agentPanel.bindHeader(state);
+  settingsMenu.bind(state);
   for (const p of PANELS) p.bind(state);
-}
-
-function renderLanguageSwitch(): string {
-  const language = getLanguage();
-  return `
-    <div class="language-toggle" role="group" aria-label="${htmlEsc(t("language.switcherAria"))}">
-      <button class="language-toggle__button" type="button" data-lang-option="zh" aria-pressed="${language === "zh" ? "true" : "false"}">中文</button>
-      <button class="language-toggle__button" type="button" data-lang-option="en" aria-pressed="${language === "en" ? "true" : "false"}">en</button>
-    </div>
-  `;
-}
-
-function bindLanguageSwitch(): void {
-  document.querySelectorAll<HTMLButtonElement>("[data-lang-option]").forEach((option) => {
-    option.addEventListener("click", () => {
-      const nextLanguage = option.dataset.langOption;
-      if (!isSupportedLanguage(nextLanguage) || getLanguage() === nextLanguage) return;
-      setLanguage(nextLanguage);
-      render();
-    });
-  });
 }
 
 function connectionStatusBar(): string {
@@ -267,177 +251,128 @@ function bindConnectionStatusBar(): void {
 }
 
 // ---------------------------------------------------------------------------
-// In-app updater (macOS). Mirrors the connection-status badge + popover above.
-// The updater plugin is configured in tauri.conf.json; check() is gated off in
-// dev because the plugin only truly downloads/installs in bundled builds.
+// In-app updater (macOS). Updates download + install silently in the background;
+// the only thing the user ever sees or clicks is a `restart to finish` chip once
+// an update is staged. Checks fire on launch, when the window returns to the
+// foreground, and when a task finishes — throttled, and skipped while an update
+// is already downloading or staged. The updater plugin is configured in
+// tauri.conf.json; check() is gated off in dev because it only installs in
+// bundled builds.
 // ---------------------------------------------------------------------------
 
-type UpdatePhase = "idle" | "available" | "downloading" | "ready" | "error";
+type UpdatePhase = "idle" | "downloading" | "ready";
 
 interface UpdateState {
   phase: UpdatePhase;
+  /** Latest available version — shown in the restart chip's hover tooltip. */
   version?: string;
-  notes?: string;
-  downloaded?: number;
-  total?: number;
-  error?: string;
 }
-
-const RELEASES_URL = "https://github.com/socai-io/socai/releases/latest";
 
 let updateState: UpdateState = { phase: "idle" };
 let updateHandle: Update | null = null;
-let updatePopoverOpen = false;
+// Installed app version — fetched once at startup for the chip's hover tooltip.
+let currentVersion = "";
+// Throttle so "check whenever the app foregrounds" can't hammer the endpoint.
+let lastUpdateCheck = 0;
+const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
+// Inline warning shown when restart is clicked while a task is still running.
+let restartWarn = false;
 
-function updateStatusBar(): string {
-  if (updateState.phase === "idle") return "";
+// Only the `ready` state renders — downloading is silent, errors retry quietly.
+function renderUpdateChip(): string {
+  if (updateState.phase !== "ready") return "";
   return `
-    <div class="update-status" aria-live="polite">
-      ${updateBadge()}
-      ${updatePopoverOpen ? renderUpdateDialog() : ""}
+    <div class="update-chip-wrap">
+      <button id="update-chip" type="button" class="update-chip" aria-label="${htmlEsc(t("update.restartToUpdate"))}">
+        <span class="update-chip-glyph" aria-hidden="true">↑</span>
+        <span class="update-chip-label">${htmlEsc(t("update.restartToUpdate"))}</span>
+      </button>
+      ${restartWarn ? renderRestartWarn() : updateTooltip()}
     </div>
   `;
 }
 
-function updateBadge(): string {
-  const expanded = updatePopoverOpen ? "true" : "false";
-  const aria = htmlEsc(t("update.toggleAria"));
-  const open = `<button id="update-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}" aria-label="${aria}">`;
-  switch (updateState.phase) {
-    case "available":
-      return `${open}<i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>${htmlEsc(t("update.available"))}</button>`;
-    case "downloading":
-      return `${open}<i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>${htmlEsc(t("update.downloading"))} <span data-update-progress>${htmlEsc(formatUpdateProgress())}</span></button>`;
-    case "ready":
-      return `${open}<i class="badge-dot badge-dot-ink" aria-hidden="true"></i>${htmlEsc(t("update.restartToFinish"))}</button>`;
-    case "error":
-      return `${open}<i class="badge-dot badge-dot-muted" aria-hidden="true"></i>${htmlEsc(t("update.failed"))}</button>`;
-    default:
-      return "";
-  }
-}
-
-function formatUpdateProgress(): string {
-  if (updateState.total && updateState.total > 0 && updateState.downloaded != null) {
-    const pct = Math.min(100, Math.round((updateState.downloaded / updateState.total) * 100));
-    return `${pct}%`;
-  }
-  return "…";
-}
-
-function renderUpdateDialog(): string {
-  const version = updateState.version ?? "";
-  const head = `
-    <div class="connection-dialog-head">
-      <p class="t-eyebrow connection-dialog-title">${htmlEsc(t("update.title"))}</p>
-      ${version ? `<span class="badge"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>${htmlEsc(version)}</span>` : ""}
-    </div>`;
-
-  let body = "";
-  let actions = "";
-
-  switch (updateState.phase) {
-    case "available":
-      body = `
-        <div>
-          <p class="t-eyebrow">${htmlEsc(t("update.newVersion"))}</p>
-          <p class="t-mono">${htmlEsc(version)}</p>
-        </div>
-        ${updateState.notes ? `<p class="t-small subtle update-notes">${htmlEsc(updateState.notes)}</p>` : ""}`;
-      actions = `
-        <button id="update-start" type="button" class="btn-primary btn-compact">${htmlEsc(t("update.upgradeAndRestart"))}</button>
-        <button id="update-github" type="button" class="btn-ghost btn-compact">${htmlEsc(t("update.viewOnGithub"))}</button>`;
-      break;
-    case "downloading":
-      body = `
-        <div>
-          <p class="t-eyebrow">${htmlEsc(t("update.downloading"))}</p>
-          <p class="t-mono" data-update-progress>${htmlEsc(formatUpdateProgress())}</p>
-        </div>`;
-      break;
-    case "ready":
-      body = `<p class="t-small subtle">${htmlEsc(t("update.readyHint"))}</p>`;
-      actions = `<button id="update-restart" type="button" class="btn-primary btn-compact">${htmlEsc(t("update.restartNow"))}</button>`;
-      break;
-    case "error":
-      body = `<p class="t-small subtle update-notes">${htmlEsc(updateState.error ?? t("update.failed"))}</p>`;
-      actions = `
-        <button id="update-start" type="button" class="btn-primary btn-compact">${htmlEsc(t("update.retry"))}</button>
-        <button id="update-github" type="button" class="btn-ghost btn-compact">${htmlEsc(t("update.viewOnGithub"))}</button>`;
-      break;
-  }
-
+function updateTooltip(): string {
+  if (!currentVersion || !updateState.version) return "";
   return `
-    <div class="topbar-popover update-dialog" role="dialog" aria-label="${htmlEsc(t("update.dialogAria"))}">
-      ${head}
-      ${body}
-      ${actions ? `<div class="update-actions">${actions}</div>` : ""}
+    <span class="update-tooltip" role="tooltip">
+      <span class="update-tooltip-old">${htmlEsc(currentVersion)}</span>
+      <span class="update-tooltip-arrow" aria-hidden="true">→</span>
+      <span class="update-tooltip-new">${htmlEsc(updateState.version)}</span>
+    </span>
+  `;
+}
+
+function renderRestartWarn(): string {
+  return `
+    <div class="topbar-popover update-warn" role="dialog" aria-label="${htmlEsc(t("update.restartToUpdate"))}">
+      <p class="t-small">${htmlEsc(t("update.taskRunningWarn"))}</p>
+      <div class="update-warn-actions">
+        <button id="update-restart-anyway" type="button" class="btn-primary btn-compact">${htmlEsc(t("update.restartAnyway"))}</button>
+        <button id="update-restart-cancel" type="button" class="btn-ghost btn-compact">${htmlEsc(t("update.later"))}</button>
+      </div>
     </div>
   `;
 }
 
-function bindUpdateStatusBar(): void {
-  document.getElementById("update-toggle")?.addEventListener("click", () => {
-    updatePopoverOpen = !updatePopoverOpen;
+function bindUpdateChip(): void {
+  document.getElementById("update-chip")?.addEventListener("click", (event) => {
+    event.stopPropagation();
+    // Relaunching interrupts any running task, so guard it: warn first with an
+    // explicit escape hatch.
+    if (agentPanel.hasActiveTask()) {
+      restartWarn = true;
+      render();
+      return;
+    }
+    doRelaunch();
+  });
+  document.getElementById("update-restart-anyway")?.addEventListener("click", () => {
+    restartWarn = false;
+    doRelaunch();
+  });
+  document.getElementById("update-restart-cancel")?.addEventListener("click", () => {
+    restartWarn = false;
     render();
   });
-  document.getElementById("update-github")?.addEventListener("click", () => {
-    invoke("open_external", { url: RELEASES_URL }).catch((e) => console.error("open_external failed:", e));
-  });
-  document.getElementById("update-start")?.addEventListener("click", () => {
-    void startUpgrade();
-  });
-  document.getElementById("update-restart")?.addEventListener("click", () => {
-    relaunch().catch((e) => console.error("relaunch failed:", e));
-  });
 }
 
-async function startUpgrade(): Promise<void> {
+function doRelaunch(): void {
+  relaunch().catch((e) => console.error("relaunch failed:", e));
+}
+
+// Download + install the staged update silently. Surfaces the restart chip only
+// once it's installed; a failure resets to idle so the next trigger retries.
+async function startBackgroundUpgrade(): Promise<void> {
   if (!updateHandle) return;
-  updateState = { ...updateState, phase: "downloading", downloaded: 0, total: 0, error: undefined };
-  render();
+  updateState = { ...updateState, phase: "downloading" };
   try {
-    await updateHandle.downloadAndInstall((event) => {
-      switch (event.event) {
-        case "Started":
-          updateState.total = event.data.contentLength ?? 0;
-          updateState.downloaded = 0;
-          break;
-        case "Progress":
-          updateState.downloaded = (updateState.downloaded ?? 0) + event.data.chunkLength;
-          // Patch the readout in place so a chunky download doesn't trigger a
-          // full re-render per chunk (mirrors the appendTaskEvent precedent).
-          document.querySelectorAll("[data-update-progress]").forEach((el) => {
-            el.textContent = formatUpdateProgress();
-          });
-          break;
-        case "Finished":
-          break;
-      }
-    });
+    await updateHandle.downloadAndInstall();
     updateState = { ...updateState, phase: "ready" };
     render();
   } catch (e) {
-    console.error("update install failed:", e);
-    updateState = { ...updateState, phase: "error", error: `${e}` };
-    render();
+    console.error("update download/install failed:", e);
+    updateState = { phase: "idle" };
   }
 }
 
-async function scheduleUpdateCheck(): Promise<void> {
+// Check for an update and, if found, kick off the silent background download.
+// Triggered on launch, foreground, and task-finish; throttled, and skipped while
+// an update is already downloading or staged.
+async function maybeCheckForUpdate(): Promise<void> {
   // The updater only truly installs in a bundled build; skip the network check
   // in `tauri dev` so it never nags or errors during local development.
   if (import.meta.env.DEV) return;
+  if (updateState.phase !== "idle") return;
+  const now = Date.now();
+  if (now - lastUpdateCheck < UPDATE_CHECK_INTERVAL_MS) return;
+  lastUpdateCheck = now;
   try {
     const update = await check();
     if (!update) return;
     updateHandle = update;
-    updateState = {
-      phase: "available",
-      version: update.version,
-      notes: update.body || undefined,
-    };
-    render();
+    updateState = { phase: "idle", version: update.version };
+    void startBackgroundUpgrade();
   } catch (e) {
     // Update checks are best-effort; never block the app on a failed check.
     console.error("update check failed:", e);
@@ -460,11 +395,14 @@ function bindGlobalDismiss(): void {
       connectionDetailsOpen = false;
       changed = true;
     }
-    if (updatePopoverOpen && !eventPathHasClass(event, "update-status")) {
-      updatePopoverOpen = false;
+    if (!eventPathHasClass(event, "agent-status") && agentPanel.closeHeaderConfig()) {
       changed = true;
     }
-    if (!eventPathHasClass(event, "agent-status") && agentPanel.closeHeaderConfig()) {
+    if (settingsMenu.isOpen() && !eventPathHasClass(event, "settings-menu") && settingsMenu.closePopover()) {
+      changed = true;
+    }
+    if (restartWarn && !eventPathHasClass(event, "update-chip-wrap")) {
+      restartWarn = false;
       changed = true;
     }
 
@@ -490,6 +428,8 @@ async function main(): Promise<void> {
   // rows append in place to preserve scroll.
   await listen<AgentTaskEventPayload>("agent_task:event", (event) => {
     if (agentPanel.appendTaskEvent(event.payload)) render();
+    // A finished task is a good, quiet moment to check for an update.
+    if (isTaskFinishedEvent(event.payload)) void maybeCheckForUpdate();
   });
 
   let initialTasks: AgentTaskSnapshot[] = [];
@@ -510,21 +450,55 @@ async function main(): Promise<void> {
   } catch (e) {
     console.error("agent_task_list failed:", e);
   }
+  try {
+    currentVersion = await getVersion();
+  } catch (e) {
+    console.error("getVersion failed:", e);
+  }
+  await settingsMenu.loadConfig();
   render();
   bindGlobalDismiss();
+  installUpdatePreviewHook();
   void hydrateTaskEvents(initialTasks);
-  void scheduleUpdateCheck();
+  void maybeCheckForUpdate();
 
   const refresh = (): void => {
     invoke("cdp_refresh").catch((e) => console.error("cdp_refresh failed:", e));
     agentPanel.refreshModels()
       .then(() => render())
       .catch((e) => console.error("agent_list_models refresh failed:", e));
+    // Foreground is the primary update-check trigger; the check throttles itself.
+    void maybeCheckForUpdate();
   };
   window.addEventListener("focus", refresh);
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") refresh();
   });
+}
+
+const TERMINAL_TASK_EVENT_KINDS = new Set<AgentTaskEventPayload["kind"]>([
+  "done",
+  "completed",
+  "failed",
+  "cancelled",
+  "interrupted",
+]);
+
+function isTaskFinishedEvent(payload: AgentTaskEventPayload): boolean {
+  if (TERMINAL_TASK_EVENT_KINDS.has(payload.kind)) return true;
+  const status = payload.snapshot?.status;
+  return status === "completed" || status === "failed" || status === "cancelled" || status === "interrupted";
+}
+
+// Dev-only: force the `restart to finish` chip so its appearance and the
+// running-task warning can be exercised without a bundled build + real feed.
+// `__previewUpdate()` in the webview console shows the chip; reload to clear.
+function installUpdatePreviewHook(): void {
+  if (!import.meta.env.DEV) return;
+  (window as Window & { __previewUpdate?: () => void }).__previewUpdate = () => {
+    updateState = { phase: "ready", version: "0.5.0" };
+    render();
+  };
 }
 
 async function hydrateTaskEvents(tasks: AgentTaskSnapshot[]): Promise<void> {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -153,7 +153,7 @@ function render(): void {
         <div class="brand">${MARK_SVG}<span class="brand-name">socai</span></div>
         ${renderUpdateChip()}
         <div class="topbar-controls">
-          <div class="status-capsule" role="group" aria-label="${htmlEsc(t("chrome.dialogAria"))}">
+          <div class="status-capsule" role="group" aria-label="${htmlEsc(t("status.capsuleAria"))}">
             ${connectionStatusBar()}
             <span class="status-capsule__divider" aria-hidden="true"></span>
             ${agentPanel.renderHeader()}

--- a/app/src/panels/settings.ts
+++ b/app/src/panels/settings.ts
@@ -1,0 +1,380 @@
+//! Topbar settings menu. A gear button opens a popover that carries the
+//! language toggle plus the preferences that mirror `~/.socai/config.json`
+//! (output directory, chrome source/profile) and a display-only timezone.
+//!
+//! Settings save automatically: discrete controls (language, timezone, chrome
+//! source) persist on change; path fields persist on commit (blur/enter). The
+//! UI updates optimistically, then re-seeds from the persisted truth so it
+//! reflects any normalization the core applies (e.g. relative → absolute paths).
+//! Chrome + output write through the `config_set`/`config_unset` Tauri commands
+//! (validated and saved by `socai_core::config`); timezone is a frontend-only
+//! display preference kept in localStorage via `setTimezone`.
+
+import { invoke } from "@tauri-apps/api/core";
+import type { ShellState } from "../main";
+import { esc } from "../lib/html";
+import {
+  getLanguage,
+  getTimezone,
+  isSupportedLanguage,
+  setLanguage,
+  setTimezone,
+  t,
+} from "../lib/i18n";
+
+/** Mirrors the `DesktopConfig` returned by the `config_get` command. */
+interface DesktopConfig {
+  chrome_source: string;
+  chrome_profile_dir: string;
+  chrome_profile_dir_default: string;
+  output_dir: string;
+  output_dir_default: string;
+}
+
+interface SettingsDraft {
+  timezone: string;
+  output_dir: string;
+  chrome_source: string;
+  chrome_profile_dir: string;
+}
+
+type SaveStatus = "" | "saving" | "saved" | "error";
+
+// Curated IANA zones — the same shortlist the prototype offered. "system"
+// (the local zone) is rendered separately as the first option.
+const TIMEZONES = [
+  "Asia/Shanghai",
+  "Asia/Hong_Kong",
+  "Asia/Tokyo",
+  "Asia/Singapore",
+  "Europe/London",
+  "Europe/Berlin",
+  "America/New_York",
+  "America/Los_Angeles",
+  "UTC",
+];
+
+const GEAR_SVG = `
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="3.2"></circle>
+    <path d="M19.4 13a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.56-1H3a2 2 0 1 1 0-4h.09a1.7 1.7 0 0 0 1.56-1.11 1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34H9a1.7 1.7 0 0 0 1-1.56V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87V9a1.7 1.7 0 0 0 1.56 1H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.51 1z"></path>
+  </svg>
+`;
+
+export namespace settingsMenu {
+  let open = false;
+  let config: DesktopConfig | null = null;
+  let draft: SettingsDraft | null = null;
+  let status: SaveStatus = "";
+  let statusTimer: number | null = null;
+
+  /** Load the persisted config once at startup. Best-effort: a failure leaves
+   *  the menu in a "could not load" state without blocking the app. */
+  export async function loadConfig(): Promise<void> {
+    try {
+      config = await invoke<DesktopConfig>("config_get");
+    } catch (err) {
+      console.error("config_get failed:", err);
+      config = null;
+    }
+  }
+
+  export function isOpen(): boolean {
+    return open;
+  }
+
+  export function closePopover(): boolean {
+    if (!open) return false;
+    open = false;
+    return true;
+  }
+
+  export function render(shell: ShellState): string {
+    const expanded = open ? "true" : "false";
+    return `
+      <div class="settings-menu">
+        <button
+          id="settings-toggle"
+          type="button"
+          class="icon-button ${open ? "icon-button-active" : ""}"
+          aria-label="${esc(t("settings.aria"))}"
+          aria-expanded="${expanded}"
+        >${GEAR_SVG}</button>
+        ${open ? renderPopover(shell) : ""}
+      </div>
+    `;
+  }
+
+  function renderPopover(shell: ShellState): string {
+    if (!draft) seedDraft();
+    if (!config || !draft) {
+      return `
+        <div class="topbar-popover settings-popover" role="dialog" aria-label="${esc(t("settings.title"))}">
+          <p class="t-small subtle">${esc(t("common.loading"))}</p>
+        </div>
+      `;
+    }
+    return `
+      <div class="topbar-popover settings-popover" role="dialog" aria-label="${esc(t("settings.title"))}">
+        ${renderGeneralGroup(draft)}
+        ${renderOutputGroup(config, draft)}
+        ${renderChromeGroup(shell, config, draft)}
+        ${renderStatus()}
+      </div>
+    `;
+  }
+
+  function renderGeneralGroup(d: SettingsDraft): string {
+    const language = getLanguage();
+    const zone = localZone();
+    const systemLabel = zone ? `${t("settings.timezoneSystem")} · ${zone}` : t("settings.timezoneSystem");
+    const options = [
+      `<option value="system" ${d.timezone === "system" ? "selected" : ""}>${esc(systemLabel)}</option>`,
+      ...TIMEZONES.map(
+        (tz) => `<option value="${esc(tz)}" ${d.timezone === tz ? "selected" : ""}>${esc(tz)}</option>`,
+      ),
+    ].join("");
+    return `
+      <section class="settings-group">
+        <p class="settings-group-label">${esc(t("settings.general"))}</p>
+        <div class="settings-row">
+          <span class="t-small settings-row-label">${esc(t("settings.language"))}</span>
+          <div class="language-toggle" role="group" aria-label="${esc(t("language.switcherAria"))}">
+            <button class="language-toggle__button" type="button" data-settings-lang="zh" aria-pressed="${language === "zh" ? "true" : "false"}">中文</button>
+            <button class="language-toggle__button" type="button" data-settings-lang="en" aria-pressed="${language === "en" ? "true" : "false"}">en</button>
+          </div>
+        </div>
+        <div class="settings-row">
+          <label class="t-small settings-row-label" for="settings-timezone">${esc(t("settings.timezone"))}</label>
+          <select id="settings-timezone" class="input-field settings-row-select">${options}</select>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderOutputGroup(c: DesktopConfig, d: SettingsDraft): string {
+    return `
+      <section class="settings-group">
+        <p class="settings-group-label">${esc(t("settings.output"))}</p>
+        <div class="settings-field">
+          <label class="t-small settings-field-label" for="settings-output-dir">${esc(t("settings.outputDir"))}</label>
+          <div class="settings-path-row">
+            <input
+              id="settings-output-dir"
+              class="input-field settings-input-mono"
+              type="text"
+              spellcheck="false"
+              placeholder="${esc(c.output_dir_default)}"
+              value="${esc(d.output_dir)}"
+            />
+            <button type="button" class="btn-ghost btn-compact" data-settings-browse="settings-output-dir">${esc(t("settings.browse"))}</button>
+          </div>
+          <p class="t-small subtle settings-field-hint">${esc(t("settings.outputHint"))}</p>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderChromeGroup(shell: ShellState, c: DesktopConfig, d: SettingsDraft): string {
+    const managed = d.chrome_source === "managed";
+    const detail = managed
+      ? `
+        <div class="settings-field">
+          <label class="t-small settings-field-label" for="settings-profile-dir">${esc(t("settings.profileDir"))}</label>
+          <div class="settings-path-row">
+            <input
+              id="settings-profile-dir"
+              class="input-field settings-input-mono"
+              type="text"
+              spellcheck="false"
+              placeholder="${esc(c.chrome_profile_dir_default)}"
+              value="${esc(d.chrome_profile_dir)}"
+            />
+            <button type="button" class="btn-ghost btn-compact" data-settings-browse="settings-profile-dir">${esc(t("settings.browse"))}</button>
+          </div>
+          <p class="t-small subtle settings-field-hint">${esc(t("settings.profileHint"))}</p>
+        </div>
+      `
+      : renderEndpointField(shell);
+    // "existing browser" is the product default, so it leads the toggle.
+    return `
+      <section class="settings-group">
+        <p class="settings-group-label">${esc(t("settings.chrome"))}</p>
+        <div class="settings-field">
+          <span class="t-small settings-field-label">${esc(t("settings.source"))}</span>
+          <div class="seg-toggle" role="group">
+            <button type="button" class="seg-toggle__button" data-settings-source="existing" aria-pressed="${managed ? "false" : "true"}">${esc(t("settings.sourceExisting"))}</button>
+            <button type="button" class="seg-toggle__button" data-settings-source="managed" aria-pressed="${managed ? "true" : "false"}">${esc(t("settings.sourceManaged"))}</button>
+          </div>
+        </div>
+        ${detail}
+      </section>
+    `;
+  }
+
+  // The "existing browser" endpoint is auto-discovered by the core (there is no
+  // stored endpoint to edit), so the field is informational: show the live
+  // endpoint when connected, otherwise a "not connected" placeholder.
+  function renderEndpointField(shell: ShellState): string {
+    const status = shell.status;
+    const value = status.state === "connected" ? status.endpoint : t("settings.endpointDisconnected");
+    return `
+      <div class="settings-field">
+        <span class="t-small settings-field-label">${esc(t("settings.endpoint"))}</span>
+        <input class="input-field settings-input-mono" type="text" value="${esc(value)}" readonly disabled />
+        <p class="t-small subtle settings-field-hint">${esc(t("settings.endpointHint"))}</p>
+      </div>
+    `;
+  }
+
+  function renderStatus(): string {
+    const text =
+      status === "saving"
+        ? t("common.saving")
+        : status === "saved"
+          ? t("settings.saved")
+          : status === "error"
+            ? t("settings.saveFailed")
+            : t("settings.autosaveHint");
+    return `<p class="t-small subtle settings-status${status === "error" ? " result-error" : ""}">${esc(text)}</p>`;
+  }
+
+  export function bind(shell: ShellState): void {
+    document.getElementById("settings-toggle")?.addEventListener("click", (event) => {
+      event.stopPropagation();
+      open = !open;
+      if (open) seedDraft();
+      shell.rerender();
+    });
+
+    if (!open || !draft) return;
+
+    document.querySelectorAll<HTMLButtonElement>("[data-settings-lang]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const next = button.dataset.settingsLang;
+        if (!isSupportedLanguage(next) || getLanguage() === next) return;
+        setLanguage(next);
+        shell.rerender();
+      });
+    });
+
+    const timezone = document.getElementById("settings-timezone") as HTMLSelectElement | null;
+    timezone?.addEventListener("change", () => {
+      if (!draft) return;
+      draft.timezone = timezone.value;
+      setTimezone(timezone.value);
+      // Re-render the whole shell so task timestamps everywhere pick up the zone.
+      flashSaved(shell);
+    });
+
+    // Path fields commit on change (blur/enter), not per keystroke.
+    bindPathField("settings-output-dir", "runs.dir", shell);
+    bindPathField("settings-profile-dir", "chrome.profile_dir", shell);
+
+    document.querySelectorAll<HTMLButtonElement>("[data-settings-browse]").forEach((button) => {
+      // No native directory picker is wired (no dialog plugin); focus the field
+      // so the path stays directly editable.
+      button.addEventListener("click", () => {
+        const target = document.getElementById(button.dataset.settingsBrowse ?? "") as HTMLInputElement | null;
+        target?.focus();
+      });
+    });
+
+    document.querySelectorAll<HTMLButtonElement>("[data-settings-source]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const next = button.dataset.settingsSource;
+        if (next) void persistSource(next, shell);
+      });
+    });
+  }
+
+  function bindPathField(inputId: string, key: string, shell: ShellState): void {
+    const input = document.getElementById(inputId) as HTMLInputElement | null;
+    input?.addEventListener("change", () => {
+      void persistPath(key, input.value, shell);
+    });
+  }
+
+  function seedDraft(): void {
+    draft = {
+      timezone: getTimezone(),
+      output_dir: config?.output_dir ?? "",
+      chrome_source: config?.chrome_source || "existing",
+      chrome_profile_dir: config?.chrome_profile_dir ?? "",
+    };
+  }
+
+  async function persistSource(value: string, shell: ShellState): Promise<void> {
+    if (!draft || draft.chrome_source === value) return;
+    draft.chrome_source = value; // optimistic — toggle + sub-field update immediately
+    status = "saving";
+    shell.rerender();
+    try {
+      await invoke("config_set", { key: "chrome.profile", value });
+      await loadConfig();
+      seedDraft();
+      flashSaved(shell);
+    } catch (err) {
+      console.error("config_set chrome.profile failed:", err);
+      await loadConfig();
+      seedDraft();
+      setError(shell);
+    }
+  }
+
+  async function persistPath(key: string, raw: string, shell: ShellState): Promise<void> {
+    if (!draft || !config) return;
+    const value = raw.trim();
+    const current = (key === "runs.dir" ? config.output_dir : config.chrome_profile_dir).trim();
+    if (value === current) return; // no change vs the persisted value
+    if (key === "runs.dir") draft.output_dir = value;
+    else draft.chrome_profile_dir = value;
+    status = "saving";
+    shell.rerender();
+    try {
+      if (value) {
+        await invoke("config_set", { key, value });
+      } else {
+        // Clearing a field reverts it to the product default.
+        await invoke("config_unset", { key });
+      }
+      await loadConfig();
+      seedDraft();
+      flashSaved(shell);
+    } catch (err) {
+      console.error(`config write ${key} failed:`, err);
+      await loadConfig();
+      seedDraft();
+      setError(shell);
+    }
+  }
+
+  function flashSaved(shell: ShellState): void {
+    status = "saved";
+    if (statusTimer !== null) window.clearTimeout(statusTimer);
+    statusTimer = window.setTimeout(() => {
+      status = "";
+      shell.rerender();
+    }, 1600);
+    shell.rerender();
+  }
+
+  function setError(shell: ShellState): void {
+    status = "error";
+    if (statusTimer !== null) window.clearTimeout(statusTimer);
+    statusTimer = window.setTimeout(() => {
+      status = "";
+      shell.rerender();
+    }, 2600);
+    shell.rerender();
+  }
+
+  // The local zone the "system (local)" option resolves to, e.g. "Asia/Shanghai".
+  function localZone(): string {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+    } catch {
+      return "";
+    }
+  }
+}

--- a/app/src/panels/settings.ts
+++ b/app/src/panels/settings.ts
@@ -64,6 +64,7 @@ const GEAR_SVG = `
 export namespace settingsMenu {
   let open = false;
   let config: DesktopConfig | null = null;
+  let loadError = false;
   let draft: SettingsDraft | null = null;
   let status: SaveStatus = "";
   let statusTimer: number | null = null;
@@ -73,9 +74,11 @@ export namespace settingsMenu {
   export async function loadConfig(): Promise<void> {
     try {
       config = await invoke<DesktopConfig>("config_get");
+      loadError = false;
     } catch (err) {
       console.error("config_get failed:", err);
       config = null;
+      loadError = true;
     }
   }
 
@@ -106,6 +109,13 @@ export namespace settingsMenu {
   }
 
   function renderPopover(shell: ShellState): string {
+    if (loadError) {
+      return `
+        <div class="topbar-popover settings-popover" role="dialog" aria-label="${esc(t("settings.title"))}">
+          <p class="t-small subtle result-error">${esc(t("settings.loadFailed"))}</p>
+        </div>
+      `;
+    }
     if (!draft) seedDraft();
     if (!config || !draft) {
       return `
@@ -202,7 +212,7 @@ export namespace settingsMenu {
         <p class="settings-group-label">${esc(t("settings.chrome"))}</p>
         <div class="settings-field">
           <span class="t-small settings-field-label">${esc(t("settings.source"))}</span>
-          <div class="seg-toggle" role="group">
+          <div class="seg-toggle" role="group" aria-label="${esc(t("settings.source"))}">
             <button type="button" class="seg-toggle__button" data-settings-source="existing" aria-pressed="${managed ? "false" : "true"}">${esc(t("settings.sourceExisting"))}</button>
             <button type="button" class="seg-toggle__button" data-settings-source="managed" aria-pressed="${managed ? "true" : "false"}">${esc(t("settings.sourceManaged"))}</button>
           </div>
@@ -243,7 +253,17 @@ export namespace settingsMenu {
     document.getElementById("settings-toggle")?.addEventListener("click", (event) => {
       event.stopPropagation();
       open = !open;
-      if (open) seedDraft();
+      if (open) {
+        // Reopening retries a failed initial load so the error state isn't a
+        // dead-end (the in-menu controls that re-fetch don't render on failure).
+        if (loadError || !config) {
+          void loadConfig().then(() => {
+            seedDraft();
+            shell.rerender();
+          });
+        }
+        seedDraft();
+      }
       shell.rerender();
     });
 

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -93,6 +93,11 @@ export namespace agentPanel {
     return task.events.length !== before && taskId === selectedTaskId;
   }
 
+  // Whether any task is running or queued — used to guard the app restart.
+  export function hasActiveTask(): boolean {
+    return tasks.some((task) => task.status === "running" || task.status === "queued");
+  }
+
   export function renderHeader(): string {
     const showConfig = configOpen || selectedNeedsKey();
     return `

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -143,9 +143,125 @@ body.has-paper > * { position: relative; z-index: 1; }
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: var(--sp-2);
-  flex-wrap: wrap;
+  gap: var(--sp-3);
+  flex-wrap: nowrap;
 }
+
+/* ── status capsule — merges chrome + agent into one monitor ────── */
+.status-capsule {
+  display: inline-flex;
+  align-items: stretch;
+  flex: 0 0 auto;
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  transition: border-color var(--t-fast) var(--ease);
+}
+.status-capsule:hover { border-color: var(--line-strong); }
+.status-capsule .connection-status,
+.status-capsule .agent-status { position: relative; display: inline-flex; gap: 0; }
+/* badges become flush, borderless segments inside the capsule */
+.status-capsule .badge {
+  border: 0;
+  background: transparent;
+  border-radius: var(--r-pill);
+  padding: 5px 12px;
+}
+.status-capsule .badge-button:hover { border-color: transparent; background: var(--ink-7); }
+.status-capsule .connection-status .badge { border-radius: var(--r-pill) 0 0 var(--r-pill); }
+.status-capsule .agent-status .badge { border-radius: 0 var(--r-pill) var(--r-pill) 0; }
+.status-capsule__divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 5px 0;
+  background: var(--line);
+  flex: 0 0 auto;
+}
+
+/* ── update chip — solid-ink "restart to finish" (download is silent) ── */
+.update-chip-wrap { position: relative; display: inline-flex; flex: 0 0 auto; }
+.update-chip {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--ink-0);
+  background: var(--ink-0);
+  color: var(--ink-9);
+  border-radius: var(--r-pill);
+  padding: 5px 12px 5px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  position: relative;
+  transition: opacity var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+}
+.update-chip:hover { opacity: 0.82; }
+.update-chip:disabled { cursor: wait; opacity: 0.6; }
+.update-chip-glyph { display: inline-flex; font-size: 12px; font-weight: 600; line-height: 1; }
+.update-chip-label { font-weight: 500; }
+
+/* running-task guard popover, anchored under the restart chip. The chip lives
+   on the left of the header, so open rightward to stay on-screen. */
+.update-warn { width: 248px; gap: var(--sp-2); left: 0; right: auto; }
+.update-warn p { margin: 0; }
+.update-warn-actions { display: flex; align-items: center; gap: var(--sp-2); }
+
+/* hover tooltip — current → latest, no log. Left-anchored to match the chip's
+   position on the left of the header. */
+.update-tooltip {
+  position: absolute;
+  top: calc(100% + var(--sp-2));
+  left: 0;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: var(--ink-0);
+  color: var(--ink-9);
+  border-radius: var(--r-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow: var(--shadow-pop);
+  opacity: 0;
+  transform: translateY(-2px);
+  pointer-events: none;
+  transition:
+    opacity var(--t-fast) var(--ease),
+    transform var(--t-fast) var(--ease);
+}
+.update-chip-wrap:hover .update-tooltip { opacity: 1; transform: translateY(0); }
+.update-tooltip-old { color: var(--ink-5); }
+.update-tooltip-arrow { color: var(--ink-4); }
+.update-tooltip-new { color: var(--ink-9); font-weight: 500; }
+
+/* ── icon button (settings gear) ───────────────────────────────── */
+.settings-menu { position: relative; display: inline-flex; flex: 0 0 auto; }
+.icon-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  color: var(--fg-soft);
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
+}
+.icon-button:hover { color: var(--ink-0); border-color: var(--line-strong); }
+.icon-button-active { color: var(--ink-0); border-color: var(--line-strong); background: var(--ink-7); }
 .language-toggle {
   display: inline-flex;
   align-items: center;
@@ -180,8 +296,7 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .language-toggle__button[aria-pressed="true"]:hover { color: var(--ink-9); }
 .connection-status,
-.agent-status,
-.update-status {
+.agent-status {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
@@ -268,17 +383,6 @@ body.has-paper > * { position: relative; z-index: 1; }
 .connection-meta-wide { grid-column: 1 / -1; }
 .connection-endpoint { word-break: break-all; }
 .agent-config-popover { width: min(420px, calc(100vw - var(--sp-6))); }
-.update-actions {
-  display: flex;
-  gap: var(--sp-2);
-}
-.update-notes {
-  margin: 0;
-  max-height: 160px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
 .agent-config-title { margin: 0; }
 .agent-config-field,
 .agent-config-key {
@@ -308,6 +412,78 @@ body.has-paper > * { position: relative; z-index: 1; }
   flex: 1;
   min-width: 0;
 }
+
+/* ── settings popover ──────────────────────────────────────────── */
+.settings-popover { width: 360px; gap: var(--sp-4); max-height: min(78vh, 620px); overflow-y: auto; }
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding-bottom: var(--sp-4);
+  border-bottom: var(--hairline);
+}
+.settings-group:last-of-type { border-bottom: 0; padding-bottom: 0; }
+/* section header — sans + semibold + ink, distinct from the mono/eyebrow labels
+   elsewhere and from the lighter field/row labels below it. */
+.settings-group-label {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink-1);
+}
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+.settings-row-label { color: var(--fg-muted); flex: 0 0 auto; }
+/* control on the right of a settings-row (e.g. the timezone select) fills the
+   remaining width so the full zone stays visible. */
+.settings-row-select { flex: 1 1 auto; min-width: 0; }
+.settings-field { display: flex; flex-direction: column; gap: 6px; }
+.settings-field-label { color: var(--fg-muted); }
+.settings-field-hint { margin: 0; line-height: 1.45; text-wrap: pretty; }
+.settings-input-mono { font-family: var(--font-mono); font-size: 12px; }
+.settings-path-row { display: flex; align-items: stretch; gap: var(--sp-2); }
+.settings-path-row .input-field { flex: 1; min-width: 0; }
+.settings-path-row .btn-ghost { flex: 0 0 auto; white-space: nowrap; }
+/* auto-save status line (saving… / saved / error / idle hint) */
+.settings-status { margin: 0; min-height: 16px; }
+
+/* segmented control (chrome source) */
+.seg-toggle {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 2px;
+  padding: 2px;
+  border: var(--hairline);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+}
+.seg-toggle__button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  border-radius: var(--r-pill);
+  color: var(--fg-soft);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  padding: 6px 12px;
+  white-space: nowrap;
+  transition:
+    background-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+.seg-toggle__button:hover { color: var(--ink-0); }
+.seg-toggle__button[aria-pressed="true"] { background: var(--ink-0); color: var(--ink-9); }
+.seg-toggle__button[aria-pressed="true"]:hover { color: var(--ink-9); }
 .agent-model-list {
   display: flex;
   flex-direction: column;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -235,7 +235,8 @@ body.has-paper > * { position: relative; z-index: 1; }
     opacity var(--t-fast) var(--ease),
     transform var(--t-fast) var(--ease);
 }
-.update-chip-wrap:hover .update-tooltip { opacity: 1; transform: translateY(0); }
+.update-chip-wrap:hover .update-tooltip,
+.update-chip-wrap:focus-within .update-tooltip { opacity: 1; transform: translateY(0); }
 .update-tooltip-old { color: var(--ink-5); }
 .update-tooltip-arrow { color: var(--ink-4); }
 .update-tooltip-new { color: var(--ink-9); font-weight: 500; }

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -190,7 +190,7 @@ pub(crate) async fn endpoint_from_active_port(profile: &Path) -> Option<Endpoint
     })
 }
 
-pub(crate) fn managed_chrome_user_data_dir() -> anyhow::Result<PathBuf> {
+pub fn managed_chrome_user_data_dir() -> anyhow::Result<PathBuf> {
     if let Some(home) = env_var("SOCAI_HOME") {
         return Ok(PathBuf::from(shellexpand(&home)).join("chrome-profile"));
     }

--- a/core/src/cdp/mod.rs
+++ b/core/src/cdp/mod.rs
@@ -9,8 +9,8 @@ pub use self::connection::{
     BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile, StatusPayload, TargetInfo,
 };
 pub use self::endpoint::{
-    discover_existing_chrome_endpoint, open_remote_debugging_page, resolve_explicit_endpoint,
-    wait_for_existing_chrome_endpoint, Endpoint,
+    discover_existing_chrome_endpoint, managed_chrome_user_data_dir, open_remote_debugging_page,
+    resolve_explicit_endpoint, wait_for_existing_chrome_endpoint, Endpoint,
 };
 pub use self::pages::PageSessionManager;
 pub use self::session::PageSession;


### PR DESCRIPTION
## Summary

- **Status capsule** — merges the chrome-status and agent-status badges into a single pill separated by a hairline divider, reducing topbar clutter while preserving both signals.
- **Settings gear menu** — new ⚙ button opens a popover with language, timezone, output-directory, and chrome source/profile preferences. Auto-saves on change; no explicit Save button. Wired to `~/.socai/config.json` via new `config_get` / `config_set` / `config_unset` Tauri commands that delegate fully to `socai_core::config`.
- **Silent background updater** — update download happens invisibly; a left-positioned `↑ restart to update` chip appears only when the staged artifact is ready. Checks fire on launch, window focus, visibility change, and task finish (30-min throttle). If a task is running when the user clicks the chip, a guard popover offers "restart anyway" or "later". DEV-only `window.__previewUpdate()` hook for UI testing.

<img width="2812" height="2172" alt="CleanShot 2026-06-23 at 23 25 53@2x" src="https://github.com/user-attachments/assets/b6d3148f-4850-4062-b5f1-13be0e0997f8" />


## Changed files

| File | What changed |
|------|-------------|
| `app/src-tauri/src/commands.rs` | `DesktopConfig` struct + `config_get/set/unset` commands; default-path helpers mirror core env-var resolution |
| `app/src-tauri/src/lib.rs` | Registers the three new commands in `generate_handler!` |
| `app/src/panels/settings.ts` | **New** — full settings menu module (render, bind, auto-save, draft management) |
| `app/src/panels/tasks.ts` | Added `hasActiveTask()` for the update-restart guard |
| `app/src/main.ts` | Topbar restructure: capsule layout, update chip, trigger wiring, DEV preview hook, removed old language switcher |
| `app/src/lib/i18n.ts` | Added `settings.*` and `update.*` keys; timezone state + `getTimezone`/`setTimezone` exports; pruned orphaned `update.*` keys |
| `app/src/styles.css` | Status capsule, update chip + tooltip + warn popover, settings popover + groups + seg-toggle — all using existing monochrome token set |

## Test plan

- [ ] Status capsule renders chrome + agent segments; each segment's popover still opens correctly
- [ ] Settings gear opens popover; language, timezone, chrome source toggle, path fields all save without explicit button press — "saved" flash appears
- [ ] Chrome seg-toggle: existing-first order; switching to managed shows profile-dir field; switching back shows endpoint field
- [ ] Timezone "system (local)" option shows local IANA zone inline; selecting a named zone updates task timestamps
- [ ] Output-dir field: clear reverts to default placeholder; type a path + blur persists it
- [ ] In DEV: `window.__previewUpdate()` shows the restart chip on the left of the header
- [ ] Click chip with no active task → relaunch (needs a real staged update; otherwise the Tauri command is a no-op)
- [ ] Click chip with a running task → warn popover appears; "later" dismisses; "restart anyway" proceeds
- [ ] Window focus and visibilitychange trigger `maybeCheckForUpdate()` (add a `console.log` to verify in DEV if needed)
- [ ] zh locale: "重启更新", "独立配置文件", "现有浏览器", "已保存" all display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)