### PR TITLE
refactor(xhs): slim search/author/preview output, fix date, point at artifact

### DIFF
--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -64,10 +64,6 @@ impl XhsAuthorProfile {
         map.insert("display_name".into(), json!(self.display_name));
         map.insert("title".into(), json!(self.display_name));
         map.insert("xhs_id".into(), json!(self.xhs_id));
-        map.insert(
-            "profile_url".into(),
-            json!(normalize_url(&self.profile_url)),
-        );
         map.insert("url".into(), json!(normalize_url(&self.profile_url)));
         map.insert("bio".into(), json!(self.bio));
         map.insert("ip_location".into(), json!(self.ip_location));

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -240,7 +240,9 @@ const SocaiXhsPageScripts = (() => {
           author_url: card.user?.userId ? `https://www.xiaohongshu.com/user/profile/${card.user.userId}` : '',
           likes: String(card.interactInfo?.likedCount || card.interactInfo?.likes || ''),
           cover_url: cleanImageUrl(card.cover?.urlDefault || card.cover?.urlPre || ''),
-          type: card.type || '',
+          // XHS's raw type is "normal" for image/text notes; map it to "image"
+          // so cards share the note vocabulary ("image"/"video").
+          type: card.type === 'normal' ? 'image' : (card.type || ''),
           position: i,
           xsec_token: token,
           link: id && token
@@ -527,6 +529,43 @@ const SocaiXhsPageScripts = (() => {
     // here are almost always media overlay or layout noise.
     if (lines.length > 1 || cleaned.length > 40) return '';
     return cleaned;
+  }
+
+  // Normalize a Xiaohongshu `.date` label into a stable form. XHS renders the
+  // publish date several ways: absolute ("2024-03-28", "03-28", often prefixed
+  // "编辑于" and/or suffixed with a location like "北京"), or relative for recent
+  // posts ("刚刚", "5分钟前", "11小时前", "今天 13:31", "昨天 13:31", "前天",
+  // "5天前"). The previous extractor only matched the absolute forms, so any
+  // relative date came back empty. Resolve relative dates against now so the
+  // field is comparable downstream; fall back to the trimmed raw text rather
+  // than emptying the field on anything unrecognized.
+  function normalizeXhsDate(value) {
+    const t = norm(value);
+    if (!t) return '';
+    // Absolute token wins (scoped to the short `.date` text, so this can't grab
+    // a "13-15" fragment from the note body). Pass it through unchanged.
+    const abs = t.match(/\d{4}-\d{1,2}-\d{1,2}|\d{1,2}-\d{1,2}/);
+    if (abs) return abs[0];
+    const now = new Date();
+    const fmt = (d) => {
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      // Mirror XHS's own convention: year only when it isn't the current year.
+      return d.getFullYear() === now.getFullYear()
+        ? `${mm}-${dd}`
+        : `${d.getFullYear()}-${mm}-${dd}`;
+    };
+    const daysAgo = (n) => {
+      const d = new Date(now);
+      d.setDate(d.getDate() - n);
+      return d;
+    };
+    if (/刚刚|今天|^\d+\s*(?:秒|分钟|小时)前/.test(t)) return fmt(now);
+    if (/昨天/.test(t)) return fmt(daysAgo(1));
+    if (/前天/.test(t)) return fmt(daysAgo(2));
+    const dm = t.match(/^(\d+)\s*天前/);
+    if (dm) return fmt(daysAgo(parseInt(dm[1], 10)));
+    return t;
   }
 
   function unwrapStateValue(value) {
@@ -825,7 +864,7 @@ const SocaiXhsPageScripts = (() => {
       root,
       { excludeComments: true },
     );
-    const date = (dateText.match(/\d{4}-\d{1,2}-\d{1,2}|\d{1,2}-\d{1,2}/) || [''])[0];
+    const date = normalizeXhsDate(dateText);
     const locationText = cleanLocationText(
       firstVisibleText(['.location, .poi, [class*="location"], [class*="poi"]'], root, { excludeComments: true })
     );

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -746,6 +746,11 @@ fn lean_scan_payload(payload: &mut Value) {
     obj.remove("search");
     obj.remove("sampling");
     obj.remove("timing");
+    // `ok: true` is pure noise — a successful bundle is self-evident from its
+    // notes. Keep `ok: false` (with its `reason`): there it's the failure signal.
+    if obj.get("ok").and_then(Value::as_bool) == Some(true) {
+        obj.remove("ok");
+    }
     let notes_read = obj
         .get("notes")
         .and_then(Value::as_array)
@@ -765,21 +770,46 @@ fn lean_scan_payload(payload: &mut Value) {
     }
 }
 
-/// Trim one scanned-note entry to the lean shape: drop the body-source marker
-/// (`content_source`) and the per-extract wait diagnostics (`wait`,
-/// `top_comments_wait`), and collapse `top_comments` to a plain array of comment
-/// texts. Applies to both freshly-read and reused (cached) entities; the full
-/// objects stay in the run artifact.
+/// Per-note entity fields kept in the lean output handed to the LLM: the basic
+/// human-readable post (title/author/content/date), the engagement counts, the
+/// comment texts, and the two locators (`note_id`, `url`). Everything else —
+/// hashtags, images, image_count, author ids/urls, location, type, video,
+/// content_source, and the wait diagnostics — stays only in the run artifact,
+/// which the LLM can re-read by `note_id` when it needs the dropped detail.
+const LEAN_NOTE_FIELDS: &[&str] = &[
+    "note_id",
+    "url",
+    "title",
+    "author",
+    "content",
+    "date",
+    "likes",
+    "favorites",
+    "comments_count",
+    "top_comments",
+];
+
+/// Trim one scanned-note entry to the lean shape: drop the per-entry provenance
+/// wrappers (`source_position`, `ok`, `skipped`, plus failure detail), collapse
+/// `top_comments` to a plain array of comment texts, and whitelist the entity to
+/// [`LEAN_NOTE_FIELDS`]. Applies to both freshly-read and reused (cached)
+/// entities; the full objects stay in the run artifact.
 fn lean_scan_note(note: &mut Value) {
     let Some(entry) = note.as_object_mut() else {
         return;
     };
+    // The entity is the only thing handed back; the provenance wrappers around
+    // it (history dedup status, source ordinal, read status) are diagnostics.
+    entry.remove("source_position");
+    entry.remove("ok");
+    entry.remove("skipped");
+    entry.remove("error");
+    entry.remove("open");
     let Some(entity) = entry.get_mut("entity").and_then(Value::as_object_mut) else {
         return;
     };
-    entity.remove("content_source");
-    entity.remove("wait");
-    entity.remove("top_comments_wait");
+    // Collapse comment objects to their text before the whitelist runs (the
+    // whitelist keeps `top_comments`, but we want the plain-string form).
     if let Some(comments) = entity.get_mut("top_comments").and_then(Value::as_array_mut) {
         let texts: Vec<Value> = comments
             .iter()
@@ -787,6 +817,87 @@ fn lean_scan_note(note: &mut Value) {
             .filter(|text| text.as_str().is_some_and(|s| !s.is_empty()))
             .collect();
         entity.insert("top_comments".into(), Value::Array(texts));
+    }
+    entity.retain(|key, _| LEAN_NOTE_FIELDS.contains(&key.as_str()));
+}
+
+/// Per-note properties that live only in the full scan artifact (dropped from
+/// the lean notes by [`lean_scan_note`]). Surfaced in the artifact pointer so
+/// the LLM knows what a `note_id` lookup can recover.
+const ARTIFACT_EXTRA_NOTE_PROPERTIES: &[&str] = &[
+    "hashtags",
+    "images (index, url)",
+    "image_count",
+    "video",
+    "type",
+    "author_id",
+    "author_url",
+    "location",
+    "content_source",
+    "top_comments (full objects: text, author, likes, time)",
+];
+
+/// Per-card properties that live only in the `search --preview` artifact
+/// (dropped from the lean cards by [`lean_preview_cards`]).
+const ARTIFACT_EXTRA_PREVIEW_CARD_PROPERTIES: &[&str] = &[
+    "author_id",
+    "author_url",
+    "cover_url",
+    "xsec_token",
+    "position",
+    "already_analyzed",
+    "history_level",
+    "history_include_media",
+];
+
+/// Append a pointer to the full run artifact so the LLM knows the lean output is
+/// abridged and can re-read the artifact (keyed by each note's `note_id`) for
+/// the dropped detail. `extra_properties` lists what the artifact carries beyond
+/// the lean fields, so the LLM can decide whether a lookup is worth it without
+/// opening the file blind.
+fn attach_artifact_pointer(
+    payload: &mut Value,
+    artifact_path: Option<String>,
+    extra_properties: &[&str],
+) {
+    let Some(path) = artifact_path else {
+        return;
+    };
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert(
+        "artifact".into(),
+        json!({
+            "path": path,
+            "note": "Full untrimmed results. Look up a note by note_id for the fields trimmed below.",
+            "extra_note_properties": extra_properties,
+        }),
+    );
+}
+
+/// Per-card fields kept in the lean `search --preview` output. Card-only mode
+/// can't fill the body fields (content/date/comments), so it keeps the subset
+/// that overlaps the full-scan note shape — note_id, url, title, author, likes —
+/// plus `type` (image/video). The card's note link is exposed as `url` to match
+/// the note shape (the raw card calls it `link`).
+const LEAN_PREVIEW_CARD_FIELDS: &[&str] = &["note_id", "url", "title", "author", "likes", "type"];
+
+/// Trim each `search --preview` card to [`LEAN_PREVIEW_CARD_FIELDS`], renaming
+/// `link` → `url` for parity with the full-scan note shape. The full cards stay
+/// in the run artifact.
+fn lean_preview_cards(payload: &mut Value) {
+    let Some(cards) = payload.get_mut("cards").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for card in cards.iter_mut() {
+        let Some(obj) = card.as_object_mut() else {
+            continue;
+        };
+        if let Some(link) = obj.remove("link") {
+            obj.insert("url".into(), link);
+        }
+        obj.retain(|key, _| LEAN_PREVIEW_CARD_FIELDS.contains(&key.as_str()));
     }
 }
 
@@ -1379,14 +1490,45 @@ impl Tool for SearchTool {
             if let Some(cards) = value.get_mut("cards") {
                 self.history.annotate_cards(cards);
             }
-            // `submit` is the search-submission diagnostic (strategy + page-state
-            // echo). Keep it only when the search failed (where it explains why)
-            // and drop it on success.
             let failed = value.get("ok").and_then(Value::as_bool) == Some(false);
+            // On success, persist the full card bundle as an artifact (same as
+            // the full scan) so the trimmed return can point back at it. A failed
+            // preview has no cards worth keeping — its `submit`/`reason` are the
+            // only useful detail — so it isn't persisted or trimmed.
             if !failed {
+                let artifact_path = ctx
+                    .write_json_artifact(
+                        &format!("xhs_search_preview_{}", sanitize_for_filename(&query)),
+                        &value,
+                        "artifacts",
+                        "search",
+                        "json",
+                        &format!(
+                            "Search preview: {query} ({} cards)",
+                            value
+                                .get("cards")
+                                .and_then(Value::as_array)
+                                .map(Vec::len)
+                                .unwrap_or(0)
+                        ),
+                        json!({"site": "xhs", "category": "search_preview"}),
+                    )
+                    .ok()
+                    .map(|rel| ctx.run_dir.join(rel).to_string_lossy().into_owned());
                 if let Some(obj) = value.as_object_mut() {
+                    // `submit` is the search-submission diagnostic (strategy +
+                    // page-state echo), `reason` is empty on success, and `ok`
+                    // is self-evident — drop them to match the full-scan output.
                     obj.remove("submit");
+                    obj.remove("reason");
+                    obj.remove("ok");
                 }
+                lean_preview_cards(&mut value);
+                attach_artifact_pointer(
+                    &mut value,
+                    artifact_path,
+                    ARTIFACT_EXTRA_PREVIEW_CARD_PROPERTIES,
+                );
             }
             return Ok(json_result(&value));
         }
@@ -1581,26 +1723,32 @@ impl Tool for SearchTool {
         }
 
         // Persist as artifact so it shows up in the run dir + working memory.
-        let _ = ctx.write_json_artifact(
-            &format!("xhs_search_{}", sanitize_for_filename(&query)),
-            &payload,
-            "artifacts",
-            "search",
-            "json",
-            &format!(
-                "Search: {query} ({} notes)",
-                payload
-                    .get("notes")
-                    .and_then(Value::as_array)
-                    .map(Vec::len)
-                    .unwrap_or(0)
-            ),
-            json!({"site": "xhs", "category": "search"}),
-        );
+        // `write_json_artifact` returns the run-dir-relative path; the pointer we
+        // hand the LLM uses the absolute path so it's directly openable.
+        let artifact_path = ctx
+            .write_json_artifact(
+                &format!("xhs_search_{}", sanitize_for_filename(&query)),
+                &payload,
+                "artifacts",
+                "search",
+                "json",
+                &format!(
+                    "Search: {query} ({} notes)",
+                    payload
+                        .get("notes")
+                        .and_then(Value::as_array)
+                        .map(Vec::len)
+                        .unwrap_or(0)
+                ),
+                json!({"site": "xhs", "category": "search"}),
+            )
+            .ok()
+            .map(|rel| ctx.run_dir.join(rel).to_string_lossy().into_owned());
 
         // Artifact above keeps the full bundle; trim what we return so the
-        // agent/CLI output stays small.
+        // agent/CLI output stays small, then point at the artifact for the rest.
         lean_scan_payload(&mut payload);
+        attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
         Ok(json_result(&payload))
     }
 }
@@ -1814,19 +1962,23 @@ impl Tool for AuthorScanTool {
         } else {
             display_name
         };
-        let _ = ctx.write_json_artifact(
-            &format!("xhs_author_scan_{}", sanitize_for_filename(&author_id)),
-            &payload,
-            "artifacts",
-            "author_scan",
-            "json",
-            &format!("Author scan: {label} ({} notes)", cards.len()),
-            json!({"site": "xhs", "category": "author_scan"}),
-        );
+        let artifact_path = ctx
+            .write_json_artifact(
+                &format!("xhs_author_scan_{}", sanitize_for_filename(&author_id)),
+                &payload,
+                "artifacts",
+                "author_scan",
+                "json",
+                &format!("Author scan: {label} ({} notes)", cards.len()),
+                json!({"site": "xhs", "category": "author_scan"}),
+            )
+            .ok()
+            .map(|rel| ctx.run_dir.join(rel).to_string_lossy().into_owned());
 
         // Artifact above keeps the full bundle; trim what we return so the
-        // agent/CLI output stays small.
+        // agent/CLI output stays small, then point at the artifact for the rest.
         lean_scan_payload(&mut payload);
+        attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
         Ok(json_result(&payload))
     }
 }


### PR DESCRIPTION
## Why

The `search` / `author_scan` / `search --preview` JSON handed to the agent/CLI still carried more than an LLM needs to read at a glance, eating context. This trims the returned shape to the basics and points back at the full run artifact for on-demand detail. The artifact remains the complete, untrimmed bundle.

## What changed

**Lean per-note output (search + author_scan, same code path → CLI, desktop, TUI all benefit)**
- Whitelist each note entity to the basic readable post — `title`, `author`, `content`, `date`, `likes`, `favorites`, `comments_count`, `top_comments` — plus the two locators `note_id` + `url`.
- Drop `hashtags`, `images`, `image_count`, `author_id`, `author_url`, `location`, `type`, `video`, `content_source`, wait diagnostics.
- Drop the per-entry `source_position` / `ok` / `skipped` wrappers (keep the `entity` wrapper).
- Drop top-level `ok: true` (kept as `ok: false` + `reason` on failure).
- Append an `artifact` block: **absolute path** + a list of the per-note properties that only live in the artifact, so the LLM can re-read it keyed by `note_id`.

**`search --preview` (mode A)**
- Now persists the full card bundle as an artifact on success (previously wrote none), then trims each card to `{note_id, url, title, author, likes, type}`, renames `link` → `url`, and drops `ok`/`reason`/`submit` noise. Failed previews are unchanged.

**Naming / consistency**
- author profile emitted `profile_url` and `url` as byte-identical duplicates → drop `profile_url`, keep `url`.
- Normalize search-card `type` `"normal"` → `"image"` so cards share the note vocabulary (`"image"`/`"video"`).

**Date fix**
- The `.date` extractor only matched absolute `YYYY-MM-DD` / `MM-DD`, so XHS relative labels (`5天前`, `昨天 13:31`, `刚刚`, …) came back empty. Now resolved against the scrape time (year shown only when not the current year, mirroring XHS), with raw-text fallback so the field is never silently empty.

## Size impact (captured `北京咖啡厅` samples, 10 notes)
- `search`: 59,950 → 19,197 bytes (≈32%)
- `search --preview`: 8,957 → 4,545 bytes (≈51%)

---

## Sample: `search` per-note entry (real capture, untruncated)

**Before** — one returned `notes[]` entry:

```json
{
  "entity": {
    "author": "Sitara.星迴",
    "author_id": "607fc36e0000000001007666",
    "author_url": "https://www.xiaohongshu.com/user/profile/607fc36e0000000001007666?channel_type=web_search_result_notes&xsec_token=AB-afJp70_HAuMJG7lVI8hLNhw510XV2PLwepXkQ2RNcQ%3D&xsec_source=pc_note",
    "comments_count": "39",
    "content": "一时感觉在上海\n一时感觉在成都\n转念一想\n确实还是在北京\n三里屯的院中院真的很宝藏\n树影光斑🍃\n感谢这个不冷不热 清风徐徐的季节\n迷迷糊糊的时候必须还是喝冰美式☕️最到位\n选了洪都拉斯雪莉🫘一点点威士忌的香气\n太好喝了\n\n#这才是周末该有的样子 #北京咖啡店 #我的咖啡日记 #我是美食活地图",
    "date": "06-14",
    "favorites": "182",
    "hashtags": [
      "#这才是周末该有的样子",
      "#北京咖啡店",
      "#我的咖啡日记",
      "#我是美食活地图"
    ],
    "image_count": 8,
    "images": [
      {
        "index": 0,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/6f6ad8f5e861e94fa715cde23ca3b51d/1040g008321d5h7huno005o3vodn08tj6arbmcg8!nd_dft_wlteh_webp_3"
      },
      {
        "index": 1,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/db5c93d47c60b02d11db2355106ac92f/notes_uhdr/1040g3qg321d5och1nu0g5o3vodn08tj6kofj0v8!nd_dft_wlteh_webp_3"
      },
      {
        "index": 2,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/0c10b362c54d5179aa5967f717d61d41/notes_uhdr/1040g3qg321d5och1nu105o3vodn08tj62h85vag!nd_dft_wlteh_webp_3"
      },
      {
        "index": 3,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/2ea63fe527ae77e730e06879195fd9af/notes_uhdr/1040g3qg321d5och1nu1g5o3vodn08tj67a1aen0!nd_dft_wlteh_webp_3"
      },
      {
        "index": 4,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/ef532276a7409ed2f9377b4a5daf13fd/1040g008321d5h7huno0g5o3vodn08tj65fdc590!nd_dft_wlteh_webp_3"
      },
      {
        "index": 5,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/03a5544b314131abc100949ff15d0fe1/1040g008321d5h7huno105o3vodn08tj6avq2ip0!nd_dft_wlteh_webp_3"
      },
      {
        "index": 6,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/940a14fcda0b2b5761dec23727e55ffe/notes_uhdr/1040g3qg321d5och1nu305o3vodn08tj6egpf7qo!nd_dft_wlteh_webp_3"
      },
      {
        "index": 7,
        "url": "https://sns-webpic-qc.xhscdn.com/202606231707/7a984ae082a92effa322b0130a4601f6/notes_uhdr/1040g3qg321d5och1nu3g5o3vodn08tj635m5v3o!nd_dft_wlteh_webp_3"
      }
    ],
    "likes": "177",
    "location": "",
    "note_id": "6a2e93b4000000001702d032",
    "title": "今天的北京咖啡店啊，chill到让我恍惚了…",
    "top_comments": [
      "这家店很多年前我记得在那里花园一楼",
      "国贸那块的致璞也很不错，可以去试试",
      "图二是哪儿呀？",
      "北京现在是不是很热了呀亲",
      "我也以为是上海",
      "保住Baristar",
      "好看",
      "店名？去溜达过呀 没见到",
      "太好看了😍",
      "确实哦"
    ],
    "type": "image",
    "url": "https://www.xiaohongshu.com/explore/6a2e93b4000000001702d032?xsec_token=AB3s5XaYo5crE3GTOg-7kWnJ3Y9UGE37SVlq6p4xyADuQ=&xsec_source=pc_search&source=web_explore_feed",
    "video": {}
  },
  "skipped": {
    "analysis_count": 1,
    "first_seen_at": "2026-06-23T09:07:46.314590+00:00",
    "last_seen_at": "2026-06-23T09:07:46.314590+00:00",
    "level": "deep",
    "reason": "already_analyzed"
  },
  "source_position": 3
}
```

**After** — same entry:

```json
{
  "entity": {
    "author": "Sitara.星迴",
    "comments_count": "39",
    "content": "一时感觉在上海\n一时感觉在成都\n转念一想\n确实还是在北京\n三里屯的院中院真的很宝藏\n树影光斑🍃\n感谢这个不冷不热 清风徐徐的季节\n迷迷糊糊的时候必须还是喝冰美式☕️最到位\n选了洪都拉斯雪莉🫘一点点威士忌的香气\n太好喝了\n\n#这才是周末该有的样子 #北京咖啡店 #我的咖啡日记 #我是美食活地图",
    "date": "06-14",
    "favorites": "182",
    "likes": "177",
    "note_id": "6a2e93b4000000001702d032",
    "title": "今天的北京咖啡店啊，chill到让我恍惚了…",
    "top_comments": [
      "这家店很多年前我记得在那里花园一楼",
      "国贸那块的致璞也很不错，可以去试试",
      "图二是哪儿呀？",
      "北京现在是不是很热了呀亲",
      "我也以为是上海",
      "保住Baristar",
      "好看",
      "店名？去溜达过呀 没见到",
      "太好看了😍",
      "确实哦"
    ],
    "url": "https://www.xiaohongshu.com/explore/6a2e93b4000000001702d032?xsec_token=AB3s5XaYo5crE3GTOg-7kWnJ3Y9UGE37SVlq6p4xyADuQ=&xsec_source=pc_search&source=web_explore_feed"
  }
}
```

Plus, once per bundle, the pointer at the full artifact:

```json
"artifact": {
  "path": "/Users/tonychong/.socai/runs/20260628_111200_xhs_search_北京咖啡厅/artifacts/001_xhs_search_北京咖啡厅.json",
  "note": "Full untrimmed results. Look up a note by note_id for the fields trimmed below.",
  "extra_note_properties": [
    "hashtags", "images (index, url)", "image_count", "video", "type",
    "author_id", "author_url", "location", "content_source",
    "top_comments (full objects: text, author, likes, time)"
  ]
}
```

---

## Sample: `search --preview` (real capture, one card shown)

> Before and after are separate runs, so volatile fields (`xsec_token` in the url, like counts) differ — compare the shape, not the values.

**Before** — top-level + one `cards[]` entry:

```json
{
  "cards": [
    {
      "already_analyzed": true,
      "author": "花椒汽水",
      "author_id": "6530de85000000002b0001a0",
      "author_url": "https://www.xiaohongshu.com/user/profile/6530de85000000002b0001a0",
      "cover_url": "https://sns-webpic-qc.xhscdn.com/202606231622/c12d4404cb974675569c593f65dc193b/note_pre_post_uhdr/1040g3r03203kqlddia305p9grq2qo0d0ag0jm88!nc_n_webp_mw_1",
      "history_include_media": false,
      "history_level": "deep",
      "likes": "2224",
      "link": "https://www.xiaohongshu.com/explore/6a040da100000000080323c8?xsec_token=AB4cMjmRK3OMIgO2Cxk0l7K0zNud6OW1t5odvqkNxiUnY%3D&xsec_source=pc_search",
      "note_id": "6a040da100000000080323c8",
      "position": 3,
      "title": "北京18个适合🍃一个人呆一整天的地儿（合集",
      "type": "normal",
      "xsec_token": "AB4cMjmRK3OMIgO2Cxk0l7K0zNud6OW1t5odvqkNxiUnY="
    }
  ],
  "count": 10,
  "filters": {},
  "ok": true,
  "query": "北京咖啡厅",
  "reason": "",
  "url": "https://www.xiaohongshu.com/search_result_ai?keyword=%25E5%258C%2597%25E4%25BA%25AC%25E5%2592%2596%25E5%2595%25A1%25E5%258E%2585&source=web_explore_feed"
}
```

**After** — top-level + same card (note `type: normal → image`, `link → url`, new `artifact` block):

```json
{
  "artifact": {
    "path": "/Users/tonychong/.socai/runs/20260628_130704_xhs_search_北京咖啡厅/artifacts/001_xhs_search_preview_北京咖啡厅.json",
    "note": "Full untrimmed results. Look up a note by note_id for the fields trimmed below.",
    "extra_note_properties": [
      "author_id",
      "author_url",
      "cover_url",
      "xsec_token",
      "position",
      "already_analyzed",
      "history_level",
      "history_include_media"
    ]
  },
  "cards": [
    {
      "author": "花椒汽水",
      "likes": "2280",
      "note_id": "6a040da100000000080323c8",
      "title": "北京18个适合🍃一个人呆一整天的地儿（合集",
      "type": "image",
      "url": "https://www.xiaohongshu.com/explore/6a040da100000000080323c8?xsec_token=AB4cMjmRK3OMIgO2Cxk0l7K9R0CTSzFW6B6LkSjlAu8Hw%3D&xsec_source=pc_search"
    }
  ],
  "count": 10,
  "filters": {},
  "query": "北京咖啡厅",
  "run": {
    "dir": "/Users/tonychong/.socai/runs/20260628_130704_xhs_search_北京咖啡厅",
    "id": "20260628_130704_xhs_search_北京咖啡厅"
  },
  "url": "https://www.xiaohongshu.com/search_result?keyword=%25E5%258C%2597%25E4%25BA%25AC%25E5%2592%2596%25E5%2595%25A1%25E5%258E%2585&source=web_user_page"
}
```

---

## Testing
- `cargo test -p socai-core --lib sites::xhs` — 32 passed.
- JS extractor `node --check` passes; date normalization spot-checked across absolute / relative / cross-year / unrecognized / empty inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
