### PR TITLE
fix(xhs): gate author_scan download_media on !preview in tool call

### DIFF
--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1677,7 +1677,12 @@ impl Tool for AuthorScanTool {
             .ok_or_else(|| anyhow::anyhow!("missing author_id"))?
             .to_string();
         let preview = get_bool(&input, "preview", false);
-        let download_media = get_bool(&input, "download_media", false);
+        // download_media only applies when notes are opened, so gate it on a
+        // full scan. Without this, a `preview=true, download_media=true` call
+        // would still spin up the media pipeline and emit media metadata even
+        // though no note is opened (the schema documents it as ignored in
+        // preview, and the CLI dispatcher gates it the same way).
+        let download_media = !preview && get_bool(&input, "download_media", false);
         let num_notes = input
             .get("num_notes")
             .and_then(Value::as_i64)


### PR DESCRIPTION
## What

Follow-up to #150. Gates `download_media` on `!preview` inside `AuthorScanTool::call`, so a direct agent call with `preview=true, download_media=true` no longer spins up the media pipeline or emits media metadata when no notes are opened.

## Why

This addresses [Copilot's review comment on #150](https://github.com/socai-io/socai/pull/150#discussion_r3487377972), which landed **after** #150 was already squash-merged — so the fix never made it into `main`. The bug is currently live.

`AuthorScanTool::call` read `download_media` unconditionally, then branched on `if !preview`. Unlike `SearchTool::call` (whose preview path returns early before `download_media` is read), and unlike the CLI dispatcher `run_author_scan` (which already gates `download_media = !preview && …`), the agent-facing tool path left it ungated. That contradicted the schema, which documents `download_media` as "Ignored in preview mode."

## Change

```rust
let download_media = !preview && get_bool(&input, "download_media", false);
```

One line plus an explanatory comment. With this, preview-mode `author_scan` calls never initialize the media processor or write a media manifest, matching the schema, `search`, and the CLI.

## Verification

- `cargo check -p socai-core` — clean
- `cargo test -p socai-core sites::xhs` — 32 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)