### PR TITLE
feat(xhs): always download media in the app/TUI agent interface

### DIFF
--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -82,10 +82,12 @@ pub fn xhs_tools_with_llm_provider(
             page: page.clone(),
             llm_provider,
             history: history.clone(),
+            always_download_media: false,
         }),
         Arc::new(AuthorScanTool {
             page: page.clone(),
             history,
+            always_download_media: false,
         }),
         Arc::new(PageStateTool { page }),
     ]
@@ -96,13 +98,21 @@ pub fn xhs_macro_tools_with_llm_provider(
     llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
+    // The app/TUI agent interface always downloads note media so the offline
+    // files are on hand for deeper analysis; the CLI keeps its --download-media
+    // opt-in via the full tool set above.
     vec![
         Arc::new(SearchTool {
             page: page.clone(),
             llm_provider,
             history: history.clone(),
+            always_download_media: true,
         }) as Arc<dyn Tool>,
-        Arc::new(AuthorScanTool { page, history }),
+        Arc::new(AuthorScanTool {
+            page,
+            history,
+            always_download_media: true,
+        }),
     ]
 }
 
@@ -1420,6 +1430,9 @@ pub struct SearchTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
+    /// Force media download regardless of the `download_media` input. Set by the
+    /// app/TUI macro factory; the CLI/full set leaves the input in control.
+    always_download_media: bool,
 }
 
 #[async_trait]
@@ -1542,7 +1555,7 @@ impl Tool for SearchTool {
         // and pull top comments. Per-note image vision is off (it's the one
         // genuinely expensive enrichment and not needed for topic research).
         let include_media = false;
-        let download_media = get_bool(&input, "download_media", false);
+        let download_media = self.always_download_media || get_bool(&input, "download_media", false);
 
         let media = media_for(
             ctx,
@@ -1769,6 +1782,9 @@ impl Tool for SearchTool {
 pub struct AuthorScanTool {
     page: Arc<PageSession>,
     history: Arc<XhsHistoryStore>,
+    /// Force media download regardless of the `download_media` input. Set by the
+    /// app/TUI macro factory; the CLI/full set leaves the input in control.
+    always_download_media: bool,
 }
 
 #[async_trait]
@@ -1830,7 +1846,8 @@ impl Tool for AuthorScanTool {
         // would still spin up the media pipeline and emit media metadata even
         // though no note is opened (the schema documents it as ignored in
         // preview, and the CLI dispatcher gates it the same way).
-        let download_media = !preview && get_bool(&input, "download_media", false);
+        let download_media =
+            !preview && (self.always_download_media || get_bool(&input, "download_media", false));
         let num_notes = input
             .get("num_notes")
             .and_then(Value::as_i64)


### PR DESCRIPTION
## What

The desktop app and TUI agents drive the macro `search` / `author_scan` tools. This makes those tools **always download note media (images + video)** into the run dir, so the offline files are on hand for deeper task analysis — the agent no longer has to decide.

## How

- Added a private `always_download_media: bool` to `SearchTool` and `AuthorScanTool`.
- `xhs_macro_tools_with_llm_provider` (the app/TUI agent surface, via `default_agent_tools`) builds both tools with `always_download_media: true`.
- `xhs_tools_with_llm_provider` (the full set behind the CLI commands) leaves it `false`.
- Each tool's `call()` ORs it in: `self.always_download_media || get_bool(&input, "download_media", false)`. `author_scan` keeps its existing `!preview` gate (no media on a cards-only scan).

## Scope / what's unchanged

- **CLI keeps its explicit opt-in** — `socai xhs search --download-media` still flows through the full tool set, which honors the per-call input.
- **Agent-facing surface untouched** — no changes to the tool JSON schema, descriptions, or the `knowledge.md` playbook. The agent doesn't need to know; the forced flag simply wins.

## Reviewer notes

- One file, +20/−3.
- Applies to both the desktop app and the terminal TUI, since they share the macro-tool factory through `SiteSpec.default_agent_tools`.
- For `author_scan`, media is captured only on a full scan (notes opened); `preview=true` still returns cards only with no media, matching existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)