### PR TITLE
fix(site): show release version in header

### DIFF
--- a/.claude/skills/socai-release/SKILL.md
+++ b/.claude/skills/socai-release/SKILL.md
@@ -133,8 +133,15 @@ Vercel Git integration is connected to `socai-io/socai` with production branch `
 After the GitHub release verification, confirm the live site has caught up to the new version. The auto-deploy usually finishes within ~1 minute of the `main` push; allow for that and re-check if it is still mid-build.
 
 ```bash
-# visible version on the live pages must equal the just-published X.Y.Z
-for p in "" "contact"; do printf "/%s -> " "$p"; curl -s "https://socai.io/$p" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | sort -u | tr '\n' ' '; echo; done
+# visible nav release chip on the live pages must equal the just-published X.Y.Z.
+# Use data-release-version instead of grepping every semver-looking string because
+# font/CDN URLs in the HTML can contain unrelated version numbers.
+version="$(gh release view --repo socai-io/socai --json tagName --jq '.tagName' | sed 's/^v//')"
+for p in "" "contact"; do
+  found="$(curl -fsS "https://socai.io/$p" | grep -oE 'data-release-version="[0-9]+\.[0-9]+\.[0-9]+"' | sed -E 's/^data-release-version="([^"]+)"$/\1/' | sort -u)"
+  printf "/%s -> %s\n" "$p" "${found:-<none>}"
+  test "$found" = "$version"
+done
 curl -sI https://socai.io/         | grep -iE '^HTTP'              # 200
 curl -sI https://www.socai.io/     | grep -iE '^HTTP|^location'   # 308 -> https://socai.io/
 curl -sI https://socai.io/download | grep -iE '^HTTP|^location'   # 307 -> GitHub latest DMG

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,17 +1,23 @@
 ---
-import { message } from "../lib/i18n";
+import { formatMessage, message } from "../lib/i18n";
 
 interface Props {
     messages: Record<string, Record<string, unknown>>;
     language: string;
+    releaseVersion?: string;
 }
 
-const { messages, language } = Astro.props;
+const { messages, language, releaseVersion } = Astro.props;
 
 const githubUrl = "/github";
 const contactPath = "/contact";
 
 const t = (path: string) => message(messages, path, language);
+const format = (path: string, values: Record<string, string | number>) =>
+    formatMessage(messages, path, values, language);
+const releaseValues = releaseVersion
+    ? JSON.stringify({ version: releaseVersion })
+    : undefined;
 ---
 
 <header
@@ -60,6 +66,18 @@ const t = (path: string) => message(messages, path, language);
         <a class="nav-text-link" href={contactPath} data-i18n="nav.contact"
             >{t("nav.contact")}</a
         >
+        {
+            releaseVersion && (
+                <span
+                    class="release-chip"
+                    data-release-version={releaseVersion}
+                    data-i18n="nav.releaseLabel"
+                    data-i18n-values={releaseValues}
+                >
+                    {format("nav.releaseLabel", { version: releaseVersion })}
+                </span>
+            )
+        }
         <a class="nav-link nav-link--github" href={githubUrl}>
             <svg
                 viewBox="0 0 16 16"

--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -8,6 +8,7 @@ import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
+import { resolveReleaseVersion } from "../lib/release";
 
 const { frontmatter, headings = [] } = Astro.props;
 const {
@@ -135,6 +136,7 @@ const messages = {
 const message = (path: string, language = defaultLanguage) =>
     messageFor(messages, path, language);
 const pageTitle = message("meta.title");
+const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -194,7 +196,11 @@ const pageTitle = message("meta.title");
     </head>
     <body>
         <div class="site-shell">
-            <SiteHeader messages={messages} language={defaultLanguage} />
+            <SiteHeader
+                messages={messages}
+                language={defaultLanguage}
+                releaseVersion={releaseVersion}
+            />
 
             <main class="article-main">
                 <article class="article">

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import "../../styles/global.css";
 import SiteHeader from "../../components/SiteHeader.astro";
 import SiteFooter from "../../components/SiteFooter.astro";
 import { message as messageFor } from "../../lib/i18n";
+import { resolveReleaseVersion } from "../../lib/release";
 
 const currentYear = new Date().getFullYear();
 const siteUrl = "https://socai.io";
@@ -98,6 +99,7 @@ const message = (path: string, language = defaultLanguage) =>
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
+const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -167,7 +169,11 @@ const socialImageAlt = message("meta.socialImageAlt");
     </head>
     <body>
         <div class="site-shell">
-            <SiteHeader messages={messages} language={defaultLanguage} />
+            <SiteHeader
+                messages={messages}
+                language={defaultLanguage}
+                releaseVersion={releaseVersion}
+            />
 
             <main class="blog-main">
                 <section class="blog" aria-labelledby="blog-title">

--- a/site/src/pages/connect.astro
+++ b/site/src/pages/connect.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
+import { resolveReleaseVersion } from "../lib/release";
 
 const currentYear = new Date().getFullYear();
 const siteUrl = "https://socai.io";
@@ -120,6 +121,7 @@ const message = (path: string, language = defaultLanguage) =>
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
+const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -192,6 +194,7 @@ const socialImageAlt = message("meta.socialImageAlt");
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
+                releaseVersion={releaseVersion}
             />
 
             <main class="setup-main">

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { message as messageFor } from "../lib/i18n";
+import { resolveReleaseVersion } from "../lib/release";
 
 const githubIssuesUrl = "https://github.com/socai-io/socai/issues";
 const qrImage = "/wechat-group-qr.jpg";
@@ -85,6 +86,7 @@ const message = (path: string, language = defaultLanguage) =>
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
+const releaseVersion = await resolveReleaseVersion();
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -157,6 +159,7 @@ const socialImageAlt = message("meta.socialImageAlt");
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
+                releaseVersion={releaseVersion}
             />
 
             <main class="contact-main">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -228,6 +228,7 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
             <SiteHeader
                 messages={messages}
                 language={defaultLanguage}
+                releaseVersion={releaseVersion}
             />
 
             <main class="page-main">

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -199,7 +199,19 @@ button:focus-visible {
   color: var(--ink-0);
 }
 
+.release-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  color: var(--fg-soft);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
 .release-meta,
+.release-chip,
 .site-footer,
 .window-title,
 .status-pill,


### PR DESCRIPTION
## Summary\n- add a shared release version chip to the site header\n- render the resolved release version on /contact and other pages using SiteHeader\n- update the release runbook to verify the stable data-release-version marker instead of grepping unrelated semver strings\n\n## Test\n- cd site && pnpm build\n- verified built / and /contact include data-release-version="0.3.3"