### PR TITLE
fix: close page sessions with owning CDP client

### DIFF
--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -340,11 +340,12 @@ impl PageSession {
         // have disconnected/reconnected or switched profile by the time a
         // session is dropped/cancelled; cleanup should still target the browser
         // that owns this target id.
-        self.client
+        let result = self
+            .client
             .execute("Target.closeTarget", json!({ "targetId": target_id }))
-            .await?;
+            .await;
         self.owner.unregister_owned_target(&target_id).await;
-        Ok(())
+        result.map(|_| ())
     }
 }
 

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -335,12 +335,12 @@ impl PageSession {
     /// Close the underlying tab. Consumes the session.
     pub async fn close(self) -> anyhow::Result<()> {
         let target_id = self.target_id.clone();
-        let client = self
-            .owner
-            .browser_client()
-            .await
-            .ok_or_else(|| anyhow!("CDP browser websocket is not connected"))?;
-        client
+        // Use the browser websocket that created/attached this PageSession, not
+        // whatever browser client the runtime currently holds. The runtime may
+        // have disconnected/reconnected or switched profile by the time a
+        // session is dropped/cancelled; cleanup should still target the browser
+        // that owns this target id.
+        self.client
             .execute("Target.closeTarget", json!({ "targetId": target_id }))
             .await?;
         self.owner.unregister_owned_target(&target_id).await;


### PR DESCRIPTION
## Summary

Follow-up to #113's scoped raw-CDP browser WebSocket lifecycle.

`PageSession::close` now sends `Target.closeTarget` through the `RawCdpClient` stored on that page session instead of asking the runtime for its current browser client.

## Why

A `PageSession` target belongs to the browser WebSocket that created/attached it. If the runtime disconnects/reconnects or switches profile before cleanup runs, using the runtime's current client can either fail or target the wrong browser. Using the session-bound client keeps tab cleanup tied to the browser connection that owns the target id.

## Validation

```bash
cargo check --locked
cargo test --workspace --locked
git diff --check
```

Live smoke:

```bash
PROFILE=/tmp/smoke-close-$$ \
SOCAI_HOME=/tmp/smoke-home-close-$$ \
RUST_LOG=info,async_tungstenite=off,tungstenite=off,hyper=off,reqwest=off \
cargo run -q --manifest-path /tmp/socai_cdp_smoke/Cargo.toml -- "$PROFILE"
```

This launched managed Chrome, created an owned page target, navigated to XHS, closed the page via `PageSession::close`, and disconnected without leaving the temporary Chrome process running.
