### PR TITLE
refactor(xhs): replace author_scan `read_notes` with `preview`

### DIFF
--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -55,7 +55,7 @@ without opening any note).
 
 ### Author / creator research
 
-Call `author_scan(author_id=..., num_notes=N, read_notes=true|false,
+Call `author_scan(author_id=..., num_notes=N, preview=true|false,
 download_media=...)` when the task asks about a specific author/creator and you
 have an `author_id`, can extract the trailing id from a profile URL, or a
 previous macro result surfaced an author id worth expanding.
@@ -63,10 +63,11 @@ previous macro result surfaced an author id worth expanding.
 If the user only gives a display name or handle, first discover candidates with
 a focused `search` or ask the user for the profile URL/author id.
 
-Use `read_notes=true` when you need the author's recent note bodies/comments;
-otherwise the profile header plus note cards may be enough. For author media
-downloads, `download_media=true` only matters when `read_notes=true`, because
-media is downloaded while reading notes.
+By default it opens each note for its body + top comments; pass `preview=true`
+for a fast cards-only pass when the profile header plus note cards are enough.
+For author media downloads, `download_media=true` only matters on a full scan
+(it is ignored with `preview=true`), because media is downloaded while reading
+notes.
 
 ### Note details
 

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -300,20 +300,24 @@ fn run_author_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) ->
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
-        // Default reads each note; --preview returns cards only.
+        // Default opens each note; --preview returns cards only.
         let preview = args
             .get("preview")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let download_media = args
-            .get("download_media")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        // download_media only applies when notes are opened. Drop it on preview
+        // runs so the run envelope doesn't advertise a `media_dir` for media that
+        // is never downloaded (mirrors `search`).
+        let download_media = !preview
+            && args
+                .get("download_media")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
         author_scan_command(
             page,
             &author_id,
             num_notes,
-            !preview,
+            preview,
             download_media,
             debug_snapshot,
         )
@@ -386,14 +390,14 @@ pub async fn author_scan_command(
     page: Arc<PageSession>,
     author_id: &str,
     num_notes: Option<i64>,
-    read_notes: bool,
+    preview: bool,
     download_media: bool,
     debug_snapshot: bool,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         AUTHOR_SCAN_COMMAND,
-        author_scan_input(author_id, num_notes, read_notes, download_media)?,
+        author_scan_input(author_id, num_notes, preview, download_media)?,
         debug_snapshot,
     )
     .await
@@ -427,7 +431,7 @@ fn search_input(
 fn author_scan_input(
     author_id: &str,
     num_notes: Option<i64>,
-    read_notes: bool,
+    preview: bool,
     download_media: bool,
 ) -> anyhow::Result<Value> {
     let mut input = json!({
@@ -436,8 +440,8 @@ fn author_scan_input(
     if let Some(n) = num_notes {
         input["num_notes"] = json!(n.max(1));
     }
-    if read_notes {
-        input["read_notes"] = json!(true);
+    if preview {
+        input["preview"] = json!(true);
     }
     if download_media {
         input["download_media"] = json!(true);
@@ -1605,13 +1609,15 @@ impl Tool for SearchTool {
     }
 }
 
-/// author_scan(author_id, num_notes?, read_notes?) -> author profile bundle
+/// author_scan(author_id, num_notes?, preview?, download_media?) -> author profile bundle
 ///
 /// Composite macro mirroring `search`, but entered from an author's profile
 /// page instead of a search query: open `…/user/profile/<id>` → read the author
 /// header (bio, xhs id, IP location, follower/following/like counts) → collect
-/// note summary cards in page order (scrolling to reach `num_notes`) → when
-/// `read_notes` is set, open each note and read its body + top comments.
+/// note summary cards in page order (scrolling to reach `num_notes`) → by
+/// default open each note and read its body + top comments. With `preview =
+/// true` it returns the note cards only, without opening any note — the fast
+/// cards-only path exposed on the CLI as `author --preview`.
 pub struct AuthorScanTool {
     page: Arc<PageSession>,
     history: Arc<XhsHistoryStore>,
@@ -1627,10 +1633,11 @@ impl Tool for AuthorScanTool {
         "Xiaohongshu author/creator scan: open an author's profile page by id → \
          read the author header (display name, xhs id, bio, IP location, \
          follower/following/liked-&-collected counts) → collect their note \
-         summary cards in page order (titles/likes/covers only; pass `num_notes` \
-         to scroll the grid for more, omit for just the first screen). Pass \
-         `read_notes=true` to also open each collected note and read its body \
-         + top comments (like `search`; latency scales with the card count). \
+         summary cards in page order (pass `num_notes` to scroll the grid for \
+         more, omit for just the first screen) → open each collected note and \
+         read its body + top comments (like `search`; latency scales with the \
+         card count). Pass `preview=true` for a fast cards-only pass that \
+         returns the note cards (titles/likes/covers) without opening any note. \
          Use this for creator research — it's like `search` but scoped to one \
          author instead of a query."
     }
@@ -1648,14 +1655,14 @@ impl Tool for AuthorScanTool {
                     "description": "Collect at least this many note cards, scrolling the profile grid (lazy-loaded). Omit for the first screen only.",
                     "minimum": 1
                 },
-                "read_notes": {
+                "preview": {
                     "type": "boolean",
-                    "description": "Open each collected note and read its body + top comments. Off by default (summaries only).",
+                    "description": "Fast cards-only mode: return the note cards (titles/likes/covers) without opening notes or reading bodies/comments. Off by default (full scan: each note opened for its body + top comments).",
                     "default": false
                 },
                 "download_media": {
                     "type": "boolean",
-                    "description": "When reading notes, download their images/videos into the run dir, include local_path fields, and emit a stable media_manifest_path.",
+                    "description": "Download each note's images/videos into the run dir, include local_path fields, and emit a stable media_manifest_path. Ignored in preview mode.",
                     "default": false
                 }
             },
@@ -1669,7 +1676,7 @@ impl Tool for AuthorScanTool {
             .filter(|id| !id.is_empty())
             .ok_or_else(|| anyhow::anyhow!("missing author_id"))?
             .to_string();
-        let read_notes = get_bool(&input, "read_notes", false);
+        let preview = get_bool(&input, "preview", false);
         let download_media = get_bool(&input, "download_media", false);
         let num_notes = input
             .get("num_notes")
@@ -1740,9 +1747,10 @@ impl Tool for AuthorScanTool {
             history_snapshot.annotate_cards(cards_value);
         }
 
-        // Optionally open each collected note and read body + top comments.
+        // By default open each collected note and read body + top comments;
+        // `preview` returns the cards only and skips this.
         let mut notes: Vec<Value> = Vec::new();
-        if read_notes {
+        if !preview {
             for card in &cards {
                 if !card.note_id.is_empty() {
                     ctx.add_search_note_ids(std::slice::from_ref(&card.note_id));
@@ -1789,8 +1797,8 @@ impl Tool for AuthorScanTool {
             "sampling": {
                 "num_notes": num_notes,
                 "collected": cards.len(),
-                "read_notes": read_notes,
-                "comments_per_note": if read_notes { TOP_COMMENTS_PER_NOTE } else { 0 },
+                "preview": preview,
+                "comments_per_note": if preview { 0 } else { TOP_COMMENTS_PER_NOTE },
                 "download_media": download_media,
             },
             "timing": { "media": media_timing },


### PR DESCRIPTION
## What

Deprecates the `read_notes` flag from `author_scan` and collapses it onto a single `preview` flag that mirrors `search`. `search` already used `preview`; this brings `author_scan` in line so both XHS macros expose one consistent knob.

| flag | behavior |
|---|---|
| `preview=false` (default) | full scan — open each note, read body + top comments |
| `preview=true` | cards only — titles/likes/covers, no notes opened |

## Why

`author_scan`'s `read_notes` was the **inverse polarity** of the `preview` flag `search` already used, and the CLI papered over it by translating `--preview` into `!preview` internally. That indirection hid a real inconsistency: the two entry points disagreed on the default.

| interface | old default |
|---|---|
| `search` (CLI + agent) | full scan |
| `author_scan` **CLI** | full scan |
| `author_scan` **agent tool** | cards only |

Removing the inversion makes `author_scan` structurally identical to `search` from CLI flag → dispatcher → `*_command` → `*_input` → tool schema → `call()` body — which is what the doc comment always claimed ("Composite macro mirroring `search`") but `read_notes` quietly violated.

## ⚠️ Behavior change

This **flips the agent-facing `author_scan` default from cards-only → full-scan**. An agent calling `author_scan(author_id=...)` with no flags now opens every collected note (higher latency/cost) and must pass `preview=true` for the old cheap behavior. The **CLI default is unchanged** (`socai xhs author <id>` already did a full scan) — this change actually *resolves* the latent CLI-vs-agent mismatch.

## Changes

- **`core/src/sites/xhs/tools.rs`**
  - `run_author_scan`: dropped the `!preview` inversion; `preview` flows straight through. Also drops `download_media` on preview runs (mirrors `search`) so the run envelope doesn't advertise a `media_dir` for media never fetched.
  - `author_scan_command` / `author_scan_input`: param renamed `read_notes` → `preview`; emitted JSON key is now `"preview"`.
  - `AuthorScanTool`: doc comment, `description()`, and `input_schema` updated; `read_notes` schema property replaced by `preview` (default `false`); `download_media` now documented as "Ignored in preview mode."
  - `call()` body: reads `preview`; note-opening loop runs `if !preview`; sampling output reports `"preview"` instead of `"read_notes"`.
- **`core/src/sites/xhs/knowledge.md`**: agent guidance now says `author_scan` opens notes by default and to pass `preview=true` for cards-only.

No CLI arg or README changes needed — both already exposed `author --preview`; this PR only removes the internal `read_notes` translation layer behind it.

## Output-contract note

`sampling.read_notes` in the result payload is renamed to `sampling.preview` (inverted value). Verified nothing downstream consumes it — Rust, the Tauri app, and the TUI all render off the presence of a `cards` array, not the sampling block.

## Verification

- `cargo check --workspace` — clean
- `cargo test -p socai-core sites::xhs` — 32 passed
- `grep` confirms zero `read_notes` / `readNotes` / `read-notes` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)