### PR TITLE
Add artifact helpers for macro agents

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -4,9 +4,9 @@ use crate::timeline::{agent_event_to_timeline, AgentTaskEventKind, AgentTaskEven
 use anyhow::Result;
 use serde_json::{json, Map, Value};
 use socai_core::agent::{
-    catalog_models_for, configured_default_model_for, configured_default_provider, make_run_dir,
-    provider_credential_kind, resolve_provider, save_default_model, AgentEvent, CredentialKind,
-    ModelCatalogEntry, Provider,
+    artifact_agent_tools, catalog_models_for, configured_default_model_for,
+    configured_default_provider, make_run_dir, provider_credential_kind, resolve_provider,
+    save_default_model, AgentEvent, CredentialKind, ModelCatalogEntry, Provider,
 };
 use socai_core::runtime::{
     create_llm_provider_for, ensure_llm_provider_configured_for,
@@ -674,7 +674,8 @@ async fn run_agent_task_on_fresh_page(
     }
     let outcome = async {
         let agent_tools = site.default_agent_tools.unwrap_or(site.agent_tools);
-        let tools = agent_tools(page.clone(), llm_provider.clone()).await?;
+        let mut tools = agent_tools(page.clone(), llm_provider.clone()).await?;
+        tools.extend(artifact_agent_tools());
         let (tx, rx) = tokio::sync::broadcast::channel::<AgentEvent>(256);
         let pump = pump_agent_task_events(app, registry.clone(), task_id.clone(), telemetry, rx);
 

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -15,12 +15,12 @@ use rustyline::hint::Hinter;
 use rustyline::history::DefaultHistory;
 use rustyline::validate::Validator;
 use rustyline::{Cmd, CompletionType, Config, Editor, EventHandler, Helper, KeyEvent, Modifiers};
+use socai_core::agent::{artifact_agent_tools, local_agent_tools, make_run_dir, Session};
 use socai_core::agent::{
     catalog_models_for, config_for, configured_default_model_for, provider_credential_kind,
     resolve_provider, save_api_key, save_default_model, AgentEvent, Backend, CredentialKind,
     ModelCatalogEntry, Provider, PROVIDERS,
 };
-use socai_core::agent::{local_agent_tools, make_run_dir, Session};
 use socai_core::runtime::{
     create_llm_provider, run_agent_task as run_agent_with_tools, AgentRunConfig, SocaiRuntime,
 };
@@ -630,6 +630,7 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     };
     let agent_tools = site.default_agent_tools.unwrap_or(site.agent_tools);
     let mut tools = agent_tools(page, llm_provider.clone()).await?;
+    tools.extend(artifact_agent_tools());
     tools.extend(local_agent_tools());
 
     // Track run_id + latest assistant text live off the event stream so we can

--- a/core/src/agent/artifact_tools.rs
+++ b/core/src/agent/artifact_tools.rs
@@ -1,0 +1,619 @@
+//! Artifact helper tools for macro-agent runs.
+//!
+//! Macro site tools intentionally return compact payloads to keep the LLM
+//! context usable, while the full evidence bundle lives under the current
+//! run directory and is registered in `RunState`. These tools give the agent a
+//! two-level artifact workflow:
+//!
+//! - `artifact_list`: high-level inventory of saved artifacts and post-like
+//!   records without local media paths.
+//! - `artifact_read`: focused deep dive into one artifact or note, optionally
+//!   inlining selected local media files for vision-capable models.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::agent::run_state::ArtifactRecord;
+use crate::agent::tool::{SharedTool, Tool, ToolContext, ToolResult, ToolResultBlock};
+
+const DEFAULT_LIST_LIMIT: usize = 50;
+const DEFAULT_READ_MAX_CHARS: usize = 40_000;
+const DEFAULT_MAX_MEDIA: usize = 4;
+const HARD_MAX_MEDIA: usize = 8;
+const MAX_INLINE_MEDIA_BYTES: u64 = 4 * 1024 * 1024;
+
+pub fn artifact_agent_tools() -> Vec<SharedTool> {
+    vec![Arc::new(ArtifactListTool), Arc::new(ArtifactReadTool)]
+}
+
+pub struct ArtifactListTool;
+
+#[async_trait]
+impl Tool for ArtifactListTool {
+    fn name(&self) -> &str {
+        "artifact_list"
+    }
+
+    fn description(&self) -> &str {
+        "List saved artifacts from this run and summarize post-like records at a high level. Use this before deep artifact reads to see what evidence is available without opening every full JSON/media file. The high-level post list intentionally omits local media paths; use artifact_read for a focused deep dive."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of high-level posts to return.",
+                    "default": DEFAULT_LIST_LIMIT,
+                    "minimum": 1
+                },
+                "include_posts": {
+                    "type": "boolean",
+                    "description": "Extract high-level note/post summaries from known macro artifacts.",
+                    "default": true
+                }
+            }
+        })
+    }
+
+    fn always_available(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let limit = input
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|n| n.max(1) as usize)
+            .unwrap_or(DEFAULT_LIST_LIMIT);
+        let include_posts = input
+            .get("include_posts")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        let artifacts = artifact_records(ctx);
+        let artifact_values: Vec<Value> = artifacts
+            .iter()
+            .map(|record| artifact_summary(record))
+            .collect();
+
+        let mut posts = Vec::new();
+        if include_posts {
+            for record in &artifacts {
+                if posts.len() >= limit {
+                    break;
+                }
+                let Some(payload) = read_artifact_json(ctx, record)? else {
+                    continue;
+                };
+                let remaining = limit.saturating_sub(posts.len());
+                posts.extend(high_level_posts(&payload, record, remaining));
+            }
+        }
+
+        let result = json!({
+            "run": {
+                "id": ctx.run_id,
+            },
+            "artifacts": artifact_values,
+            "posts": posts,
+            "posts_count": posts.len(),
+        });
+        Ok(json_tool_result(&result))
+    }
+}
+
+pub struct ArtifactReadTool;
+
+#[async_trait]
+impl Tool for ArtifactReadTool {
+    fn name(&self) -> &str {
+        "artifact_read"
+    }
+
+    fn description(&self) -> &str {
+        "Read a specific saved artifact or deep-dive into one note/post from a macro artifact. Use `artifact_list` first, then pass an artifact `key`/`path` and optionally `note_id`. Set `include_media=true` only for especially interesting notes when you want to inspect downloaded local media."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "description": "Provide at least one of key, path, or note_id. The tool validates this at runtime.",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Artifact registry key from artifact_list, e.g. 001_xhs_topic_scan_query."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Registered artifact path from artifact_list, relative to the current run dir."
+                },
+                "note_id": {
+                    "type": "string",
+                    "description": "Optional XHS note id to extract from the selected artifact, or from any macro artifact if key/path is omitted."
+                },
+                "json_pointer": {
+                    "type": "string",
+                    "description": "Optional RFC 6901 JSON Pointer to read a subsection of the artifact. Ignored when note_id is used."
+                },
+                "include_media": {
+                    "type": "boolean",
+                    "description": "Inline selected downloaded image media for the focused note/artifact. Use sparingly after choosing interesting posts.",
+                    "default": false
+                },
+                "max_media": {
+                    "type": "integer",
+                    "description": "Maximum number of local image media files to inline when include_media=true.",
+                    "default": DEFAULT_MAX_MEDIA,
+                    "minimum": 1,
+                    "maximum": HARD_MAX_MEDIA
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": "Maximum JSON/text characters returned in the text block.",
+                    "default": DEFAULT_READ_MAX_CHARS,
+                    "minimum": 1000
+                }
+            }
+        })
+    }
+
+    fn always_available(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let max_chars = input
+            .get("max_chars")
+            .and_then(Value::as_u64)
+            .map(|n| n.max(1_000) as usize)
+            .unwrap_or(DEFAULT_READ_MAX_CHARS);
+        let include_media = input
+            .get("include_media")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let max_media = input
+            .get("max_media")
+            .and_then(Value::as_u64)
+            .map(|n| n.max(1) as usize)
+            .unwrap_or(DEFAULT_MAX_MEDIA)
+            .min(HARD_MAX_MEDIA);
+        let note_id = input
+            .get("note_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+
+        let artifacts = artifact_records(ctx);
+        let selected = select_artifact(ctx, &artifacts, &input, note_id)?;
+        let Some((record, payload)) = selected else {
+            anyhow::bail!("no matching artifact found");
+        };
+
+        let mut media_paths = Vec::new();
+        let value = if let Some(note_id) = note_id {
+            let note = find_note_entry(&payload, note_id)
+                .ok_or_else(|| anyhow::anyhow!("note_id not found in artifact: {note_id}"))?;
+            if include_media {
+                collect_local_media_paths(&note, &mut media_paths);
+            }
+            json!({
+                "artifact": artifact_summary(&record),
+                "note": note,
+            })
+        } else if let Some(pointer) = input
+            .get("json_pointer")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let sub = payload.pointer(pointer).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "json_pointer not found in artifact {}: {pointer}",
+                    record.path
+                )
+            })?;
+            if include_media {
+                collect_local_media_paths(sub, &mut media_paths);
+            }
+            json!({
+                "artifact": artifact_summary(&record),
+                "json_pointer": pointer,
+                "value": sub,
+            })
+        } else {
+            if include_media {
+                collect_local_media_paths(&payload, &mut media_paths);
+            }
+            json!({
+                "artifact": artifact_summary(&record),
+                "value": payload,
+            })
+        };
+
+        let mut blocks = vec![ToolResultBlock::text(truncate_text(
+            &serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+            max_chars,
+        ))];
+        if include_media {
+            append_media_blocks(ctx, &mut blocks, &media_paths, max_media)?;
+        }
+        Ok(ToolResult::blocks(blocks))
+    }
+}
+
+fn artifact_records(ctx: &ToolContext) -> Vec<ArtifactRecord> {
+    ctx.run_state
+        .as_ref()
+        .map(|state| state.artifact_records())
+        .unwrap_or_default()
+}
+
+fn artifact_summary(record: &ArtifactRecord) -> Value {
+    json!({
+        "key": record.key,
+        "path": record.path,
+        "label": record.label,
+        "kind": record.kind,
+        "source_tool": record.source_tool,
+        "turn": record.turn,
+        "summary": record.summary,
+        "metadata": record.metadata,
+    })
+}
+
+fn read_artifact_json(ctx: &ToolContext, record: &ArtifactRecord) -> anyhow::Result<Option<Value>> {
+    let path = safe_run_path(&ctx.run_dir, &record.path)?;
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+        return Ok(None);
+    };
+    if !ext.eq_ignore_ascii_case("json") {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&path)?;
+    Ok(serde_json::from_str(&text).ok())
+}
+
+fn safe_run_path(run_dir: &Path, raw: &str) -> anyhow::Result<PathBuf> {
+    let raw_path = PathBuf::from(raw.trim());
+    let candidate = if raw_path.is_absolute() {
+        raw_path
+    } else {
+        run_dir.join(raw_path)
+    };
+    let run_dir = run_dir
+        .canonicalize()
+        .unwrap_or_else(|_| run_dir.to_path_buf());
+    let canonical = candidate.canonicalize().map_err(|err| {
+        anyhow::anyhow!("cannot access artifact path {}: {err}", candidate.display())
+    })?;
+    if !canonical.starts_with(&run_dir) {
+        anyhow::bail!("artifact path escapes current run directory: {}", raw);
+    }
+    Ok(canonical)
+}
+
+fn select_artifact(
+    ctx: &ToolContext,
+    artifacts: &[ArtifactRecord],
+    input: &Value,
+    note_id: Option<&str>,
+) -> anyhow::Result<Option<(ArtifactRecord, Value)>> {
+    let key = input
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let path = input
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if let Some(key) = key {
+        let record = artifacts
+            .iter()
+            .find(|record| record.key == key)
+            .ok_or_else(|| anyhow::anyhow!("artifact key not found: {key}"))?;
+        let payload = read_artifact_json(ctx, record)?
+            .ok_or_else(|| anyhow::anyhow!("artifact is not readable JSON: {}", record.path))?;
+        return Ok(Some((record.clone(), payload)));
+    }
+
+    if let Some(path) = path {
+        let record = artifacts
+            .iter()
+            .find(|record| record.path == path)
+            .ok_or_else(|| {
+                anyhow::anyhow!("artifact path is not registered in this run: {path}")
+            })?;
+        let payload = read_artifact_json(ctx, record)?
+            .ok_or_else(|| anyhow::anyhow!("artifact is not readable JSON: {}", record.path))?;
+        return Ok(Some((record.clone(), payload)));
+    }
+
+    if let Some(note_id) = note_id {
+        for record in artifacts {
+            let Some(payload) = read_artifact_json(ctx, record)? else {
+                continue;
+            };
+            if find_note_entry(&payload, note_id).is_some() {
+                return Ok(Some((record.clone(), payload)));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn high_level_posts(payload: &Value, record: &ArtifactRecord, limit: usize) -> Vec<Value> {
+    let mut out = Vec::new();
+    if let Some(notes) = payload.get("notes").and_then(Value::as_array) {
+        for (idx, note) in notes.iter().enumerate().take(limit) {
+            if let Some(summary) = note_summary(note, idx, record) {
+                out.push(summary);
+            }
+        }
+    }
+    out
+}
+
+fn note_summary(note: &Value, index: usize, record: &ArtifactRecord) -> Option<Value> {
+    let entity = note
+        .get("entity")
+        .filter(|value| value.is_object())
+        .unwrap_or(note);
+    let note_id = string_field(entity, "note_id");
+    let title = string_field(entity, "title");
+    if note_id.is_empty() && title.is_empty() {
+        return None;
+    }
+    let media_counts = media_counts(entity);
+    Some(json!({
+        "index": index,
+        "note_id": empty_to_null(note_id),
+        "title": empty_to_null(title),
+        "author": empty_to_null(string_field(entity, "author")),
+        "author_id": empty_to_null(string_field(entity, "author_id")),
+        "url": empty_to_null(string_field(entity, "url")),
+        "type": empty_to_null(string_field(entity, "type")),
+        "likes": empty_to_null(string_field(entity, "likes")),
+        "favorites": empty_to_null(string_field(entity, "favorites")),
+        "comments_count": empty_to_null(string_field(entity, "comments_count")),
+        "image_count": entity.get("image_count").cloned().unwrap_or(Value::Null),
+        "media_count": media_counts.0,
+        "local_media_count": media_counts.1,
+        "has_local_media": media_counts.1 > 0,
+        "artifact_key": record.key,
+        "artifact_path": record.path,
+    }))
+}
+
+fn find_note_entry(payload: &Value, note_id: &str) -> Option<Value> {
+    let notes = payload.get("notes").and_then(Value::as_array)?;
+    for note in notes {
+        let entity = note
+            .get("entity")
+            .filter(|value| value.is_object())
+            .unwrap_or(note);
+        if string_field(entity, "note_id") == note_id {
+            return Some(note.clone());
+        }
+    }
+    None
+}
+
+fn media_counts(value: &Value) -> (usize, usize) {
+    let mut total = 0usize;
+    let mut local = 0usize;
+    if let Some(images) = value.get("images").and_then(Value::as_array) {
+        total += images.len();
+        local += images
+            .iter()
+            .filter(|image| !string_field(image, "local_path").is_empty())
+            .count();
+    }
+    if let Some(video) = value.get("video").filter(|video| video.is_object()) {
+        if !string_field(video, "url").is_empty() || !string_field(video, "resolved_url").is_empty()
+        {
+            total += 1;
+        }
+        if !string_field(video, "local_path").is_empty()
+            || !string_field(video, "poster_local_path").is_empty()
+        {
+            local += 1;
+        }
+    }
+    (total, local)
+}
+
+fn collect_local_media_paths(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for key in ["local_path", "poster_local_path", "frame_path"] {
+                if let Some(path) = map.get(key).and_then(Value::as_str) {
+                    let path = path.trim();
+                    if !path.is_empty() && !out.iter().any(|existing| existing == path) {
+                        out.push(path.to_string());
+                    }
+                }
+            }
+            for value in map.values() {
+                collect_local_media_paths(value, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_local_media_paths(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn append_media_blocks(
+    ctx: &ToolContext,
+    blocks: &mut Vec<ToolResultBlock>,
+    paths: &[String],
+    max_media: usize,
+) -> anyhow::Result<()> {
+    let mut added = 0usize;
+    for raw_path in paths {
+        if added >= max_media {
+            break;
+        }
+        let path = match safe_run_path(&ctx.run_dir, raw_path) {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
+        let Some(media_type) = image_media_type(&path) else {
+            continue;
+        };
+        let meta = match std::fs::metadata(&path) {
+            Ok(meta) if meta.is_file() && meta.len() <= MAX_INLINE_MEDIA_BYTES => meta,
+            _ => continue,
+        };
+        let bytes = std::fs::read(&path)?;
+        use base64::Engine as _;
+        let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        blocks.push(ToolResultBlock::text(format!(
+            "Media {} ({} bytes)",
+            raw_path,
+            meta.len()
+        )));
+        blocks.push(ToolResultBlock::Image {
+            data,
+            media_type: media_type.to_string(),
+        });
+        added += 1;
+    }
+    if added == 0 && !paths.is_empty() {
+        blocks.push(ToolResultBlock::text(
+            "No supported local image media could be inlined; inspect the listed paths outside the agent if needed.",
+        ));
+    }
+    Ok(())
+}
+
+fn image_media_type(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => Some("image/png"),
+        Some("jpg") | Some("jpeg") => Some("image/jpeg"),
+        Some("webp") => Some("image/webp"),
+        Some("gif") => Some("image/gif"),
+        _ => None,
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn empty_to_null(value: String) -> Value {
+    if value.is_empty() {
+        Value::Null
+    } else {
+        Value::String(value)
+    }
+}
+
+fn truncate_text(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(max_chars).collect();
+    format!("{kept}\n…[truncated at {max_chars} chars]")
+}
+
+fn json_tool_result(value: &Value) -> ToolResult {
+    ToolResult::text(serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record() -> ArtifactRecord {
+        ArtifactRecord {
+            key: "001_scan".into(),
+            path: "artifacts/001_scan.json".into(),
+            label: "scan".into(),
+            kind: "json".into(),
+            source_tool: "xhs_search".into(),
+            turn: Some(1),
+            summary: "scan summary".into(),
+            metadata: json!({"site": "xhs"}),
+        }
+    }
+
+    #[test]
+    fn high_level_posts_summarizes_notes_without_media_paths() {
+        let payload = json!({
+            "notes": [{
+                "ok": true,
+                "entity": {
+                    "note_id": "note1",
+                    "title": "Title",
+                    "author": "Author",
+                    "author_id": "user1",
+                    "url": "https://example.test/note1",
+                    "likes": "10",
+                    "comments_count": "2",
+                    "images": [{"local_path": "site_media/note1/0.jpg"}]
+                }
+            }]
+        });
+
+        let posts = high_level_posts(&payload, &record(), 10);
+
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0]["note_id"], json!("note1"));
+        assert_eq!(posts[0]["local_media_count"], json!(1));
+        assert!(serde_json::to_string(&posts[0])
+            .unwrap()
+            .find("site_media/note1/0.jpg")
+            .is_none());
+    }
+
+    #[test]
+    fn find_note_entry_finds_nested_entity() {
+        let payload = json!({"notes": [{"entity": {"note_id": "note1", "title": "Title"}}]});
+
+        let note = find_note_entry(&payload, "note1").expect("note exists");
+
+        assert_eq!(note["entity"]["title"], json!("Title"));
+    }
+
+    #[test]
+    fn safe_run_path_rejects_outside_paths() {
+        let root =
+            std::env::temp_dir().join(format!("socai_artifact_tool_test_{}", std::process::id()));
+        let run_dir = root.join("run");
+        let outside = root.join("outside.json");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        std::fs::write(run_dir.join("inside.json"), "{}").unwrap();
+        std::fs::write(&outside, "{}").unwrap();
+
+        assert!(safe_run_path(&run_dir, "inside.json").is_ok());
+        assert!(safe_run_path(&run_dir, outside.to_string_lossy().as_ref()).is_err());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -38,6 +38,9 @@ use crate::agent::signature::tool_call_signature;
 use crate::agent::system_prompt::build_system_prompt;
 use crate::agent::tool::{SharedTool, ToolContext, ToolResult, ToolResultBlock};
 
+const TOOL_RESULT_IMAGE_MAX_BLOCKS: usize = 4;
+const TOOL_RESULT_IMAGE_MAX_BASE64_CHARS: usize = 6_000_000;
+
 /// Events streamed to subscribers while the agent is running.
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
@@ -609,16 +612,16 @@ fn tool_result_to_content(result: &ToolResult) -> Vec<ToolResultContent> {
 
 /// Squash a tool_result for the chat history:
 /// - text blocks → compressed JSON-aware truncation
-/// - image blocks → text placeholder. If a preceding text block contained
-///   "Screenshot saved to <path>", the placeholder names that path so the
-///   model can still cite it in the final report.
+/// - image blocks → preserve a small bounded set so explicit artifact/media
+///   deep dives can actually be seen by vision-capable models; oversized or
+///   excess images become text placeholders.
 ///
-/// Returns a single Text block (or `(empty result)` when nothing usable
-/// remained). The raw bodies still hit disk via tool_results/*.json, so
-/// nothing is lost — we just keep the chat-history budget bounded.
+/// Raw bodies still hit disk via tool_results/*.json, so nothing is lost — we
+/// just keep the chat-history budget bounded.
 fn bound_content_for_history(content: &[ToolResultContent]) -> Vec<ToolResultContent> {
     let mut screenshot_path: Option<String> = None;
     let mut parts: Vec<String> = Vec::new();
+    let mut images: Vec<ToolResultContent> = Vec::new();
     for block in content {
         match block {
             ToolResultContent::Text { text } => {
@@ -629,6 +632,15 @@ fn bound_content_for_history(content: &[ToolResultContent]) -> Vec<ToolResultCon
                 if !compressed.trim().is_empty() {
                     parts.push(compressed);
                 }
+            }
+            ToolResultContent::Image { data, media_type }
+                if images.len() < TOOL_RESULT_IMAGE_MAX_BLOCKS
+                    && data.len() <= TOOL_RESULT_IMAGE_MAX_BASE64_CHARS =>
+            {
+                images.push(ToolResultContent::Image {
+                    data: data.clone(),
+                    media_type: media_type.clone(),
+                });
             }
             ToolResultContent::Image { .. } => {
                 parts.push(match &screenshot_path {
@@ -643,9 +655,15 @@ fn bound_content_for_history(content: &[ToolResultContent]) -> Vec<ToolResultCon
         combined = compress_text_maybe_json(&combined, TOOL_RESULT_TEXT_MAX_CHARS);
     }
     if combined.is_empty() {
-        combined = "(empty result)".to_string();
+        combined = if images.is_empty() {
+            "(empty result)".to_string()
+        } else {
+            "(image result)".to_string()
+        };
     }
-    vec![ToolResultContent::Text { text: combined }]
+    let mut out = vec![ToolResultContent::Text { text: combined }];
+    out.extend(images);
+    out
 }
 
 /// `"Screenshot saved to /tmp/x.png"` → `Some("/tmp/x.png")`.
@@ -738,4 +756,54 @@ fn build_assistant_blocks(response: &LLMResponse, visible_texts: &[String]) -> V
         });
     }
     blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bound_content_preserves_small_images() {
+        let content = vec![
+            ToolResultContent::Text {
+                text: "note".into(),
+            },
+            ToolResultContent::Image {
+                data: "abcd".into(),
+                media_type: "image/png".into(),
+            },
+        ];
+
+        let bounded = bound_content_for_history(&content);
+
+        assert!(matches!(bounded[0], ToolResultContent::Text { .. }));
+        assert!(matches!(bounded[1], ToolResultContent::Image { .. }));
+    }
+
+    #[test]
+    fn bound_content_omits_excess_images() {
+        let content: Vec<ToolResultContent> = (0..(TOOL_RESULT_IMAGE_MAX_BLOCKS + 1))
+            .map(|_| ToolResultContent::Image {
+                data: "abcd".into(),
+                media_type: "image/png".into(),
+            })
+            .collect();
+
+        let bounded = bound_content_for_history(&content);
+        let image_count = bounded
+            .iter()
+            .filter(|block| matches!(block, ToolResultContent::Image { .. }))
+            .count();
+        let text = bounded
+            .iter()
+            .filter_map(|block| match block {
+                ToolResultContent::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(image_count, TOOL_RESULT_IMAGE_MAX_BLOCKS);
+        assert!(text.contains("Image omitted"));
+    }
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -5,6 +5,7 @@
 //! `sites` module and call into `cdp` themselves.
 
 pub mod api_errors;
+pub mod artifact_tools;
 pub mod compaction;
 pub mod file_bash_tools;
 pub mod llm;
@@ -19,6 +20,7 @@ pub mod signature;
 pub mod system_prompt;
 pub mod tool;
 
+pub use self::artifact_tools::{artifact_agent_tools, ArtifactListTool, ArtifactReadTool};
 pub use self::file_bash_tools::{local_agent_tools, BashTool, ReadFileTool};
 pub use self::llm::{
     AnthropicBackend, Backend, Block, LLMResponse, Message, MessageContent, MessageRole,

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -49,27 +49,24 @@ task asks about a topic, keyword, market, trend, product category, or group of
 XHS posts.
 
 `search_scan` searches, optionally applies filters, samples notes from results,
-reads note bodies and top comments by default, writes artifacts, and returns a
-compact bundle. Set `preview=true` only when card metadata is enough and note
-bodies / comments are unnecessary. Default `num_notes` is modest; increase it
-only when the question needs broader evidence. Use `download_media=true` when
-the user explicitly needs local image/video files.
+reads note bodies and top comments by default, downloads available media into
+local artifacts, and returns a compact bundle. Set `preview=true` only when card
+metadata is enough and note bodies / comments are unnecessary. Default
+`num_notes` is modest; increase it only when the question needs broader
+evidence.
 
 ### Author / creator research
 
-Call `author(author_id=..., profile_url=..., num_notes=N,
-read_notes=true|false, download_media=...)` when the task asks about a specific
-author/creator and you have an `author_id`, can pass a profile URL containing
-`/user/profile/<id>`, or a previous search result surfaced an author id worth
-expanding.
+Call `author(author_id=..., profile_url=..., num_notes=N)` when the task asks
+about a specific author/creator and you have an `author_id`, can pass a profile
+URL containing `/user/profile/<id>`, or a previous search result surfaced an
+author id worth expanding.
 
 If the user only gives a display name or handle, first discover candidates with
 a focused `search_scan` or ask the user for the profile URL/author id.
 
-Use `read_notes=true` when you need the author's recent note bodies/comments;
-otherwise the profile header plus note cards may be enough. For author media
-downloads, `download_media=true` only matters when `read_notes=true`, because
-media is downloaded while reading notes.
+`author` reads recent note bodies/comments and downloads available media into
+local artifacts so creator analysis has post-level evidence.
 
 ### Note details
 
@@ -86,9 +83,15 @@ ids, source URLs, warnings, and artifact references to decide whether more
 evidence is needed. Do not repeat the same macro call unless the previous result
 was insufficient, partial, or used the wrong query/author/depth.
 
+Use `artifact_list` for a high-level inventory of collected posts/artifacts.
+It is the right first step when you need to see what evidence is already local.
+Use `artifact_read` for a focused deep dive into one artifact or one interesting
+note. Set `include_media=true` on `artifact_read` only when visual evidence is
+material; do not inspect every downloaded media file up front.
+
 Full comment objects and untrimmed bundles may live in run artifacts even when
-the returned tool payload is compact. Media downloaded with `download_media`
-lives locally in the run directory and is referenced from manifests.
+the returned tool payload is compact. Downloaded media lives locally in the run
+directory and is referenced from manifests/artifacts.
 
 Some cards or note entries may be marked as previously analyzed (for example
 `already_analyzed`, `history_level`, `history_include_media`, `skipped`, or a

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -984,9 +984,13 @@ fn lean_scan_note(note: &mut Value) {
     let Some(entity) = entry.get_mut("entity").and_then(Value::as_object_mut) else {
         return;
     };
+    let media_summary = lean_entity_media_summary(entity);
     entity.remove("content_source");
     entity.remove("wait");
     entity.remove("top_comments_wait");
+    entity.remove("images");
+    entity.remove("video");
+    entity.insert("media_summary".into(), media_summary);
     if let Some(comments) = entity.get_mut("top_comments").and_then(Value::as_array_mut) {
         let texts: Vec<Value> = comments
             .iter()
@@ -995,6 +999,52 @@ fn lean_scan_note(note: &mut Value) {
             .collect();
         entity.insert("top_comments".into(), Value::Array(texts));
     }
+}
+
+fn lean_entity_media_summary(entity: &Map<String, Value>) -> Value {
+    let image_count = entity
+        .get("images")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .or_else(|| {
+            entity
+                .get("image_count")
+                .and_then(Value::as_i64)
+                .and_then(|count| usize::try_from(count).ok())
+        })
+        .unwrap_or_default();
+    let local_image_count = entity
+        .get("images")
+        .and_then(Value::as_array)
+        .map(|images| {
+            images
+                .iter()
+                .filter(|image| get_str(image, "local_path").is_some_and(|path| !path.is_empty()))
+                .count()
+        })
+        .unwrap_or_default();
+    let video = entity.get("video").filter(|video| video.is_object());
+    let has_video = video.is_some_and(|video| {
+        get_str(video, "url").is_some_and(|url| !url.is_empty())
+            || get_str(video, "resolved_url").is_some_and(|url| !url.is_empty())
+            || get_str(video, "local_path").is_some_and(|path| !path.is_empty())
+    });
+    let local_video_count = video
+        .filter(|video| {
+            get_str(video, "local_path").is_some_and(|path| !path.is_empty())
+                || get_str(video, "poster_local_path").is_some_and(|path| !path.is_empty())
+        })
+        .map(|_| 1)
+        .unwrap_or_default();
+    let media_count = image_count + usize::from(has_video);
+    let local_media_count = local_image_count + local_video_count;
+    json!({
+        "media_count": media_count,
+        "image_count": image_count,
+        "has_video": has_video,
+        "local_media_count": local_media_count,
+        "has_local_media": local_media_count > 0,
+    })
 }
 
 /// open_note(note_id?, index?, wait_seconds?) -> {ok, ...}
@@ -1492,7 +1542,7 @@ impl Tool for ExtractProfileTool {
     }
 }
 
-const SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION: &str = "Download note images/videos into the command run_dir, include local_path fields in returned notes, and write a stable media_manifest.json surfaced by media_manifest_path.";
+const SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION: &str = "Always enabled for this macro. Downloads note images/videos into the run dir, includes local_path fields in artifacts, and writes a stable media manifest.";
 
 fn search_scan_description() -> &'static str {
     "Self-contained Xiaohongshu search_scan macro: start from any page, search by query, optionally apply filters, and by default read selected notes with top comments. Set `preview=true` for card-only search results without opening notes. Use this for XHS topic, trend, keyword, market, and note-evidence research. Do not repeat the same search_scan unless the previous one was clearly insufficient."
@@ -1531,6 +1581,17 @@ fn search_scan_input_schema(
         },
         "required": ["query"]
     })
+}
+
+fn force_macro_media_input(input: &mut Value, force_read_notes: bool) -> anyhow::Result<()> {
+    let Some(obj) = input.as_object_mut() else {
+        anyhow::bail!("macro input must be an object");
+    };
+    obj.insert("download_media".into(), json!(true));
+    if force_read_notes {
+        obj.insert("read_notes".into(), json!(true));
+    }
+    Ok(())
 }
 
 fn normalize_author_input(input: &mut Value) -> anyhow::Result<()> {
@@ -1641,13 +1702,14 @@ impl Tool for SearchScanTool {
     }
 
     fn input_schema(&self) -> Value {
-        search_scan_input_schema(false, SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION)
+        search_scan_input_schema(true, SEARCH_SCAN_DOWNLOAD_MEDIA_DESCRIPTION)
     }
 
-    async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+    async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         if get_bool(&input, "preview", false) {
             return self.search_preview(input).await;
         }
+        force_macro_media_input(&mut input, false)?;
 
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
@@ -1891,7 +1953,7 @@ impl Tool for AuthorScanTool {
     }
 
     fn description(&self) -> &str {
-        "Self-contained Xiaohongshu author/creator macro: open an author's profile page by author_id or profile_url, read the author header (display name, xhs id, bio, IP location, follower/following/liked-&-collected counts), collect note cards in page order, and optionally read each collected note body + top comments. Use this for creator research scoped to one author."
+        "Self-contained Xiaohongshu author/creator macro: open an author's profile page by author_id or profile_url, read the author header (display name, xhs id, bio, IP location, follower/following/liked-&-collected counts), read recent notes with top comments, always download available media into local artifacts, and return structured results plus artifact references. Use this for creator research scoped to one author."
     }
 
     fn input_schema(&self) -> Value {
@@ -1914,13 +1976,13 @@ impl Tool for AuthorScanTool {
                 },
                 "read_notes": {
                     "type": "boolean",
-                    "description": "Open each collected note and read its body + top comments. Off by default (summaries only).",
-                    "default": false
+                    "description": "Always enabled for this macro. Opens each collected note and reads its body + top comments so artifacts contain post-level evidence.",
+                    "default": true
                 },
                 "download_media": {
                     "type": "boolean",
-                    "description": "When reading notes, download their images/videos into the run dir, include local_path fields, and emit a stable media_manifest_path.",
-                    "default": false
+                    "description": "Always enabled for this macro. Downloads note images/videos into the run dir while reading notes and writes a stable media manifest.",
+                    "default": true
                 }
             }
         })
@@ -1928,6 +1990,7 @@ impl Tool for AuthorScanTool {
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         normalize_author_input(&mut input)?;
+        force_macro_media_input(&mut input, true)?;
         let author_id = get_str(&input, "author_id")
             .map(str::trim)
             .filter(|id| !id.is_empty())
@@ -2219,5 +2282,40 @@ mod tests {
 
         assert_eq!(input["author_id"], json!("abc123"));
         assert_eq!(input["read_notes"], json!(true));
+    }
+
+    #[test]
+    fn force_macro_media_overrides_media_flags() {
+        let mut search = json!({"query": "coffee", "download_media": false});
+        force_macro_media_input(&mut search, false).expect("search input should normalize");
+        assert_eq!(search["download_media"], json!(true));
+        assert!(search.get("read_notes").is_none());
+
+        let mut author = json!({"author_id": "abc", "read_notes": false, "download_media": false});
+        force_macro_media_input(&mut author, true).expect("author input should normalize");
+        assert_eq!(author["download_media"], json!(true));
+        assert_eq!(author["read_notes"], json!(true));
+    }
+
+    #[test]
+    fn lean_scan_note_replaces_media_paths_with_summary() {
+        let mut note = json!({
+            "entity": {
+                "note_id": "note1",
+                "images": [{"local_path": "site_media/note1/0.jpg"}],
+                "video": {},
+                "top_comments": [],
+            }
+        });
+
+        lean_scan_note(&mut note);
+
+        let entity = note.get("entity").unwrap();
+        assert!(entity.get("images").is_none());
+        assert!(entity.get("video").is_none());
+        assert_eq!(entity["media_summary"]["local_media_count"], json!(1));
+        assert!(!serde_json::to_string(entity)
+            .unwrap()
+            .contains("site_media/note1/0.jpg"));
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #145.

- Add default agent artifact helper tools:
  - `artifact_list` for high-level current-run artifact/post inventory without local media paths.
  - `artifact_read` for focused artifact/note deep dives, with opt-in bounded media inlining.
- Wire artifact helpers into both GUI and TUI agent tool sets.
- Force the default XHS macro tools to prepare media artifacts automatically:
  - `search_scan` detail mode always runs with `download_media=true`.
  - `author` always runs with `read_notes=true` and `download_media=true`.
- Keep macro return payloads lean by replacing image/video local path details with a `media_summary`; full media paths remain in artifacts for focused reads.
- Preserve a bounded number of image tool-result blocks in agent history so explicit `artifact_read(include_media=true)` media deep dives can be seen by vision-capable models.
- Update XHS agent knowledge to teach list-first/deep-read-on-demand artifact use.

Closes #135
Part of #133

## Validation

- `cargo check`
- `cargo test -p socai-core artifact_tools::tests`
- `cargo test -p socai-core sites::xhs::tools::tests`
- `cargo test -p socai-core sites::xhs::media_manifest::tests`
- `cargo test -p socai-core telemetry::tool_call::tests`
- `cargo test -p socai-core bound_content`
- `git diff --check`

## Notes

- Artifact helpers are intentionally current-run scoped for this stack. Prior-run artifact UX can be added later with an explicit run selector.
- Media is downloaded by default for macro tools, but media inspection remains opt-in through `artifact_read(include_media=true)`.
