### PR TITLE
fix(app): make full titlebar draggable + harden macOS traffic-light placement

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -141,19 +141,20 @@ pub fn run() {
                 // laying out the title bar, and no focus/resize event is guaranteed
                 // to follow to correct it. Re-apply on the main thread shortly after
                 // the window settles. Idempotent — a no-op when already correct, so
-                // it never flickers.
-                for delay_ms in [250u64, 750] {
-                    let win_retry = win.clone();
-                    std::thread::spawn(move || {
-                        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                // it never flickers. Runs on the shared async runtime (no dedicated
+                // OS threads); the two waits land the retries ~250ms and ~750ms in.
+                let win_retry = win.clone();
+                tauri::async_runtime::spawn(async move {
+                    for gap_ms in [250u64, 500] {
+                        tokio::time::sleep(std::time::Duration::from_millis(gap_ms)).await;
                         let win_main = win_retry.clone();
                         let _ = win_retry.run_on_main_thread(move || {
                             if let Ok(ptr) = win_main.ns_window() {
                                 reposition_traffic_lights(ptr, x, y);
                             }
                         });
-                    });
-                }
+                    }
+                });
                 let win_for_events = win.clone();
                 win.on_window_event(move |event| {
                     if matches!(

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -136,6 +136,24 @@ pub fn run() {
                 if let Ok(ptr) = win.ns_window() {
                     reposition_traffic_lights(ptr, x, y);
                 }
+                // Cold-launch backstop: on first launch (Gatekeeper scan, busy
+                // system) the setup-time placement can run before AppKit finishes
+                // laying out the title bar, and no focus/resize event is guaranteed
+                // to follow to correct it. Re-apply on the main thread shortly after
+                // the window settles. Idempotent — a no-op when already correct, so
+                // it never flickers.
+                for delay_ms in [250u64, 750] {
+                    let win_retry = win.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                        let win_main = win_retry.clone();
+                        let _ = win_retry.run_on_main_thread(move || {
+                            if let Ok(ptr) = win_main.ns_window() {
+                                reposition_traffic_lights(ptr, x, y);
+                            }
+                        });
+                    });
+                }
                 let win_for_events = win.clone();
                 win.on_window_event(move |event| {
                     if matches!(

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -137,7 +137,7 @@ function render(): void {
   root.innerHTML = `
     <div class="shell">
       <header class="topbar" data-tauri-drag-region>
-        <div class="topbar-left ${sidebarOpen ? "topbar-left--bordered" : ""}">
+        <div class="topbar-left ${sidebarOpen ? "topbar-left--bordered" : ""}" data-tauri-drag-region>
           <button
             id="sidebar-toggle"
             type="button"
@@ -147,7 +147,7 @@ function render(): void {
           >${PANEL_ICON_SVG}</button>
           ${renderUpdateChip()}
         </div>
-        <div class="topbar-controls">
+        <div class="topbar-controls" data-tauri-drag-region>
           <div class="status-capsule" role="group" aria-label="${htmlEsc(t("status.capsuleAria"))}">
             ${connectionStatusBar()}
             <span class="status-capsule__divider" aria-hidden="true"></span>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -142,11 +142,15 @@ body.has-paper > * { position: relative; z-index: 1; }
   flex: 0 0 auto;
   z-index: 30;
 }
-/* Overlay titlebar drag surface — the bare header area drags; the buttons and
-   toggles inside stay clickable (they lack the attribute). Tauri's drag.js
-   turns a mousedown here into `plugin:window|start_dragging`, which the ACL
-   gates: the window only moves because capabilities/default.json grants
-   `core:window:allow-start-dragging` (NOT part of core:default). Don't drop it. */
+/* Overlay titlebar drag surface — the header AND its two zone wrappers
+   (.topbar-left, .topbar-controls) each carry data-tauri-drag-region so the
+   whole bar drags, including the left gutter under the traffic lights. A bare
+   attribute only fires on a *direct* hit (Tauri's isDragRegion), so interactive
+   children (toggle, badges, gear) and popover text are never the drag target and
+   stay clickable/selectable. Tauri's drag.js turns a qualifying mousedown into
+   `plugin:window|start_dragging`, which the ACL gates: the window only moves
+   because capabilities/default.json grants `core:window:allow-start-dragging`
+   (NOT part of core:default). Don't drop it. */
 .topbar[data-tauri-drag-region] {
   cursor: default;
   -webkit-user-select: none;
@@ -391,10 +395,10 @@ body.has-paper > * { position: relative; z-index: 1; }
   border-radius: var(--r-4);
   box-shadow: var(--shadow-pop);
   /* Re-enable selection inside popovers: they are descendants of the drag
-     region (.topbar) and would otherwise inherit its user-select:none, making
-     copyable text — the CDP endpoint URL, the Chrome profile path — unselectable.
+     region and would otherwise inherit its user-select:none, making copyable
+     text — the CDP endpoint URL, the Chrome profile path — unselectable.
      Safe for dragging: a bare data-tauri-drag-region only drags when the mousedown
-     target IS .topbar, never these descendants. */
+     target IS the element carrying it, never these descendants. */
   -webkit-user-select: text;
   user-select: text;
 }


### PR DESCRIPTION
## What

Two fixes to the macOS overlay titlebar.

**1. The whole titlebar is now draggable.** The left zone — the traffic-light gutter and the area around the sidebar toggle — could not be used to drag the window. Tauri's `isDragRegion` (drag.js) only starts a drag when the mousedown target *itself* carries `data-tauri-drag-region`; only the outer `<header class="topbar">` had it, so clicks on the `.topbar-left` / `.topbar-controls` child zones never dragged. Added the bare attribute to both zones.

- Interactive children (sidebar toggle, status badges, gear) stay clickable — drag.js bails the instant it sees a clickable element with no drag attribute.
- Popover text (CDP endpoint URL, Chrome profile path) stays selectable — a bare attribute only fires on a *direct* hit, and that text is never the drag-owning element.

**2. Hardened the traffic-light reposition against a cold-launch race.** The native lights are placed once in `setup()` and re-applied on focus/resize. On a cold first launch (Gatekeeper scan, busy system) the setup-time placement can run before AppKit finishes laying out the title bar, with no guaranteed focus/resize event afterward to correct it — leaving the lights misaligned with the CSS-centered toggle. Re-apply on the main thread at +250ms and +750ms; idempotent, so it's a no-op (no flicker) when the initial placement was already correct.

## Why

User reported, on the released 0.3.3 desktop app: the traffic lights and sidebar toggle don't align, and the left area can't drag the window (both "seemed fine in dev").

- The **drag bug is deterministic** and confirmed by reading Tauri 2.11's `drag.js` — it was present in dev too.
- The **alignment** could not be reproduced on current 0.3.3: built and measured the release on the reporter's machine across the full window lifecycle (setup → focus → +2s/+5s, terminal launch and LaunchServices double-click) — native light center 26.0px vs toggle 25.5px, aligned at all times. The cold-launch race is the most plausible remaining cause, hence a low-risk hardening rather than a confirmed fix.

## Reviewer notes

- No behavior change when the initial placement is already correct (the re-apply is idempotent).
- CSS changes are comment-only (updated to reflect that three elements now carry the drag attribute, and that popover text-selection is still safe).
- `core:window:allow-start-dragging` in `capabilities/default.json` is still required for any of this to drag.
- Verified `pnpm run build` (tsc + vite) and `cargo build --release` both compile clean; built and launched the bundle. Visual confirmation of the alignment hardening is pending the reporter's cold-launch test (screenshot/AX inspection is TCC-blocked in this environment).