### PR TITLE
[codex] stream CLI scan progress on stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,6 +4991,7 @@ version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
+ "indicatif",
  "inquire",
  "libc",
  "reqwest 0.12.28",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,14 @@ Browser/session ownership lives in `core/src/runtime/` and `core/src/cdp/`; the
 CLI daemon/socket plumbing stays thin. See the
 [Rust CLI rules in AGENTS.md](./AGENTS.md#rust-cli--cli).
 
+Long-running site commands keep stdout machine-readable: the final command
+result is the only JSON written there. Interactive progress is transported as
+structured core events through the daemon and rendered on stderr. The default
+behavior draws English progress bars only when stderr is an interactive
+terminal, so non-interactive agents and scripts receive no progress output.
+Desktop and TUI agents call core tools directly and continue to receive the
+unchanged `ToolResult`.
+
 ### TUI
 
 Running `socai` with no subcommand opens the terminal UI (same `socai-cli`

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ uuid = { version = "1", features = ["v4"] }
 tracing-subscriber.workspace = true
 rustyline.workspace = true
 inquire.workspace = true
+indicatif = "0.18"
 
 [lints]
 workspace = true

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -4,6 +4,7 @@ use socai_core::telemetry::{query_text_enabled, telemetry_enabled, Telemetry, Te
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use socai_core::agent::tool::{ToolProgressEvent, ToolProgressSender};
 use socai_core::runtime::SocaiRuntime;
 use socai_core::sites::{find_site, SiteCommand, SiteSpec};
 #[cfg(unix)]
@@ -18,7 +19,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time::{sleep, timeout, Instant};
 
 pub const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
@@ -146,6 +147,19 @@ struct DaemonResponse {
     build_id: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct DaemonProgressFrame {
+    #[serde(rename = "type")]
+    kind: String,
+    id: String,
+    event: ToolProgressEvent,
+}
+
+enum DaemonLine {
+    Progress(ToolProgressEvent),
+    Response(DaemonResponse),
+}
+
 impl DaemonResponse {
     fn success(id: String, result: Value) -> Self {
         Self {
@@ -255,8 +269,9 @@ pub async fn send_or_spawn(
     command: &str,
     args: Value,
     command_timeout: Duration,
+    on_progress: &mut dyn FnMut(ToolProgressEvent),
 ) -> Result<Value> {
-    let err = match send_request(site, command, args.clone(), command_timeout).await {
+    let err = match send_request(site, command, args.clone(), command_timeout, on_progress).await {
         Ok(result) => return Ok(result),
         Err(err) => err,
     };
@@ -274,11 +289,19 @@ pub async fn send_or_spawn(
         None => {}
     }
     spawn_daemon().await?;
-    send_request(site, command, args, command_timeout).await
+    send_request(site, command, args, command_timeout, on_progress).await
 }
 
 pub async fn stop_daemon() -> Result<bool> {
-    match send_request("", "shutdown", json!({}), Duration::from_secs(10)).await {
+    match send_request(
+        "",
+        "shutdown",
+        json!({}),
+        Duration::from_secs(10),
+        &mut |_| {},
+    )
+    .await
+    {
         Ok(_) => Ok(true),
         Err(_) => Ok(false),
     }
@@ -295,19 +318,46 @@ async fn serve_client(
 
     while reader.read_line(&mut line).await? != 0 {
         let request: DaemonRequest = serde_json::from_str(line.trim_end())?;
+        let request_id = request.id.clone();
+        let (progress_tx, mut progress_rx) = mpsc::unbounded_channel();
         let mut disconnect_probe = String::new();
-        tokio::select! {
-            response = handle_request(request, state.clone(), stop.clone()) => {
-                writer
-                    .write_all(serde_json::to_string(&response)?.as_bytes())
-                    .await?;
-                writer.write_all(b"\n").await?;
-            }
-            read = reader.read_line(&mut disconnect_probe) => {
-                if read? == 0 {
-                    return Ok(());
+        let response = handle_request(request, state.clone(), stop.clone(), Some(progress_tx));
+        tokio::pin!(response);
+        let disconnect = reader.read_line(&mut disconnect_probe);
+        tokio::pin!(disconnect);
+        let mut progress_open = true;
+        loop {
+            tokio::select! {
+                biased;
+                event = progress_rx.recv(), if progress_open => {
+                    match event {
+                        Some(event) => {
+                            let frame = DaemonProgressFrame {
+                                kind: "progress".to_string(),
+                                id: request_id.clone(),
+                                event,
+                            };
+                            writer
+                                .write_all(serde_json::to_string(&frame)?.as_bytes())
+                                .await?;
+                            writer.write_all(b"\n").await?;
+                        }
+                        None => progress_open = false,
+                    }
                 }
-                anyhow::bail!("daemon client sent another request before the previous response");
+                response = &mut response => {
+                    writer
+                        .write_all(serde_json::to_string(&response)?.as_bytes())
+                        .await?;
+                    writer.write_all(b"\n").await?;
+                    break;
+                }
+                read = &mut disconnect => {
+                    if read? == 0 {
+                        return Ok(());
+                    }
+                    anyhow::bail!("daemon client sent another request before the previous response");
+                }
             }
         }
         line.clear();
@@ -320,6 +370,7 @@ async fn handle_request(
     request: DaemonRequest,
     state: Arc<Mutex<DaemonState>>,
     stop: Arc<Notify>,
+    progress: Option<ToolProgressSender>,
 ) -> DaemonResponse {
     let id = request.id.clone();
     let command = request.command.clone();
@@ -382,7 +433,7 @@ async fn handle_request(
         let mut state = state.lock().await;
         state.last_activity = Instant::now();
         state
-            .run_site_command(&id, site, spec, request.args, &telemetry)
+            .run_site_command(&id, site, spec, request.args, &telemetry, progress)
             .await
     }
     .await;
@@ -411,6 +462,7 @@ impl DaemonState {
         spec: &'static SiteCommand,
         args: Value,
         telemetry: &DaemonTelemetry,
+        progress: Option<ToolProgressSender>,
     ) -> Result<Value> {
         let started = Instant::now();
         let result = async {
@@ -422,7 +474,7 @@ impl DaemonState {
             // home_url here would force an extra `/explore` load before the
             // command then navigates again — wasted time for no benefit.
             let page = self.runtime.ensure_site_page(site.id, "").await?;
-            (spec.run)(page, args.clone(), debug_snapshot).await
+            (spec.run)(page, args.clone(), debug_snapshot, progress).await
         }
         .await;
         self.track_tool_trace(
@@ -519,6 +571,7 @@ async fn send_request(
     command: &str,
     args: Value,
     request_timeout: Duration,
+    on_progress: &mut dyn FnMut(ToolProgressEvent),
 ) -> Result<Value> {
     let paths = daemon_paths()?;
     let (stream, auth) = connect_daemon(&paths).await?;
@@ -544,42 +597,60 @@ async fn send_request(
             .write_all(serde_json::to_string(&request)?.as_bytes())
             .await?;
         writer.write_all(b"\n").await?;
-        reader.read_line(&mut line).await?;
-        if line.trim().is_empty() {
-            return Err(anyhow!("empty daemon response"));
-        }
-        let response: DaemonResponse = serde_json::from_str(line.trim_end())?;
-        if !response.ok {
-            let message = response
-                .error
-                .unwrap_or_else(|| "daemon command failed".to_string());
-            return Err(match response.code.as_deref() {
-                Some(CODE_VERSION_MISMATCH) => {
-                    anyhow::Error::new(DaemonClientError::VersionMismatch(message))
+        loop {
+            line.clear();
+            let read = reader.read_line(&mut line).await?;
+            if read == 0 || line.trim().is_empty() {
+                return Err(anyhow!("empty daemon response"));
+            }
+            let response = match parse_daemon_line(line.trim_end())? {
+                DaemonLine::Progress(event) => {
+                    on_progress(event);
+                    continue;
                 }
-                Some(CODE_STALE_DAEMON) => {
-                    anyhow::Error::new(DaemonClientError::StaleDaemon(message))
-                }
-                _ => anyhow!("{message}"),
-            });
+                DaemonLine::Response(response) => response,
+            };
+            if !response.ok {
+                let message = response
+                    .error
+                    .unwrap_or_else(|| "daemon command failed".to_string());
+                return Err(match response.code.as_deref() {
+                    Some(CODE_VERSION_MISMATCH) => {
+                        anyhow::Error::new(DaemonClientError::VersionMismatch(message))
+                    }
+                    Some(CODE_STALE_DAEMON) => {
+                        anyhow::Error::new(DaemonClientError::StaleDaemon(message))
+                    }
+                    _ => anyhow!("{message}"),
+                });
+            }
+            // Legacy daemons (pre build checking) execute commands without
+            // validating; their responses lack the build identity. Treat them as
+            // stale so they get replaced rather than silently serving old code.
+            if !matches!(command, "ping" | "shutdown")
+                && (response.version.as_deref() != Some(PROTOCOL_VERSION)
+                    || response.build_id.as_deref() != Some(process_build_id()))
+            {
+                return Err(anyhow::Error::new(DaemonClientError::StaleDaemon(
+                    "socai daemon predates build checking or runs a different build".to_string(),
+                )));
+            }
+            return response
+                .result
+                .ok_or_else(|| anyhow!("daemon response missing result"));
         }
-        // Legacy daemons (pre build checking) execute commands without
-        // validating; their responses lack the build identity. Treat them as
-        // stale so they get replaced rather than silently serving old code.
-        if !matches!(command, "ping" | "shutdown")
-            && (response.version.as_deref() != Some(PROTOCOL_VERSION)
-                || response.build_id.as_deref() != Some(process_build_id()))
-        {
-            return Err(anyhow::Error::new(DaemonClientError::StaleDaemon(
-                "socai daemon predates build checking or runs a different build".to_string(),
-            )));
-        }
-        response
-            .result
-            .ok_or_else(|| anyhow!("daemon response missing result"))
     })
     .await
     .map_err(|_| anyhow!("daemon request timed out after {:?}", request_timeout))?
+}
+
+fn parse_daemon_line(line: &str) -> Result<DaemonLine> {
+    let value: Value = serde_json::from_str(line)?;
+    if value.get("type").and_then(Value::as_str) == Some("progress") {
+        let frame: DaemonProgressFrame = serde_json::from_value(value)?;
+        return Ok(DaemonLine::Progress(frame.event));
+    }
+    Ok(DaemonLine::Response(serde_json::from_value(value)?))
 }
 
 async fn spawn_daemon() -> Result<()> {
@@ -591,7 +662,7 @@ async fn spawn_daemon() -> Result<()> {
 
     let deadline = Instant::now() + STARTUP_TIMEOUT;
     while Instant::now() < deadline {
-        if send_request("", "ping", json!({}), Duration::from_secs(2))
+        if send_request("", "ping", json!({}), Duration::from_secs(2), &mut |_| {})
             .await
             .is_ok()
         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod daemon;
+mod progress;
 mod tui;
 mod version;
 
@@ -175,7 +176,24 @@ async fn run_site_command(
     } else {
         daemon::DEFAULT_COMMAND_TIMEOUT
     };
-    let result = daemon::send_or_spawn(site.id, command.name, args, timeout).await?;
+    let preview = args
+        .get("preview")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let show_reading = site.id == "xhs" && !preview;
+    let show_ocr = args.get("ocr").and_then(Value::as_bool).unwrap_or(false);
+    let total = args
+        .get("num_notes")
+        .and_then(Value::as_i64)
+        .unwrap_or(10)
+        .max(1) as u64;
+    let mut renderer = progress::ProgressRenderer::new(show_reading, show_ocr, total);
+    let result = {
+        let mut on_progress = |event| renderer.update(event);
+        daemon::send_or_spawn(site.id, command.name, args, timeout, &mut on_progress).await
+    };
+    renderer.finish();
+    let result = result?;
     print_command_result(&result, matches.get_flag("pretty"))
 }
 

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -1,0 +1,134 @@
+use std::io::{self, IsTerminal};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use socai_core::agent::tool::{ToolProgressEvent, ToolProgressPhase, ToolProgressStatus};
+
+pub struct ProgressRenderer {
+    ui: Option<ProgressUi>,
+}
+
+impl ProgressRenderer {
+    pub fn new(show_reading: bool, show_ocr: bool, total: u64) -> Self {
+        let enabled = io::stderr().is_terminal() && (show_reading || show_ocr);
+        Self {
+            ui: enabled.then(|| ProgressUi::new(show_reading, show_ocr, total)),
+        }
+    }
+
+    pub fn update(&mut self, event: ToolProgressEvent) {
+        if let Some(ui) = &mut self.ui {
+            ui.update(event);
+        }
+    }
+
+    pub fn finish(&mut self) {
+        if let Some(ui) = &mut self.ui {
+            ui.finish();
+        }
+    }
+}
+
+fn truncate_title(title: &str) -> String {
+    const MAX_CHARS: usize = 64;
+    let sanitized: String = title
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect();
+    let sanitized = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = sanitized.chars();
+    let prefix: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{prefix}…")
+    } else {
+        prefix
+    }
+}
+
+struct ProgressUi {
+    multi: MultiProgress,
+    status: ProgressBar,
+    reading: Option<ProgressBar>,
+    ocr: Option<ProgressBar>,
+    reading_finished: bool,
+}
+
+impl ProgressUi {
+    fn new(show_reading: bool, show_ocr: bool, total: u64) -> Self {
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::stderr());
+        // Build the full layout before the first draw. Dynamically inserting
+        // the OCR bar after Reading has already rendered leaves stale lines in
+        // some terminals.
+        let reading = show_reading.then(|| multi.add(progress_bar("Reading", total)));
+        let ocr = show_ocr.then(|| multi.add(progress_bar("Local OCR", total)));
+        let status = multi.add(ProgressBar::new_spinner());
+        status.set_style(
+            ProgressStyle::with_template("{msg}")
+                .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+        );
+        Self {
+            multi,
+            status,
+            reading,
+            ocr,
+            reading_finished: !show_reading,
+        }
+    }
+
+    fn update(&mut self, event: ToolProgressEvent) {
+        let bar = match event.phase {
+            ToolProgressPhase::Reading => self.reading.as_ref(),
+            ToolProgressPhase::Ocr => self.ocr.as_ref(),
+        };
+        let Some(bar) = bar else {
+            return;
+        };
+        bar.set_length(event.total);
+        bar.set_position(event.current.min(event.total));
+
+        match (event.phase, event.status) {
+            (ToolProgressPhase::Reading, ToolProgressStatus::ItemStarted) => {
+                if let Some(title) = event.title.as_deref() {
+                    self.status
+                        .set_message(format!("Reading: {}", truncate_title(title)));
+                }
+            }
+            (ToolProgressPhase::Reading, ToolProgressStatus::Finished) => {
+                self.reading_finished = true;
+                self.status.set_message("Finalizing results…");
+                bar.finish();
+            }
+            (ToolProgressPhase::Ocr, ToolProgressStatus::ItemStarted) if self.reading_finished => {
+                if let Some(title) = event.title.as_deref() {
+                    self.status
+                        .set_message(format!("Running OCR: {}", truncate_title(title)));
+                }
+            }
+            (ToolProgressPhase::Ocr, ToolProgressStatus::Finished) => {
+                bar.finish();
+            }
+            _ => {}
+        }
+    }
+
+    fn finish(&mut self) {
+        if let Some(bar) = &self.reading {
+            bar.finish_and_clear();
+        }
+        if let Some(bar) = &self.ocr {
+            bar.finish_and_clear();
+        }
+        self.status.finish_and_clear();
+        let _ = self.multi.clear();
+    }
+}
+
+fn progress_bar(label: &str, total: u64) -> ProgressBar {
+    let bar = ProgressBar::new(total);
+    bar.set_prefix(label.to_string());
+    bar.set_style(
+        ProgressStyle::with_template("{prefix:>10} [{bar:32}] {pos:>3}/{len:3}")
+            .unwrap_or_else(|_| ProgressStyle::default_bar())
+            .progress_chars("=>-"),
+    );
+    bar
+}

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -19,8 +19,42 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::mpsc;
 
 use crate::agent::run_state::RunState;
+
+/// Machine-readable progress emitted by long-running tools. Core code reports
+/// state only; entrypoints decide whether and how to render it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolProgressPhase {
+    Reading,
+    Ocr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolProgressStatus {
+    ItemStarted,
+    ItemCompleted,
+    Finished,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolProgressEvent {
+    pub phase: ToolProgressPhase,
+    pub status: ToolProgressStatus,
+    /// Completed items in this phase.
+    pub current: u64,
+    /// Current target. A final event may lower this when a feed ends early.
+    pub total: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+pub type ToolProgressSender = mpsc::UnboundedSender<ToolProgressEvent>;
 
 /// Content block returned by a tool. Mirrors the subset of Anthropic's
 /// content blocks we actually use.
@@ -112,6 +146,7 @@ pub struct ToolContext {
     pub active_tool_name: String,
     pub run_state: Option<Arc<RunState>>,
     pub enabled_sites: Arc<Mutex<BTreeSet<String>>>,
+    progress: Option<ToolProgressSender>,
     counters: Arc<Mutex<Counters>>,
     /// Notes the agent has already processed at a given level. Used by
     /// macros like `search` to short-circuit repeated reads of the
@@ -156,9 +191,23 @@ impl ToolContext {
             active_tool_name: String::new(),
             run_state: None,
             enabled_sites: Arc::new(Mutex::new(BTreeSet::new())),
+            progress: None,
             counters: Arc::new(Mutex::new(Counters::default())),
             processed_notes: Arc::new(Mutex::new(BTreeMap::new())),
             search_note_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn with_progress_sender(mut self, progress: Option<ToolProgressSender>) -> Self {
+        self.progress = progress;
+        self
+    }
+
+    /// Best-effort progress delivery. A closed receiver must never fail the
+    /// underlying tool call.
+    pub fn report_progress(&self, event: ToolProgressEvent) {
+        if let Some(progress) = &self.progress {
+            let _ = progress.send(event);
         }
     }
 

--- a/core/src/sites/dy/tools.rs
+++ b/core/src/sites/dy/tools.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
+use crate::agent::tool::ToolProgressSender;
 use crate::agent::{Backend as LlmProvider, Tool, ToolContext, ToolResult};
 use crate::cdp::PageSession;
 use crate::sites::dy::DouyinPageRuntime;
@@ -109,7 +110,12 @@ pub static DY_SITE: SiteSpec = SiteSpec {
     ],
 };
 
-fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+fn run_search(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
+) -> BoxFuture<Value> {
     Box::pin(async move {
         run_tool_command(
             ToolCommand {
@@ -124,12 +130,18 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             &dy_tools(page),
             args,
             debug_snapshot,
+            progress,
         )
         .await
     })
 }
 
-fn run_page_state(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+fn run_page_state(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
+) -> BoxFuture<Value> {
     Box::pin(async move {
         let wait_seconds = get_f64(&args, "wait_seconds", 330.0);
         run_tool_command(
@@ -152,6 +164,7 @@ fn run_page_state(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> 
             &dy_tools(page),
             args,
             debug_snapshot,
+            progress,
         )
         .await
     })

--- a/core/src/sites/registry.rs
+++ b/core/src/sites/registry.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use crate::agent::tool::ToolProgressSender;
 use crate::agent::{Backend as LlmProvider, Tool};
 use crate::cdp::PageSession;
 
@@ -20,8 +21,9 @@ pub type BoxFuture<T> = Pin<Box<dyn Future<Output = anyhow::Result<T>> + Send>>;
 pub type AgentToolsFn = fn(Arc<PageSession>, Arc<dyn LlmProvider>) -> BoxFuture<Vec<Arc<dyn Tool>>>;
 pub type AgentInstructionsFn = fn(&str) -> String;
 
-/// One-shot CLI/daemon command: `(page, JSON args, debug_snapshot)` → JSON.
-pub type CommandRunFn = fn(Arc<PageSession>, Value, bool) -> BoxFuture<Value>;
+/// One-shot CLI/daemon command: `(page, JSON args, debug_snapshot, progress)` → JSON.
+pub type CommandRunFn =
+    fn(Arc<PageSession>, Value, bool, Option<ToolProgressSender>) -> BoxFuture<Value>;
 
 pub struct SiteSpec {
     /// Short site id — doubles as the CLI subcommand (`socai <id> <tool>`),

--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -11,6 +11,7 @@ use std::{path::Path, sync::Arc};
 
 use serde_json::{json, Value};
 
+use crate::agent::tool::ToolProgressSender;
 use crate::agent::{make_run_dir, Tool, ToolContext, ToolResult};
 use crate::cdp::{with_snapshot_recording, PageSession};
 use crate::sites::registry::BoxFuture;
@@ -40,6 +41,7 @@ pub async fn run_tool_command(
     tools: &[Arc<dyn Tool>],
     input: Value,
     debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
 ) -> anyhow::Result<Value> {
     // Run-dir label: site + command, plus the command's identifying input when
     // it has one, so runs are tellable apart at a glance
@@ -55,7 +57,7 @@ pub async fn run_tool_command(
             }
         }
     }
-    let (run_dir, ctx) = command_context_for_label(cmd.site_id, &label);
+    let (run_dir, ctx) = command_context_for_label(cmd.site_id, &label, progress);
     // Persist the full command input up front (best-effort) so a run is
     // debuggable from its dir alone — including the exact args — even when the
     // tool errors out partway.
@@ -121,7 +123,7 @@ pub async fn call_site_tool(
 /// run-dir name (`<ts>_<site>_<command>[_<identifier>]`, where the optional
 /// identifier is the command's first non-empty `query`/`author_id` input).
 pub fn command_context(site_id: &str, label: &str) -> (String, ToolContext) {
-    command_context_for_label(site_id, &format!("{site_id}_{label}"))
+    command_context_for_label(site_id, &format!("{site_id}_{label}"), None)
 }
 
 pub fn run_metadata(ctx: &ToolContext, include_media_dir: bool) -> Value {
@@ -153,14 +155,18 @@ pub(crate) fn attach_run_metadata(mut data: Value, run: &Value) -> Value {
     data
 }
 
-fn command_context_for_label(site_id: &str, label: &str) -> (String, ToolContext) {
+fn command_context_for_label(
+    site_id: &str,
+    label: &str,
+    progress: Option<ToolProgressSender>,
+) -> (String, ToolContext) {
     let run_dir = make_run_dir(label);
     let run_id = run_dir
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or(label)
         .to_string();
-    let ctx = ToolContext::new(run_id, run_dir.clone());
+    let ctx = ToolContext::new(run_id, run_dir.clone()).with_progress_sender(progress);
     ctx.enable_site(site_id);
     (run_dir.display().to_string(), ctx)
 }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -5,8 +5,12 @@
 //! visible, note modal open, etc.). The caller is responsible for creating
 //! the page and closing it after `run_agent` returns.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use crate::agent::tool::{
+    ToolProgressEvent, ToolProgressPhase, ToolProgressSender, ToolProgressStatus,
+};
 use crate::agent::{Backend as LlmProvider, Tool, ToolContext, ToolResult};
 use crate::cdp::PageSession;
 use crate::media::{ocr_diagnostics, ocr_warm_up, timing_delta, MediaProcessor, TimingSnapshot};
@@ -289,7 +293,12 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
 /// `search` dispatches on `--preview`: default opens each result (full scan —
 /// body + top comments); `--preview` returns result cards only (titles/likes/
 /// covers) without opening any note.
-fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+fn run_search(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
+) -> BoxFuture<Value> {
     Box::pin(async move {
         let query = required_string(&args, "query")?;
         let filters = args.get("filters").cloned();
@@ -325,12 +334,18 @@ fn run_search(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxF
             ocr,
             preview,
             debug_snapshot,
+            progress,
         )
         .await
     })
 }
 
-fn run_author_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) -> BoxFuture<Value> {
+fn run_author_scan(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
+) -> BoxFuture<Value> {
     Box::pin(async move {
         let author_id = required_string(&args, "author_id")?;
         // Default to DEFAULT_NUM_NOTES so omitting --num-notes collects a fixed
@@ -363,6 +378,7 @@ fn run_author_scan(page: Arc<PageSession>, args: Value, debug_snapshot: bool) ->
             download_media,
             ocr,
             debug_snapshot,
+            progress,
         )
         .await
     })
@@ -413,6 +429,7 @@ pub async fn search_command(
     ocr: bool,
     preview: bool,
     debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
 ) -> anyhow::Result<Value> {
     // `command_name` is passed through so the run-dir label and envelope reflect
     // the actual command the caller invoked. `preview` selects the cards-only
@@ -426,6 +443,7 @@ pub async fn search_command(
         spec,
         search_input(query, filters, num_notes, download_media, ocr, preview)?,
         debug_snapshot,
+        progress,
     )
     .await
 }
@@ -439,12 +457,14 @@ pub async fn author_scan_command(
     download_media: bool,
     ocr: bool,
     debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
 ) -> anyhow::Result<Value> {
     run_xhs_tool_command(
         page,
         AUTHOR_SCAN_COMMAND,
         author_scan_input(author_id, num_notes, preview, download_media, ocr)?,
         debug_snapshot,
+        progress,
     )
     .await
 }
@@ -508,6 +528,7 @@ async fn run_xhs_tool_command(
     spec: XhsCommandSpec,
     input: Value,
     debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
 ) -> anyhow::Result<Value> {
     let tools = xhs_tools(page.clone());
     run_tool_command(
@@ -523,6 +544,7 @@ async fn run_xhs_tool_command(
         &tools,
         input,
         debug_snapshot,
+        progress,
     )
     .await
 }
@@ -655,6 +677,120 @@ fn skipped_note_entry(card: &XhsNoteCard, reason: &str, history: &XhsHistoryStor
         "skipped": skipped,
         "entity": entity,
     })
+}
+
+fn progress_title(card: &XhsNoteCard) -> Option<String> {
+    let title = card.title.trim();
+    (!title.is_empty()).then(|| title.to_string())
+}
+
+fn report_item_progress(
+    ctx: &ToolContext,
+    phase: ToolProgressPhase,
+    status: ToolProgressStatus,
+    current: usize,
+    total: usize,
+    item_index: Option<usize>,
+    title: Option<String>,
+) {
+    ctx.report_progress(ToolProgressEvent {
+        phase,
+        status,
+        current: current as u64,
+        total: total as u64,
+        item_index: item_index.map(|value| value as u64),
+        title,
+    });
+}
+
+#[derive(Clone)]
+struct ScanProgress {
+    ctx: ToolContext,
+    total: usize,
+    ocr_completed: Arc<AtomicU64>,
+}
+
+impl ScanProgress {
+    fn new(ctx: &ToolContext, total: usize) -> Self {
+        Self {
+            ctx: ctx.clone(),
+            total,
+            ocr_completed: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn reading_started(&self, item_index: usize, title: Option<String>) {
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Reading,
+            ToolProgressStatus::ItemStarted,
+            item_index.saturating_sub(1),
+            self.total,
+            Some(item_index),
+            title,
+        );
+    }
+
+    fn reading_completed(&self, item_index: usize, title: Option<String>) {
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Reading,
+            ToolProgressStatus::ItemCompleted,
+            item_index,
+            self.total,
+            Some(item_index),
+            title,
+        );
+    }
+
+    fn ocr_started(&self, item_index: usize, title: Option<String>) {
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Ocr,
+            ToolProgressStatus::ItemStarted,
+            self.ocr_completed.load(Ordering::Relaxed) as usize,
+            self.total,
+            Some(item_index),
+            title,
+        );
+    }
+
+    fn ocr_completed(&self, item_index: usize, title: Option<String>) {
+        let current = self.ocr_completed.fetch_add(1, Ordering::Relaxed) + 1;
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Ocr,
+            ToolProgressStatus::ItemCompleted,
+            current as usize,
+            self.total,
+            Some(item_index),
+            title,
+        );
+    }
+
+    fn finish_reading(&self, actual: usize) {
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Reading,
+            ToolProgressStatus::Finished,
+            actual,
+            actual,
+            None,
+            None,
+        );
+    }
+
+    fn finish_ocr(&self, actual: usize) {
+        report_item_progress(
+            &self.ctx,
+            ToolProgressPhase::Ocr,
+            ToolProgressStatus::Finished,
+            actual,
+            actual,
+            None,
+            None,
+        );
+    }
 }
 
 /// Open one already-selected card, read its body at `level`, attach top
@@ -814,6 +950,9 @@ fn spawn_note_ocr(
     sem: &Arc<tokio::sync::Semaphore>,
     entry: &Value,
     epoch: std::time::Instant,
+    progress: ScanProgress,
+    item_index: usize,
+    title: Option<String>,
 ) -> Option<tokio::task::JoinHandle<NoteOcrResult>> {
     // Only fresh successful reads (they carry `ok`); cache hits carry `skipped`
     // and already have their ocr_text.
@@ -839,12 +978,14 @@ fn spawn_note_ocr(
     let mut images = images;
     Some(tokio::spawn(async move {
         let _permit = sem.acquire_owned().await;
+        progress.ocr_started(item_index, title.clone());
         // Measure wall start→end relative to the shared scan epoch so the perf
         // file can show each note's OCR span on the same timeline as the browse
         // loop (started_ms < browse_ms ⇒ that OCR ran while browsing continued).
         let started_ms = epoch.elapsed().as_millis() as u64;
         let predict = media.ocr_downloaded_images(&mut images).await;
         let finished_ms = epoch.elapsed().as_millis() as u64;
+        progress.ocr_completed(item_index, title);
         NoteOcrResult {
             images,
             started_ms,
@@ -1883,12 +2024,30 @@ impl Tool for SearchTool {
             // OCR'd without being saved to the run dir.
             if ocr {
                 if let Some(cards) = value.get_mut("cards").and_then(Value::as_array_mut) {
+                    report_item_progress(
+                        ctx,
+                        ToolProgressPhase::Ocr,
+                        ToolProgressStatus::ItemStarted,
+                        0,
+                        cards.len(),
+                        None,
+                        None,
+                    );
                     let media = MediaProcessor::for_run_dir(&ctx.run_dir, None)?;
                     let cover_t0 = std::time::Instant::now();
                     let predict = media.ocr_cover_images(cards, XHS_HOME_URL).await;
                     let wall = cover_t0.elapsed();
                     // Cover OCR timing goes to the perf file; cards keep only ocr_text.
                     write_cover_ocr_perf(ctx, cards.len(), predict, wall);
+                    report_item_progress(
+                        ctx,
+                        ToolProgressPhase::Ocr,
+                        ToolProgressStatus::Finished,
+                        cards.len(),
+                        cards.len(),
+                        None,
+                        None,
+                    );
                 }
             }
             let failed = value.get("ok").and_then(Value::as_bool) == Some(false);
@@ -2030,6 +2189,7 @@ impl Tool for SearchTool {
         // download; tasks are joined after the browse loop.
         let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
         let mut pending_ocr: Vec<(usize, tokio::task::JoinHandle<NoteOcrResult>)> = Vec::new();
+        let scan_progress = ScanProgress::new(ctx, want);
         // Wall-clock markers so the perf file can show how much OCR overlapped
         // the browse loop (the pipeline benefit) vs. spilled past it.
         let browse_t0 = std::time::Instant::now();
@@ -2061,6 +2221,9 @@ impl Tool for SearchTool {
                 ctx.add_search_note_ids(std::slice::from_ref(&card.note_id));
             }
             selected.push(card.clone());
+            let item_index = notes.len() + 1;
+            let title = progress_title(&card);
+            scan_progress.reading_started(item_index, title.clone());
 
             let entry = scan_card_note(
                 &xhs,
@@ -2080,13 +2243,25 @@ impl Tool for SearchTool {
             notes.push(entry);
             let idx = notes.len() - 1;
             if ocr {
-                if let Some(handle) = spawn_note_ocr(&media, &ocr_sem, &notes[idx], browse_t0) {
+                if let Some(handle) = spawn_note_ocr(
+                    &media,
+                    &ocr_sem,
+                    &notes[idx],
+                    browse_t0,
+                    scan_progress.clone(),
+                    item_index,
+                    title.clone(),
+                ) {
                     pending_ocr.push((idx, handle));
+                } else {
+                    scan_progress.ocr_completed(item_index, title.clone());
                 }
             }
             let _ = xhs.close_note(0.6).await;
+            scan_progress.reading_completed(item_index, title);
         }
 
+        scan_progress.finish_reading(notes.len());
         let browse_ms = browse_t0.elapsed().as_millis() as u64;
         // Join background OCR (epoch = browse start, so the timings line up with
         // browse_ms) and merge results back into the notes in place.
@@ -2096,6 +2271,7 @@ impl Tool for SearchTool {
         // the notes so the JSON artifact stays LLM-facing (ocr_text only).
         if ocr {
             write_note_ocr_perf(ctx, &notes, browse_ms, &ocr_timings);
+            scan_progress.finish_ocr(notes.len());
         }
 
         let mut media_timing = match (&media, &media_baseline) {
@@ -2368,11 +2544,15 @@ impl Tool for AuthorScanTool {
             // download; tasks are joined after the loop.
             let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
             let mut pending_ocr: Vec<(usize, tokio::task::JoinHandle<NoteOcrResult>)> = Vec::new();
+            let scan_progress = ScanProgress::new(ctx, cards.len());
             let browse_t0 = std::time::Instant::now();
             for card in &cards {
                 if !card.note_id.is_empty() {
                     ctx.add_search_note_ids(std::slice::from_ref(&card.note_id));
                 }
+                let item_index = notes.len() + 1;
+                let title = progress_title(card);
+                scan_progress.reading_started(item_index, title.clone());
                 let entry = scan_card_note(
                     &xhs,
                     &self.history,
@@ -2389,28 +2569,63 @@ impl Tool for AuthorScanTool {
                 notes.push(entry);
                 let idx = notes.len() - 1;
                 if ocr {
-                    if let Some(handle) = spawn_note_ocr(&media, &ocr_sem, &notes[idx], browse_t0) {
+                    if let Some(handle) = spawn_note_ocr(
+                        &media,
+                        &ocr_sem,
+                        &notes[idx],
+                        browse_t0,
+                        scan_progress.clone(),
+                        item_index,
+                        title.clone(),
+                    ) {
                         pending_ocr.push((idx, handle));
+                    } else {
+                        scan_progress.ocr_completed(item_index, title.clone());
                     }
                 }
                 let _ = xhs.close_note(0.6).await;
+                scan_progress.reading_completed(item_index, title);
             }
+            scan_progress.finish_reading(notes.len());
             let browse_ms = browse_t0.elapsed().as_millis() as u64;
             let ocr_timings =
                 join_note_ocr(&mut notes, pending_ocr, &self.history, "deep", false).await;
             if ocr {
                 write_note_ocr_perf(ctx, &notes, browse_ms, &ocr_timings);
+                scan_progress.finish_ocr(notes.len());
             }
         } else if ocr {
             // Preview + OCR: read each note card's cover image (fetched to
             // memory, not saved), mirroring the search preview path.
-            if let Some(cards_value) = profile_value.get_mut("note_cards").and_then(Value::as_array_mut)
+            if let Some(cards_value) = profile_value
+                .get_mut("note_cards")
+                .and_then(Value::as_array_mut)
             {
+                report_item_progress(
+                    ctx,
+                    ToolProgressPhase::Ocr,
+                    ToolProgressStatus::ItemStarted,
+                    0,
+                    cards_value.len(),
+                    None,
+                    None,
+                );
                 let cover_media = MediaProcessor::for_run_dir(&ctx.run_dir, None)?;
                 let covers = cards_value.len();
                 let cover_t0 = std::time::Instant::now();
-                let predict = cover_media.ocr_cover_images(cards_value, XHS_HOME_URL).await;
+                let predict = cover_media
+                    .ocr_cover_images(cards_value, XHS_HOME_URL)
+                    .await;
                 write_cover_ocr_perf(ctx, covers, predict, cover_t0.elapsed());
+                report_item_progress(
+                    ctx,
+                    ToolProgressPhase::Ocr,
+                    ToolProgressStatus::Finished,
+                    covers,
+                    covers,
+                    None,
+                    None,
+                );
             }
         }
 


### PR DESCRIPTION
## Summary

- stream structured tool progress from the Rust core through the CLI daemon
- render interactive Reading and Local OCR progress bars on stderr with the current note title
- keep stdout reserved for the final JSON result and leave desktop/TUI tool results unchanged
- use a fixed, pre-sized terminal layout to avoid stale duplicate lines and initial `0/0` bars

## Why

Long-running XHS scans previously produced no visible progress. The detached daemon could not print directly to the invoking terminal, so progress now travels over the existing daemon connection as typed events and is rendered only by the foreground CLI.

The first multi-bar implementation inserted the OCR bar after rendering had started and initialized bars with zero length. Some terminals retained the old Reading line or rendered a filled `0/0` bar. Building the complete layout up front with the requested note count fixes both cases.

## Impact

- interactive CLI users see English progress for note reading and OCR
- non-interactive agents and scripts receive no progress output
- final command JSON remains unchanged on stdout

## Validation

- `cargo test -p socai-cli`
- `cargo test -p socai-core --lib`
- `cargo check --workspace`
- `git diff --check`
