### PR TITLE
Add SEO blog: Xiaohongshu automation tools landscape (zh + en)

### DIFF
--- a/docs/xhs-tools-landscape.md
+++ b/docs/xhs-tools-landscape.md
@@ -498,3 +498,5 @@ MCP/发布工具"，而是**小红书研究产品**。
   **两者结合**：通用 agent 负责开放式探索与兜底，垂类工具提供"这个站点该怎么稳妥
   操作"的固化能力。socai 把站点知识 + 多模态 + 产品形态捆在一起，正是在押注这种
   "垂类纵深不会被通用框架轻易抹平"。
+
+网页可读版：[小红书自动化会被封号吗？我把 7 个开源工具的源码都读了一遍](https://socai.io/blog/xiaohongshu-automation-tools)（[English](https://socai.io/blog/xiaohongshu-automation-tools)）

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,4 +3,10 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   site: 'https://socai.io',
   output: 'static',
+  markdown: {
+    // The site is monochrome/light; Shiki's default github-dark theme fights
+    // that and hard-codes a dark background on code blocks via inline styles.
+    // Disable it so plain <pre><code> picks up our own .prose styling.
+    syntaxHighlight: false,
+  },
 });

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -18,4 +18,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://socai.io/blog</loc>
+    <lastmod>2026-06-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://socai.io/blog/zh/xiaohongshu-automation-tools</loc>
+    <lastmod>2026-06-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://socai.io/blog/xiaohongshu-automation-tools</loc>
+    <lastmod>2026-06-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -10,7 +10,6 @@ interface Props {
 const { messages, language, currentYear } = Astro.props;
 
 const githubUrl = "/github";
-const downloadPath = "/download";
 const connectPath = "/connect";
 const contactPath = "/contact";
 
@@ -24,9 +23,6 @@ const t = (path: string) => message(messages, path, language);
         data-i18n-aria-label="footer.linksAria"
     >
         <a href={githubUrl}>github</a>
-        <a href={downloadPath} data-i18n="footer.download"
-            >{t("footer.download")}</a
-        >
         <a href={connectPath} data-i18n="footer.connect">{t("footer.connect")}</a
         >
         <a href={contactPath} data-i18n="footer.contact">{t("footer.contact")}</a

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -5,11 +5,13 @@ interface Props {
     messages: Record<string, Record<string, unknown>>;
     language: string;
     currentYear: number;
+    showBlog?: boolean;
 }
 
-const { messages, language, currentYear } = Astro.props;
+const { messages, language, currentYear, showBlog = false } = Astro.props;
 
 const githubUrl = "/github";
+const blogPath = "/blog";
 const connectPath = "/connect";
 const contactPath = "/contact";
 
@@ -23,6 +25,13 @@ const t = (path: string) => message(messages, path, language);
         data-i18n-aria-label="footer.linksAria"
     >
         <a href={githubUrl}>github</a>
+        {
+            showBlog && (
+                <a href={blogPath} data-i18n="footer.blog">
+                    {t("footer.blog")}
+                </a>
+            )
+        }
         <a href={connectPath} data-i18n="footer.connect">{t("footer.connect")}</a
         >
         <a href={contactPath} data-i18n="footer.contact">{t("footer.contact")}</a

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -5,10 +5,9 @@ interface Props {
     messages: Record<string, Record<string, unknown>>;
     language: string;
     currentYear: number;
-    showBlog?: boolean;
 }
 
-const { messages, language, currentYear, showBlog = false } = Astro.props;
+const { messages, language, currentYear } = Astro.props;
 
 const githubUrl = "/github";
 const blogPath = "/blog";
@@ -25,13 +24,7 @@ const t = (path: string) => message(messages, path, language);
         data-i18n-aria-label="footer.linksAria"
     >
         <a href={githubUrl}>github</a>
-        {
-            showBlog && (
-                <a href={blogPath} data-i18n="footer.blog">
-                    {t("footer.blog")}
-                </a>
-            )
-        }
+        <a href={blogPath} data-i18n="footer.blog">{t("footer.blog")}</a>
         <a href={connectPath} data-i18n="footer.connect">{t("footer.connect")}</a
         >
         <a href={contactPath} data-i18n="footer.contact">{t("footer.contact")}</a

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,26 +1,17 @@
 ---
-import { message, formatMessage } from "../lib/i18n";
+import { message } from "../lib/i18n";
 
 interface Props {
     messages: Record<string, Record<string, unknown>>;
     language: string;
-    releaseVersion: string;
 }
 
-const { messages, language, releaseVersion } = Astro.props;
+const { messages, language } = Astro.props;
 
 const githubUrl = "/github";
-const connectPath = "/connect";
 const contactPath = "/contact";
 
 const t = (path: string) => message(messages, path, language);
-const releaseValues = JSON.stringify({ version: releaseVersion });
-const releaseLabel = formatMessage(
-    messages,
-    "nav.releaseLabel",
-    { version: releaseVersion },
-    language,
-);
 ---
 
 <header
@@ -66,9 +57,6 @@ const releaseLabel = formatMessage(
         aria-label={t("nav.linksAria")}
         data-i18n-aria-label="nav.linksAria"
     >
-        <a class="nav-text-link" href={connectPath} data-i18n="nav.connect"
-            >{t("nav.connect")}</a
-        >
         <a class="nav-text-link" href={contactPath} data-i18n="nav.contact"
             >{t("nav.contact")}</a
         >
@@ -106,12 +94,5 @@ const releaseLabel = formatMessage(
                 aria-pressed="false">en</button
             >
         </div>
-        <span
-            class="release-chip"
-            data-release-chip
-            data-i18n-aria-label="nav.releaseLabel"
-            data-i18n-values={releaseValues}
-            aria-label={releaseLabel}>{releaseVersion}</span
-        >
     </nav>
 </header>

--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -1,0 +1,271 @@
+---
+// Layout for Markdown blog posts. Each post is a plain `.md` file under
+// `src/pages/blog/` that sets `layout: ../../layouts/BlogPost.astro` plus a
+// little frontmatter (title / description / date / lang / faq …). The rendered
+// Markdown arrives through <slot/>; this file owns the page shell, SEO, TOC and
+// chrome so the post body stays clean, hand-editable Markdown.
+import "../styles/global.css";
+import SiteHeader from "../components/SiteHeader.astro";
+import SiteFooter from "../components/SiteFooter.astro";
+import { message as messageFor } from "../lib/i18n";
+
+const { frontmatter, headings = [] } = Astro.props;
+const {
+    title,
+    description,
+    eyebrow,
+    date,
+    dateLabel,
+    readingTime,
+    footnote,
+    lang = "zh",
+    ogImage,
+    alternates = [],
+    faq = [],
+} = frontmatter;
+
+const isZh = lang !== "en";
+const currentYear = new Date().getFullYear();
+const siteUrl = "https://socai.io";
+const canonicalUrl = `${siteUrl}${Astro.url.pathname.replace(/\/$/, "")}`;
+const socialImageUrl = ogImage
+    ? `${siteUrl}${ogImage}`
+    : `${siteUrl}/social-card.png`;
+const defaultLanguage = isZh ? "zh" : "en";
+const defaultHtmlLanguage = isZh ? "zh-CN" : "en";
+const dateIso = date ? new Date(date).toISOString().slice(0, 10) : undefined;
+
+// Section-level table of contents, built from the headings Astro extracts from
+// the Markdown (slugs match the ids it auto-assigns to each heading).
+const toc = headings.filter((h: { depth: number }) => h.depth === 2);
+
+// hreflang alternates: every translation plus this page itself.
+const alternateLinks = [
+    { hreflang: lang, href: canonicalUrl },
+    ...alternates.map((a: { hreflang: string; href: string }) => ({
+        hreflang: a.hreflang,
+        href: `${siteUrl}${a.href}`,
+    })),
+];
+
+const backLabel = isZh ? "← 博客" : "← Blog";
+const backFootLabel = isZh ? "← 回到博客" : "← Back to the blog";
+const tocLabel = isZh ? "目录" : "Contents";
+const faqHeading = isZh ? "常见问题" : "FAQ";
+
+const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+        { "@type": "ListItem", position: 1, name: isZh ? "首页" : "Home", item: `${siteUrl}/` },
+        { "@type": "ListItem", position: 2, name: isZh ? "博客" : "Blog", item: `${siteUrl}/blog` },
+        { "@type": "ListItem", position: 3, name: title, item: canonicalUrl },
+    ],
+};
+
+const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description,
+    datePublished: dateIso,
+    dateModified: dateIso,
+    author: { "@type": "Organization", name: "socai" },
+    publisher: { "@type": "Organization", name: "socai" },
+    mainEntityOfPage: canonicalUrl,
+    image: socialImageUrl,
+    inLanguage: defaultHtmlLanguage,
+};
+
+const faqLd = faq.length
+    ? {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faq.map((item: { q: string; a: string }) => ({
+              "@type": "Question",
+              name: item.q,
+              acceptedAnswer: { "@type": "Answer", text: item.a },
+          })),
+      }
+    : null;
+
+// Chrome-only strings (header / footer). The post body is the Markdown slot and
+// stays in its authored language regardless of the toggle.
+const messages = {
+    en: {
+        meta: { title: `${title} · socai` },
+        nav: {
+            primaryAria: "primary navigation",
+            homeAria: "socai home",
+            linksAria: "site links",
+            github: "github",
+            connect: "connect chrome",
+            contact: "contact",
+            languageAria: "language",
+            releaseLabel: "release version {version}",
+        },
+        footer: {
+            linksAria: "footer links",
+            blog: "blog",
+            connect: "connect guide",
+            contact: "contact",
+        },
+    },
+    zh: {
+        meta: { title: `${title} · socai` },
+        nav: {
+            primaryAria: "主导航",
+            homeAria: "socai 首页",
+            linksAria: "站点链接",
+            github: "github",
+            connect: "连接 Chrome",
+            contact: "联系",
+            languageAria: "语言",
+            releaseLabel: "发布版本 {version}",
+        },
+        footer: {
+            linksAria: "页脚链接",
+            blog: "博客",
+            connect: "连接教程",
+            contact: "联系",
+        },
+    },
+};
+
+const message = (path: string, language = defaultLanguage) =>
+    messageFor(messages, path, language);
+const pageTitle = message("meta.title");
+---
+
+<html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{pageTitle}</title>
+        <meta name="description" content={description} />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href={canonicalUrl} />
+        {
+            alternateLinks.map((a) => (
+                <link rel="alternate" hreflang={a.hreflang} href={a.href} />
+            ))
+        }
+
+        <meta property="og:type" content="article" />
+        <meta property="og:site_name" content="socai" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={description} />
+        {dateIso && <meta property="article:published_time" content={dateIso} />}
+        <meta property="og:image" content={socialImageUrl} />
+        <meta property="og:image:type" content="image/png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={socialImageUrl} />
+
+        <meta name="theme-color" content="#fafaf9" />
+        <meta name="application-name" content="socai" />
+        <meta name="apple-mobile-web-app-title" content="socai" />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/apple-touch-icon.png"
+        />
+        <link rel="manifest" href="/site.webmanifest" />
+
+        <script type="application/ld+json" set:html={JSON.stringify(articleLd)} />
+        <script
+            type="application/ld+json"
+            set:html={JSON.stringify(breadcrumbLd)}
+        />
+        {
+            faqLd && (
+                <script
+                    type="application/ld+json"
+                    set:html={JSON.stringify(faqLd)}
+                />
+            )
+        }
+    </head>
+    <body>
+        <div class="site-shell">
+            <SiteHeader messages={messages} language={defaultLanguage} />
+
+            <main class="article-main">
+                <article class="article">
+                    <header class="article__head">
+                        <a class="article__back" href="/blog">{backLabel}</a>
+                        {eyebrow && <span class="article__eyebrow">{eyebrow}</span>}
+                        <h1>{title}</h1>
+                        <div class="article__meta">
+                            {dateLabel && <time datetime={dateIso}>{dateLabel}</time>}
+                            {dateLabel && readingTime && <span aria-hidden="true">·</span>}
+                            {readingTime && <span>{readingTime}</span>}
+                        </div>
+                    </header>
+
+                    {
+                        toc.length > 1 && (
+                            <nav class="toc" aria-label={tocLabel}>
+                                <span class="toc__label">{tocLabel}</span>
+                                <ol>
+                                    {toc.map((h: { slug: string; text: string }) => (
+                                        <li>
+                                            <a href={`#${h.slug}`}>{h.text}</a>
+                                        </li>
+                                    ))}
+                                </ol>
+                            </nav>
+                        )
+                    }
+
+                    <div class="prose">
+                        <slot />
+                    </div>
+
+                    {
+                        faq.length > 0 && (
+                            <section class="faq" aria-label={faqHeading}>
+                                <h2>{faqHeading}</h2>
+                                {faq.map((item: { q: string; a: string }) => (
+                                    <details class="faq__item">
+                                        <summary>{item.q}</summary>
+                                        <p>{item.a}</p>
+                                    </details>
+                                ))}
+                            </section>
+                        )
+                    }
+
+                    <footer class="article__foot">
+                        {footnote && <p class="article__foot-note">{footnote}</p>}
+                        <a class="article__back article__back--foot" href="/blog"
+                            >{backFootLabel}</a
+                        >
+                    </footer>
+                </article>
+            </main>
+
+            <SiteFooter
+                messages={messages}
+                language={defaultLanguage}
+                currentYear={currentYear}
+                showBlog={true}
+            />
+        </div>
+
+        <script
+            id="site-i18n"
+            type="application/json"
+            set:html={JSON.stringify(messages)}
+        />
+        <script>
+            import "../scripts/site.ts";
+        </script>
+    </body>
+</html>

--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -255,7 +255,6 @@ const pageTitle = message("meta.title");
                 messages={messages}
                 language={defaultLanguage}
                 currentYear={currentYear}
-                showBlog={true}
             />
         </div>
 

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,0 +1,227 @@
+---
+import "../../styles/global.css";
+import SiteHeader from "../../components/SiteHeader.astro";
+import SiteFooter from "../../components/SiteFooter.astro";
+import { message as messageFor } from "../../lib/i18n";
+
+const currentYear = new Date().getFullYear();
+const siteUrl = "https://socai.io";
+const canonicalUrl = `${siteUrl}/blog`;
+const socialImageUrl = `${siteUrl}/social-card.png`;
+const defaultLanguage = "zh";
+const defaultHtmlLanguage =
+    defaultLanguage === "zh" ? "zh-CN" : defaultLanguage;
+
+// Newest first. Each post is single-language; the blog index shows only the
+// posts matching the current site language (see [data-post-lang] in site.ts).
+const posts = [
+    {
+        href: "/blog/zh/xiaohongshu-automation-tools",
+        lang: "zh",
+        dateIso: "2026-06-07",
+        dateLabel: "2026 / 06",
+        title: "小红书自动化会被封号吗？我把 7 个开源工具的源码都读了一遍",
+        excerpt:
+            "逆向 API 还是浏览器自动化、签名与风控怎么过、哪种最容易被封，以及 socai 在这张地图里的位置。七个有代表性的小红书自动化开源项目，逐个读源码。",
+        more: "阅读全文 →",
+    },
+    {
+        href: "/blog/xiaohongshu-automation-tools",
+        lang: "en",
+        dateIso: "2026-06-07",
+        dateLabel: "2026 / 06",
+        title: "Will Xiaohongshu automation get you banned? I read the source of 7 open-source tools",
+        excerpt:
+            "Reverse-engineered API vs browser automation, signing and risk control, which gets banned fastest, and where socai fits. Reading the source of 7 Xiaohongshu tools.",
+        more: "Read more →",
+    },
+];
+
+const messages = {
+    en: {
+        meta: {
+            title: "博客 · socai",
+            description:
+                "The socai blog: notes on Xiaohongshu automation and browser agents.",
+            socialImageAlt: "socai blog",
+        },
+        nav: {
+            primaryAria: "primary navigation",
+            homeAria: "socai home",
+            linksAria: "site links",
+            github: "github",
+            connect: "connect chrome",
+            contact: "contact",
+            languageAria: "language",
+            releaseLabel: "release version {version}",
+        },
+        blog: {
+            heading: "Blog",
+        },
+        footer: {
+            linksAria: "footer links",
+            connect: "connect guide",
+            contact: "contact",
+        },
+    },
+    zh: {
+        meta: {
+            title: "博客 · socai",
+            description:
+                "socai 博客，记录小红书自动化、浏览器 agent 相关的文章。",
+            socialImageAlt: "socai 博客",
+        },
+        nav: {
+            primaryAria: "主导航",
+            homeAria: "socai 首页",
+            linksAria: "站点链接",
+            github: "github",
+            connect: "连接 Chrome",
+            contact: "联系",
+            languageAria: "语言",
+            releaseLabel: "发布版本 {version}",
+        },
+        blog: {
+            heading: "博客",
+        },
+        footer: {
+            linksAria: "页脚链接",
+            connect: "连接教程",
+            contact: "联系",
+        },
+    },
+};
+
+const message = (path: string, language = defaultLanguage) =>
+    messageFor(messages, path, language);
+
+const pageTitle = message("meta.title");
+const pageDescription = message("meta.description");
+const socialImageAlt = message("meta.socialImageAlt");
+---
+
+<html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{pageTitle}</title>
+        <meta
+            name="description"
+            content={pageDescription}
+            data-i18n-content="meta.description"
+        />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href={canonicalUrl} />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="socai" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta
+            property="og:title"
+            content={pageTitle}
+            data-i18n-content="meta.title"
+        />
+        <meta
+            property="og:description"
+            content={pageDescription}
+            data-i18n-content="meta.description"
+        />
+        <meta property="og:image" content={socialImageUrl} />
+        <meta property="og:image:type" content="image/png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta
+            property="og:image:alt"
+            content={socialImageAlt}
+            data-i18n-content="meta.socialImageAlt"
+        />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content={pageTitle}
+            data-i18n-content="meta.title"
+        />
+        <meta
+            name="twitter:description"
+            content={pageDescription}
+            data-i18n-content="meta.description"
+        />
+        <meta name="twitter:image" content={socialImageUrl} />
+        <meta
+            name="twitter:image:alt"
+            content={socialImageAlt}
+            data-i18n-content="meta.socialImageAlt"
+        />
+
+        <meta name="theme-color" content="#fafaf9" />
+        <meta name="application-name" content="socai" />
+        <meta name="apple-mobile-web-app-title" content="socai" />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/apple-touch-icon.png"
+        />
+        <link rel="manifest" href="/site.webmanifest" />
+    </head>
+    <body>
+        <div class="site-shell">
+            <SiteHeader messages={messages} language={defaultLanguage} />
+
+            <main class="blog-main">
+                <section class="blog" aria-labelledby="blog-title">
+                    <header class="blog__head">
+                        <h1 id="blog-title" data-i18n="blog.heading">
+                            {message("blog.heading")}
+                        </h1>
+                    </header>
+
+                    <ul class="post-list">
+                        {
+                            posts.map((post) => (
+                                <li
+                                    class="post-item"
+                                    data-post-lang={post.lang}
+                                    hidden={post.lang !== defaultLanguage}
+                                >
+                                    <a class="post-card" href={post.href}>
+                                        <div class="post-card__meta">
+                                            <time datetime={post.dateIso}>
+                                                {post.dateLabel}
+                                            </time>
+                                        </div>
+                                        <h2 class="post-card__title">
+                                            {post.title}
+                                        </h2>
+                                        <p class="post-card__excerpt">
+                                            {post.excerpt}
+                                        </p>
+                                        <span class="post-card__more">
+                                            {post.more}
+                                        </span>
+                                    </a>
+                                </li>
+                            ))
+                        }
+                    </ul>
+                </section>
+            </main>
+
+            <SiteFooter
+                messages={messages}
+                language={defaultLanguage}
+                currentYear={currentYear}
+            />
+        </div>
+
+        <script
+            id="site-i18n"
+            type="application/json"
+            set:html={JSON.stringify(messages)}
+        />
+        <script>
+            import "../../scripts/site.ts";
+        </script>
+    </body>
+</html>

--- a/site/src/pages/blog/xiaohongshu-automation-tools.md
+++ b/site/src/pages/blog/xiaohongshu-automation-tools.md
@@ -1,0 +1,275 @@
+---
+layout: ../../layouts/BlogPost.astro
+lang: en
+title: "Will Xiaohongshu automation get you banned? I read the source of 7 open-source tools (2026.6)"
+description: "Does automating Xiaohongshu (RedNote) get your account banned? I read the source of 7 representative open-source tools, scrapers, reverse-engineered APIs, MCP servers, CDP browser automation, and broke down how they work, what they can do, the real ban risk, and how to choose."
+date: 2026-06-07
+dateLabel: June 2026
+readingTime: 20 min read
+alternates:
+  - hreflang: zh
+    href: /blog/zh/xiaohongshu-automation-tools
+footnote: This is a snapshot of the open-source Xiaohongshu automation and data-collection landscape as of June 2026. The platform and these projects keep changing, so treat conclusions as dated, check the source.
+---
+
+If you work with Xiaohongshu (RedNote), sooner or later you ask: can a program search notes, scrape comments, even post for me automatically? It can, GitHub is full of tools that do exactly this. But the very next question is: will doing this get my account banned?
+
+I wanted to answer both, so I read the source code of seven representative open-source Xiaohongshu automation projects end to end. This post is what I took away: how they actually operate Xiaohongshu, how far each can go, which is most likely to get banned, and where socai, the one I'm building, sits among them.
+
+Here's the map first, ordered newest to oldest, so socai is at the top, the other seven tools follow, and the oldest is at the bottom. Star counts are live; the start dates are mine, to give you a feel for the timeline. Click a project name to jump to its GitHub.
+
+| # | Project | Stars | Start | Lang | Route | One-liner |
+|---|---|---|---|---|---|---|
+| 1 | [socai-io/socai](https://github.com/socai-io/socai) | ![](https://img.shields.io/github/stars/socai-io/socai?style=flat&label=&color=555) | 2026/6 | Rust | browser (raw CDP) | XHS content research + multimodal enrichment, as a product |
+| 2 | [autoclaw-cc/xiaohongshu-skills](https://github.com/autoclaw-cc/xiaohongshu-skills) | ![](https://img.shields.io/github/stars/autoclaw-cc/xiaohongshu-skills?style=flat&label=&color=555) | 2026/3 | Python | browser (CDP/ext) | extension bridge + SKILL.md skill set |
+| 3 | [jackwener/xiaohongshu-cli](https://github.com/jackwener/xiaohongshu-cli) | ![](https://img.shields.io/github/stars/jackwener/xiaohongshu-cli?style=flat&label=&color=555) | 2026/3 | Python | reverse API | agent-friendly reverse-API CLI |
+| 4 | [white0dew/XiaohongshuSkills](https://github.com/white0dew/XiaohongshuSkills) | ![](https://img.shields.io/github/stars/white0dew/XiaohongshuSkills?style=flat&label=&color=555) | 2026/2 | Python | browser (raw CDP) | CDP-direct publishing / ops tool |
+| 5 | [xpzouying/x-mcp](https://github.com/xpzouying/x-mcp) | ![](https://img.shields.io/github/stars/xpzouying/x-mcp?style=flat&label=&color=555) | 2025/10 | ext + cloud | browser (extension) | zero-deploy version of xiaohongshu-mcp (cloud relay + local extension) |
+| 6 | [xpzouying/xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) | ![](https://img.shields.io/github/stars/xpzouying/xiaohongshu-mcp?style=flat&label=&color=555) | 2025/8 | Go | browser (go-rod) | self-hosted XHS MCP server |
+| 7 | [NanmiCoder/MediaCrawler](https://github.com/NanmiCoder/MediaCrawler) | ![](https://img.shields.io/github/stars/NanmiCoder/MediaCrawler?style=flat&label=&color=555) | 2023/6 | Python | reverse API* | multi-platform data-collection framework (XHS is one of many) |
+| 8 | [ReaJason/xhs](https://github.com/ReaJason/xhs) | ![](https://img.shields.io/github/stars/ReaJason/xhs?style=flat&label=&color=555) | 2023/4 *(inactive)* | Python | reverse API | pluggable-signing HTTP client library, the ancestor |
+
+\* MediaCrawler now fetches data mainly through the reverse API, but still uses a browser / CDP for login state and environment.
+
+## 1. Xiaohongshu automation has exactly two technical routes: reverse API vs browser automation
+
+The seven tools look wildly different, there's a Python library, a CLI, MCP servers, browser extensions. But strip it all down and there's only one real difference: who talks to Xiaohongshu's servers.
+
+One option is the tool does it itself. Reimplement Xiaohongshu's request-signing algorithm in Python or Go, assemble the headers yourself, and hit the API directly with something like requests / httpx. I'll call this the reverse API. This route doesn't touch the page during normal operation, though it may still borrow a browser to grab login state, initialize cookies, or for anti-detection.
+
+The other option is to let the browser do it for you. Open a real browser you've already logged into, and let the page's own JS handle searching and sending requests, including the signing. The tool never touches the signature itself. I'll call this browser automation.
+
+Both routes have to clear the same wall: Xiaohongshu's signing plus risk control. The only difference is who computes the signature, the reverse API does it itself, browser automation lets the page do it. Don't underestimate that single choice: whether a tool can scale, how painful it is to maintain, how easily it gets banned, and whether it can run inside your everyday browser are basically all decided by it.
+
+### The reverse route: the signing is already a shared library
+
+Reverse-engineering is an endless tug-of-war. Xiaohongshu changes the signing algorithm every so often, and whoever reverse-engineers it has to rewrite it. That dirty, exhausting work has by now been pulled out of the individual projects into a shared library everyone uses: [xhshow](https://github.com/Cloxl/xhshow) (by Cloxl, MIT). It reimplements the whole `x-s` / `x-s-common` algorithm, the custom Base64 alphabet, a CRC variant, packing the runtime environment into JSON, `a3_hash`, and so on, in pure Python, and exposes `sign_headers_get` / `sign_headers_post`. jackwener/xiaohongshu-cli is basically "xhshow + anti-detection + a nice CLI"; MediaCrawler now outsources its signing to it too (and even patched a GET-request `a3_hash` bug for it).
+
+The older ReaJason/xhs plays it differently: it doesn't bundle signing at all, but leaves `sign` as a constructor argument (`XhsClient(cookie, sign=...)`) for you to pass in, its official example uses Playwright to call the page's `window._webmsxyw`. Both approaches are the same admission: reverse-engineering rots fast, so either everyone pools effort into one shared library, or you punt it entirely to the caller.
+
+Either way, the fate of the reverse route is sealed: Xiaohongshu changes the signing and the whole batch of tools stops working at once. That's a big structural reason ReaJason/xhs and xiaohongshu-cli built up so much maintenance pressure and eventually went inactive (here "inactive" means the author stopped adding features; whether they still answer usage questions is anyone's guess).
+
+### The browser route: pull it apart along three axes
+
+People often treat "use an extension" and "use CDP" as two competing routes. That's a mix-up. First, to be clear:
+
+> Extension, CDP, and Playwright aren't three routes, they're three ways of "controlling the browser" within the browser-automation route. All three require you to be really logged in, all three work by injecting JS into the page (evaluate), and what they can do overlaps heavily. What an extension can do (hook fetch, read cookies, operate in your real profile), CDP can mostly do too (intercept `Fetch` / `Network`, `Network.getAllCookies`, attach to a Chrome with a debug port open). The real differences are deployment, when you attach, how much access you have, and how much of the page lifecycle you can observe.
+
+The browser route really has three axes worth separating, and they're independent, you can mix and match. Put them together and you get a project's full picture.
+
+Axis one: what you use to control the browser.
+
+| Control surface | Examples | Trade-off |
+|---|---|---|
+| Playwright | MediaCrawler (early) | built-in auto-wait, locators; stable to write, but drags in Node and a few hundred MB of Chromium, heavy |
+| CDP direct (raw ws / go-rod / chromiumoxide) | xiaohongshu-mcp, XiaohongshuSkills, autoclaw, socai | light, single binary, fine-grained control, but you handle waiting and retries yourself |
+| Browser extension (MV3) | autoclaw, x-mcp | runs natively in your everyday browser, no debug port needed, but users must install it and you're bound by the store |
+
+The real difference between Playwright and CDP direct is "how thick the wrapper is": Playwright adds, on top of CDP, auto-wait (actions wait for elements to be clickable) and locators (selectors that survive re-renders), a whole toolkit built for humans writing tests, at the cost of a Node runtime plus a few hundred MB of version-pinned Chromium. CDP direct wraps the protocol thinly and gives you lightness plus full control over timing. For tools that stay resident and get called over and over, CDP direct usually pays off better, which is why xiaohongshu-mcp and socai both pick it.
+
+Compared with CDP, an extension's hard difference isn't just capability, it's where it lives and how much it sees: an extension doesn't make you restart Chrome with `--remote-debugging-port`, and it can sit and watch the page across `document_start`, the MAIN world, and `webRequest`. x-mcp pushes this advantage to the extreme (zero deploy); socai and xiaohongshu-mcp accept "you need a debug port open" in exchange for not depending on an extension.
+
+Axis two: how you read the data out (increasing robustness).
+
+1. Scrape the DOM: `querySelector` field by field, most direct, but breaks the moment the page changes, and fields are often missing.
+2. Read the page's own state: `window.__INITIAL_STATE__`, the big JSON Xiaohongshu injects during server-side rendering, more complete and more stable than the DOM. xiaohongshu-mcp, autoclaw, and socai all prefer this.
+3. Intercept network requests: hook `fetch` / `XHR` (in the MAIN world for an extension, or via CDP's `Fetch` domain) and grab the raw response of the page's already-signed requests, the most complete and most stable. autoclaw's `interceptor.js` is the textbook example.
+
+Axis three: whose browser profile you use.
+
+- Attach to your everyday Chrome (real login, real fingerprint, hardest to detect): socai by default (`discover_existing_chrome_endpoint`); autoclaw and x-mcp naturally, since they're extensions.
+- Launch a separate Chrome (a dedicated user-data-dir, you scan to log in yourself): good for isolation and running multiple accounts in parallel. Supported by socai (`socai config set chrome.profile managed`), xiaohongshu-mcp (headless + cookie file), and XiaohongshuSkills (per-account).
+
+### How these tools branched out over time
+
+The two routes didn't appear side by side out of nowhere, they grew along the timeline as "who's using it, and for what" shifted, and you can trace who copied or forked whom. Here's the family tree:
+
+```
+Reverse-API lineage
+   ReaJason/xhs (2023/4, ancestor: data model + pluggable signing)
+        │ mutual credits
+        ▼
+   MediaCrawler (2023/6, multi-platform)     Cloxl/xhshow (shared signing lib, MIT)
+        └──────── now outsources to ───────►  ◄─────── thin wrapper ───────┐
+                                            jackwener/xiaohongshu-cli (2026/3)
+
+Browser lineage
+   xpzouying/xiaohongshu-mcp (2025/8, Go·go-rod, the MCP benchmark)
+        │ same author·zero-deploy            ╲ file-by-file Python port + extension
+        ▼                                    ▼
+   xpzouying/x-mcp (2025/10)            autoclaw-cc/xiaohongshu-skills (2026/3)
+   (cloud relay + local extension)      (CDP/extension dual backend, SKILL.md, risk analysis)
+
+   white0dew/XiaohongshuSkills (2026/2, standalone raw-CDP publishing tool)
+   socai (raw CDP + multimodal + integrated product)
+```
+
+A few facts you can confirm from the source: xhshow is effectively the bedrock of the reverse route (both MediaCrawler and xiaohongshu-cli use it; the former even fixed a bug in it); ReaJason/xhs set down the early endpoints, enums and helper conventions that everyone after kept reusing; x-mcp is the same author's zero-deploy version of xiaohongshu-mcp (the original README recommends it directly); autoclaw is essentially a file-by-file port of xiaohongshu-mcp from Go to Python, plus an extension. xpzouying alone contributed two key nodes, and you could say a good half of the MCP-era Xiaohongshu tools grew around his work.
+
+Straighten out the timeline and you get one through-line, "the user changed, so the tools changed": in 2023 it was developers scraping data for read-only analysis, reverse-engineering the signing themselves; through 2024 to mid-2025, pure reverse-engineering got too hard to maintain and everyone moved to browser automation plus anti-detection; in the second half of 2025 came the MCP era, where the user shifted from developers to AI agents and the goal shifted from reading to writing / publishing; and by 2026 the execution environment is literally your own real browser, data extraction has leveled up to intercepting network requests, and the reverse-engineering veterans have gone quiet one by one. Three trends run through it all: from "reverse-scraping" toward "operating as a real person"; from "compute the signature yourself" to "let the page sign" to "intercept the page's finished output"; and from "a library for developers" to "a tool for agents" to "a zero-deploy product for ordinary users".
+
+## 2. Xiaohongshu's signing and risk control: what x-s and xsec_token actually are
+
+Signing and risk control aren't the root of every difference, the root is the "who operates it" mechanism above. But it's the one wall both routes have to climb, and the basis for understanding ban risk. This section drills in a bit; if you don't want the details, skip to section 3.
+
+### Which signing headers each request carries
+
+Every Xiaohongshu web API call carries a set of custom headers, four of them core:
+
+- `x-s`: the main signature. Computed by a heavily obfuscated piece of frontend JS (the early entry point was `window._webmsxyw(url, data)`, later renamed) from the request path, body, timestamp, and the `a1` in your cookie. Internally it uses a shuffled custom Base64 alphabet, a CRC32 variant (the `mrc()` you'll see in the code), and several rounds of bit manipulation.
+- `x-t`: a millisecond timestamp, fed into the `x-s` computation, also used server-side to check freshness.
+- `x-s-common`: a JSON blob describing "what your client looks like", custom-Base64-encoded into the header, it contains the SDK version, OS, the `xhs-pc-web` marker, the `a1` from your cookie, the `b1` from localStorage, plus a CRC over those fields. It packs "who you are and what your environment looks like" right into the signature, so forging it means making the whole environment add up.
+- `x-b3-traceid`: a tracing ID; random is fine.
+
+Two identity variables are the reverse route's soft spots: `a1` (the visitor fingerprint in the cookie, which the signature leans on heavily, the reverse side either steals a real one or fabricates a valid-looking one) and `b1` (the environment fingerprint in localStorage, note it's not in the cookie, so plain HTTP can't get it at all, and reverse tools often have to leave it blank or fake an approximation). Not having b1 is one of the pure-HTTP route's built-in weaknesses.
+
+There's also a key point that's easy to miss: different parts of the site use different signing schemes.
+
+| Surface | host | Signing | Difficulty |
+|---|---|---|---|
+| browse / search / interact | `edith.xiaohongshu.com` | the `x-s` family | main battlefield, reversed the most thoroughly |
+| create / publish | `creator.xiaohongshu.com` | a separate scheme (see the `XYW_` prefix in code) | reversed separately, little public info |
+| support / commerce | `customer.xiaohongshu.com` | yet another, relatively simple | occasionally used |
+
+So for the reverse route to be "fully featured", it has to crack several signing schemes separately, another structural reason its maintenance cost is high.
+
+### xsec_token: a ticket that comes with each note
+
+`xsec_token` is a ticket bound to one specific note. Viewing details, scraping comments, liking, and saving all require it. A few traits:
+
+- It comes paired: the token arrives together with the note, from the previous step's list or search results (it's in the note URL's query, like `…/explore/{note_id}?xsec_token=…&xsec_source=pc_feed`).
+- It carries a source marker `xsec_source`: values like `pc_feed`, `pc_search`, marking "which entry point you saw this note through". This is an anti-scraping design, it ties "reading this note" to "you got here through normal browsing", so you can't conjure a note_id out of thin air and read its detail directly; you have to go through a list first.
+- It's reusable for a short while: once you have it you can cache it for a bit (xiaohongshu-cli does), but it expires and becomes invalid.
+
+This constraint deeply shapes every tool's interface design (detail and interaction endpoints almost all require both feed_id and xsec_token), and explains why navigating straight to `/explore/<id>` (without a token) often gets bounced to a blank or verification page, which is exactly why socai's anti-scraping rules say "click in from a search or profile card, don't assemble the URL yourself".
+
+### A valid signature isn't enough: behavioral risk control
+
+A valid signature is just the entry ticket. Even if you sign every request correctly, the platform still judges, from several angles, whether you "look like a bot":
+
+- Frequency and rhythm: how many requests per unit time, and whether the intervals are too regular to be human (real people have jitter).
+- Device-fingerprint consistency: whether `a1` / `b1`, the UA, the `sec-ch-ua` trio, timezone, and screen parameters are internally consistent and match your history. Pure-HTTP tools are the easiest to expose here, however well you fake the headers, you're still missing the TLS fingerprint and JS-runtime traits a real browser has.
+- The server's risk verdict: after a few calls, the frontend SDK reports the server's conclusion (something like `isRiskUser`) via APM. autoclaw's `risk_analyzer.py` intercepts and parses exactly this report.
+
+The consequences escalate step by step: captcha (slider, click-to-select) → throttling (slow you down or just return empty results) → feature restrictions → a ban. The pattern: low-frequency, restrained reads are safest; repeated bulk reads, opening a pile of notes in a short window, and jumping straight to detail pages can all trip risk control; and high-frequency writes are where the bans really happen (more in the next two sections).
+
+## 3. Why "auto-publishing" gets you banned fastest
+
+Treating "operating Xiaohongshu" as one undifferentiated thing misses an important distinction. Split it into two buckets by how involved it is: searching, viewing, and liking are "light" single-step actions; publishing a note is a "heavy" multi-step flow.
+
+### Search, view detail, like — the light stuff
+
+Search, view detail, scrape comments, like, save, follow, they share "one step, small change" (reads have no side effects, an interaction is one action at a time), all need xsec_token, and the ban risk is relatively low. The two routes implement them differently:
+
+- Reverse API: sign the request and hit the endpoint, GET for search / detail, POST for like / comment, and take the data from the JSON the API returns.
+- Browser automation: drive the browser to search and open notes, read the data from `__INITIAL_STATE__` or an intercepted response; interactions click the buttons on the page (or trigger the page's own requests).
+
+### Publishing a note — the heavy stuff
+
+Posting images or video is a whole different magnitude:
+
+- A multi-step, stateful flow: get the upload credential → upload the images / video (large files get chunked) → create the note.
+- Reverse API: you have to switch to the creator domain, reverse a separate signing scheme, and reimplement the entire upload protocol (ReaJason/xhs's `upload_file_with_slice` and xiaohongshu-cli's `get_upload_permit` prove pure-API publishing is possible, but it's far more work).
+- Browser automation: always goes through the Creator Center's web flow, fill in the title and body, upload, write hashtags, hit publish. This path depends heavily on the Creator Center's page structure, and breaks whenever the platform redesigns it (XiaohongshuSkills' README specifically mentions reworking selectors for the "Feb–Mar 2026 Creator Center redesign").
+
+In short: publishing is the headline selling point of almost every MCP / Skill tool, yet it's precisely the most fragile (multi-step and tied to redesigns) and the most ban-prone class. That's also why a read-only "research" tool (like socai) and a publish-heavy "ops" tool (xiaohongshu-mcp / x-mcp / Skills) end up looking completely different.
+
+## 4. The 7 open-source Xiaohongshu automation projects, one by one (plus socai)
+
+Going through them newest to oldest.
+
+### socai-io/socai — content research + multimodal enrichment, as a product
+
+- Browser automation via raw CDP, written in Rust, reading `__INITIAL_STATE__`, attached by default to your real Chrome (`discover_existing_chrome_endpoint`; you can also switch permanently to a separate profile with `socai config set chrome.profile managed`, default path `~/.socai/chrome-profile`). All JS extractors live in `page_scripts.js`, injected via `Runtime.evaluate` and returning JSON, the same data-extraction philosophy as xiaohongshu-mcp and autoclaw.
+- The focus is "read / research", not "write / ops": `search_notes`, `topic_scan`, `extract_note`, `extract_comments`, `extract_profile`, `scroll_in_note`, `collect_carousel_images`, and so on, there are no publish / interact write tools for now, the mirror image of the publish-heavy MCP / Skill tools.
+- The only one doing real content understanding: image OCR, vision descriptions, and video transcription / summary / keyframe descriptions. The others basically stop at "grab text and count things"; socai takes "actually understand a note" down to the content layer.
+- Three delivery surfaces in one: an agentless tool CLI (a resident daemon, warm across calls), an agent TUI, and a Tauri desktop app, a local integrated product, rare in public repos, not just a library / CLI / server / extension.
+
+### autoclaw-cc/xiaohongshu-skills — extension bridge + skill set
+
+Browser automation, and it implements both control surfaces: an abstraction with the same interface as CDP's `Page`, with a switchable backend:
+
+- raw CDP (`cdp.py`), or
+- an extension bridge (`bridge.py` + `extension/`): an MV3 extension connects over `ws://localhost:9333` to a local `bridge_server.py` and executes in your real, logged-in browser; `interceptor.js` hooks `fetch` / `XHR` early in the `document_start` MAIN world and grabs the responses of the page's already-signed requests directly.
+
+Both backends share one upper layer, and that layer is essentially a file-by-file port of xiaohongshu-mcp (Go) into Python (each file's docstring notes "corresponds to Go's xiaohongshu/xxx.go"). Its extra depth is in `risk_analyzer.py`: it parses the intercepted APM report and outputs a structured risk-control report, the only one of the seven that turns "reading the platform's risk verdict on you" into a feature. The interface is five `SKILL.md` files (auth / publish / explore / interact / content-ops) plus a unified CLI.
+
+### jackwener/xiaohongshu-cli — an agent-friendly reverse CLI
+
+Reverse API; `signing.py` is a thin wrapper over xhshow, `creator_signing.py` bundles creator-side signing, and it starts no browser at runtime. Two highlights. First, the most careful anti-detection (to offset the inherent pure-HTTP disadvantage): a fixed macOS Chrome fingerprint, `sec-ch-ua` alignment, a stable session-long identity, Gaussian jitter between requests, and exponential-backoff cooldown when it hits a captcha. Second, agent as a first-class citizen: commands support `--yaml` / `--json`, default to YAML when not a TTY; responses are wrapped uniformly as `ok / schema_version / data / error` with enum error codes; and there's short-index navigation (`xhs read 1` reuses item 1 of the last list). It covers search, read, interact, publish, and notifications, the most fully featured of the reverse route and the best suited to be called by scripts and agents. Also inactive now (March 2026).
+
+### white0dew/XiaohongshuSkills — a CDP-direct publishing / ops tool
+
+Browser automation via raw CDP, `scripts/cdp_publish.py` (a single 192KB file) uses `websockets` directly to send and receive `Page.*`, `Runtime.*`, `Input.*` CDP commands, with no Playwright or go-rod. `chrome_launcher.py` starts Chrome with a debug port and a per-account user-data-dir (multi-account), and also supports connecting to a remote CDP and headless mode. It started as publishing-only and has since expanded to search, detail, comments, like / save, profiles, notification scraping, and exporting a content dashboard to CSV. It ships a CLI + `SKILL.md` + Claude Code onboarding docs, usable by humans and agents alike. Its heavy reliance on page structure makes "Creator Center redesigns" its number-one maintenance burden.
+
+### xpzouying/x-mcp — the zero-deploy version (cloud relay + local extension)
+
+Same author as xiaohongshu-mcp, built for "non-technical users put off by the original's deployment". The key is to see its architecture clearly, it doesn't move go-rod to the cloud, it swaps in a different mechanism:
+
+- You install a (closed-source) Chrome extension in your own browser;
+- The extension connects to the cloud over WebSocket (`wss://mcp.aredink.com/ws`);
+- The cloud exposes MCP over HTTP (`/mcp` + `X-API-Key`) to AI clients;
+- AI calls → the cloud relays → the extension executes in your local real browser → the result is sent back.
+
+So all the actions that actually operate the page happen in your local browser (via the extension), and the cloud only does two things: host the MCP endpoint, and handle multi-tenant auth and forwarding. "SaaS" here means the MCP server / relay is hosted in the cloud, not that the automation runs in the cloud. For contrast: xiaohongshu-mcp is "spin up a local headless browser + go-rod", x-mcp is "your real browser + extension" with the MCP server end moved to the cloud, different mechanism, but both belong to browser automation. Its tool interface (`xhs_*`) mirrors xiaohongshu-mcp. The pitch is zero deployment, reusing your everyday login state, and being able to watch and even intervene in the browser; onboarding is a single `claude mcp add --transport http`. This GitHub repo has almost no source (just README, SKILL.md, an onboarding guide, and a privacy policy), the one commercialized form in this comparison.
+
+### xpzouying/xiaohongshu-mcp — the self-hosted MCP server benchmark
+
+Browser automation, specifically go-rod (CDP) + stealth + a separate headless browser. It reads data via `MustEval` on `__INITIAL_STATE__`, writes through the DOM, and does search filtering by clicking filter tags by position. The interface is MCP over StreamableHTTP (Gin mounted at `/mcp`, default port 18060, and notably not stdio, so it can be containerized, there's a Docker image). The toolset is complete: publishing supports scheduling, original-content declaration, visibility range, and product binding; detail supports scrolling to load all comments and expanding nested replies. It's the most influential Xiaohongshu tool of the second-half-2025 MCP wave, and x-mcp and autoclaw above are both its descendants. Aimed at developers who can self-host a Go service / Docker, and their AI clients.
+
+### NanmiCoder/MediaCrawler — a multi-platform collection framework
+
+Not Xiaohongshu-only, it's a multi-platform scraping framework spanning Xiaohongshu, Douyin, Kuaishou, Bilibili, Weibo, Tieba, and Zhihu, with Xiaohongshu just a submodule under `media_platform/xhs/`. Its route has changed several times: early on it injected via Playwright to get signatures, now it outsources signing to xhshow's pure algorithm, while still keeping a CDP mode that connects to a local Chrome for stronger anti-detection, the several signing implementations coexisting in the code are fossils of that history. Its engineering completeness is the highest of the seven: an IP proxy pool, seven storage backends, login-state caching, comment word clouds, concurrency control, and a FastAPI + Vite WebUI. It's positioned for developers / data analysts doing bulk offline collection, essentially read-only. There's a closed-source MediaCrawler Pro alongside it (no Playwright, resumable crawls, multi-account, a content-deconstruction agent), the classic "open-source for funnel, closed-source for money".
+
+### ReaJason/xhs — the ancestor, an HTTP client library
+
+The oldest of the seven (April 2023), the `XhsClient` library on PyPI, which the author describes as "practicing Python". Reverse API, pluggable signing. Its historical significance is that it defined a shared vocabulary for everyone after it: the `Note` / `FeedType` / `SearchSortType` enums, helpers like `get_imgs_url_from_note`, widely reused, with MediaCrawler crediting it mutually. It covers search, detail, comments, profiles, and a full publishing chain (including chunked upload). Now inactive.
+
+## 5. Ranking the ban risk, and the manual work you still have to do
+
+After all the technical talk, users really care about just two things: will I get banned, and how much do I have to do by hand.
+
+### What actually gets you banned
+
+Ban risk comes down to two factors, both tied to "which route you take":
+
+1. Whether your requests look human, pure HTTP (reverse API) lacks b1 and lacks a real browser's TLS and JS-runtime fingerprint, so it's the easiest to spot; letting a real browser sign (browser automation) comes with the full set of environment traits and is markedly less likely to be flagged. This is one of the deeper reasons the reverse route went quiet and the browser route rose.
+2. Action type and frequency, read < interact < publish, low-frequency < high-frequency. Bans almost always happen on high-frequency writes, and that has little to do with which route you took.
+
+From that, a ban-risk ranking (low to high), all assuming low frequency, restraint, and a healthy account:
+
+- Lowest: real browser + read-only (socai's current form; autoclaw's read mode), closest to a real person browsing, though repeatedly opening notes in bulk can still trip risk control.
+- Lower: moderate writes on the browser route (xiaohongshu-mcp / XiaohongshuSkills, assuming you control frequency).
+- Medium: high-frequency writes from any tool (bulk publishing / interaction are both dangerous).
+- Higher: pure-HTTP reverse (ReaJason/xhs, xiaohongshu-cli), fingerprint and rhythm expose you most easily, which is why xiaohongshu-cli had to invest so heavily in Gaussian jitter and cooldowns to compensate.
+
+> In one line: ban risk is roughly "how human your requests look" times "how often you write". Which route you take affects the first; how restrained you are affects the second.
+
+### Once it's set up, what you still have to do by hand
+
+Now that everyone runs things through an agent, "can you code / do you know Docker" is no longer the main barrier, the agent can run commands and read errors for you. What really decides the experience is how many steps in the whole flow still require you, the human:
+
+- Can you get it working in one go: do the dependencies install, do the port / extension connect on the first try, or do you fiddle endlessly.
+- Do you have to scan / verify by hand often: how often the login expires, whether expiry means pulling out your phone to scan again and clearing a slider, the most frequent, most flow-breaking manual bit.
+- Do you have to click a confirmation each time: whether an automated action triggers a browser / page confirm dialog that a human has to click.
+- Can it run unattended on repeat: can tasks queue and run one after another, or does it get cut off by risk control after a few and need a human to reset.
+
+By that standard the differences are big: pure-HTTP tools have low manual overhead once working, but post-inactivity "getting it working" is itself hard and brittle; the browser route requires a first scan-to-login (then reuses login state), and a separate profile or an attached real browser keeps login state longest and scans least; and any tool, the moment it hits a captcha / risk control, sees its "remaining manual work" spike, which loops back to the previous section: fewer high-frequency writes, fewer interruptions. socai attaches to your existing Chrome profile by default, so login state is the smoothest; for isolation, `socai config set chrome.profile managed` switches to a separate profile (you scan to log in there once first).
+
+### These tools and gray-market account farms are not the same thing
+
+Zoom out a bit: this batch of open-source tools and "industrial-scale gray-market operation of Xiaohongshu" are two different worlds, the latter is who the platform's risk control is really up against. Drawing this line clearly helps you see the ceiling on what this batch of tools (socai included) can do and how risky they are.
+
+| Dimension | This batch of open-source tools | Gray-market farms |
+|---|---|---|
+| Protocol layer | web (`xiaohongshu.com`, x-s signing) | mostly app-side protocol (reverse the APK, protobuf, stronger hardening) |
+| Devices | one real device / one browser | device farms (group / cloud control), device-spoofing frameworks, hooked fingerprints |
+| Accounts | one or a few | account pools (hundreds to thousands) + SMS platforms + account warming |
+| Network | local IP or a few proxies | residential proxy pools, 4G SIM banks, one IP per device |
+| Goal | personal research / ops / learning | inflating numbers, warming accounts, bulk ads, data resale |
+
+Three key differences: (1) web vs app, the open-source tools almost all target the web (more info, signing relatively reversible), while the gray market more often cracks the app protocol; (2) single point vs farm, open source is "one real person's automation", the gray market is "thousands of fake people industrialized", whose core assets are the scaled supply of devices / accounts / IPs and device-spoofing ability, not the signature itself; (3) intensity, the gray market is in a full-time arms race with platform risk control, while the open-source tools merely "try to look human". This batch all sits on the "personal scale, real identity" side, which means they shouldn't touch the device-spoofing / account-pool stuff, and their product boundary should be designed around "low frequency, explainable, human-can-take-over".
+
+## 6. socai: a low-ban-risk Xiaohongshu research tool
+
+In short, socai is the rare tool in this batch built for reading and research rather than publishing and ops. It attaches to your real, logged-in Chrome by default and stays read-first, so it sits in the lowest tier of the ban-risk ranking above; it's also the only one that truly understands content, beyond grabbing text, it does image OCR and video transcription, exactly the capability that makes topic research and competitor analysis valuable. It's not just a library or a script but a local product that unifies a CLI, a TUI, and a desktop app. Looking ahead, multimodal plus parallel multi-agent work can turn "research a Xiaohongshu topic" from reading notes one by one into deep-reading N in parallel and handing you an insight. If you want to read a topic thoroughly at low risk, that's exactly what it's for, [see socai on GitHub →](https://github.com/socai-io/socai).

--- a/site/src/pages/blog/zh/xiaohongshu-automation-tools.md
+++ b/site/src/pages/blog/zh/xiaohongshu-automation-tools.md
@@ -1,0 +1,275 @@
+---
+layout: ../../../layouts/BlogPost.astro
+lang: zh
+title: "小红书自动化会被封号吗？我把 7 个开源工具的源码都读了一遍（2026.6）"
+description: "小红书自动化会不会被封号？我把 7 个有代表性的开源工具（爬虫、逆向 API、MCP、CDP 浏览器自动化）的源码都读了一遍，讲清楚它们的原理、能力边界、封号风险，以及该怎么选。"
+date: 2026-06-07
+dateLabel: 2026 年 6 月
+readingTime: 约 20 分钟
+alternates:
+  - hreflang: en
+    href: /blog/xiaohongshu-automation-tools
+footnote: 这篇记录的是截至 2026 年 6 月的小红书自动化与数据采集开源生态；平台和这些项目都在变，结论可能过时，具体请以源码为准。
+---
+
+做小红书的人迟早会问一个问题：能不能让程序帮我自动搜笔记、抓评论、甚至自动发？能，GitHub 上这类工具一抓一大把。但紧接着第二个问题就来了：这么搞会不会被封号？
+
+这两个问题我都想弄明白，干脆把七个有代表性的小红书（XHS / RedNote）自动化开源项目的源码从头到尾翻了一遍。这篇就是翻完之后的笔记：它们到底怎么操作小红书、能做到什么程度、哪种最容易被封，以及我自己在做的 socai 跟它们比是个什么位置。
+
+先放一张总表当地图，按出现时间从新到老排，所以最上面是 socai，往下依次是其它七个工具，最老的在最底下。Star 数是实时的，起始时间是我标的，方便你感受这条时间轴。点项目名能直接跳到它的 GitHub。
+
+| # | 项目 | Stars | 起始 | 语言 | 路线 | 一句话定位 |
+|---|---|---|---|---|---|---|
+| 1 | [socai-io/socai](https://github.com/socai-io/socai) | ![](https://img.shields.io/github/stars/socai-io/socai?style=flat&label=&color=555) | 2026/6 | Rust | 浏览器(裸 CDP) | XHS 内容研究 + 多模态富集的集成产品 |
+| 2 | [autoclaw-cc/xiaohongshu-skills](https://github.com/autoclaw-cc/xiaohongshu-skills) | ![](https://img.shields.io/github/stars/autoclaw-cc/xiaohongshu-skills?style=flat&label=&color=555) | 2026/3 | Python | 浏览器(CDP/插件) | 插件 Bridge + SKILL.md 技能集 |
+| 3 | [jackwener/xiaohongshu-cli](https://github.com/jackwener/xiaohongshu-cli) | ![](https://img.shields.io/github/stars/jackwener/xiaohongshu-cli?style=flat&label=&color=555) | 2026/3 | Python | 逆向 API | agent 友好的逆向 API CLI |
+| 4 | [white0dew/XiaohongshuSkills](https://github.com/white0dew/XiaohongshuSkills) | ![](https://img.shields.io/github/stars/white0dew/XiaohongshuSkills?style=flat&label=&color=555) | 2026/2 | Python | 浏览器(裸 CDP) | CDP 直连的发布/运营工具 |
+| 5 | [xpzouying/x-mcp](https://github.com/xpzouying/x-mcp) | ![](https://img.shields.io/github/stars/xpzouying/x-mcp?style=flat&label=&color=555) | 2025/10 | 插件+云 | 浏览器(插件) | xiaohongshu-mcp 的零部署版（云中继 + 本地插件） |
+| 6 | [xpzouying/xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) | ![](https://img.shields.io/github/stars/xpzouying/xiaohongshu-mcp?style=flat&label=&color=555) | 2025/8 | Go | 浏览器(go-rod) | 自托管的 XHS MCP server |
+| 7 | [NanmiCoder/MediaCrawler](https://github.com/NanmiCoder/MediaCrawler) | ![](https://img.shields.io/github/stars/NanmiCoder/MediaCrawler?style=flat&label=&color=555) | 2023/6 | Python | 逆向 API* | 多平台数据采集框架（XHS 只是其一） |
+| 8 | [ReaJason/xhs](https://github.com/ReaJason/xhs) | ![](https://img.shields.io/github/stars/ReaJason/xhs?style=flat&label=&color=555) | 2023/4 *(停更)* | Python | 逆向 API | 可插拔签名的 HTTP 客户端库，生态鼻祖 |
+
+\* MediaCrawler 现在主要靠逆向 API 取数，但仍然会用浏览器 / CDP 处理登录态和环境。
+
+## 一、小红书自动化只有两条技术路线：逆向 API vs 浏览器自动化
+
+七个工具看着五花八门，有 Python 库、有命令行、有 MCP server、还有浏览器插件。但拆到底，区别只有一个：到底谁去跟小红书的服务器打交道。
+
+一种是工具自己上。把小红书网页里那套请求签名算法用 Python 或 Go 照着重写一遍，自己拼好请求头，用 requests / httpx 这类库直接打小红书的接口。我后面都叫它逆向 API。这条路平时不碰网页，但要拿登录状态、初始化 cookie 或者反检测的时候，可能还得借一下浏览器。
+
+另一种是让浏览器替你上。开一个你已经登录好的真实浏览器，搜索、发请求这些动作都交给网页自己的 JS 去做，签名也是网页算的，工具自己根本不碰。我后面叫它浏览器自动化。
+
+两条路最后都得过小红书的签名加风控这一关，差别只在于签名是谁算出来的：逆向 API 自己算，浏览器自动化让网页算。别小看这一个选择，一个工具能不能规模化、维护起来累不累、容不容易被封、能不能直接跑在你日常用的浏览器里，基本都被它决定了。
+
+### 逆向这条路：签名其实早就被做成了一个公共库
+
+逆向是个没完没了的拉锯战。小红书隔三差五改一次签名算法，逆向的人就得跟着重写一遍。这种又脏又累的活，现在已经被从各个项目里抽出来、变成了一个大家共用的库：[xhshow](https://github.com/Cloxl/xhshow)（作者 Cloxl，MIT 协议）。它把 `x-s`、`x-s-common` 这套签名算法，自定义的 Base64 码表、CRC 变种、把运行环境打包成 JSON、`a3_hash` 等等，用纯 Python 重写了一遍，对外就给你 `sign_headers_get` / `sign_headers_post` 两个函数。jackwener/xiaohongshu-cli 基本就是「xhshow + 反检测 + 一个好看的命令行」；MediaCrawler 现在也把签名外包给它（还反过来给它修过 GET 请求 `a3_hash` 的 bug）。
+
+更早的 ReaJason/xhs 玩法不太一样：它干脆不自带签名，而是把 sign 留成一个构造参数（`XhsClient(cookie, sign=...)`）让你自己传进去，它官方例子是用 Playwright 去调网页里的 `window._webmsxyw` 来签。两种做法其实是同一个意思：逆向这玩意儿太容易过期了，要么大家凑钱养一个公共库，要么干脆甩锅给调用方。
+
+但不管哪种，走逆向这条路的命运是绑死的：小红书一改签名，这一票工具集体歇菜。ReaJason/xhs 和 xiaohongshu-cli 后面维护压力大、最后停更，很大一部分就是这个原因（这里说的「停更」是作者不再加新功能了，还回不回答使用问题就不好说了）。
+
+### 浏览器这条路：可以从三个方面拆开看
+
+很多人会把「用插件」和「用 CDP」当成两种不同的路线，这其实搞混了。先说清楚一件事：
+
+> 插件、CDP、Playwright，这三个不是三条路线，而是浏览器自动化这条路里「怎么控制浏览器」的三种方式。它们都要你真实登录、都靠往页面里注入 JS（evaluate）来干活，能干的事高度重叠。插件能做的（hook fetch、读 cookie、在你真实的浏览器配置里操作），CDP 基本也能做（拦 `Fetch` / `Network`、`Network.getAllCookies`、连到开了调试端口的 Chrome）。真正的区别在于：怎么部署、什么时候挂上去、权限多大、能看到页面多少生命周期。
+
+浏览器这条路真正值得分开看的是三个方面，而且它们互不相干、可以随便组合，拼在一起才是一个项目完整的样子。
+
+第一个方面，用什么去控制浏览器：
+
+| 控制方式 | 代表 | 取舍 |
+|---|---|---|
+| Playwright | MediaCrawler（早期） | 自带 auto-wait、locator，写起来稳；但要拖一个 Node 加几百兆的 Chromium，重 |
+| CDP 直连（裸 ws / go-rod / chromiumoxide） | xiaohongshu-mcp、XiaohongshuSkills、autoclaw、socai | 轻、单个二进制、控制粒度细；但等待、重试都得自己处理 |
+| 浏览器插件（MV3） | autoclaw、x-mcp | 天生跑在你日常浏览器里、不用开调试端口；但要让用户装插件、还受应用商店约束 |
+
+Playwright 和 CDP 直连的本质区别就是「包了多厚」：Playwright 在 CDP 之上加了 auto-wait（动作会自动等元素可点）、locator（选择器抗页面重渲染）这一整套为「人写测试」准备的东西，代价是一个 Node 运行时加几百兆绑定版本的 Chromium；CDP 直连只把协议薄薄包一层，换来轻量和对时序的完全掌控。对那种要长期挂着、被反复调用的工具，CDP 直连通常更划算，这也是 xiaohongshu-mcp、socai 都选它的原因。
+
+插件相比 CDP，硬区别不只是能力，更在于「装在哪、能看到多少」：插件不用你拿 `--remote-debugging-port` 重启 Chrome，而且能在 `document_start`、MAIN world、`webRequest` 这些生命周期里一直盯着页面。x-mcp 把这条优势用到了极致（零部署），socai 和 xiaohongshu-mcp 则接受「得开个调试端口」来换「不依赖插件」。
+
+第二个方面，数据怎么读出来（越往后越靠谱）：
+
+1. 直接抓 DOM：用 `querySelector` 一个个抠字段，最直观，但页面一改就废，字段还经常缺。
+2. 读页面里现成的状态，`window.__INITIAL_STATE__` 就是小红书服务端渲染时塞进页面的一大坨 JSON，比 DOM 全、也更稳。xiaohongshu-mcp、autoclaw、socai 都优先读这个。
+3. 拦网络请求：hook `fetch` / `XHR`（插件在 MAIN world 里，或者用 CDP 的 `Fetch` 域），直接把页面已经签好名的请求响应抓下来，最全最稳。autoclaw 的 `interceptor.js` 就是这么干的。
+
+第三个方面，用谁的浏览器配置（profile）：
+
+- 挂在你日常用的 Chrome 上（真实登录、真实指纹，最不容易被发现）：socai 默认就是这样（`discover_existing_chrome_endpoint`），autoclaw、x-mcp 因为是插件天然如此。
+- 自己另起一个独立 Chrome（专用配置目录，要自己扫码登录）：好处是能隔离、能多账号并行。socai（`socai config set chrome.profile managed`）、xiaohongshu-mcp（无头加 cookie 文件）、XiaohongshuSkills（按账号分开）都支持。
+
+### 这些工具是怎么一步步分化出来的
+
+这两条路不是凭空一起冒出来的，而是随着「谁在用、用来干嘛」的变化，沿着时间慢慢长出来的，而且谁抄谁、谁是谁改的，都有迹可循。我画了张图：
+
+```
+逆向 API 一脉
+   ReaJason/xhs (2023/4, 鼻祖：数据模型 + 可插拔签名)
+        │ 互相致谢
+        ▼
+   MediaCrawler (2023/6, 多平台)        Cloxl/xhshow (签名公共库, MIT)
+        └──────── 现在外包给 ──────►  ◄─────── 薄封装 ────────┐
+                                            jackwener/xiaohongshu-cli (2026/3)
+
+浏览器一脉
+   xpzouying/xiaohongshu-mcp (2025/8, Go·go-rod, MCP 标杆)
+        │ 同作者·零部署版             ╲ 一个文件一个文件翻成 Python + 加插件
+        ▼                            ▼
+   xpzouying/x-mcp (2025/10)     autoclaw-cc/xiaohongshu-skills (2026/3)
+   (云中继 + 本地插件)            (CDP/插件双后端, SKILL.md, 风控分析)
+
+   white0dew/XiaohongshuSkills (2026/2, 独立的裸 CDP 发布工具)
+   socai (裸 CDP + 多模态 + 集成产品)
+```
+
+几个有源码能对上的事实：xhshow 是逆向这条路实际上的地基（MediaCrawler、xiaohongshu-cli 都用它，前者还给它修过 bug）；ReaJason/xhs 立下了早期那套接口、枚举和 helper 写法，后来者一直在沿用；x-mcp 是 xiaohongshu-mcp 同一个作者出的零部署版（原版 README 直接推荐）；autoclaw 基本是把 xiaohongshu-mcp 一个文件一个文件从 Go 翻成 Python、再加了插件。xpzouying 一个人贡献了两个关键节点，可以说 MCP 时代的小红书工具有一大半是围着他这套东西长起来的。
+
+把时间线拉直，就是一条「用的人变了，工具也跟着变」的主线：2023 年是开发者在爬数据做只读分析，自己逆向签名；2024 到 2025 上半年，纯逆向太难维护，大家转向浏览器自动化加反检测；2025 下半年进入 MCP 时代，用的人从开发者变成了 AI agent，目标也从「读」转向「写 / 发布」；到 2026，执行环境直接变成你本人的真实浏览器，取数也升级到拦截网络请求，几个逆向老将陆续停更。三条贯穿始终的趋势：从「逆向爬取」走向「以真人身份操作」；从「自己造签名」到「让网页代签」再到「直接拦页面成品」；从「开发者用的库」到「agent 用的工具」再到「普通人用的零部署产品」。
+
+## 二、小红书的签名和风控：x-s、xsec_token 到底是什么
+
+签名和风控不是所有差异的根源，根源是上面那个「谁来操作」的机制。但它是两条路都绕不开的同一堵墙，也是看懂封号风险的基础。这一节往里钻一点，不想看细节的可以直接跳到第三节。
+
+### 每个请求要带哪些签名头
+
+小红书网页端每次调接口，都得带一组它自己定义的请求头，核心是四个：
+
+- `x-s`：签名的主体。由一段混淆得很厉害的前端 JS（早期入口叫 `window._webmsxyw(url, data)`，后来改过名）算出来，输入是请求路径、body、时间戳，还有 cookie 里的 `a1`。里面用了打乱过的自定义 Base64 码表、CRC32 的变种（代码里常见的 `mrc()`）和好几轮位运算。
+- `x-t`：毫秒级时间戳，参与 `x-s` 的计算，服务端也拿它校验有没有过期。
+- `x-s-common`：一段描述「你这个客户端长什么样」的 JSON，用自定义 Base64 编码后塞进请求头，里面有 SDK 版本、操作系统、`xhs-pc-web` 标识、cookie 里的 `a1`、localStorage 里的 `b1`，还有给前面这些字段算的 CRC 校验值。等于把「你是谁、你的环境长啥样」一起打包进了签名，想伪造就得连环境一块编圆。
+- `x-b3-traceid`：链路追踪用的 ID，随机生成就行。
+
+走逆向这条路，有两个变量是软肋：`a1`（cookie 里的访客指纹，签名重度依赖它，逆向方要么偷一个真的、要么自己造一个格式合法的）和 `b1`（localStorage 里的环境指纹，注意它不在 cookie 里，纯 HTTP 根本拿不到，逆向工具经常只能留空或者糊弄一个近似值）。b1 拿不到，就是纯 HTTP 这条路天生的一个破绽。
+
+还有个容易被忽略但很关键的点：不同业务用的签名方案是不一样的。
+
+| 业务 | host | 签名 | 难度 |
+|---|---|---|---|
+| 浏览 / 搜索 / 互动 | `edith.xiaohongshu.com` | `x-s` 这一套 | 主战场，逆向得最透 |
+| 创作 / 发布 | `creator.xiaohongshu.com` | 另一套（代码里见 `XYW_` 前缀） | 单独逆向，资料少 |
+| 客服 / 商业 | `customer.xiaohongshu.com` | 又一套，相对简单 | 偶尔用到 |
+
+所以逆向想做到「功能全」，得把好几套签名分别都啃下来，这是它维护成本高的又一个原因。
+
+### xsec_token：每篇笔记自带的一张门票
+
+`xsec_token` 是一张绑定到具体某篇笔记的门票，看详情、抓评论、点赞收藏都得带着它。它有几个特点：
+
+- 成对出现：它跟笔记是一起给你的，来自上一步的列表或搜索结果（就在笔记 URL 的 query 里，像 `…/explore/{note_id}?xsec_token=…&xsec_source=pc_feed`）。
+- 带个来源标记 `xsec_source`：值是 `pc_feed`、`pc_search` 之类，标明「你是从哪个入口看到这篇笔记的」。这是一种反爬设计，它把「读这篇笔记」和「你是经过正常浏览才看到它的」绑在一起，你没法凭空拿一个 note_id 直接去读详情，必须先走一遍列表。
+- 能短时间复用：拿到后可以缓存一会儿（xiaohongshu-cli 就缓存了），但会过期、会失效。
+
+这条限制几乎影响了所有工具的接口设计（详情、互动这些接口基本都要求你同时传 feed_id 和 xsec_token），也解释了为什么你直接去访问 `/explore/<id>`（不带 token）经常会被怼成一个空白页或者验证页，这正是 socai 的反爬规则里要求「从搜索 / 个人主页的卡片点进去，别自己拼 URL」的原因。
+
+### 光签名对还不够：行为风控
+
+签名合法只是拿到入场券。就算你每个请求都签对了，平台还会从好几个角度判断你「像不像机器人」：
+
+- 频率和节奏：单位时间发了多少请求、间隔是不是规律得不像人（真人是有抖动的）。
+- 设备指纹对不对得上：`a1` / `b1`、UA、`sec-ch-ua` 这三件套、时区、屏幕参数，彼此自不自洽、跟历史一不一致。纯 HTTP 的工具最容易在这儿露馅，请求头拼得再像，也少了真浏览器才有的 TLS 指纹和 JS 运行时特征。
+- 服务端的风控结论：前端 SDK 跑几次之后，会把服务端给你的判定（类似 `isRiskUser`）通过 APM 上报。autoclaw 的 `risk_analyzer.py` 就把这个上报拦下来解析了。
+
+被风控之后是一级一级来的：先是验证码（滑块、点选），再是限流（降速或者直接给你空结果），然后功能受限，最后封号。规律是：低频、克制的「读」最安全；反复批量读、短时间打开一堆笔记、直接跳详情页，都可能触发风控；而高频的「写」才是封号的重灾区（下面两节细说）。
+
+## 三、为什么「自动发布」最容易被封号
+
+把「操作小红书」笼统看成一回事，会漏掉一个很重要的区别。其实按麻烦程度分两类就够了：搜索、看、点赞这类是「轻」的单步操作；发笔记是「重」的多步流程。
+
+### 搜索、看详情、点赞这类轻操作
+
+搜索、看详情、抓评论、点赞、收藏、关注，共同点是一步就完、改动很小（读没有副作用，互动一次就一个动作），都要带 xsec_token，封号风险相对低。两条路实现方式不同：
+
+- 逆向 API：直接签好请求打接口，GET 搜索 / 详情、POST 点赞评论，数据从接口返回的 JSON 里取。
+- 浏览器自动化：开浏览器去搜、去点开笔记，数据从 `__INITIAL_STATE__` 或者拦下来的响应里读；互动就是去点页面上的按钮（或者触发页面自己的请求）。
+
+### 发笔记这类重操作
+
+发图文、发视频就完全是另一个量级了：
+
+- 多步、还带状态：先拿上传凭证 → 上传图片 / 视频（大文件还得切片）→ 创建笔记。
+- 逆向 API：得切到 creator 这个域、再逆向另一套签名，还要把整个上传协议照着实现一遍（ReaJason/xhs 的 `upload_file_with_slice`、xiaohongshu-cli 的 `get_upload_permit` 证明纯接口发布是能做的，但工作量大得多）。
+- 浏览器自动化：一律走创作者中心的网页流程，填标题正文、上传、写话题标签、点发布。这条路死死依赖创作者中心的页面结构，平台一改版就坏（XiaohongshuSkills 的 README 专门提到要为「2026 年 2 到 3 月创作者中心改版」重新改选择器）。
+
+一句话：发布几乎是所有 MCP / Skill 工具的主打卖点，但它偏偏是最容易坏（多步又跟着改版）、也最容易被封的一类。这也是为什么纯读的「研究型」工具（比如 socai）和重发布的「运营型」工具（xiaohongshu-mcp / x-mcp / Skills 这种）会长成完全不同的样子。
+
+## 四、7 个小红书自动化开源项目逐个点评（外加 socai）
+
+下面按出现时间从新到老，挨个说一遍。
+
+### socai-io/socai — 内容研究 + 多模态富集的集成产品
+
+- 走浏览器自动化里的裸 CDP，用 Rust 写，读 `__INITIAL_STATE__`，默认挂在你真实的 Chrome 上（`discover_existing_chrome_endpoint`；也能用 `socai config set chrome.profile managed` 永久切到独立配置，默认路径 `~/.socai/chrome-profile`）。所有 JS 抽取脚本集中在 `page_scripts.js`，通过 `Runtime.evaluate` 注入、返回 JSON，取数思路跟 xiaohongshu-mcp、autoclaw 是一类。
+- 重心在「读 / 研究」而不是「写 / 运营」：`search_notes`、`topic_scan`、`extract_note`、`extract_comments`、`extract_profile`、`scroll_in_note`、`collect_carousel_images` 这些，目前没有发布 / 互动的写工具，跟那些主打发布的 MCP / Skill 工具正好相反。
+- 唯一一个真正做内容理解的：图片 OCR、用 vision 描述图片，视频转写 / 摘要 / 抽帧描述。另外几个基本都停在「取文字加数数」，socai 把「把一篇笔记真正读懂」做到了内容这一层。
+- 三种用法合一：不带 agent 的工具命令行（daemon 常驻、跨调用还热着）、agent TUI、还有 Tauri 桌面应用，公开仓库里少见的本地集成产品，不只是一个库 / 命令行 / server / 插件。
+
+### autoclaw-cc/xiaohongshu-skills — 插件 Bridge + 技能集
+
+走浏览器自动化，而且两种控制方式都做了：上层抽象出一个跟 CDP `Page` 一样接口的东西，底下可以切，
+
+- 裸 CDP（`cdp.py`），或者
+- 插件 Bridge（`bridge.py` 加 `extension/`）：MV3 插件通过 `ws://localhost:9333` 连本地的 `bridge_server.py`，在你真实已登录的浏览器里执行；`interceptor.js` 在 `document_start` 的 MAIN world 里抢先 hook `fetch` / `XHR`，直接把页面已经签好名的请求响应抓下来。
+
+两种后端共用同一套上层逻辑，而这套逻辑基本是把 xiaohongshu-mcp（Go）一个文件一个文件翻成 Python（每个文件的 docstring 都标了「对应 Go 的 xiaohongshu/xxx.go」）。它额外有个深度功能在 `risk_analyzer.py`：把拦下来的 APM 上报解析了，输出一份结构化的风控报告，这是七个里唯一一个把「读出平台对你的风控判定」做成功能的。接口是 5 个 `SKILL.md`（auth / publish / explore / interact / content-ops）加一个统一命令行。
+
+### jackwener/xiaohongshu-cli — 为 agent 设计的逆向 CLI
+
+走逆向 API，`signing.py` 是 xhshow 的薄封装、`creator_signing.py` 自带创作者端签名，跑的时候不开浏览器。两个亮点。一是反检测做得最用心（毕竟纯 HTTP 先天吃亏）：固定一套 macOS Chrome 指纹、`sec-ch-ua` 对齐、整个会话身份稳定、请求之间加高斯抖动、撞到验证码就指数退避冷却。二是天生为 agent 设计：命令支持 `--yaml` / `--json`，不是终端就默认输出 YAML；返回值统一包成 `ok / schema_version / data / error` 加枚举错误码；还能用短编号导航（`xhs read 1` 直接复用上次列表的第 1 条）。功能覆盖搜索、阅读、互动、发布、通知，是逆向这条路里功能最全、最适合被脚本和 agent 调用的一个。也已经停更了（2026 年 3 月）。
+
+### white0dew/XiaohongshuSkills — CDP 直连的发布 / 运营工具
+
+走浏览器自动化里的裸 CDP，`scripts/cdp_publish.py`（单文件 192KB）直接用 `websockets` 收发 `Page.*`、`Runtime.*`、`Input.*` 这些 CDP 命令，不依赖 Playwright 或 go-rod。`chrome_launcher.py` 负责起 Chrome，带调试端口，而且按账号分开 user-data-dir（支持多账号），也能连远程 CDP 和无头模式。一开始只做发布，现在扩到了搜索、详情、评论、点赞收藏、个人主页、通知抓取，还能把内容数据看板导出成 CSV。提供命令行加 `SKILL.md` 加 Claude Code 接入文档，人用 agent 用都行。强依赖页面结构，所以「创作者中心改版」是它最大的维护负担。
+
+### xpzouying/x-mcp — 零部署版（云中继 + 本地插件）
+
+跟 xiaohongshu-mcp 同一个作者，专门为「被原版部署劝退的非技术用户」做的。这里要把它的架构看清楚，它不是把 go-rod 搬到云上跑，而是换了一套玩法：
+
+- 你在自己浏览器里装一个（闭源的）Chrome 插件；
+- 插件通过 WebSocket 连到云端（`wss://mcp.aredink.com/ws`）；
+- 云端把 MCP over HTTP（`/mcp` 加 `X-API-Key`）暴露给 AI 客户端；
+- AI 一调用 → 云端转发 → 插件在你本地真实浏览器里执行 → 结果再传回去。
+
+也就是说，真正操作网页的所有动作都发生在你本地浏览器里（靠插件），云端只干两件事：托管 MCP 端点、做多租户鉴权和转发。所谓「SaaS」指的是 MCP server 这个中继被托管在云上，而不是自动化在云上跑。对比一下：xiaohongshu-mcp 是「本地自己起无头浏览器加 go-rod」，x-mcp 是「你的真实浏览器加插件」再把 MCP server 端搬上云，玩法不同，但都属于浏览器自动化。工具接口（`xhs_*`）跟 xiaohongshu-mcp 一一对应。卖点是零部署、复用你日常登录状态、还能在浏览器里实时看到甚至插手，接入只要 `claude mcp add --transport http` 一行。它这个 GitHub 仓库基本没源码（就 README、SKILL.md、接入文档、隐私政策），是这次对比里唯一一个商业化形态的样本。
+
+### xpzouying/xiaohongshu-mcp — 自托管 MCP server 标杆
+
+走浏览器自动化，具体是 go-rod（CDP）加 stealth 加一个独立的无头浏览器。读数据用 `MustEval` 取 `__INITIAL_STATE__`，写操作走 DOM，搜索筛选靠按位置点筛选标签。接口是 MCP over StreamableHTTP（用 Gin 挂在 `/mcp`，默认端口 18060，注意不走 stdio，所以能装进容器，有 Docker 镜像）。功能很全：发布支持定时、原创声明、可见范围、带货商品绑定，看详情能滚动加载全部评论、展开二级回复。它是 2025 下半年 MCP 这波里最有影响力的小红书工具，上面的 x-mcp 和 autoclaw 都是它的衍生。面向的是能自己部署 Go 服务 / Docker 的开发者和他们的 AI 客户端。
+
+### NanmiCoder/MediaCrawler — 多平台采集框架
+
+它不是只做小红书的，而是把小红书、抖音、快手、B 站、微博、贴吧、知乎一锅端的多平台爬虫框架，小红书只是 `media_platform/xhs/` 下面的一个子模块。它的路线变过好几次：早期用 Playwright 注入拿签名，现在把签名外包给 xhshow 纯算法，同时还留着 CDP 模式连本地 Chrome 来增强反检测，代码里好几套签名实现并存，就是这段历史留下的化石。工程完成度是七个里最高的：IP 代理池、七种存储后端、登录态缓存、评论词云、并发控制、还有 FastAPI 加 Vite 的 WebUI。定位是给开发者、数据分析做批量离线采集，基本纯读。它还有个闭源的 MediaCrawler Pro（去掉 Playwright、断点续爬、多账号、内容解构 agent），典型的「开源引流、闭源赚钱」。
+
+### ReaJason/xhs — 生态鼻祖，一个 HTTP 客户端库
+
+七个里最老的（2023 年 4 月），就是 PyPI 上那个 `XhsClient` 库，作者自己说是「练 Python」写的。走逆向 API，签名可以自己插。它的历史意义在于给后来者定了一套公共词汇：`Note` / `FeedType` / `SearchSortType` 这些枚举、`get_imgs_url_from_note` 这类 helper，被后面一堆项目沿用，MediaCrawler 跟它互相致谢。功能覆盖搜索、详情、评论、个人主页，还有完整的发布链路（含切片上传）。现在已经停更。
+
+## 五、封号风险排个序，再说说你还得自己动手的部分
+
+讲了一堆技术，但用户真正关心的其实就两件事：会不会被封，以及用起来要我自己动多少手。
+
+### 到底什么情况会被封
+
+封号风险主要看两点，而且都跟「走哪条路」有关：
+
+1. 请求像不像真人发的，纯 HTTP（逆向 API）缺 b1、缺真浏览器的 TLS 和 JS 运行时指纹，最容易被识破；让真浏览器去签名（浏览器自动化）天生带齐全套环境特征，被发现的概率明显低。这也是逆向那条路陆续停更、浏览器那条路起来的深层原因之一。
+2. 操作类型和频率，读 < 互动 < 发布，低频 < 高频。封号几乎都发生在高频写，跟你走哪条路关系不大。
+
+按这个给个封号风险排序（从低到高，前提都是低频、克制、账号本身正常）：
+
+- 最低：挂真实浏览器加只读（socai 现在的形态，autoclaw 的读模式），最接近真人看内容，但反复批量打开笔记还是可能触发风控。
+- 较低：浏览器路线的适度写（xiaohongshu-mcp / XiaohongshuSkills，前提是控制频率）。
+- 中等：任何工具的高频写（批量发布、批量互动都危险）。
+- 较高：纯 HTTP 逆向（ReaJason/xhs、xiaohongshu-cli），指纹和节奏最容易露馅，所以 xiaohongshu-cli 才不得不下血本做高斯抖动加冷却来补救。
+
+> 一句话总结：封号风险差不多等于「请求像不像真人」乘以「写操作的频率」。走哪条路影响前者，用得克不克制影响后者。
+
+### 配好之后，你还得自己动手做什么
+
+现在人人都让 agent 帮忙跑，「会不会写代码、懂不懂 Docker」已经不是主要门槛了，agent 能替你敲命令、看报错。真正决定体验的，是整个流程里还剩多少非你本人不可的环节：
+
+- 能不能一次配通：依赖装不装得上、端口 / 扩展能不能一次连上，还是要反复折腾。
+- 要不要老是手动扫码、过验证：登录多久失效一次、失效了是不是又得掏手机扫码、过滑块，这是最高频、最打断状态的人工活。
+- 要不要每次点确认弹窗：自动化的动作会不会触发浏览器 / 页面的确认框，得人去点。
+- 能不能放着让它无人值守地连续跑：任务能不能排队一条条执行，还是跑几条就被风控打断、得人来重置。
+
+按这个标准，差别挺大：纯 HTTP 工具一旦配通，人工成分很低，但停更之后「配通」这一步本身就又难又容易碎；浏览器路线第一次得扫码登录（之后复用登录状态），独立配置或挂真实浏览器的登录状态最持久、扫码最少；而任何工具只要一撞上验证码 / 风控，「剩余人工」立刻飙升，又绕回上一节：少做高频写，才能少被打断。socai 默认挂你已有的 Chrome 配置，登录状态最省心；想隔离的话，用 `socai config set chrome.profile managed` 切到独立配置（要在新配置里先扫码登录一次）。
+
+### 这些工具，和灰产群控不是一回事
+
+把视野再放大一点：这批开源工具，跟「大规模灰产、工业化操作小红书」完全是两个世界，后者才是平台风控真正的对手。把这条界划清楚，能帮你看清这批工具（包括 socai）的能力和风险上限。
+
+| 维度 | 这批开源工具 | 灰产群控 |
+|---|---|---|
+| 协议层 | 网页端（`xiaohongshu.com`，x-s 签名） | 多为 App 端协议（逆向 APK、protobuf、更强加固） |
+| 设备 | 单台真机 / 单浏览器 | 真机农场（群控 / 云控）、改机框架、hook 改设备指纹 |
+| 账号 | 单账号或少量 | 账号池（成百上千）加接码平台加养号 |
+| 网络 | 本机 IP 或少量代理 | 住宅代理池、4G 卡池、一机一 IP |
+| 目标 | 个人研究 / 运营 / 学习 | 刷量、养号、批量广告、数据倒卖 |
+
+三个关键区别：一是网页端还是 App 端，开源工具几乎都打网页端（资料多、签名相对好逆），灰产更多去啃 App 协议；二是单点还是农场，开源是「一个真人的自动化」，灰产是「上千个假人的工业化」，它的核心资产是设备、账号、IP 的规模化供给和改机能力，根本不是签名本身；三是对抗强度，灰产跟平台风控是全职在打军备竞赛，开源工具只是「尽量装得像真人」。这批工具都站在「个人尺度、真人身份」这一边，这决定了它们不该去碰改机、账号池那一套，也决定了产品边界应该围着「低频、能解释、能随时人工接手」来设计。
+
+## 六、socai：一个低封号风险的小红书研究工具
+
+简单说，socai 就是这批工具里少见的、专门为「读和研究」而不是「发布运营」做的那一个。它默认挂在你真实登录的 Chrome 上、以只读为主，所以在上一节的封号风险排序里处在最低那一档；它也是唯一一个真正把内容读懂的，除了取文字，还做图片 OCR、视频转写和理解，这恰好是做选题、竞品研究最值钱的能力。形态上它不是一个库或一段脚本，而是命令行、TUI 和桌面 app 合一的本地产品。再往前一步，多模态加多 agent 并行，可以把「研究一个小红书话题」从一篇篇读，变成并行深读 N 篇再给你一份洞察。如果你正想安全、低风险地把一个话题读透、做选题或竞品研究，它就是为这个场景做的，[在 GitHub 上看 socai →](https://github.com/socai-io/socai)。

--- a/site/src/pages/connect.astro
+++ b/site/src/pages/connect.astro
@@ -3,7 +3,6 @@ import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
-import { resolveReleaseVersion } from "../lib/release";
 
 const currentYear = new Date().getFullYear();
 const siteUrl = "https://socai.io";
@@ -59,8 +58,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
-            download: "download",
-            connect: "connect",
+            connect: "connect guide",
             contact: "contact",
         },
     },
@@ -108,8 +106,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
-            download: "下载",
-            connect: "连接",
+            connect: "连接教程",
             contact: "联系",
         },
     },
@@ -121,7 +118,6 @@ const message = (path: string, language = defaultLanguage) =>
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
-const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -194,7 +190,6 @@ const releaseVersion = await resolveReleaseVersion();
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
-                releaseVersion={releaseVersion}
             />
 
             <main class="setup-main">

--- a/site/src/pages/connect.astro
+++ b/site/src/pages/connect.astro
@@ -58,6 +58,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
+            blog: "blog",
             connect: "connect guide",
             contact: "contact",
         },
@@ -106,6 +107,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
+            blog: "博客",
             connect: "连接教程",
             contact: "联系",
         },

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -41,6 +41,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
+            blog: "blog",
             connect: "connect guide",
             contact: "contact",
         },
@@ -71,6 +72,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
+            blog: "博客",
             connect: "连接教程",
             contact: "联系",
         },

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -3,7 +3,6 @@ import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
-import { resolveReleaseVersion } from "../lib/release";
 
 const githubIssuesUrl = "https://github.com/socai-io/socai/issues";
 const qrImage = "/wechat-group-qr.jpg";
@@ -42,8 +41,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
-            download: "download",
-            connect: "connect",
+            connect: "connect guide",
             contact: "contact",
         },
     },
@@ -73,8 +71,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
-            download: "下载",
-            connect: "连接",
+            connect: "连接教程",
             contact: "联系",
         },
     },
@@ -86,7 +83,6 @@ const message = (path: string, language = defaultLanguage) =>
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
-const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -159,7 +155,6 @@ const releaseVersion = await resolveReleaseVersion();
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
-                releaseVersion={releaseVersion}
             />
 
             <main class="contact-main">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -68,8 +68,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
-            download: "download",
-            connect: "connect",
+            connect: "connect guide",
             contact: "contact",
         },
         prompts: [
@@ -103,7 +102,7 @@ const messages = {
             actionsAria: "下载和源码",
             download: "下载 macOS 版",
             github: "在 github 查看",
-            releaseMeta: "macOS 13+ · 通用构建 · {version}",
+            releaseMeta: "macOS 13+ · {version}",
         },
         preview: {
             sectionAria: "socai app 预览",
@@ -129,8 +128,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
-            download: "下载",
-            connect: "连接",
+            connect: "连接教程",
             contact: "联系",
         },
         prompts: [
@@ -228,7 +226,6 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
-                releaseVersion={releaseVersion}
             />
 
             <main class="page-main">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -68,7 +68,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
-            blog: "博客",
+            blog: "blog",
             connect: "connect guide",
             contact: "contact",
         },
@@ -456,7 +456,6 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
                 messages={messages}
                 language={defaultLanguage}
                 currentYear={currentYear}
-                showBlog={true}
             />
         </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -68,6 +68,7 @@ const messages = {
         },
         footer: {
             linksAria: "footer links",
+            blog: "博客",
             connect: "connect guide",
             contact: "contact",
         },
@@ -128,6 +129,7 @@ const messages = {
         },
         footer: {
             linksAria: "页脚链接",
+            blog: "博客",
             connect: "连接教程",
             contact: "联系",
         },
@@ -454,6 +456,7 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
                 messages={messages}
                 language={defaultLanguage}
                 currentYear={currentYear}
+                showBlog={true}
             />
         </div>
 

--- a/site/src/scripts/site.ts
+++ b/site/src/scripts/site.ts
@@ -170,6 +170,12 @@ const applyLanguage = (language, shouldPersist = false) => {
         option.setAttribute("aria-pressed", String(isActive));
     });
 
+    // Blog index: show only the posts written in the current language.
+    document.querySelectorAll("[data-post-lang]").forEach((element) => {
+        (element as HTMLElement).hidden =
+            element.getAttribute("data-post-lang") !== nextLanguage;
+    });
+
     startTypewriter(
         dictionary[nextLanguage]?.prompts || dictionary.zh?.prompts || [],
     );

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1400,3 +1400,436 @@ a.contact-alt__row:hover {
     display: none;
   }
 }
+
+/* ── Blog index ───────────────────────────────────────────── */
+.blog-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.blog {
+  width: min(100%, 760px);
+  padding: clamp(48px, 7vw, 72px) clamp(20px, 4vw, 40px) 64px;
+}
+
+.blog__head {
+  max-width: 620px;
+  margin-bottom: clamp(36px, 5vw, 48px);
+}
+
+.blog__eyebrow {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blog h1 {
+  margin: 0 0 16px;
+  color: var(--ink-0);
+  font-size: clamp(28px, 5.5vw, 44px);
+  font-weight: 500;
+  letter-spacing: -0.028em;
+  line-height: 1.05;
+}
+
+.blog__subtitle {
+  margin: 0;
+  color: var(--fg-soft);
+  font-size: clamp(14px, 2.4vw, 17px);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.post-list {
+  display: grid;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.post-card {
+  display: block;
+  padding: clamp(22px, 3.5vw, 28px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition:
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.post-card:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-2);
+}
+
+.post-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.post-card__tag {
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  text-transform: uppercase;
+}
+
+.post-card__title {
+  margin: 0 0 10px;
+  color: var(--ink-0);
+  font-size: clamp(19px, 3vw, 24px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.post-card__excerpt {
+  margin: 0 0 16px;
+  color: var(--fg-soft);
+  font-size: 14.5px;
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+
+.post-card__more {
+  color: var(--ink-0);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* ── Article ──────────────────────────────────────────────── */
+.article-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.article {
+  width: min(100%, 880px);
+  padding: clamp(40px, 6vw, 64px) clamp(20px, 5vw, 56px) 64px;
+}
+
+.article__back {
+  display: inline-block;
+  margin-bottom: 28px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.01em;
+}
+
+.article__back:hover {
+  color: var(--ink-0);
+}
+
+.article__eyebrow {
+  display: inline-block;
+  margin-bottom: 16px;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.article__head h1 {
+  margin: 0 0 20px;
+  color: var(--ink-0);
+  font-size: clamp(26px, 5vw, 40px);
+  font-weight: 500;
+  letter-spacing: -0.028em;
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+.article__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: clamp(28px, 4vw, 40px);
+  border-bottom: 1px solid var(--line);
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+/* prose: long-form reading body */
+.prose {
+  padding-top: clamp(28px, 4vw, 40px);
+  color: var(--fg-muted);
+  font-size: 16px;
+  line-height: 1.75;
+}
+
+.prose > * {
+  text-wrap: pretty;
+}
+
+.prose p {
+  margin: 0 0 20px;
+}
+
+.prose strong {
+  color: var(--ink-0);
+  font-weight: 600;
+}
+
+.prose a {
+  color: var(--ink-0);
+  text-decoration: underline;
+  text-decoration-color: var(--line-strong);
+  text-underline-offset: 3px;
+}
+
+.prose a:hover {
+  text-decoration-color: var(--ink-0);
+}
+
+.prose h2 {
+  margin: clamp(40px, 6vw, 56px) 0 16px;
+  padding-top: clamp(20px, 3vw, 28px);
+  border-top: 1px solid var(--line);
+  color: var(--ink-0);
+  font-size: clamp(21px, 3.4vw, 28px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.prose h3 {
+  margin: clamp(28px, 4vw, 36px) 0 12px;
+  color: var(--ink-0);
+  font-size: clamp(17px, 2.8vw, 20px);
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+
+.prose ul,
+.prose ol {
+  margin: 0 0 20px;
+  padding-left: 1.35em;
+}
+
+.prose li {
+  margin-bottom: 8px;
+}
+
+.prose li::marker {
+  color: var(--fg-soft);
+}
+
+.prose code {
+  padding: 1px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.84em;
+  word-break: break-word;
+}
+
+.prose pre {
+  margin: 0 0 24px;
+  padding: 18px 20px;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  line-height: 1.5;
+}
+
+.prose pre code {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  white-space: pre;
+}
+
+.prose blockquote {
+  margin: 0 0 24px;
+  padding: 4px 0 4px 20px;
+  border-left: 2px solid var(--ink-0);
+  color: var(--fg);
+}
+
+.prose blockquote p {
+  margin: 0;
+}
+
+.prose table {
+  display: block;
+  width: 100%;
+  margin: 0 0 24px;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+.prose th,
+.prose td {
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.prose th {
+  background: var(--surface-2);
+  color: var(--ink-0);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.prose td {
+  color: var(--fg-muted);
+}
+
+.prose img {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.article__foot {
+  margin-top: clamp(40px, 6vw, 56px);
+  padding-top: clamp(24px, 3.5vw, 32px);
+  border-top: 1px solid var(--line);
+}
+
+.article__foot-note {
+  margin: 0 0 24px;
+  color: var(--fg-soft);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.article__back--foot {
+  margin-bottom: 0;
+}
+
+/* table of contents */
+.toc {
+  margin-top: clamp(28px, 4vw, 40px);
+  padding: 20px 24px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.toc__label {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.toc ol {
+  margin: 0;
+  padding-left: 1.4em;
+  color: var(--fg-muted);
+  font-size: 14.5px;
+  line-height: 1.5;
+}
+
+.toc li {
+  margin-bottom: 6px;
+}
+
+.toc li::marker {
+  color: var(--fg-soft);
+}
+
+.toc a {
+  color: var(--fg-muted);
+}
+
+.toc a:hover {
+  color: var(--ink-0);
+}
+
+/* FAQ accordion */
+.faq {
+  margin-top: clamp(40px, 6vw, 56px);
+  padding-top: clamp(24px, 3.5vw, 32px);
+  border-top: 1px solid var(--line);
+}
+
+.faq > h2 {
+  margin: 0 0 16px;
+  color: var(--ink-0);
+  font-size: clamp(20px, 3vw, 26px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.faq__item {
+  border-bottom: 1px solid var(--line);
+}
+
+.faq__item summary {
+  padding: 16px 28px 16px 0;
+  position: relative;
+  color: var(--ink-0);
+  font-size: 15.5px;
+  font-weight: 500;
+  list-style: none;
+  cursor: pointer;
+}
+
+.faq__item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq__item summary::after {
+  content: "+";
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 18px;
+}
+
+.faq__item[open] summary::after {
+  content: "−";
+}
+
+.faq__item p {
+  margin: 0;
+  padding: 0 0 18px;
+  color: var(--fg-muted);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+@media (max-width: 720px) {
+  .prose {
+    font-size: 15px;
+  }
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -158,8 +158,7 @@ button:focus-visible {
   background: var(--line-strong);
 }
 
-.nav-link,
-.release-chip {
+.nav-link {
   display: inline-flex;
   align-items: center;
   border-radius: 4px;
@@ -200,7 +199,6 @@ button:focus-visible {
   color: var(--ink-0);
 }
 
-.release-chip,
 .release-meta,
 .site-footer,
 .window-title,
@@ -214,12 +212,6 @@ button:focus-visible {
 .button__external {
   font-family: var(--font-mono);
   letter-spacing: var(--ls-mono);
-}
-
-.release-chip {
-  color: var(--fg-soft);
-  font-size: 11px;
-  letter-spacing: 0.04em;
 }
 
 .page-main {
@@ -737,10 +729,6 @@ html[data-language="zh"] .hero h1 {
 }
 
 @media (max-width: 420px) {
-  .release-chip {
-    display: none;
-  }
-
   .hero {
     padding-inline: 10px;
   }


### PR DESCRIPTION
## What

Adds a `/blog` section to the marketing site for SEO, with a long-form technical article on the Xiaohongshu (RedNote) automation tooling landscape, in both Chinese and English.

### Pages
- `/blog` — blog index. Lists posts; shows only the post matching the current site language (zh ↔ en toggle).
- `/blog/zh/xiaohongshu-automation-tools` — Chinese article.
- `/blog/xiaohongshu-automation-tools` — English article.
- Articles are plain Markdown (`.md`) rendered through a shared `BlogPost.astro` layout, so they're easy to hand-edit.

### Article
Reads the source of 7 representative open-source Xiaohongshu automation projects and compares them across: reverse-engineered API vs browser automation, signing & risk control (`x-s` / `xsec_token`), ban risk, and where socai fits. Includes a comparison table (with live star badges), a lineage diagram, and per-project breakdowns.

### SEO
- Keyword-oriented title/headings; per-article meta description.
- `BlogPosting` + `BreadcrumbList` JSON-LD; `hreflang` cross-links between zh/en.
- In-article table of contents (auto-built from headings).
- Sitemap entries; README link to the article.

### Site chrome
- Footer now has a site-wide `blog` / `博客` link.
- (Bundled) header/version-chip + footer download-link trim.

## Notes
- Brand stays lowercase `socai`; design stays monochrome (gray star badges, hairlines, no accent color).
- No redirects added for the earlier temporary slugs — they were never indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)