### PR TITLE
feat(app): redesign shell as sidebar + workspace (Socai Today)

### DIFF
--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -46,7 +46,11 @@ const messages = {
 
   "status.capsuleAria": { en: "chrome and agent status", zh: "chrome 与智能体状态" },
 
+  "sidebar.collapseAria": { en: "collapse sidebar", zh: "收起侧边栏" },
+  "sidebar.expandAria": { en: "expand sidebar", zh: "展开侧边栏" },
+
   "update.restartToUpdate": { en: "restart to update", zh: "重启更新" },
+  "update.chip": { en: "update", zh: "更新" },
   "update.taskRunningWarn": {
     en: "a task is running — restarting will interrupt it.",
     zh: "有任务正在运行 — 重启会中断它。",
@@ -107,24 +111,19 @@ const messages = {
     zh: "还没有检测到 codex 登录。登录完成后返回 socai。",
   },
 
-  "task.pagesAria": { en: "task pages", zh: "任务页面" },
   "task.new": { en: "new task", zh: "新任务" },
   "task.history": { en: "history", zh: "历史" },
-  "task.historyTitle": { en: "task history", zh: "任务历史" },
-  "task.historyDescription": {
-    en: "review completed, failed, interrupted, and running tasks.",
-    zh: "查看已完成、失败、中断和运行中的任务。",
-  },
   "task.historyAria": { en: "task history", zh: "任务历史" },
   "task.selected": { en: "selected task", zh: "已选任务" },
   "task.selectedAria": { en: "selected task", zh: "已选任务" },
   "task.noTasks": { en: "no tasks yet.", zh: "暂无任务。" },
   "task.cancel": { en: "cancel", zh: "取消" },
   "task.finalAnswer": { en: "final answer", zh: "最终答案" },
+  "task.timeline": { en: "timeline", zh: "时间线" },
+  "task.errorLabel": { en: "error", zh: "错误" },
   "task.waitingForEvents": { en: "waiting for events…", zh: "等待事件…" },
   "task.noTimeline": { en: "no event timeline available.", zh: "暂无事件时间线。" },
   "task.emptyDetail": { en: "start a task or choose one from history.", zh: "启动一个任务或从历史中选择。" },
-  "task.run": { en: "run", zh: "运行" },
 
   "task.hero": { en: "what should socai research?", zh: "想让 socai 研究什么？" },
   "task.lede": {
@@ -138,9 +137,6 @@ const messages = {
     en: "tell socai what you want researched…\neach task opens its own temporary chrome tab.",
     zh: "告诉 socai 你想研究什么…\n每个任务都会打开自己的临时 chrome 标签页。",
   },
-  "task.recent": { en: "recent", zh: "最近" },
-  "task.viewHistory": { en: "view history", zh: "查看历史" },
-  "task.noRecent": { en: "no recent tasks yet.", zh: "暂无最近任务。" },
   "task.today": { en: "today", zh: "今天" },
   "task.yesterday": { en: "yesterday", zh: "昨天" },
 } as const satisfies Record<string, Record<Language, string>>;
@@ -224,11 +220,6 @@ export function formatTabs(count: number): string {
 export function formatTaskCount(count: number): string {
   if (currentLanguage === "zh") return `${count} 个任务`;
   return `${count} task${count === 1 ? "" : "s"}`;
-}
-
-export function formatRunningTaskCount(count: number): string {
-  if (currentLanguage === "zh") return `${count} 个任务运行中`;
-  return `${count} task${count === 1 ? "" : "s"} running`;
 }
 
 export function formatTurns(count: number): string {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -112,18 +112,19 @@ export interface ShellState {
   rerender: () => void;
 }
 
-interface PanelModule {
-  label: string;
-  render: (shell: ShellState) => string;
-  bind: (shell: ShellState) => void;
-}
-
-const PANELS: PanelModule[] = [
-  { label: "tasks", render: agentPanel.render, bind: agentPanel.bind },
-];
-
 let status: Status = { state: "disconnected", reason: "starting" };
 let connectionDetailsOpen = false;
+// The sidebar (task history rail) starts expanded; the topbar toggle collapses it.
+let sidebarOpen = true;
+
+// Sidebar-collapse toggle glyph (mirrors the prototype's PanelIcon). On macOS
+// the native traffic lights sit to its left; the .topbar-left gutter clears them.
+const PANEL_ICON_SVG = `
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect x="3" y="4.5" width="18" height="15" rx="2.5"></rect>
+    <line x1="9.5" y1="4.5" x2="9.5" y2="19.5"></line>
+  </svg>
+`;
 
 function shell(): ShellState {
   return { status, rerender: render };
@@ -133,19 +134,20 @@ function render(): void {
   const root = document.getElementById("app");
   if (!root) return;
   const state = shell();
-  const sections = PANELS
-    .map(
-      (p) => `
-      <section class="section">
-        ${p.render(state)}
-      </section>`,
-    )
-    .join("");
   root.innerHTML = `
     <div class="shell">
       <header class="topbar" data-tauri-drag-region>
-        <div class="topbar-controls">
+        <div class="topbar-left ${sidebarOpen ? "topbar-left--bordered" : ""}">
+          <button
+            id="sidebar-toggle"
+            type="button"
+            class="icon-button"
+            aria-label="${htmlEsc(t(sidebarOpen ? "sidebar.collapseAria" : "sidebar.expandAria"))}"
+            aria-expanded="${sidebarOpen ? "true" : "false"}"
+          >${PANEL_ICON_SVG}</button>
           ${renderUpdateChip()}
+        </div>
+        <div class="topbar-controls">
           <div class="status-capsule" role="group" aria-label="${htmlEsc(t("status.capsuleAria"))}">
             ${connectionStatusBar()}
             <span class="status-capsule__divider" aria-hidden="true"></span>
@@ -154,14 +156,25 @@ function render(): void {
           ${settingsMenu.render(state)}
         </div>
       </header>
-      <main class="stack">${sections}</main>
+      <div class="body">
+        ${sidebarOpen ? agentPanel.renderSidebar() : ""}
+        <main class="workspace-main">${agentPanel.renderWorkspace(state)}</main>
+      </div>
     </div>
   `;
   bindConnectionStatusBar();
   bindUpdateChip();
+  bindSidebarToggle();
   agentPanel.bindHeader(state);
   settingsMenu.bind(state);
-  for (const p of PANELS) p.bind(state);
+  agentPanel.bind(state);
+}
+
+function bindSidebarToggle(): void {
+  document.getElementById("sidebar-toggle")?.addEventListener("click", () => {
+    sidebarOpen = !sidebarOpen;
+    render();
+  });
 }
 
 function connectionStatusBar(): string {
@@ -225,7 +238,8 @@ function bindConnectionStatusBar(): void {
     connectionDetailsOpen = false;
     invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
   });
-  document.getElementById("chrome-status-toggle")?.addEventListener("click", async () => {
+  document.getElementById("chrome-status-toggle")?.addEventListener("click", async (event) => {
+    event.stopPropagation();
     const opening = !connectionDetailsOpen;
     if (opening) {
       try {
@@ -278,7 +292,7 @@ function renderUpdateChip(): string {
     <div class="update-chip-wrap">
       <button id="update-chip" type="button" class="update-chip" aria-label="${htmlEsc(t("update.restartToUpdate"))}">
         <span class="update-chip-glyph" aria-hidden="true">↑</span>
-        <span class="update-chip-label">${htmlEsc(t("update.restartToUpdate"))}</span>
+        <span class="update-chip-label">${htmlEsc(t("update.chip"))}</span>
       </button>
       ${restartWarn ? renderRestartWarn() : updateTooltip()}
     </div>

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -161,9 +161,13 @@ export function renderAgentEvent(ev: AgentTaskEventPayload): string {
 }
 
 // Elapsed run time: started→finished, or started→now while still running.
+// A terminal task without a finished_at has no meaningful end, so we show no
+// duration rather than a figure that keeps ticking up against the wall clock.
 function formatDuration(task: AgentTaskView): string | null {
   if (!task.started_at) return null;
-  const end = task.finished_at ?? Date.now();
+  const running = task.status === "running" || task.status === "queued";
+  const end = task.finished_at ?? (running ? Date.now() : null);
+  if (end === null) return null;
   const seconds = Math.max(0, Math.round((end - task.started_at) / 1000));
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -1,57 +1,50 @@
+//! Sidebar (task history list) + the selected-task detail pane.
+//!
+//! The detail body uses the "split" layout: timeline ‖ final answer, each
+//! filling the pane. When only one panel has content — a running task with no
+//! answer yet, or a failed task that produced only an error — it falls back to a
+//! single stacked panel. (Narrow windows fold split into a stack via CSS.)
+
 import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
 import { renderMarkdown } from "../lib/markdown";
 import { formatTaskCount, formatTaskTimestamp, formatTokenUsage, formatTurns, taskStatusLabel, t } from "../lib/i18n";
 import type { AgentTaskView } from "./tasks";
 
-export interface TaskHistoryPageProps {
+export interface SidebarProps {
   tasks: AgentTaskView[];
-  selectedTask: AgentTaskView | undefined;
   selectedTaskId: string | null;
+  /** True while the compose view is showing — no row should read as selected. */
+  composing: boolean;
 }
 
-export function renderHistoryPage(props: TaskHistoryPageProps): string {
+export function renderSidebar(props: SidebarProps): string {
   return `
-    <div class="history-page">
-      <div class="history-page-head">
-        <div>
-          <p class="t-eyebrow result-label">${esc(t("task.historyTitle"))}</p>
-          <p class="t-small subtle">${esc(t("task.historyDescription"))}</p>
-        </div>
-        <button id="history-new-task" type="button" class="btn-ghost">${esc(t("task.new"))}</button>
+    <aside class="sidebar" aria-label="${esc(t("task.historyAria"))}">
+      <div class="sidebar-head">
+        <button id="sidebar-new" type="button" class="sidebar-new">
+          <span class="sidebar-new-glyph" aria-hidden="true">+</span>${esc(t("task.new"))}
+        </button>
       </div>
-      ${renderTaskWorkspace(props)}
-    </div>
+      <div class="sidebar-list-head">
+        <p class="t-eyebrow result-label">${esc(t("task.history"))}</p>
+        <span class="t-small subtle">${esc(formatTaskCount(props.tasks.length))}</span>
+      </div>
+      <div class="sidebar-list">
+        ${renderTaskRows(props)}
+      </div>
+    </aside>
   `;
 }
 
-function renderTaskWorkspace(props: TaskHistoryPageProps): string {
-  return `
-    <div class="tasks-layout">
-      <aside class="task-list" aria-label="${esc(t("task.historyAria"))}">
-        <div class="task-list-head">
-          <p class="t-eyebrow result-label">${esc(t("task.history"))}</p>
-          <span class="t-small subtle">${esc(formatTaskCount(props.tasks.length))}</span>
-        </div>
-        <div class="task-list-body">
-          ${renderTaskRows(props.tasks, props.selectedTaskId)}
-        </div>
-      </aside>
-      <section class="task-detail" aria-label="${esc(t("task.selectedAria"))}">
-        ${props.selectedTask ? renderSelectedTask(props.selectedTask) : renderNoTaskSelected()}
-      </section>
-    </div>
-  `;
-}
-
-function renderTaskRows(tasks: AgentTaskView[], selectedTaskId: string | null): string {
-  if (tasks.length === 0) {
+function renderTaskRows(props: SidebarProps): string {
+  if (props.tasks.length === 0) {
     return `<p class="t-small placeholder task-list-empty">${esc(t("task.noTasks"))}</p>`;
   }
-  return [...tasks]
+  return [...props.tasks]
     .sort((a, b) => b.created_at - a.created_at)
     .map((task) => {
-      const active = task.task_id === selectedTaskId ? "task-row-active" : "";
+      const active = !props.composing && task.task_id === props.selectedTaskId ? "task-row-active" : "";
       return `
         <button type="button" class="task-row ${active}" data-task-id="${esc(task.task_id)}">
           <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true">${taskStatusGlyph(task.status)}</span>
@@ -65,67 +58,95 @@ function renderTaskRows(tasks: AgentTaskView[], selectedTaskId: string | null): 
     .join("");
 }
 
-function renderSelectedTask(task: AgentTaskView): string {
-  const tokenLine = task.input_tokens !== null && task.output_tokens !== null
-    ? ` · ${formatTokenUsage(task.input_tokens, task.output_tokens)}`
+export function renderTaskDetail(task: AgentTaskView | undefined): string {
+  if (!task) return renderEmptyDetail();
+
+  const running = task.status === "running" || task.status === "queued";
+  const hasTimeline = task.events.length > 0 || running;
+  const hasResult = !!task.final_text || !!task.error;
+  const bothPanels = hasTimeline && hasResult;
+
+  let body: string;
+  if (bothPanels) {
+    body = `
+      <div class="detail-split">
+        <div class="detail-col">${renderTimelinePanel(task)}</div>
+        <div class="detail-col">${renderResultPanel(task)}</div>
+      </div>
+    `;
+  } else {
+    body = `
+      <div class="detail-body detail-body--stacked">
+        ${hasTimeline ? renderTimelinePanel(task) : ""}
+        ${hasResult ? renderResultPanel(task) : ""}
+        ${!hasTimeline && !hasResult ? `<p class="t-small placeholder">${esc(t("task.noTimeline"))}</p>` : ""}
+      </div>
+    `;
+  }
+
+  return `${renderDetailHead(task, running)}${body}`;
+}
+
+function renderDetailHead(task: AgentTaskView, running: boolean): string {
+  const time = formatTaskTimestamp(task.started_at ?? task.created_at);
+  const duration = formatDuration(task);
+  const tokens = task.input_tokens !== null && task.output_tokens !== null
+    ? formatTokenUsage(task.input_tokens, task.output_tokens)
     : "";
+  const dotClass = running ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow";
+  const items = [
+    `<span class="task-meta-item task-meta-status"><i class="badge-dot ${dotClass}" aria-hidden="true"></i>${esc(taskStatusLabel(task.status))}</span>`,
+    time ? `<span class="task-meta-item">${esc(time)}</span>` : "",
+    duration ? `<span class="task-meta-item">${esc(duration)}</span>` : "",
+    task.model ? `<span class="task-meta-item t-mono">${esc(task.model)}</span>` : "",
+    task.turns !== null && task.turns !== undefined ? `<span class="task-meta-item">${esc(formatTurns(task.turns))}</span>` : "",
+    tokens ? `<span class="task-meta-item">${esc(tokens)}</span>` : "",
+  ].join("");
   return `
     <div class="task-detail-head">
-      <div>
-        <p class="t-eyebrow result-label">${esc(t("task.selected"))}</p>
+      <div class="task-detail-headinfo">
         <h2 class="t-h3 task-detail-title">${esc(task.task)}</h2>
+        <div class="task-detail-meta">${items}</div>
       </div>
-      <div class="task-detail-actions">
-        <span class="badge"><i class="badge-dot ${task.status === "running" ? "badge-dot-ink badge-dot-pulse" : "badge-dot-hollow"}" aria-hidden="true"></i>${esc(taskStatusLabel(task.status))}</span>
-        ${canCancel(task) ? `<button type="button" class="btn-ghost btn-compact" data-cancel-task="${esc(task.task_id)}">${esc(t("task.cancel"))}</button>` : ""}
-      </div>
+      ${running ? `
+        <div class="task-detail-actions">
+          <button type="button" class="btn-ghost btn-compact" data-cancel-task="${esc(task.task_id)}">${esc(t("task.cancel"))}</button>
+        </div>` : ""}
     </div>
-
-    ${renderTaskTimeline(task)}
-
-    ${
-      task.error
-        ? `<pre class="result-pre result-error">${esc(task.error)}</pre>`
-        : ""
-    }
-    ${
-      task.final_text
-        ? `
-          <div class="agent-outcome">
-            <p class="t-eyebrow result-label">${esc(t("task.finalAnswer"))}</p>
-            <div class="result-pre result-md">${renderMarkdown(task.final_text.trim())}</div>
-            <p class="t-small subtle">${esc(t("task.run"))} ${esc(task.run_id ?? task.task_id)}${task.turns !== null ? ` · ${esc(formatTurns(task.turns))}` : ""}${esc(tokenLine)}</p>
-            ${task.run_dir ? `<p class="t-small subtle">run_dir: <span class="t-mono">${esc(task.run_dir)}</span></p>` : ""}
-          </div>`
-        : ""
-    }
   `;
 }
 
-function renderTaskTimeline(task: AgentTaskView): string {
-  if (task.events.length > 0) {
-    return `
-      <div class="result-block">
-        <div class="event-stream" data-agent-events="${esc(task.task_id)}">
-          ${task.events.map(renderAgentEvent).join("")}
-        </div>
-      </div>
-    `;
-  }
-  if (task.status === "running" || task.status === "queued") {
-    return `
-      <div class="result-block">
-        <div class="event-stream" data-agent-events="${esc(task.task_id)}">
-          <p class="t-small placeholder" data-events-placeholder>${esc(t("task.waitingForEvents"))}</p>
-        </div>
-      </div>
-    `;
-  }
-  if (task.final_text) return "";
-  return `<p class="t-small placeholder">${esc(t("task.noTimeline"))}</p>`;
+function renderTimelinePanel(task: AgentTaskView): string {
+  const hasEvents = task.events.length > 0;
+  const rows = hasEvents
+    ? task.events.map(renderAgentEvent).join("")
+    : `<p class="t-small placeholder" data-events-placeholder>${esc(t("task.waitingForEvents"))}</p>`;
+  return `
+    <div class="result-block detail-panel">
+      <p class="t-eyebrow result-label detail-panel-label">${esc(t("task.timeline"))}</p>
+      <div class="event-stream" data-agent-events="${esc(task.task_id)}">${rows}</div>
+    </div>
+  `;
 }
 
-function renderNoTaskSelected(): string {
+function renderResultPanel(task: AgentTaskView): string {
+  if (task.final_text) {
+    return `
+      <div class="agent-outcome detail-panel">
+        <p class="t-eyebrow result-label detail-panel-label">${esc(t("task.finalAnswer"))}</p>
+        <div class="result-pre result-md">${renderMarkdown(task.final_text.trim())}</div>
+      </div>
+    `;
+  }
+  return `
+    <div class="agent-outcome detail-panel">
+      <p class="t-eyebrow result-label detail-panel-label">${esc(t("task.errorLabel"))}</p>
+      <pre class="result-pre result-error">${esc(task.error ?? "")}</pre>
+    </div>
+  `;
+}
+
+function renderEmptyDetail(): string {
   return `
     <div class="task-empty-detail">
       <p class="t-eyebrow result-label">${esc(t("task.selected"))}</p>
@@ -137,6 +158,18 @@ function renderNoTaskSelected(): string {
 export function renderAgentEvent(ev: AgentTaskEventPayload): string {
   const glyph = eventGlyph(ev.kind);
   return `<div class="event event-${ev.kind}"><span class="event-glyph">${glyph}</span><span class="event-text">${esc(ev.text)}</span></div>`;
+}
+
+// Elapsed run time: started→finished, or started→now while still running.
+function formatDuration(task: AgentTaskView): string | null {
+  if (!task.started_at) return null;
+  const end = task.finished_at ?? Date.now();
+  const seconds = Math.max(0, Math.round((end - task.started_at) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${String(seconds % 60).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${String(minutes % 60).padStart(2, "0")}m`;
 }
 
 function eventGlyph(kind: AgentTaskEventPayload["kind"]): string {
@@ -169,8 +202,4 @@ function taskStatusGlyph(status: AgentTaskView["status"]): string {
     case "cancelled": return "−";
     case "interrupted": return "!";
   }
-}
-
-function canCancel(task: AgentTaskView): boolean {
-  return task.status === "queued" || task.status === "running";
 }

--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -1,23 +1,20 @@
+//! Compose view: the centered hero + task textarea shown in the workspace when
+//! no task is selected (or after "new task"). When chrome is disconnected the
+//! form is masked behind a connect overlay.
+
 import type { ModelInfo, Status, ShellState } from "../main";
 import { esc } from "../lib/html";
-import {
-  formatRunningTaskCount,
-  formatTaskTimestamp,
-  taskStatusLabel,
-  t,
-} from "../lib/i18n";
-import type { AgentTaskView } from "./tasks";
+import { t } from "../lib/i18n";
 
-export interface NewTaskPageProps {
+export interface ComposePaneProps {
   shell: ShellState;
   draft: string;
   submittingTask: boolean;
   submitError: string;
-  tasks: AgentTaskView[];
   selectedModel: ModelInfo | undefined;
 }
 
-export function renderNewTaskPage(props: NewTaskPageProps): string {
+export function renderComposePane(props: ComposePaneProps): string {
   const connected = props.shell.status.state === "connected";
   const modelReady = !!props.selectedModel && props.selectedModel.has_key;
   const running = props.submittingTask;
@@ -25,7 +22,7 @@ export function renderNewTaskPage(props: NewTaskPageProps): string {
   const gated = !connected;
 
   return `
-    <div class="new-task-page">
+    <div class="compose-pane">
       <div class="new-task-compose">
         <div class="new-task-copy">
           <h2 class="t-h2">${esc(t("task.hero"))}</h2>
@@ -40,14 +37,12 @@ export function renderNewTaskPage(props: NewTaskPageProps): string {
           ${!connected ? renderConnectOverlay(props.shell.status) : ""}
         </div>
       </div>
-      ${renderRunningChip(props.tasks)}
-      ${renderTaskGlance(props.tasks)}
     </div>
   `;
 }
 
 function renderTaskForm(
-  props: NewTaskPageProps,
+  props: ComposePaneProps,
   running: boolean,
   runDisabled: boolean,
 ): string {
@@ -115,74 +110,4 @@ function renderConnectOverlay(status: Status): string {
       >${esc(t("chrome.remoteDebuggingHelp"))}</a>
     </div>
   `;
-}
-
-function renderRunningChip(tasks: AgentTaskView[]): string {
-  const running = [...tasks]
-    .filter((t) => t.status === "running" || t.status === "queued")
-    .sort((a, b) => b.created_at - a.created_at);
-  if (running.length === 0) return "";
-  const first = running[0];
-  const isOne = running.length === 1;
-  const count = formatRunningTaskCount(running.length);
-  const taskLabel = isOne
-    ? `<span class="running-chip-dot" aria-hidden="true">·</span><span class="running-chip-task">${esc(first.task)}</span>`
-    : "";
-  return `
-    <button type="button" class="running-chip" data-task-id="${esc(first.task_id)}">
-      <i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i>
-      <span class="running-chip-count">${count}</span>
-      ${taskLabel}
-      <span class="running-chip-arrow" aria-hidden="true">→</span>
-    </button>
-  `;
-}
-
-function renderTaskGlance(tasks: AgentTaskView[]): string {
-  const recent = [...tasks]
-    .filter((task) => task.status !== "running" && task.status !== "queued")
-    .sort((a, b) => b.created_at - a.created_at)
-    .slice(0, 5);
-
-  return `
-    <div class="task-glance">
-      <section class="task-glance-card">
-        <div class="task-glance-head">
-          <p class="t-eyebrow result-label">${esc(t("task.recent"))}</p>
-          <button id="recent-history-link" type="button" class="btn-ghost btn-compact">${esc(t("task.viewHistory"))}</button>
-        </div>
-        ${renderTaskSummaryRows(recent, t("task.noRecent"))}
-      </section>
-    </div>
-  `;
-}
-
-function renderTaskSummaryRows(items: AgentTaskView[], emptyText: string): string {
-  if (items.length === 0) {
-    return `<p class="t-small placeholder task-summary-empty">${esc(emptyText)}</p>`;
-  }
-  return `
-    <div class="task-summary-list">
-      ${items.map((task) => `
-        <button type="button" class="task-summary-row" data-task-id="${esc(task.task_id)}">
-          <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true">${taskStatusGlyph(task.status)}</span>
-          <span class="task-row-main">
-            <span class="task-row-title">${esc(task.task)}</span>
-            <span class="task-row-meta">${esc(taskStatusLabel(task.status))} · ${esc(formatTaskTimestamp(task.created_at))}</span>
-          </span>
-        </button>
-      `).join("")}
-    </div>
-  `;
-}
-
-function taskStatusGlyph(status: AgentTaskView["status"]): string {
-  switch (status) {
-    case "queued": return "○";
-    case "running": return "●";
-    case "completed": return "✓";
-    case "failed": return "×";
-    case "cancelled": return "−";
-    case "interrupted": return "!";
-  }
 }

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -1,6 +1,6 @@
 //! Task workspace coordinator: shared state, agent configuration popover,
-//! task event intake, and bindings. The tab bodies live in `task_new.ts` and
-//! `task_history.ts`.
+//! task event intake, and bindings. The sidebar (history list) + detail pane
+//! live in `task_history.ts`; the compose view lives in `task_new.ts`.
 
 import { invoke } from "@tauri-apps/api/core";
 import type {
@@ -12,17 +12,19 @@ import type {
 } from "../main";
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
-import { renderAgentEvent, renderHistoryPage } from "./task_history";
-import { renderNewTaskPage } from "./task_new";
+import { renderAgentEvent, renderSidebar as renderSidebarMarkup, renderTaskDetail } from "./task_history";
+import { renderComposePane } from "./task_new";
 
-type TaskPage = "new" | "history";
+// The workspace shows one of two views: the compose form (default / "new task")
+// or the selected task's detail. The sidebar history list is always present.
+type WorkspaceView = "compose" | "detail";
 export type AgentTaskView = AgentTaskSnapshot & { events: AgentTaskEventPayload[] };
 type CodexLoginStart = { message: string };
 
 // ── Agent task workspace ──────────────────────────────────────────────────
 
 export namespace agentPanel {
-  let page: TaskPage = "new";
+  let view: WorkspaceView = "compose";
   let draft = "";
   let model = "";
   let modelProvider = "";
@@ -109,7 +111,8 @@ export namespace agentPanel {
   }
 
   export function bindHeader(shell: ShellState): void {
-    document.getElementById("agent-config-toggle")?.addEventListener("click", () => {
+    document.getElementById("agent-config-toggle")?.addEventListener("click", (event) => {
+      event.stopPropagation();
       configOpen = selectedNeedsKey() ? true : !configOpen;
       shell.rerender();
     });
@@ -204,13 +207,13 @@ export namespace agentPanel {
     const selected = selectedModel();
     const expanded = configOpen || selectedNeedsKey() ? "true" : "false";
     if (!selected) {
-      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(t("agent.loading"))}</button>`;
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-muted" aria-hidden="true"></i><span class="badge-text">${esc(t("agent.label"))} · ${esc(t("agent.loading"))}</span></button>`;
     }
     const label = modelDisplayLabel(selected);
     if (!selected.has_key) {
-      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(label)} · ${esc(t("agent.keyNeeded"))}</button>`;
+      return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-hollow" aria-hidden="true"></i><span class="badge-text">${esc(t("agent.label"))} · ${esc(label)} · ${esc(t("agent.keyNeeded"))}</span></button>`;
     }
-    return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i>${esc(t("agent.label"))} · ${esc(label)}</button>`;
+    return `<button id="agent-config-toggle" type="button" class="badge badge-button" aria-expanded="${expanded}"><i class="badge-dot badge-dot-ink" aria-hidden="true"></i><span class="badge-text">${esc(t("agent.label"))} · ${esc(label)}</span></button>`;
   }
 
   function renderConfigPopover(): string {
@@ -437,48 +440,37 @@ export namespace agentPanel {
     return !!payload.snapshot;
   }
 
-  export function render(shell: ShellState): string {
-    return `
-      <div class="task-interface">
-        ${renderPageTabs()}
-        ${page === "new"
-          ? renderNewTaskPage({
-              shell,
-              draft,
-              submittingTask,
-              submitError,
-              tasks,
-              selectedModel: selectedModel(),
-            })
-          : renderHistoryPage({ tasks, selectedTask: selectedTask(), selectedTaskId })}
-      </div>
-    `;
+  // The persistent left rail: "new task" + the history list. Always rendered
+  // (when the sidebar is expanded); independent of which workspace view is up.
+  export function renderSidebar(): string {
+    return renderSidebarMarkup({
+      tasks,
+      selectedTaskId,
+      composing: view === "compose",
+    });
   }
 
-  function renderPageTabs(): string {
+  // The main pane: the compose form, or the selected task's detail.
+  export function renderWorkspace(shell: ShellState): string {
+    if (view === "compose") {
+      return renderComposePane({
+        shell,
+        draft,
+        submittingTask,
+        submitError,
+        selectedModel: selectedModel(),
+      });
+    }
     return `
-      <div class="page-switch" aria-label="${esc(t("task.pagesAria"))}">
-        <button id="page-new" type="button" class="page-switch-button ${page === "new" ? "page-switch-button-active" : ""}">${esc(t("task.new"))}</button>
-        <button id="page-history" type="button" class="page-switch-button ${page === "history" ? "page-switch-button-active" : ""}">${esc(t("task.history"))}</button>
-      </div>
+      <section class="task-detail" aria-label="${esc(t("task.selectedAria"))}">
+        ${renderTaskDetail(selectedTask())}
+      </section>
     `;
   }
 
   export function bind(shell: ShellState): void {
-    document.getElementById("page-new")?.addEventListener("click", () => {
-      page = "new";
-      shell.rerender();
-    });
-    document.getElementById("page-history")?.addEventListener("click", () => {
-      page = "history";
-      shell.rerender();
-    });
-    document.getElementById("history-new-task")?.addEventListener("click", () => {
-      page = "new";
-      shell.rerender();
-    });
-    document.getElementById("recent-history-link")?.addEventListener("click", () => {
-      page = "history";
+    document.getElementById("sidebar-new")?.addEventListener("click", () => {
+      view = "compose";
       shell.rerender();
     });
 
@@ -491,7 +483,7 @@ export namespace agentPanel {
     document.querySelectorAll<HTMLButtonElement>("[data-task-id]").forEach((btn) => {
       btn.addEventListener("click", () => {
         selectedTaskId = btn.dataset.taskId ?? null;
-        page = "history";
+        view = "detail";
         shell.rerender();
       });
     });
@@ -532,6 +524,16 @@ export namespace agentPanel {
         );
       });
 
+    // Auto-follow the selected task's timeline to the latest row after a render.
+    scrollSelectedEventsToBottom();
+  }
+
+  // Keep the event stream pinned to its newest row when the detail (re)renders,
+  // mirroring the incremental append in `appendEventRowIfSelected`.
+  function scrollSelectedEventsToBottom(): void {
+    if (!selectedTaskId) return;
+    const stream = document.querySelector<HTMLDivElement>(`[data-agent-events="${selectedTaskId}"]`);
+    if (stream) stream.scrollTop = stream.scrollHeight;
   }
 
   async function pollCodexOAuth(shell: ShellState): Promise<void> {
@@ -589,7 +591,7 @@ export namespace agentPanel {
       });
       upsertTask(snapshot);
       selectedTaskId = snapshot.task_id;
-      page = "history";
+      view = "detail";
       draft = "";
     } catch (err) {
       submitError = `${err}`;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -121,16 +121,18 @@ body.has-paper > * { position: relative; z-index: 1; }
   flex: 1;
   display: flex;
   flex-direction: column;
-  /* min-height:0 (not 100vh) so this column can constrain its children to the
-     window height — the prerequisite for the content region scrolling inside
-     instead of growing the document. */
+  /* The window frame is a row: full-height sidebar (left) + main column (right).
+     min-height/​min-width:0 let both columns constrain their children to the
+     window size so content scrolls inside instead of forcing the shell wider
+     than the viewport (which would clip the right-edge topbar controls). */
   min-height: 0;
+  min-width: 0;
 }
 .topbar {
   display: flex;
   align-items: center;
-  gap: var(--sp-4);
-  padding: var(--sp-3) var(--sp-5);
+  gap: 0;
+  padding: 0;
   border-bottom: var(--hairline);
   background: var(--surface);
   /* Fixed top of the non-scrolling shell column — it can't shrink or grow, and
@@ -150,20 +152,18 @@ body.has-paper > * { position: relative; z-index: 1; }
   -webkit-user-select: none;
   user-select: none;
 }
-/* macOS overlay titlebar — the OS keeps the native traffic lights (repositioned
-   onto our centerline in lib.rs), and the header reserves a fixed px gutter so
-   header content clears the lights. The 52px band is paired with the native
-   y=28 inset so the light cluster centers at ~26px = this band's center. */
-.is-macos .topbar {
-  padding-left: 80px;          /* clears the 3 traffic-light buttons */
-  min-height: 52px;            /* keep in sync with TRAFFIC_LIGHT_POS.y in lib.rs */
-  padding-top: 0;
-  padding-bottom: 0;
+/* macOS overlay titlebar — the OS draws the native traffic lights over the
+   top-left of the window, which is the left edge of .topbar-left. Reserve a
+   fixed gutter INSIDE that 280px zone (not on .topbar) so the zone's right edge
+   still lines up with the sidebar border below it. The 80px clears the three
+   lights; keep it in sync with TRAFFIC_LIGHT_POS in lib.rs. */
+.is-macos .topbar-left {
+  padding-left: 92px;          /* clears the 3 traffic-light buttons + breathing room before the toggle */
 }
 /* Fullscreen hides the OS traffic lights, so reclaim the gutter. Toggled via
    body.is-fullscreen in main.ts. */
-.is-macos.is-fullscreen .topbar {
-  padding-left: var(--sp-5);
+.is-macos.is-fullscreen .topbar-left {
+  padding-left: var(--sp-4);
 }
 .topbar-controls {
   margin-left: auto;
@@ -178,12 +178,20 @@ body.has-paper > * { position: relative; z-index: 1; }
 .status-capsule {
   display: inline-flex;
   align-items: stretch;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
   border: var(--hairline);
   border-radius: var(--r-pill);
   background: var(--surface);
   transition: border-color var(--t-fast) var(--ease);
 }
+/* Keep the gear + update chip fixed; let the (verbose) model badge truncate
+   first when the topbar is tight, so nothing ever clips off the right edge. */
+.topbar-controls { min-width: 0; padding-right: var(--sp-5); }
+.status-capsule .connection-status { flex: 0 0 auto; }
+.status-capsule .agent-status { flex: 0 1 auto; min-width: 0; }
+.status-capsule .agent-status .badge { min-width: 0; }
+.badge-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .status-capsule:hover { border-color: var(--line-strong); }
 .status-capsule .connection-status,
 .status-capsule .agent-status { position: relative; display: inline-flex; gap: 0; }
@@ -223,6 +231,7 @@ body.has-paper > * { position: relative; z-index: 1; }
   letter-spacing: 0.02em;
   cursor: pointer;
   position: relative;
+  white-space: nowrap;
   transition: opacity var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 .update-chip:hover { opacity: 0.82; }
@@ -577,45 +586,121 @@ body.has-paper > * { position: relative; z-index: 1; }
 .agent-provider-option.is-active .agent-model-name,
 .agent-model-option.is-active .agent-model-name { font-weight: 600; }
 
-/* ── Stacked sections ──────────────────────────────────────────── */
-.stack {
+/* ── Window frame: persistent full-width topbar, then a body row ────
+   The topbar pins the traffic lights + update chip + sidebar toggle at the
+   top-left and never moves them; below it the body holds the full-height
+   sidebar (left) and the content pane (right). */
+.body {
   flex: 1;
-  min-height: 0;             /* fill the window height and let children scroll */
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-4);
-  padding: var(--sp-4) var(--sp-5);
-  max-width: 1080px;
-  width: 100%;
-  align-self: center;
-}
-.section {
-  flex: 1;
+  min-width: 0;
   min-height: 0;
   display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
+  align-items: stretch;
 }
-.section-label {
-  margin: 0 0 var(--sp-1) 0;
-}
-
-/* ── Forms (rows shared by all panels) ─────────────────────────── */
-.row-form {
+.shell > .topbar { min-height: 52px; }
+/* Persistent top-left zone, the width of the sidebar so its right edge (and
+   the sidebar toggle pinned there) lines up with the sidebar's border below.
+   Traffic lights sit flush left; the toggle is pushed to the right edge. */
+.topbar-left {
+  flex: 0 0 280px;
+  width: 280px;
+  align-self: stretch;
   display: flex;
-  gap: var(--sp-2);
   align-items: center;
+  gap: var(--sp-3);
+  padding: 0 var(--sp-2) 0 var(--sp-4);
 }
-.row-form .input-field { flex: 1; }
+.topbar-left--bordered { border-right: var(--hairline); }
+.sidebar {
+  flex: 0 0 280px;
+  width: 280px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: var(--hairline);
+  background: var(--surface);
+}
+.sidebar-head {
+  flex: 0 0 auto;
+  padding: var(--sp-3);
+}
+.sidebar-new {
+  appearance: none;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border: var(--hairline);
+  border-radius: var(--r-3);
+  background: var(--surface);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+}
+.sidebar-new:hover { background: var(--ink-7); border-color: var(--line-strong); }
+.sidebar-new:active { background: var(--ink-6); }
+.sidebar-new-glyph { font-size: 14px; line-height: 1; color: var(--fg-soft); }
+.sidebar-list-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-3) var(--sp-2);
+}
+.sidebar-list-head .result-label { margin: 0; }
+.sidebar-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
 
-/* Universal task entrance. */
-.task-interface {
+.workspace-main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+/* The detail pane is now the main content area: drop the card chrome and let
+   it fill, with generous padding. The inner panels keep their own boxes. */
+.workspace-main > .task-detail {
+  flex: 1;
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: var(--sp-5);
+}
+/* Compose view: hero + form, centered in the main pane on a comfortable measure. */
+.compose-pane {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--sp-3);
+  justify-content: center;
+  justify-content: safe center;
+  align-items: center;
+  overflow-y: auto;
+  padding: var(--sp-6) var(--sp-5);
 }
+.compose-pane .new-task-compose { width: min(100%, 760px); padding: 0; }
+
+@media (max-width: 760px) {
+  .sidebar, .topbar-left { flex-basis: 220px; width: 220px; }
+  .workspace-main > .task-detail { padding: var(--sp-4); }
+}
+
+/* ── Compose form ──────────────────────────────────────────────── */
 .task-form {
   display: flex;
   flex-direction: column;
@@ -653,50 +738,6 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .task-context { flex: 1; }
 
-.page-switch {
-  flex: 0 0 auto;
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  padding: 2px;
-  border: var(--hairline);
-  border-radius: var(--r-pill);
-  background: var(--surface);
-}
-.page-switch-button {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  border-radius: var(--r-pill);
-  color: var(--fg-soft);
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  padding: 7px 12px;
-  white-space: nowrap;
-}
-.page-switch-button-active {
-  background: var(--ink-0);
-  color: var(--ink-9);
-}
-.new-task-page {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  /* Center the compose/glance when they fit; `safe` falls back to top-aligned
-     when the window is too short, and overflow-y keeps any spill inside this
-     region rather than scrolling the document. The plain `center` below is a
-     fallback: an engine that lacks the `safe` keyword discards that line as
-     invalid and keeps this one, so centering still works when content fits. */
-  justify-content: center;
-  justify-content: safe center;
-  overflow-y: auto;
-  gap: var(--sp-5);
-}
 .new-task-compose {
   width: min(100%, 840px);
   align-self: center;
@@ -715,109 +756,6 @@ body.has-paper > * { position: relative; z-index: 1; }
 .new-task-copy p,
 .new-task-copy h2 { margin: 0; }
 .task-form-centered .task-input { min-height: 172px; }
-.task-glance {
-  width: min(100%, 840px);
-  align-self: center;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: var(--sp-5);
-  padding-top: var(--sp-1);
-}
-.task-glance-card {
-  min-width: 0;
-}
-.task-glance-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-2);
-  margin-bottom: var(--sp-2);
-}
-.task-glance-head .result-label { margin: 0; }
-.task-summary-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-1);
-}
-.task-summary-row {
-  appearance: none;
-  display: grid;
-  grid-template-columns: 14px 1fr;
-  gap: var(--sp-2);
-  width: 100%;
-  padding: 2px 0;
-  border: 0;
-  background: transparent;
-  color: var(--fg);
-  text-align: left;
-  cursor: pointer;
-}
-.task-summary-row:hover .task-row-title { text-decoration: underline; }
-.task-summary-row .task-row-title {
-  font-size: 12px;
-  color: var(--fg-muted);
-}
-.task-summary-row .task-row-meta { font-size: 10px; }
-.task-summary-empty { color: var(--fg-faint); }
-.history-page {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-3);
-}
-.history-page-head {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-3);
-  padding-bottom: var(--sp-1);
-}
-.history-page-head .result-label { margin: 0 0 var(--sp-2) 0; }
-
-/* Task history layout. Fills the content region; the single grid row is 1fr of
-   that fixed height so both columns get a definite height to scroll within. */
-.tasks-layout {
-  flex: 1;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(220px, 0.36fr) minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
-  gap: var(--sp-3);
-  align-items: stretch;
-}
-.task-list,
-.task-detail {
-  min-width: 0;
-  min-height: 0;             /* allow the columns to be constrained + scroll */
-  border: var(--hairline);
-  border-radius: var(--r-4);
-  background: var(--surface);
-}
-.task-list {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.task-list-head {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-2);
-  padding: var(--sp-3);
-  border-bottom: var(--hairline);
-  background: var(--canvas);
-}
-.task-list-head .result-label { margin: 0; }
-.task-list-body {
-  flex: 1;
-  min-height: 0;             /* fill the column and scroll internally (was max-height:520px) */
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-}
 .task-list-empty { padding: var(--sp-3); }
 .task-row {
   appearance: none;
@@ -866,16 +804,17 @@ body.has-paper > * { position: relative; z-index: 1; }
   color: var(--fg-soft);
 }
 .task-detail {
+  min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
   padding: var(--sp-3);
   /* The detail's height is owned by its flex children (logs + answer each
-     scroll). `auto` is a safety net only: in the normal case the flex-basis:0
-     children fill exactly and this never scrolls; it engages just for odd
-     states like a failed task with a very long error block, scrolling the pane
-     instead of clipping. */
-  overflow-y: auto;
+     scroll). With the split layout the inner panels own scrolling, so the pane
+     itself never scrolls; overflow:hidden keeps any odd overflow (e.g. a failed
+     task with a very long error block) inside the pane instead of clipping. */
+  overflow: hidden;
 }
 .task-detail-head {
   flex: 0 0 auto;
@@ -892,7 +831,29 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .task-detail-head .result-label,
 .task-detail-title { margin: 0; }
-.task-detail-title { margin-top: var(--sp-2); }
+.task-detail-headinfo {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.task-detail-meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 4px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--fg-soft);
+}
+.task-meta-item { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.task-meta-item:not(:last-child)::after {
+  content: "·";
+  color: var(--fg-faint);
+  margin: 0 8px;
+}
+.task-meta-status { color: var(--fg-muted); }
 .task-empty-detail {
   flex: 1;
   display: flex;
@@ -905,10 +866,45 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .task-empty-detail .result-label { margin: 0; }
 
-@media (max-width: 760px) {
-  .task-glance,
-  .tasks-layout { grid-template-columns: 1fr; }
-  .task-list-body { max-height: 240px; }
+/* ── Task detail: timeline + result alignment ─────────────────────
+   Two arrangements share one detail pane (see TaskDetail):
+   · split   — timeline ‖ result, each gets the FULL pane height (default)
+   · stacked — a vertical stack, used when only one panel is present
+               (a running task with no answer yet, or an error-only failure)
+               and as the narrow-window fold of split.
+   The detail head stays pinned; .detail-body / .detail-split fill below it. */
+.detail-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+/* stacked: panels share the column; the answer is weighted slightly larger */
+.detail-body--stacked .result-block { flex: 1 1 0; min-height: 96px; }
+.detail-body--stacked .agent-outcome { flex: 1.35 1 0; min-height: 120px; margin-top: 0; }
+
+/* split: two equal columns, each a self-scrolling panel */
+.detail-split {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  gap: var(--sp-4);
+}
+.detail-col {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.detail-col > .detail-panel { flex: 1 1 0; min-height: 0; margin-top: 0; }
+.detail-panel-label { margin: 0; }
+
+/* narrow windows: fold the split back into a stack so neither panel is starved */
+@media (max-width: 900px) {
+  .detail-split { flex-direction: column; }
+  .detail-col { flex: 1 1 auto; min-height: 160px; }
 }
 
 /* ── Result + event stream ─────────────────────────────────────── */
@@ -1194,45 +1190,7 @@ code {
   cursor: not-allowed;
 }
 
-/* ── Running-tasks chip (appears on new-task page when any task runs) ── */
-.running-chip {
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  max-width: min(100%, 720px);
-  padding: 7px var(--sp-3);
-  border: var(--hairline);
-  border-radius: var(--r-pill);
-  background: var(--surface);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.02em;
-  color: var(--ink-1);
-  cursor: pointer;
-  transition: border-color var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
-}
-.running-chip:hover { border-color: var(--line-strong); }
-.running-chip:active { transform: scale(0.98); }
-.running-chip-count {
-  font-weight: 500;
-  white-space: nowrap;
-}
-.running-chip-dot { color: var(--fg-soft); }
-.running-chip-task {
-  color: var(--fg-muted);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.running-chip-arrow {
-  color: var(--fg-soft);
-  font-family: var(--font-mono);
-}
-.running-chip:hover .running-chip-arrow { color: var(--ink-0); }
-
-/* ── Connect overlay (shown on disconnected/connecting new-task) ──── */
+/* ── Connect overlay (shown on disconnected/connecting compose) ──── */
 .compose-form-stack {
   position: relative;
   display: flex;
@@ -1297,14 +1255,6 @@ code {
   padding: 9px var(--sp-4);
   font-size: 13px;
   text-align: center;
-}
-.connect-overlay-input {
-  align-self: stretch;
-  font-family: var(--font-mono);
-}
-.connect-overlay-error {
-  margin: 0;
-  align-self: stretch;
 }
 .connect-overlay-link {
   margin: 0;


### PR DESCRIPTION
## What

Implements the **Socai Today** handoff design (`claude.ai/design` bundle) into the desktop app, evolving the shell from the `new ⇄ history` page-tab model to a **persistent collapsible sidebar + compose/detail workspace** — the standard agent-app layout.

This is a shell-level restructure, not a rewrite: the leaf components (status capsule, connection dialog, provider-first model popover, settings gear, connect overlay, update chip, markdown answers) already existed and are reused.

<img width="2188" height="1369" alt="CleanShot 2026-06-29 at 16 44 51" src="https://github.com/user-attachments/assets/558c3676-6ea1-4fe4-92da-ab278983644a" />


## Changes

- **Topbar** → split into a 280px `topbar-left` zone (sidebar-collapse toggle + the **relocated** update chip) and the right-side status capsule + settings gear.
- **Body** → new `body` row: a collapsible `sidebar` (new-task button + live task-history list) feeding `workspace-main`.
- **Workspace** → shows **compose** (hero + task form, gated by the connect overlay) or **task detail**.
- **Task detail** → redesigned head with a single metadata row (`status · time · duration · model · turns · tokens`) and a **split** `timeline ‖ answer` body. Folds to a stacked single panel for running tasks (timeline only) and error-only failures, and on narrow windows.
- Retired the now-dead `page-switch`, recent-task **glance**, and **running-chip** (the sidebar subsumes them); removed their CSS and i18n keys.
- **CSS**: adopted the handoff stylesheet as the design source of truth, then stripped prototype-only/dead rules.
- **i18n**: added `update.chip`, `task.timeline`, `task.errorLabel`, `sidebar.{collapse,expand}Aria`; removed keys tied to the removed UI.

## Reviewer notes

- **macOS gutter fix:** the native traffic-light gutter (80px → 92px for breathing room before the toggle) lives on `.topbar-left`, *not* `.topbar`, so its right edge stays aligned with the 280px sidebar. A naive port that pushed the whole topbar would misalign them.
- **Native vs faux lights:** the prototype draws faux traffic lights; the shipping app uses the real Tauri overlay-titlebar ones, so those are intentionally not rendered.
- **Split layout only:** the prototype's design-tool "history layout" tweak (split/focused/stacked) was a previewing aid; we ship **split** (with the stacked fallback intrinsic to single-panel states). The "focused" tabbed variant and the tweaks panel are not implemented.
- **Frontend-only** — no Rust/backend or Tauri-command changes; same `cdp_*` / `agent_*` / `config_*` surface.

## Verification

- `tsc` typechecks clean; `vite build` succeeds.
- A 6-dimension adversarial fidelity audit (shell, detail, interactions, CSS, i18n, a11y) surfaced one confirmed gap — missing `stopPropagation` on the chrome/agent toggle handlers (the prototype and the app's other toggles already have it) — which is included in this PR.
- Not launched as a desktop app (the handoff README asks not to render unless requested); happy to do a live pass on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
