### PR TITLE
fix: approve pnpm desktop build scripts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "socai-app",
   "private": true,
   "version": "0.3.2",
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@11.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@google/genai': true
+  esbuild: true
+  protobufjs: true


### PR DESCRIPTION
## Summary
- pin the desktop app package manager to pnpm 11.9.0
- commit pnpm 11 `allowBuilds` approvals for the desktop dependencies that require install scripts
- fixes `pnpm dev:desktop` failing with `ERR_PNPM_IGNORED_BUILDS`

## Verification
- `cd app && pnpm install --frozen-lockfile`
