### PR TITLE
docs: fix product name typo in xhs CLI options (socia → socai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
   `publish_time` (不限/一天内/一周内/半年内), `search_scope` (不限/已看过/未看过/已关注),
   `distance` (不限/同城/附近). 不写则按默认.
   e.g. `--filter publish_time=一天内 --filter note_type=图文`
-- `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socia会自动往下翻页，获取更多帖子。
+- `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socai 会自动往下翻页，获取更多帖子。
 - `--preview` — 只拿帖子概要（标题、封面等等），不逐个打开帖子拿详情。
 - `--download-media` — 打开每篇帖子的时候 (不加`--preview`时): 把图像和视频下载到 `run_dir`
   (`site_media/`), 输出 top-level `run` (`id`, `dir`, `media_dir`), 并创建列表


### PR DESCRIPTION
Fixes a pre-existing typo in the Chinese CLI docs in the README.

Line 72 (the `--num-notes` option description) misspelled the product
name as `socia会`. This corrects it to `socai 会`:

- `socia` → `socai` (the product name is **socai**)
- adds a space before the Chinese verb `会`, matching the CJK/Latin
  spacing convention used elsewhere in the file

```diff
-- `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socia会自动往下翻页，获取更多帖子。
+- `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socai 会自动往下翻页，获取更多帖子。
```

Scope: documentation only, single line, no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)