### PR TITLE
Consolidate XHS search tools into search_scan

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ CLI binary. For day-to-day iteration, build and run from the workspace instead:
 
 ```bash
 cargo build                 # build the whole workspace (core + cli)
-cargo run -p socai-cli -- topic_scan "运营爆款思路" --num-notes 30
+cargo run -p socai-cli -- xhs search_scan "运营爆款思路" --num-notes 30
 cargo test                  # run the workspace test suite
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ cargo install --path cli --force
 小红书常用命令：
 
 ```bash
-socai xhs search "运营爆款思路" --num-notes 30 --filter publish_time=一周内 --download-media  # 搜索并逐个打开帖子，获取正文+评论，并下载图片/视频
+socai xhs search_scan "运营爆款思路" --num-notes 30 --filter publish_time=一周内 --download-media  # 搜索并逐个打开帖子，获取正文+评论，并下载图片/视频
 socai xhs author <作者id> --num-notes 10 --preview                               # 打开作者主页，拿作者简介，并逐个打开帖子读正文+评论；加 --preview 则只拿帖子概要
 socai stop                                                             # 停止 daemon（关闭工具标签页）
 ```
 
 Options:
 
-- `--filter <GROUP=OPTION>` — 对应搜索页右上角的“筛选”，仅适用于`search`命令。
+- `--filter <GROUP=OPTION>` — 对应搜索页右上角的“筛选”，仅适用于`search_scan`命令。
   以下几个筛选条件可以叠加：
   `sort` (综合/最新/最多点赞/最多评论/最多收藏), `note_type` (不限/视频/图文),
   `publish_time` (不限/一天内/一周内/半年内), `search_scope` (不限/已看过/未看过/已关注),

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -358,7 +358,7 @@ pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind 
 
 pub(crate) fn user_label(name: &str) -> String {
     match name {
-        "search_notes" => "searched xiaohongshu",
+        "search_scan" | "search" | "search_notes" | "topic_scan" => "searched xiaohongshu",
         "extract_search_cards" => "read search cards",
         "list_search_tabs" => "listed search tabs",
         "click_search_tab" => "switched search tab",
@@ -372,7 +372,7 @@ pub(crate) fn user_label(name: &str) -> String {
         "scroll_in_note" => "scrolled note",
         "collect_carousel_images" => "collected carousel images",
         "extract_profile" => "read author profile",
-        "topic_scan" => "scanned topic",
+        "author" | "author_scan" => "scanned author",
         "page_state" => "checked page state",
         _ => return name.replace('_', " "),
     }
@@ -966,12 +966,21 @@ fn raw_tool_result_value(content: &Value) -> Option<Value> {
 
 fn normalize_entities(tool: &str, value: &Value) -> Vec<TimelineEntity> {
     match tool {
-        "search_notes" => value
-            .get("cards")
-            .and_then(Value::as_array)
-            .filter(|cards| !cards.is_empty())
-            .map(|cards| vec![entity("xhs_note_card_grid", Value::Array(cards.clone()))])
-            .unwrap_or_default(),
+        "search_scan" | "search" | "search_notes" | "topic_scan" => {
+            let mut entities = if value.is_object() {
+                vec![entity("xhs_search_scan", value.clone())]
+            } else {
+                Vec::new()
+            };
+            if let Some(cards) = value
+                .get("cards")
+                .and_then(Value::as_array)
+                .filter(|cards| !cards.is_empty())
+            {
+                entities.push(entity("xhs_note_card_grid", Value::Array(cards.clone())));
+            }
+            entities
+        }
         "extract_search_cards" => value
             .as_array()
             .filter(|cards| !cards.is_empty())
@@ -1006,9 +1015,9 @@ fn normalize_entities(tool: &str, value: &Value) -> Vec<TimelineEntity> {
                 Vec::new()
             }
         }
-        "topic_scan" => {
+        "author" | "author_scan" => {
             if value.is_object() {
-                vec![entity("xhs_topic_scan", value.clone())]
+                vec![entity("xhs_author", value.clone())]
             } else {
                 Vec::new()
             }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -418,7 +418,7 @@ impl DaemonState {
             // Create the session tab blank and let the command navigate itself:
             // every site command either opens its own entry URL (e.g. `author`
             // opens the profile directly) or has a `before` hook that reaches
-            // the right page (search/topic_scan via ensure_search_ready). Passing
+            // the right page (search_scan via ensure_search_ready). Passing
             // home_url here would force an extra `/explore` load before the
             // command then navigates again — wasted time for no benefit.
             let page = self.runtime.ensure_site_page(site.id, "").await?;

--- a/core/src/agent/run_logging.rs
+++ b/core/src/agent/run_logging.rs
@@ -324,10 +324,10 @@ mod tests {
             default_runs_root_from_parts(None, Some(configured_runs_dir.clone()), Some(home)),
             configured_runs_dir
         );
-        let run_dir = make_run_dir_in_root(&configured_runs_dir, "topic scan");
+        let run_dir = make_run_dir_in_root(&configured_runs_dir, "search scan");
         assert!(run_dir.starts_with(&configured_runs_dir));
         let file_name = run_dir.file_name().and_then(|name| name.to_str()).unwrap();
-        assert!(file_name.ends_with("topic_scan"));
+        assert!(file_name.ends_with("search_scan"));
     }
 
     #[test]

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -114,13 +114,13 @@ pub struct ToolContext {
     pub enabled_sites: Arc<Mutex<BTreeSet<String>>>,
     counters: Arc<Mutex<Counters>>,
     /// Notes the agent has already processed at a given level. Used by
-    /// macros like `topic_scan` to short-circuit repeated reads of the
+    /// macros like `search_scan` to short-circuit repeated reads of the
     /// same note. Keyed by note id; value is the processed level
     /// ("deep" / "lite") and whether media was included.
     processed_notes: Arc<Mutex<BTreeMap<String, ProcessedNote>>>,
-    /// Note ids the agent has sampled via topic_scan in this run — useful
+    /// Note ids the agent has sampled via search_scan in this run — useful
     /// for "show me what I've already covered" tools.
-    topic_scan_note_ids: Arc<Mutex<Vec<String>>>,
+    search_scan_note_ids: Arc<Mutex<Vec<String>>>,
 }
 
 #[derive(Default)]
@@ -158,7 +158,7 @@ impl ToolContext {
             enabled_sites: Arc::new(Mutex::new(BTreeSet::new())),
             counters: Arc::new(Mutex::new(Counters::default())),
             processed_notes: Arc::new(Mutex::new(BTreeMap::new())),
-            topic_scan_note_ids: Arc::new(Mutex::new(Vec::new())),
+            search_scan_note_ids: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -219,9 +219,9 @@ impl ToolContext {
             && (!requested_include_media || prev.include_media)
     }
 
-    /// Append note ids to the topic-scan history (de-duped, preserving order).
-    pub fn add_topic_scan_note_ids(&self, ids: &[String]) {
-        let Ok(mut guard) = self.topic_scan_note_ids.lock() else {
+    /// Append note ids to the search-scan history (de-duped, preserving order).
+    pub fn add_search_scan_note_ids(&self, ids: &[String]) {
+        let Ok(mut guard) = self.search_scan_note_ids.lock() else {
             return;
         };
         for id in ids {
@@ -234,8 +234,8 @@ impl ToolContext {
         }
     }
 
-    pub fn topic_scan_note_ids(&self) -> Vec<String> {
-        self.topic_scan_note_ids
+    pub fn search_scan_note_ids(&self) -> Vec<String> {
+        self.search_scan_note_ids
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default()

--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -43,7 +43,7 @@ pub async fn run_tool_command(
 ) -> anyhow::Result<Value> {
     // Run-dir label: site + command, plus the command's identifying input when
     // it has one, so runs are tellable apart at a glance
-    // (…_xhs_search_notes_咖啡, …_xhs_author_<author_id>).
+    // (…_xhs_search_scan_咖啡, …_xhs_author_<author_id>).
     let mut label = format!("{}_{}", cmd.site_id, cmd.command_name);
     for key in ["query", "author_id"] {
         if let Some(value) = input.get(key).and_then(Value::as_str) {

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -140,7 +140,7 @@ impl XhsHistoryStore {
 
     /// Take an owned snapshot of all entries currently in the store. Use
     /// this when a tool mutates history during its own call (e.g.
-    /// `topic_scan` records every note it reads) but still wants to
+    /// `search_scan` records every note it reads) but still wants to
     /// annotate output cards based on what was known *before* the call —
     /// otherwise the annotation reflects this run's own writes.
     pub fn snapshot(&self) -> HistorySnapshot {

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -20,10 +20,10 @@ references.
 
 The default interactive XHS tools are intentionally high level:
 
-- `topic_scan` — V1 topic/search macro. This is the current implementation of
-  the future `xhs.search` surface.
-- `author_scan` — V1 author/profile macro. This is the current implementation
-  of the future `xhs.author` surface.
+- `search_scan` — the single topic/search macro. It replaces the older
+  `search_notes` card-only path and `topic_scan` detail path.
+- `author` — author/profile macro. This refactors the existing author scan
+  behavior under the same name as the CLI command.
 
 Stateful micro tools such as opening/closing a current note, scrolling a note,
 extracting the current modal, or reading current page state are not part of the
@@ -44,25 +44,27 @@ the route, and otherwise explain the blocker to the user.
 
 ### Topic / search research
 
-Call `topic_scan(query=..., num_notes=N, filters=..., download_media=...)` when
-the task asks about a topic, keyword, market, trend, product category, or group
-of XHS posts.
+Call `search_scan(query=..., num_notes=N, filters=..., preview=false)` when the
+task asks about a topic, keyword, market, trend, product category, or group of
+XHS posts.
 
-`topic_scan` searches, optionally applies filters, samples notes from results,
-reads note bodies and top comments, writes artifacts, and returns a compact
-bundle. Default `num_notes` is modest; increase it only when the question needs
-broader evidence. Use `download_media=true` when the user explicitly needs local
-image/video files.
+`search_scan` searches, optionally applies filters, samples notes from results,
+reads note bodies and top comments by default, writes artifacts, and returns a
+compact bundle. Set `preview=true` only when card metadata is enough and note
+bodies / comments are unnecessary. Default `num_notes` is modest; increase it
+only when the question needs broader evidence. Use `download_media=true` when
+the user explicitly needs local image/video files.
 
 ### Author / creator research
 
-Call `author_scan(author_id=..., num_notes=N, read_notes=true|false,
-download_media=...)` when the task asks about a specific author/creator and you
-have an `author_id`, can extract the trailing id from a profile URL, or a
-previous macro result surfaced an author id worth expanding.
+Call `author(author_id=..., profile_url=..., num_notes=N,
+read_notes=true|false, download_media=...)` when the task asks about a specific
+author/creator and you have an `author_id`, can pass a profile URL containing
+`/user/profile/<id>`, or a previous search result surfaced an author id worth
+expanding.
 
 If the user only gives a display name or handle, first discover candidates with
-a focused `topic_scan` or ask the user for the profile URL/author id.
+a focused `search_scan` or ask the user for the profile URL/author id.
 
 Use `read_notes=true` when you need the author's recent note bodies/comments;
 otherwise the profile header plus note cards may be enough. For author media
@@ -73,8 +75,8 @@ media is downloaded while reading notes.
 
 A standalone note-snapshot macro is deferred for V1 because direct note opening
 can require tokenized URLs or source card context. Prefer note details already
-collected by `topic_scan` or `author_scan` artifacts. If note details are
-missing, run a focused `topic_scan` or `author_scan` that can reach the note via
+collected by `search_scan` or `author` artifacts. If note details are missing,
+run a focused `search_scan` or `author` that can reach the note via
 search/profile context.
 
 ## Artifact-First Reasoning

--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -1,8 +1,8 @@
-//! Stable media manifest generation for XHS topic scans.
+//! Stable media manifest generation for XHS macro runs.
 //!
-//! `topic_scan --download-media` keeps the large per-asset manifest in a
-//! run-dir JSON file so command stdout can stay compact while callers still get
-//! a stable path to a machine-readable media registry.
+//! `search_scan --download-media` and `author --download-media` keep the large
+//! per-asset manifest in a run-dir JSON file so command stdout can stay compact
+//! while callers still get a stable path to a machine-readable media registry.
 
 use std::path::{Path, PathBuf};
 
@@ -14,6 +14,8 @@ use super::entities::XhsNoteCard;
 pub(super) fn write_media_manifest_file(
     ctx: &ToolContext,
     manifest: &Value,
+    source_tool: &str,
+    label: &str,
 ) -> std::io::Result<String> {
     std::fs::create_dir_all(&ctx.run_dir)?;
     let path = ctx.run_dir.join("media_manifest.json");
@@ -23,15 +25,15 @@ pub(super) fn write_media_manifest_file(
         &path,
         "media_manifest",
         "json",
-        "Topic scan media manifest",
+        label,
         json!({"site": "xhs", "category": "media_manifest"}),
         Some(manifest),
-        "topic_scan",
+        source_tool,
     );
     Ok(path.to_string_lossy().to_string())
 }
 
-pub(super) fn topic_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
+pub(super) fn search_scan_media_manifest(notes: &[Value], run_dir: &Path) -> Value {
     let mut assets = Vec::new();
     for note in notes {
         collect_note_media_assets(note, run_dir, &mut assets);
@@ -615,7 +617,7 @@ mod tests {
             }),
         ];
 
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let manifest = search_scan_media_manifest(&notes, dir.path());
 
         assert_eq!(manifest.as_array().unwrap().len(), 0);
     }
@@ -639,7 +641,7 @@ mod tests {
             }
         })];
 
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let manifest = search_scan_media_manifest(&notes, dir.path());
         let assets = manifest.as_array().unwrap();
 
         assert_eq!(assets.len(), 1);
@@ -672,7 +674,7 @@ mod tests {
             }
         })];
 
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let manifest = search_scan_media_manifest(&notes, dir.path());
         let assets = manifest.as_array().unwrap();
 
         assert_eq!(assets.len(), 1);
@@ -711,7 +713,7 @@ mod tests {
             }
         })];
 
-        let manifest = topic_scan_media_manifest(&notes, dir.path());
+        let manifest = search_scan_media_manifest(&notes, dir.path());
         let assets = manifest.as_array().unwrap();
 
         assert_eq!(assets.len(), 1);
@@ -737,7 +739,9 @@ mod tests {
         let ctx = ToolContext::new("run", dir.path());
         let manifest = json!([{ "note_id": "note-1", "type": "image" }]);
 
-        let path = write_media_manifest_file(&ctx, &manifest).unwrap();
+        let path =
+            write_media_manifest_file(&ctx, &manifest, "search_scan", "Search scan media manifest")
+                .unwrap();
         let expected = dir.path().join("media_manifest.json");
         let saved: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
 

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -8,8 +8,8 @@ pub use self::entities::{parse_count_text, XhsAuthorProfile, XhsNote, XhsNoteCar
 pub use self::history::{HistoryEntry, HistorySnapshot, XhsHistoryStore};
 pub use self::page::{ReadNoteOptions, XhsPageRuntime, XHS_HOME_URL};
 pub use self::tools::{
-    author_scan_command, close_open_note, ensure_search_ready, search_notes_command,
-    topic_scan_command, xhs_agent_instructions, xhs_agent_tools, xhs_default_agent_tools,
+    author_scan_command, close_open_note, ensure_search_ready, search_scan_command,
+    search_scan_preview_command, xhs_agent_instructions, xhs_agent_tools, xhs_default_agent_tools,
     xhs_macro_tools_with_llm_provider, xhs_tools, xhs_tools_with_llm_provider, XHS_KNOWLEDGE,
     XHS_SITE,
 };

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -175,7 +175,7 @@ impl<'a> XhsPageRuntime<'a> {
         self.expect_object("pageState", None).await
     }
 
-    pub async fn search_notes(
+    pub async fn search_cards(
         &self,
         query: &str,
         filters: Option<&Value>,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -21,18 +21,18 @@ use crate::sites::runner::{
     trimmed_required, PageHook, ToolCommand,
 };
 use crate::sites::xhs::media_manifest::{
-    ensure_entity_note_id, topic_scan_media_manifest, write_media_manifest_file,
+    ensure_entity_note_id, search_scan_media_manifest, write_media_manifest_file,
 };
 use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
 use crate::sites::xhs::{
     ReadNoteOptions, XhsAuthorProfile, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
 };
 
-/// Default number of notes `topic_scan` reads when the caller doesn't specify.
+/// Default number of notes `search_scan` reads when the caller doesn't specify.
 const DEFAULT_NUM_NOTES: i64 = 10;
 
 /// Top comments attached to every note read (read_note, extract_note,
-/// topic_scan, author_scan). Comments are read from the already-open note's DOM
+/// search_scan, author). Comments are read from the already-open note's DOM
 /// (one extra JS read, no extra navigation), so every note read includes them.
 const TOP_COMMENTS_PER_NOTE: i64 = 12;
 
@@ -52,8 +52,9 @@ pub fn xhs_tools_with_llm_provider(
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
     vec![
-        Arc::new(SearchNotesTool {
+        Arc::new(SearchScanTool {
             page: page.clone(),
+            llm_provider: llm_provider.clone(),
             history: history.clone(),
         }) as Arc<dyn Tool>,
         Arc::new(ExtractSearchCardsTool {
@@ -78,11 +79,6 @@ pub fn xhs_tools_with_llm_provider(
         Arc::new(ScrollInNoteTool { page: page.clone() }),
         Arc::new(CollectCarouselImagesTool { page: page.clone() }),
         Arc::new(ExtractProfileTool { page: page.clone() }),
-        Arc::new(TopicScanTool {
-            page: page.clone(),
-            llm_provider,
-            history: history.clone(),
-        }),
         Arc::new(AuthorScanTool {
             page: page.clone(),
             history,
@@ -97,7 +93,7 @@ pub fn xhs_macro_tools_with_llm_provider(
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
     vec![
-        Arc::new(TopicScanTool {
+        Arc::new(SearchScanTool {
             page: page.clone(),
             llm_provider,
             history: history.clone(),
@@ -146,11 +142,11 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
     default_agent_instructions: Some(xhs_agent_instructions),
     commands: &[
         SiteCommand {
-            name: "search",
-            tool_name: "search",
-            about: "Search Xiaohongshu. By default opens each result and returns note bodies \
-                    + top comments (a topic scan). With --preview, returns only the result \
-                    cards (titles/likes/covers) without opening any note.",
+            name: "search_scan",
+            tool_name: "search_scan",
+            about: "Search/scan Xiaohongshu. By default opens each result and returns note \
+                    bodies + top comments. With --preview, returns only the result cards \
+                    (titles/likes/covers) without opening any note.",
             args: &[
                 CommandArg {
                     key: "query",
@@ -175,7 +171,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("num-notes"),
                     value_name: "N",
                     help: "How many notes/cards to collect, scrolling the feed to reach it. \
-                           Omit for the first page only.",
+                           Defaults to 10.",
                     required: false,
                     kind: ArgKind::Int,
                 },
@@ -199,11 +195,11 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                 },
             ],
             slow: SlowWhen::Always,
-            run: run_search,
+            run: run_search_scan,
         },
         SiteCommand {
             name: "author",
-            tool_name: "author_scan",
+            tool_name: "author",
             about: "Open a Xiaohongshu author's profile and print their header (bio, xhs id, \
                     IP location, follower/following/like counts) plus their notes. By default \
                     opens each note for its body + top comments; with --preview, returns only \
@@ -250,12 +246,12 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
             run: run_author_scan,
         },
         // ── Deprecated aliases (kept so existing scripts keep working) ──
-        // Both delegate to the `search` paths and inject a `deprecation` field
+        // Both delegate to the `search_scan` paths and inject a `deprecation` field
         // into the returned JSON (the CLI client also echoes it to stderr).
         SiteCommand {
             name: "search_notes",
-            tool_name: "search_notes",
-            about: "[DEPRECATED] Use `search --preview`. Returns result cards only.",
+            tool_name: "search_scan",
+            about: "[DEPRECATED] Use `search_scan --preview`. Returns result cards only.",
             args: &[
                 CommandArg {
                     key: "query",
@@ -277,7 +273,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     key: "num_notes",
                     long: Some("num-notes"),
                     value_name: "N",
-                    help: "Cards to collect by auto-scrolling; omit for the first page only.",
+                    help: "Cards to collect by auto-scrolling; defaults to 10.",
                     required: false,
                     kind: ArgKind::Int,
                 },
@@ -287,8 +283,8 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
         },
         SiteCommand {
             name: "topic_scan",
-            tool_name: "topic_scan",
-            about: "[DEPRECATED] Use `search`. Opens each result and returns body + comments.",
+            tool_name: "search_scan",
+            about: "[DEPRECATED] Use `search_scan`. Opens each result and returns body + comments.",
             args: &[
                 CommandArg {
                     key: "query",
@@ -329,9 +325,9 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
     ],
 };
 
-/// `search` dispatches on `--preview`: default opens each result (topic scan,
-/// body + comments); `--preview` returns result cards only (search_notes).
-fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+/// `search_scan` dispatches on `--preview`: default opens each result for
+/// body + comments; `--preview` returns result cards only.
+fn run_search_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
     Box::pin(async move {
         let query = required_string(&args, "query")?;
         let filters = args.get("filters").cloned();
@@ -347,16 +343,23 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             .unwrap_or(false);
         if preview {
             // Cards only — download_media doesn't apply to a card-only read.
-            search_notes_command(page, "search", &query, filters.as_ref(), num_notes, debug_snapshot)
-                .await
+            search_scan_preview_command(
+                page,
+                "search_scan",
+                &query,
+                filters.as_ref(),
+                num_notes,
+                debug_snapshot,
+            )
+            .await
         } else {
             let download_media = args
                 .get("download_media")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
-            topic_scan_command(
+            search_scan_command(
                 page,
-                "search",
+                "search_scan",
                 &query,
                 filters.as_ref(),
                 num_notes,
@@ -396,7 +399,7 @@ fn run_search_notes_deprecated(
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
-        let envelope = search_notes_command(
+        let envelope = search_scan_preview_command(
             page,
             "search_notes",
             &query,
@@ -408,7 +411,7 @@ fn run_search_notes_deprecated(
         Ok(with_deprecation(
             envelope,
             "`search_notes` is deprecated and will be removed in a future release. \
-             Use `socai xhs search --preview` instead (same result cards).",
+             Use `socai xhs search_scan --preview` instead (same result cards).",
         ))
     })
 }
@@ -431,7 +434,7 @@ fn run_topic_scan_deprecated(
             .get("download_media")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let envelope = topic_scan_command(
+        let envelope = search_scan_command(
             page,
             "topic_scan",
             &query,
@@ -444,7 +447,7 @@ fn run_topic_scan_deprecated(
         Ok(with_deprecation(
             envelope,
             "`topic_scan` is deprecated and will be removed in a future release. \
-             Use `socai xhs search` instead (same behavior).",
+             Use `socai xhs search_scan` instead (same behavior).",
         ))
     })
 }
@@ -495,25 +498,25 @@ struct XhsCommandSpec {
     include_run_metadata: bool,
 }
 
-const SEARCH_NOTES_COMMAND: XhsCommandSpec = XhsCommandSpec {
-    command_name: "search_notes",
-    tool_name: "search_notes",
+const SEARCH_SCAN_PREVIEW_COMMAND: XhsCommandSpec = XhsCommandSpec {
+    command_name: "search_scan",
+    tool_name: "search_scan",
     before: CommandPageAction::SearchReady,
     after: CommandPageAction::None,
     include_run_metadata: false,
 };
 
-const TOPIC_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
-    command_name: "topic_scan",
-    tool_name: "topic_scan",
+const SEARCH_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
+    command_name: "search_scan",
+    tool_name: "search_scan",
     before: CommandPageAction::SearchReady,
     after: CommandPageAction::None,
     include_run_metadata: true,
 };
 
-const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
+const AUTHOR_COMMAND: XhsCommandSpec = XhsCommandSpec {
     command_name: "author",
-    tool_name: "author_scan",
+    tool_name: "author",
     // The tool navigates to the profile URL itself; just make sure no stale
     // note modal is left open before/after.
     before: CommandPageAction::CloseOpenNote,
@@ -521,7 +524,7 @@ const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
     include_run_metadata: false,
 };
 
-pub async fn search_notes_command(
+pub async fn search_scan_preview_command(
     page: Arc<PageSession>,
     command_name: &'static str,
     query: &str,
@@ -529,23 +532,23 @@ pub async fn search_notes_command(
     num_notes: Option<i64>,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
-    // `command_name` decouples the user-facing command (e.g. `search --preview`)
-    // from the underlying tool, so the run-dir label and envelope show what was
-    // actually invoked rather than the internal `search_notes` op.
+    // `command_name` decouples the user-facing command (e.g. `search_scan --preview`)
+    // from the underlying `search_scan` tool, so the run-dir label and envelope show
+    // what was actually invoked rather than the shared implementation name.
     let spec = XhsCommandSpec {
         command_name,
-        ..SEARCH_NOTES_COMMAND
+        ..SEARCH_SCAN_PREVIEW_COMMAND
     };
     run_xhs_tool_command(
         page,
         spec,
-        search_notes_input(query, filters, num_notes)?,
+        search_preview_input(query, filters, num_notes)?,
         debug_snapshot,
     )
     .await
 }
 
-pub async fn topic_scan_command(
+pub async fn search_scan_command(
     page: Arc<PageSession>,
     command_name: &'static str,
     query: &str,
@@ -554,17 +557,17 @@ pub async fn topic_scan_command(
     download_media: bool,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
-    // The user-facing `search` command shares this operation with the
-    // deprecated `topic_scan` alias; record whichever name the caller invoked
+    // The user-facing `search_scan` command shares this detail operation with
+    // the deprecated `topic_scan` alias; record whichever name the caller invoked
     // so the run-dir label and envelope reflect the actual command.
     let spec = XhsCommandSpec {
         command_name,
-        ..TOPIC_SCAN_COMMAND
+        ..SEARCH_SCAN_COMMAND
     };
     run_xhs_tool_command(
         page,
         spec,
-        topic_scan_input(query, filters, num_notes, download_media)?,
+        search_scan_input(query, filters, num_notes, download_media)?,
         debug_snapshot,
     )
     .await
@@ -580,20 +583,21 @@ pub async fn author_scan_command(
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
-        AUTHOR_SCAN_COMMAND,
+        AUTHOR_COMMAND,
         author_scan_input(author_id, num_notes, read_notes, download_media)?,
         debug_snapshot,
     )
     .await
 }
 
-fn search_notes_input(
+fn search_preview_input(
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
 ) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
+        "preview": true,
         "wait_seconds": 2.0,
     });
     if let Some(filters) = filters {
@@ -605,7 +609,7 @@ fn search_notes_input(
     Ok(input)
 }
 
-fn topic_scan_input(
+fn search_scan_input(
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
@@ -613,6 +617,7 @@ fn topic_scan_input(
 ) -> anyhow::Result<Value> {
     let mut input = json!({
         "query": trimmed_required(query, "query")?,
+        "preview": false,
     });
     if let Some(filters) = filters {
         input["filters"] = filters.clone();
@@ -801,8 +806,8 @@ fn skipped_note_entry(card: &XhsNoteCard, reason: &str, history: &XhsHistoryStor
 }
 
 /// Open one already-selected card, read its body at `level`, attach top
-/// comments, and record it in run + cross-run history. Shared by `topic_scan`
-/// (cards from search) and `author_scan` (cards from a profile page) — the only
+/// comments, and record it in run + cross-run history. Shared by `search_scan`
+/// (cards from search results) and `author` (cards from a profile page) — the only
 /// difference between those macros is where the cards come from, not how each
 /// note is read. Returns the per-note entry; the caller pushes it and closes
 /// the modal.
@@ -933,26 +938,26 @@ async fn scan_card_note(
     entry
 }
 
-/// Trim a topic_scan / author_scan bundle to the shape we hand back to the
+/// Trim a search_scan / author bundle to the shape we hand back to the
 /// agent/CLI so it doesn't dominate an LLM context window. The full payload is
 /// still written to the run artifact (`<run_dir>/artifacts/…json`), which is the
 /// place to look for everything dropped here. Diagnostic blocks (`sampling`,
-/// `timing`) and the `search` result block are dropped; the opened `notes`
+/// `timing`) and the `search_scan` result block are dropped; the opened `notes`
 /// (each trimmed by [`lean_scan_note`]) carry the per-note listing, so
-/// `author_scan`'s `profile.note_cards` — a duplicate of that listing — is
+/// `author`'s `profile.note_cards` — a duplicate of that listing — is
 /// dropped too once notes were read.
 fn lean_scan_payload(payload: &mut Value) {
     let Some(obj) = payload.as_object_mut() else {
         return;
     };
-    obj.remove("search");
+    obj.remove("search_scan");
     obj.remove("sampling");
     obj.remove("timing");
     let notes_read = obj
         .get("notes")
         .and_then(Value::as_array)
         .is_some_and(|notes| !notes.is_empty());
-    // author_scan only: `profile.note_cards` repeats the note listing now
+    // author only: `profile.note_cards` repeats the note listing now
     // carried by `notes`. Keep it only when no notes were opened (preview),
     // where it's the sole listing.
     if notes_read {
@@ -992,85 +997,6 @@ fn lean_scan_note(note: &mut Value) {
     }
 }
 
-/// search_notes(query, wait_seconds) -> {query, cards: [...]}
-pub struct SearchNotesTool {
-    page: Arc<PageSession>,
-    history: Arc<XhsHistoryStore>,
-}
-
-#[async_trait]
-impl Tool for SearchNotesTool {
-    fn name(&self) -> &str {
-        "search_notes"
-    }
-
-    fn description(&self) -> &str {
-        "Search Xiaohongshu for notes matching `query` and return result cards \
-         (id, title, author, likes, cover image). By default reads only the \
-         first results page (~19 cards, no scrolling). Pass `num_notes` to \
-         auto-scroll the feed, lazy-loading more cards until that many are \
-         collected (titles/likes/covers only — note bodies are NOT opened, so \
-         it stays fast). Optionally applies search-result `filters` (omitted \
-         groups reset to defaults); each group is single-select. Use before \
-         `open_note` to pick a note; to read note bodies + comments in one call \
-         use `topic_scan`."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "query": { "type": "string", "description": "Search query (Chinese works fine)" },
-                "filters": search_filters_schema(),
-                "num_notes": {
-                    "type": "integer",
-                    "description": "Scroll to collect at least this many cards (lazy-loaded). Omit for the first page only.",
-                    "minimum": 1
-                },
-                "wait_seconds": {
-                    "type": "number",
-                    "description": "Extra seconds to wait for cards to load",
-                    "default": 2.0
-                }
-            },
-            "required": ["query"]
-        })
-    }
-
-    async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let query = get_str(&input, "query")
-            .ok_or_else(|| anyhow::anyhow!("missing query"))?
-            .to_string();
-        let filters = input
-            .get("filters")
-            .filter(|value| !value.is_null())
-            .cloned();
-        let wait_seconds = get_f64(&input, "wait_seconds", 2.0);
-        let num_notes = input
-            .get("num_notes")
-            .and_then(Value::as_i64)
-            .filter(|n| *n > 0)
-            .map(|n| n as usize);
-        let xhs = XhsPageRuntime::new(&self.page);
-        let mut value = xhs
-            .search_notes(&query, filters.as_ref(), wait_seconds, num_notes)
-            .await?;
-        if let Some(cards) = value.get_mut("cards") {
-            self.history.annotate_cards(cards);
-        }
-        // `submit` is the search-submission diagnostic (strategy + page-state
-        // echo). The preview path writes no artifact, so keep it only when the
-        // search failed (where it explains why) and drop it on success.
-        let failed = value.get("ok").and_then(Value::as_bool) == Some(false);
-        if !failed {
-            if let Some(obj) = value.as_object_mut() {
-                obj.remove("submit");
-            }
-        }
-        Ok(json_result(&value))
-    }
-}
-
 /// open_note(note_id?, index?, wait_seconds?) -> {ok, ...}
 pub struct OpenNoteTool {
     page: Arc<PageSession>,
@@ -1084,7 +1010,7 @@ impl Tool for OpenNoteTool {
 
     fn description(&self) -> &str {
         "Open a note's detail modal on the current search results page. \
-         Specify either `note_id` (from a card returned by search_notes) or \
+         Specify either `note_id` (from a card returned by search preview) or \
          a 0-based `index` into the visible card list."
     }
 
@@ -1566,66 +1492,163 @@ impl Tool for ExtractProfileTool {
     }
 }
 
-/// topic_scan(query, filters?, num_notes?, download_media?) -> aggregated topic bundle
+const SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION: &str = "Download note images/videos into the command run_dir, include local_path fields in returned notes, and write a stable media_manifest.json surfaced by media_manifest_path.";
+
+fn search_scan_description() -> &'static str {
+    "Self-contained Xiaohongshu search_scan macro: start from any page, search by query, optionally apply filters, and by default read selected notes with top comments. Set `preview=true` for card-only search results without opening notes. Use this for XHS topic, trend, keyword, market, and note-evidence research. Do not repeat the same search_scan unless the previous one was clearly insufficient."
+}
+
+fn search_scan_input_schema(
+    download_media_default: bool,
+    download_media_description: &str,
+) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "query": { "type": "string", "description": "Search query (Chinese works fine)" },
+            "filters": search_filters_schema(),
+            "num_notes": {
+                "type": "integer",
+                "description": "Number of notes/cards to collect. Detail mode opens each selected note for body + top comments; preview mode only scrolls/collects cards.",
+                "default": DEFAULT_NUM_NOTES,
+                "minimum": 1
+            },
+            "preview": {
+                "type": "boolean",
+                "description": "Return card metadata only (titles/likes/covers) without opening notes. Defaults false, which reads note bodies + top comments.",
+                "default": false
+            },
+            "download_media": {
+                "type": "boolean",
+                "description": download_media_description,
+                "default": download_media_default
+            },
+            "wait_seconds": {
+                "type": "number",
+                "description": "Preview mode only: extra seconds to wait for cards to load.",
+                "default": 2.0
+            }
+        },
+        "required": ["query"]
+    })
+}
+
+fn normalize_author_input(input: &mut Value) -> anyhow::Result<()> {
+    if get_str(input, "author_id")
+        .map(str::trim)
+        .is_some_and(|id| !id.is_empty())
+    {
+        return Ok(());
+    }
+
+    let profile_url = get_str(input, "profile_url")
+        .or_else(|| get_str(input, "url"))
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("missing author_id or profile_url"))?;
+    let author_id = author_id_from_profile_url(profile_url).ok_or_else(|| {
+        anyhow::anyhow!("profile_url must contain /user/profile/<author_id>; got {profile_url}")
+    })?;
+
+    let Some(obj) = input.as_object_mut() else {
+        anyhow::bail!("author input must be an object");
+    };
+    obj.insert("author_id".into(), json!(author_id));
+    Ok(())
+}
+
+fn author_id_from_profile_url(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let marker = "/user/profile/";
+    let start = trimmed
+        .find(marker)
+        .map(|idx| idx + marker.len())
+        .or_else(|| {
+            trimmed
+                .find("user/profile/")
+                .map(|idx| idx + "user/profile/".len())
+        })?;
+    let tail = &trimmed[start..];
+    let id = tail
+        .split(['?', '#', '/'])
+        .next()
+        .unwrap_or_default()
+        .trim();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_string())
+    }
+}
+
+/// search_scan(query, filters?, num_notes?, preview?, download_media?) -> search_scan bundle
 ///
-/// Composite macro: search → optional search filters →
-/// collect up to `num_notes` cards in page order (scrolling the feed only when
-/// the first page is too small) → open each note and extract its body + top
-/// comments → bundle into one artifact. Prefer this for any "research a topic
-/// on XHS" task — it returns search results plus the note bodies plus comments
-/// in one tool call, so the agent doesn't have to chain 10+ tools by hand.
-///
-/// Defaults to `DEFAULT_NUM_NOTES` notes; pass a larger `num_notes` to scan
-/// more (each note is opened, so latency grows roughly linearly).
-pub struct TopicScanTool {
+/// Unified XHS search scan macro. By default it opens selected results and returns
+/// note bodies + top comments; `preview=true` returns card metadata only.
+pub struct SearchScanTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
 }
 
+impl SearchScanTool {
+    async fn search_preview(&self, input: Value) -> anyhow::Result<ToolResult> {
+        let query = get_str(&input, "query")
+            .ok_or_else(|| anyhow::anyhow!("missing query"))?
+            .to_string();
+        let filters = input
+            .get("filters")
+            .filter(|value| !value.is_null())
+            .cloned();
+        let wait_seconds = get_f64(&input, "wait_seconds", 2.0);
+        let num_notes = input
+            .get("num_notes")
+            .and_then(Value::as_i64)
+            .filter(|n| *n > 0)
+            .map(|n| n as usize)
+            .or(Some(DEFAULT_NUM_NOTES as usize));
+        let xhs = XhsPageRuntime::new(&self.page);
+        let mut value = xhs
+            .search_cards(&query, filters.as_ref(), wait_seconds, num_notes)
+            .await?;
+        if let Some(cards) = value.get_mut("cards") {
+            self.history.annotate_cards(cards);
+        }
+        // `submit` is the search-submission diagnostic (strategy + page-state
+        // echo). The preview path writes no artifact, so keep it only when the
+        // search failed (where it explains why) and drop it on success.
+        let failed = value.get("ok").and_then(Value::as_bool) == Some(false);
+        if !failed {
+            if let Some(obj) = value.as_object_mut() {
+                obj.remove("submit");
+            }
+        }
+        Ok(json_result(&value))
+    }
+}
+
 #[async_trait]
-impl Tool for TopicScanTool {
+impl Tool for SearchScanTool {
     fn name(&self) -> &str {
-        "topic_scan"
+        "search_scan"
     }
 
     fn description(&self) -> &str {
-        "Xiaohongshu topic research macro: search → optional search filters → \
-         collect up to `num_notes` cards in page order (scrolling only if the \
-         first page is too small) → open each note and read its body + top \
-         comments → return one compact bundle (search results + selected cards \
-         + note bodies + comments). Pass `download_media=true` to download \
-         note images/videos into the run dir, include local paths, and emit a \
-         stable media_manifest_path. Defaults \
-         to 10 notes; pass a larger `num_notes` to scan more (each note is \
-         opened, so latency scales with it). Prefer this for XHS topic \
-         research. Do not repeat the same scan unless the previous one was \
-         clearly insufficient."
+        search_scan_description()
     }
 
     fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "query": { "type": "string" },
-                "filters": search_filters_schema(),
-                "num_notes": {
-                    "type": "integer",
-                    "description": "Number of notes to read (body + top comments each). The first results page is used directly; only if it holds fewer than this does the feed scroll for more. Each note is opened, so latency scales with this.",
-                    "default": DEFAULT_NUM_NOTES,
-                    "minimum": 1
-                },
-                "download_media": {
-                    "type": "boolean",
-                    "description": "Download note images/videos into the command run_dir, include local_path fields in returned notes, and write a stable media_manifest.json surfaced by media_manifest_path.",
-                    "default": false
-                }
-            },
-            "required": ["query"]
-        })
+        search_scan_input_schema(false, SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION)
     }
 
     async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        if get_bool(&input, "preview", false) {
+            return self.search_preview(input).await;
+        }
+
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
             .to_string();
@@ -1656,7 +1679,7 @@ impl Tool for TopicScanTool {
 
         // Filters are applied after the initial search below, so don't pass
         // them here.
-        let search = xhs.search_notes(&query, None, 2.0, None).await?;
+        let search = xhs.search_cards(&query, None, 2.0, None).await?;
 
         // If the search never landed on a results page (search box not found,
         // login required, …) bail before the browse loop. Otherwise
@@ -1673,7 +1696,7 @@ impl Tool for TopicScanTool {
             let mut payload = json!({
                 "ok": false,
                 "query": query,
-                "search": search,
+                "search_scan": search,
                 "notes": [],
                 "reason": reason,
                 "sampling": {
@@ -1738,7 +1761,7 @@ impl Tool for TopicScanTool {
                 continue;
             }
             if !card.note_id.is_empty() {
-                ctx.add_topic_scan_note_ids(std::slice::from_ref(&card.note_id));
+                ctx.add_search_scan_note_ids(std::slice::from_ref(&card.note_id));
             }
             selected.push(card.clone());
 
@@ -1772,13 +1795,17 @@ impl Tool for TopicScanTool {
         }
 
         let media_manifest_metadata = if download_media {
-            let media_manifest = topic_scan_media_manifest(&notes, &ctx.run_dir);
+            let media_manifest = search_scan_media_manifest(&notes, &ctx.run_dir);
             let media_manifest_count = media_manifest.as_array().map(Vec::len).unwrap_or_default();
-            let (media_manifest_path, media_manifest_error) =
-                match write_media_manifest_file(ctx, &media_manifest) {
-                    Ok(path) => (Some(path), None),
-                    Err(err) => (None, Some(format!("{err:#}"))),
-                };
+            let (media_manifest_path, media_manifest_error) = match write_media_manifest_file(
+                ctx,
+                &media_manifest,
+                "search_scan",
+                "Search scan media manifest",
+            ) {
+                Ok(path) => (Some(path), None),
+                Err(err) => (None, Some(format!("{err:#}"))),
+            };
             Some((
                 media_manifest_count,
                 media_manifest_path,
@@ -1793,7 +1820,7 @@ impl Tool for TopicScanTool {
             "query": query,
             "run": run_metadata(ctx, download_media),
             "filters": filter_result,
-            "search": search,
+            "search_scan": search,
             "notes": notes,
             "sampling": {
                 "num_notes": num_notes,
@@ -1822,20 +1849,20 @@ impl Tool for TopicScanTool {
 
         // Persist as artifact so it shows up in the run dir + working memory.
         let _ = ctx.write_json_artifact(
-            &format!("xhs_topic_scan_{}", sanitize_for_filename(&query)),
+            &format!("xhs_search_scan_{}", sanitize_for_filename(&query)),
             &payload,
             "artifacts",
-            "topic_scan",
+            "search_scan",
             "json",
             &format!(
-                "Topic scan: {query} ({} notes)",
+                "Search scan: {query} ({} notes)",
                 payload
                     .get("notes")
                     .and_then(Value::as_array)
                     .map(Vec::len)
                     .unwrap_or(0)
             ),
-            json!({"site": "xhs", "category": "topic_scan"}),
+            json!({"site": "xhs", "category": "search_scan"}),
         );
 
         // Artifact above keeps the full bundle; trim what we return so the
@@ -1845,13 +1872,13 @@ impl Tool for TopicScanTool {
     }
 }
 
-/// author_scan(author_id, num_notes?, read_notes?) -> author profile bundle
+/// author(author_id/profile_url, num_notes?, read_notes?) -> author profile bundle
 ///
-/// Composite macro mirroring `topic_scan`, but entered from an author's profile
-/// page instead of a search query: open `…/user/profile/<id>` → read the author
-/// header (bio, xhs id, IP location, follower/following/like counts) → collect
-/// note summary cards in page order (scrolling to reach `num_notes`) → when
-/// `read_notes` is set, open each note and read its body + top comments.
+/// Self-contained author macro entered from an author's profile page instead of
+/// a search query: open `…/user/profile/<id>` → read the author header (bio,
+/// xhs id, IP location, follower/following/like counts) → collect note summary
+/// cards in page order (scrolling to reach `num_notes`) → when `read_notes` is
+/// set, open each note and read its body + top comments.
 pub struct AuthorScanTool {
     page: Arc<PageSession>,
     history: Arc<XhsHistoryStore>,
@@ -1860,28 +1887,25 @@ pub struct AuthorScanTool {
 #[async_trait]
 impl Tool for AuthorScanTool {
     fn name(&self) -> &str {
-        "author_scan"
+        "author"
     }
 
     fn description(&self) -> &str {
-        "Xiaohongshu author/creator scan: open an author's profile page by id → \
-         read the author header (display name, xhs id, bio, IP location, \
-         follower/following/liked-&-collected counts) → collect their note \
-         summary cards in page order (titles/likes/covers only; pass `num_notes` \
-         to scroll the grid for more, omit for just the first screen). Pass \
-         `read_notes=true` to also open each collected note and read its body \
-         + top comments (like topic_scan; latency scales with the card count). \
-         Use this for creator research — it's search_notes + topic_scan but \
-         scoped to one author instead of a query."
+        "Self-contained Xiaohongshu author/creator macro: open an author's profile page by author_id or profile_url, read the author header (display name, xhs id, bio, IP location, follower/following/liked-&-collected counts), collect note cards in page order, and optionally read each collected note body + top comments. Use this for creator research scoped to one author."
     }
 
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
+            "description": "Provide either author_id or profile_url. The tool validates this at runtime.",
             "properties": {
                 "author_id": {
                     "type": "string",
                     "description": "Xiaohongshu user id — the trailing segment of /user/profile/<id>."
+                },
+                "profile_url": {
+                    "type": "string",
+                    "description": "Xiaohongshu profile URL. The tool extracts the trailing /user/profile/<id> segment."
                 },
                 "num_notes": {
                     "type": "integer",
@@ -1898,12 +1922,12 @@ impl Tool for AuthorScanTool {
                     "description": "When reading notes, download their images/videos into the run dir, include local_path fields, and emit a stable media_manifest_path.",
                     "default": false
                 }
-            },
-            "required": ["author_id"]
+            }
         })
     }
 
-    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+    async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        normalize_author_input(&mut input)?;
         let author_id = get_str(&input, "author_id")
             .map(str::trim)
             .filter(|id| !id.is_empty())
@@ -1985,7 +2009,7 @@ impl Tool for AuthorScanTool {
         if read_notes {
             for card in &cards {
                 if !card.note_id.is_empty() {
-                    ctx.add_topic_scan_note_ids(std::slice::from_ref(&card.note_id));
+                    ctx.add_search_scan_note_ids(std::slice::from_ref(&card.note_id));
                 }
                 let entry = scan_card_note(
                     &xhs,
@@ -2010,9 +2034,14 @@ impl Tool for AuthorScanTool {
 
         // Build the media manifest from `notes` before they move into payload.
         let media_manifest_metadata = if download_media {
-            let media_manifest = topic_scan_media_manifest(&notes, &ctx.run_dir);
+            let media_manifest = search_scan_media_manifest(&notes, &ctx.run_dir);
             let media_manifest_count = media_manifest.as_array().map(Vec::len).unwrap_or_default();
-            let (path, error) = match write_media_manifest_file(ctx, &media_manifest) {
+            let (path, error) = match write_media_manifest_file(
+                ctx,
+                &media_manifest,
+                "author",
+                "Author media manifest",
+            ) {
                 Ok(path) => (Some(path), None),
                 Err(err) => (None, Some(format!("{err:#}"))),
             };
@@ -2055,13 +2084,13 @@ impl Tool for AuthorScanTool {
             display_name
         };
         let _ = ctx.write_json_artifact(
-            &format!("xhs_author_scan_{}", sanitize_for_filename(&author_id)),
+            &format!("xhs_author_{}", sanitize_for_filename(&author_id)),
             &payload,
             "artifacts",
-            "author_scan",
+            "author",
             "json",
-            &format!("Author scan: {label} ({} notes)", cards.len()),
-            json!({"site": "xhs", "category": "author_scan"}),
+            &format!("Author: {label} ({} notes)", cards.len()),
+            json!({"site": "xhs", "category": "author"}),
         );
 
         // Artifact above keeps the full bundle; trim what we return so the
@@ -2155,9 +2184,40 @@ mod tests {
     }
 
     #[test]
-    fn standalone_run_metadata_is_topic_scan_only() {
-        assert!(!SEARCH_NOTES_COMMAND.include_run_metadata);
-        assert!(TOPIC_SCAN_COMMAND.include_run_metadata);
-        assert!(!AUTHOR_SCAN_COMMAND.include_run_metadata);
+    fn standalone_run_metadata_is_detail_search_only() {
+        assert!(!SEARCH_SCAN_PREVIEW_COMMAND.include_run_metadata);
+        assert!(SEARCH_SCAN_COMMAND.include_run_metadata);
+        assert!(!AUTHOR_COMMAND.include_run_metadata);
+    }
+
+    #[test]
+    fn author_id_from_profile_url_extracts_path_segment() {
+        assert_eq!(
+            author_id_from_profile_url(
+                "https://www.xiaohongshu.com/user/profile/5ff00000000000000000abcd?xsec_token=abc#feed"
+            ),
+            Some("5ff00000000000000000abcd".to_string())
+        );
+        assert_eq!(
+            author_id_from_profile_url("/user/profile/abc123/notes"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            author_id_from_profile_url("https://www.xiaohongshu.com/explore/abc"),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_author_input_accepts_profile_url() {
+        let mut input = json!({
+            "profile_url": "https://www.xiaohongshu.com/user/profile/abc123?xsec_token=token",
+            "read_notes": true,
+        });
+
+        normalize_author_input(&mut input).expect("profile url should normalize");
+
+        assert_eq!(input["author_id"], json!("abc123"));
+        assert_eq!(input["read_notes"], json!(true));
     }
 }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -572,8 +572,8 @@ mod tests {
             "install-1",
             &json!({
                 "created_at_ms": 123,
-                "command": "topic_scan",
-                "tool_name": "topic_scan"
+                "command": "search_scan",
+                "tool_name": "search_scan"
             }),
         );
         let object = event.as_object().expect("remote event is an object");

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -77,8 +77,8 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     if let Some(cards) = data.get("cards").and_then(Value::as_array) {
         props.insert("cards_count".into(), json!(cards.len()));
     }
-    if let Some(cards) = data
-        .get("search")
+    let search_payload = data.get("search_scan").or_else(|| data.get("search"));
+    if let Some(cards) = search_payload
         .and_then(|search| search.get("cards"))
         .and_then(Value::as_array)
     {
@@ -191,7 +191,7 @@ mod tests {
             "data": {
                 "ok": true,
                 "cards": [{}, {}],
-                "search": { "cards": [{}, {}, {}] },
+                "search_scan": { "cards": [{}, {}, {}] },
                 "selected_cards": [{}],
                 "notes": [
                     { "id": "1", "body": "must not be copied" },

--- a/docs/browser-automation-evolution.md
+++ b/docs/browser-automation-evolution.md
@@ -785,7 +785,7 @@ structurally a browser-use-style agent CLI:
 
 ### 7.2 CLI tool mode — Pattern A (detached daemon)
 
-`socai search_notes` / `topic_scan` / `extract_note` are a *second, distinct*
+`socai xhs search_scan` / `extract_note` are a *second, distinct*
 CLI surface — **agentless** tool subcommands, not the agent TUI. Structurally they
 are Vercel agent-browser's CLI+daemon split (§6.1), just at a higher
 granularity (domain tool calls, not `click @e1`):

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -153,11 +153,11 @@ example:
   "id": "toolu_123",
   "turn": 1,
   "sequence_in_turn": 1,
-  "name": "search_notes",
+  "name": "search_scan",
   "label": "searched xiaohongshu",
   "args": { "query": "..." },
   "repeat_count": 1,
-  "text": "search_notes({\"query\":\"...\"})",
+  "text": "search_scan({\"query\":\"...\"})",
   "sequence": 4,
   "created_at": 1790000005000
 }
@@ -170,12 +170,12 @@ Tool results can additionally carry normalized inline entities:
   "task_id": "task-1790000000000-1",
   "kind": "tool_result",
   "id": "toolu_123",
-  "name": "search_notes",
+  "name": "search_scan",
   "label": "searched xiaohongshu",
   "ok": true,
   "duration_ms": 1400,
-  "entities": [{ "type": "xhs_note_card_grid", "data": [] }],
-  "text": "search_notes (1400ms): ...",
+  "entities": [{ "type": "xhs_search_scan", "data": {} }],
+  "text": "search_scan (1400ms): ...",
   "sequence": 5,
   "created_at": 1790000006500
 }

--- a/docs/development/telemetry-runbook.md
+++ b/docs/development/telemetry-runbook.md
@@ -19,8 +19,9 @@ it is the main signal for understanding user intent and result quality.
 
 Each supported daemon command emits one trace:
 
-- `search_notes`
-- `topic_scan`
+- `search_scan`
+- `search_notes` (deprecated alias, emitted with `tool_name=search_scan`)
+- `topic_scan` (deprecated alias, emitted with `tool_name=search_scan`)
 - `extract_note`
 
 The trace includes safe operational context such as command name, tool name,
@@ -59,13 +60,13 @@ The README should document only these user controls, not proxy/Axiom internals.
 Disable telemetry for a single command:
 
 ```bash
-SOCAI_TELEMETRY=off socai xhs topic_scan "运营爆款思路"
+SOCAI_TELEMETRY=off socai xhs search_scan "运营爆款思路"
 ```
 
 Redact query text while keeping the rest of the telemetry trace:
 
 ```bash
-SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs topic_scan "运营爆款思路"
+SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs search_scan "运营爆款思路"
 ```
 
 Accepted off values are:
@@ -192,7 +193,7 @@ request_id="runbook-smoke-$(date +%s)"
 
 curl -sS -X POST https://socai.io/v1/events \
   -H 'Content-Type: application/json' \
-  --data "{\"events\":[{\"event\":\"socai_runbook_smoke_test\",\"install_id\":\"00000000-0000-4000-8000-000000000061\",\"session_id\":\"00000000-0000-4000-8000-000000000062\",\"request_id\":\"${request_id}\",\"source\":\"runbook_smoke_test\",\"command\":\"topic_scan\",\"tool_name\":\"topic_scan\",\"query_text_enabled\":false,\"metadata\":{\"num_notes\":1},\"duration_ms\":1,\"ok\":true}]}"
+  --data "{\"events\":[{\"event\":\"socai_runbook_smoke_test\",\"install_id\":\"00000000-0000-4000-8000-000000000061\",\"session_id\":\"00000000-0000-4000-8000-000000000062\",\"request_id\":\"${request_id}\",\"source\":\"runbook_smoke_test\",\"command\":\"search_scan\",\"tool_name\":\"search_scan\",\"query_text_enabled\":false,\"metadata\":{\"num_notes\":1},\"duration_ms\":1,\"ok\":true}]}"
 ```
 
 Expected response:
@@ -226,19 +227,19 @@ socai stop || true
 Then run one command that should emit one trace:
 
 ```bash
-socai xhs topic_scan "运营爆款思路" --num-notes 1
+socai xhs search_scan "运营爆款思路" --num-notes 1
 ```
 
 Validate query redaction:
 
 ```bash
-SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs topic_scan "运营爆款思路" --num-notes 1
+SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs search_scan "运营爆款思路" --num-notes 1
 ```
 
 Validate full telemetry disable:
 
 ```bash
-SOCAI_TELEMETRY=off socai xhs topic_scan "运营爆款思路" --num-notes 1
+SOCAI_TELEMETRY=off socai xhs search_scan "运营爆款思路" --num-notes 1
 ```
 
 Use Axiom or the local JSONL buffer to confirm the expected behavior.

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -69,8 +69,9 @@ Supported command/tool mapping:
 
 | CLI daemon command | `command` | `tool_name` |
 | --- | --- | --- |
-| `search_notes` | `search_notes` | `search_notes` |
-| `topic_scan` | `topic_scan` | `topic_scan` |
+| `search_scan` | `search_scan` | `search_scan` |
+| `search_notes` (deprecated) | `search_notes` | `search_scan` |
+| `topic_scan` (deprecated) | `topic_scan` | `search_scan` |
 | `extract_note` | `extract_note` | `read_note` |
 
 Every event carries a top-level `event` field naming its type — the CLI tool
@@ -127,8 +128,7 @@ Current metadata keys:
 
 | Metadata key | Type | Source CLI flag | Omitted when |
 | --- | --- | --- | --- |
-| `metadata.tab` | string | `topic_scan --tab <value>` | `--tab` is not passed or is empty. |
-| `metadata.num_notes` | number | `topic_scan` / `search_notes` `--num-notes <n>` | `--num-notes` is not passed. |
+| `metadata.num_notes` | number | `search_scan` / `search_scan --preview` `--num-notes <n>` | `--num-notes` is not passed. |
 | `metadata.debug_snapshot` | boolean | `--debug-snapshot` | `--debug-snapshot` is not passed / false. |
 
 ### Duration, status, and safe result metrics
@@ -140,7 +140,7 @@ Current metadata keys:
 | `error` | string | First-line error summary when `ok=false`. |
 | `result_ok` | boolean | Safe `data.ok` result flag when present. |
 | `cards_count` | number | Count of top-level `cards` result entries when present. |
-| `search_cards_count` | number | Count of `search.cards` entries when present. |
+| `search_cards_count` | number | Count of `search_scan.cards` entries when present (or legacy `search.cards`). |
 | `selected_cards_count` | number | Count of selected cards when present. |
 | `notes_count` | number | Count of note result entries when present. |
 | `notes_skipped_count` | number | Count of notes marked skipped when present. |
@@ -273,12 +273,12 @@ CLI behavior in `cli/src/daemon.rs`:
   sanitization.
 - Safe result metrics are counts/booleans only, not raw XHS content.
 
-## Example: normal `topic_scan` trace
+## Example: normal `search_scan` trace
 
 A user runs:
 
 ```bash
-socai xhs topic_scan "运营爆款思路" --num-notes 12 --tab latest
+socai xhs search_scan "运营爆款思路" --num-notes 12
 ```
 
 Representative Axiom row after proxy sanitization:
@@ -300,15 +300,14 @@ Representative Axiom row after proxy sanitization:
   "cpu_count": 14,
   "terminal_app": "Ghostty",
   "parent_process": "zsh",
-  "command": "topic_scan",
-  "tool_name": "topic_scan",
+  "command": "search_scan",
+  "tool_name": "search_scan",
   "site": "xhs",
   "query_text_enabled": true,
   "query_text": "运营爆款思路",
   "query_len": 6,
   "metadata": {
-    "num_notes": 12,
-    "tab": "latest"
+    "num_notes": 12
   },
   "duration_ms": 42130,
   "ok": true,
@@ -324,12 +323,12 @@ Representative Axiom row after proxy sanitization:
 
 Axiom will also show native `_time` and `_sysTime` columns for the row.
 
-## Example: query-redacted `topic_scan` trace
+## Example: query-redacted `search_scan` trace
 
 A user runs:
 
 ```bash
-SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs topic_scan "运营爆款思路" --num-notes 12
+SOCAI_TELEMETRY_QUERY_TEXT=off socai xhs search_scan "运营爆款思路" --num-notes 12
 ```
 
 Representative Axiom row:
@@ -345,8 +344,8 @@ Representative Axiom row:
   "source": "cli_daemon",
   "app_version": "0.1.0",
   "platform": "macos",
-  "command": "topic_scan",
-  "tool_name": "topic_scan",
+  "command": "search_scan",
+  "tool_name": "search_scan",
   "site": "xhs",
   "query_text_enabled": false,
   "query_len": 6,

--- a/docs/xhs-tools-landscape.md
+++ b/docs/xhs-tools-landscape.md
@@ -347,7 +347,7 @@ interact/content-ops）+ 统一 CLI。
   （`discover_existing_chrome_endpoint`；也可通过 `socai config set chrome.profile managed`
   持久切到独立 profile，默认路径 `~/.socai/chrome-profile`）。JS 抽取器集中在 `page_scripts.js`，经
   `Runtime.evaluate` 注入、返回 JSON——取数哲学与 xiaohongshu-mcp/autoclaw 同类。
-- **能力重心是"读/研究"而非"写/运营"**：`search_notes`、`topic_scan`、
+- **能力重心是"读/研究"而非"写/运营"**：`search_scan`、
   `extract_note`、`extract_comments`、`extract_profile`、`scroll_in_note`、
   `collect_carousel_images` 等，**目前没有发布/互动的写工具**——与 publish 重的
   MCP/Skill 工具恰成镜像（§3）。


### PR DESCRIPTION
## Summary

Reworked after review feedback: this PR no longer adds `xhs_search` / `xhs_author` wrapper tools.

- Consolidate the XHS topic/search surface into one canonical `search_scan` site tool.
  - `search_scan` replaces the old agent/site tools `search_notes` and `topic_scan`.
  - Default mode reads selected notes with body + top comments.
  - `preview=true` is the card-only path that used to be `search_notes`.
  - Deprecated CLI aliases `search_notes` and `topic_scan` still work for compatibility, but both dispatch to `tool_name=search_scan` and point users to `search_scan`.
- Refactor the existing author tool under the `author` tool name instead of adding a separate author alias.
  - Accepts either `author_id` or `profile_url`.
- Rename internal search-scan helpers/state/manifest labels away from `topic_scan` / `search_notes`.
- Update app timeline normalization, telemetry docs, runbooks, README/DEVELOPMENT, and XHS agent knowledge to use `search_scan` / `author`.

Closes #136
Part of #133

## Validation

- `cargo check`
- `cargo test -p socai-core sites::xhs::tools::tests`
- `cargo test -p socai-core sites::xhs::media_manifest::tests`
- `cargo test -p socai-core telemetry::tool_call::tests`
- `cargo test -p socai-core telemetry::tests`
- `cargo test -p socai-core agent::tool::tests`
- `git diff --check`
