### PR TITLE
[codex] streamline persisted run logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ Build, run, local-dev workflows, and the reference-docs index live in
 only (CLI install + usage, desktop download); keep developer material out of it
 and in DEVELOPMENT.md instead.
 
+## Engineering rules
+
+- Generally do not add new tests to Rust code. Add them only when the user
+  explicitly asks for tests.
+
 ## Rust core — `core/`
 
 - `core/src/agent/`: generic agent loop, LLM providers, run state, tool trait.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,6 +61,17 @@ precedence override for local/dev scripts:
 .socai/runs/<run-dir>/
 ```
 
+Persisted execution data has three ownership layers:
+
+- Session/conversation: `~/.socai/sessions/<session-id>/session.json`.
+- Agent execution: `<run-dir>/run.json`, exact `llm/` steps, and nested
+  `tools/<tool-call>/` records.
+- Standalone CLI command: `<run-dir>/tool.json`; the run directory itself is
+  the single tool-call record.
+
+See [Persisted execution model](docs/data-model.md) for the exact ownership and
+file contracts. No parallel legacy/event/trace format is written.
+
 For app build targets, icon regeneration, the Tauri version-pinning rule, the
 monochrome design system, and macOS icon-cache gotchas, see the
 [Desktop app section in AGENTS.md](./AGENTS.md#desktop-app--app).

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 use serde_json::{json, Map, Value};
 use socai_core::agent::{
     catalog_models_for, configured_default_model_for, configured_default_provider, make_run_dir,
-    provider_credential_kind, resolve_provider, save_default_model, AgentEvent, CredentialKind,
-    ModelCatalogEntry, Provider,
+    mark_agent_run_status, provider_credential_kind, resolve_provider, save_default_model,
+    AgentEvent, CredentialKind, ModelCatalogEntry, Provider, Session,
 };
 use socai_core::runtime::{
     create_llm_provider_for, ensure_llm_provider_configured_for,
@@ -353,6 +353,9 @@ pub async fn agent_task_start(
     let site_id = app_site().map(|site| site.id).unwrap_or("agent");
     let run_dir = make_run_dir(&format!("{site_id} {task_text}"));
     let _ = std::fs::create_dir_all(&run_dir);
+    let session = Session::new(model.clone())
+        .map_err(|err| format!("failed to create desktop conversation session for task: {err}"))?;
+    let session_dir = session.dir.display().to_string();
     let registry = tasks.inner().clone();
     let snapshot = registry
         .create(
@@ -360,6 +363,7 @@ pub async fn agent_task_start(
             provider.clone(),
             model.clone(),
             run_dir.display().to_string(),
+            session_dir,
         )
         .await;
     let task_id = snapshot.task_id.clone();
@@ -451,6 +455,10 @@ pub async fn agent_task_cancel(
         let _ = runtime.close_target(&target_id).await;
     }
     if changed {
+        if let Some(run_dir) = snapshot.run_dir.as_deref() {
+            let _ = mark_agent_run_status(run_dir, "cancelled", None);
+        }
+        record_desktop_session(&snapshot, "[cancelled by user]", "cancelled");
         telemetry.capture(
             "socai_agent_task_end",
             json!({
@@ -500,6 +508,7 @@ async fn run_agent_task_background(
             })
             .await
         {
+            record_desktop_session(&snapshot, &format!("[task failed: {error}]"), "failed");
             telemetry.capture(
                 "socai_agent_task_end",
                 json!({
@@ -578,6 +587,7 @@ async fn run_agent_task_background(
                 })
                 .await
             {
+                record_desktop_session(&snapshot, &outcome.final_text, "completed");
                 telemetry.capture(
                     "socai_agent_task_end",
                     json!({
@@ -613,6 +623,10 @@ async fn run_agent_task_background(
                 })
                 .await
             {
+                if let Some(run_dir) = snapshot.run_dir.as_deref() {
+                    let _ = mark_agent_run_status(run_dir, "failed", Some(&error));
+                }
+                record_desktop_session(&snapshot, &format!("[task failed: {error}]"), "failed");
                 telemetry.capture(
                     "socai_agent_task_end",
                     json!({
@@ -628,6 +642,30 @@ async fn run_agent_task_background(
             }
         }
     }
+}
+
+pub(crate) fn record_interrupted_run(snapshot: &AgentTaskSnapshot, message: &str) {
+    if let Some(run_dir) = snapshot.run_dir.as_deref() {
+        let _ = mark_agent_run_status(run_dir, "interrupted", Some(message));
+    }
+    record_desktop_session(
+        snapshot,
+        &format!("[task interrupted: {message}]"),
+        "interrupted",
+    );
+}
+
+fn record_desktop_session(snapshot: &AgentTaskSnapshot, assistant: &str, status: &str) {
+    let Some(session_dir) = snapshot.session_dir.as_deref() else {
+        return;
+    };
+    let Some(run_dir) = snapshot.run_dir.as_deref() else {
+        return;
+    };
+    let Ok(mut session) = Session::load(session_dir) else {
+        return;
+    };
+    session.record_run(&snapshot.task, assistant, &PathBuf::from(run_dir), status);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -647,6 +685,20 @@ async fn run_agent_task_on_fresh_page(
     if task.is_empty() {
         anyhow::bail!("task is empty");
     }
+    let session_id = if let Some(registry) = &registry {
+        registry
+            .get(&task_id)
+            .await
+            .and_then(|snapshot| snapshot.session_dir)
+            .and_then(|dir| {
+                PathBuf::from(dir)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+            })
+    } else {
+        None
+    };
 
     ensure_llm_provider_configured_for(provider, model)?;
     let llm_provider = create_llm_provider_for(provider, model)?;
@@ -685,6 +737,7 @@ async fn run_agent_task_on_fresh_page(
             extra_instructions: agent_instructions(TAURI_AGENT_PREAMBLE),
             enabled_sites: vec![site.id.to_string()],
             run_dir,
+            session_id,
             ..AgentRunConfig::default()
         };
         let outcome = run_agent_with_tools(task, llm_provider, tools, config, tx).await;
@@ -794,17 +847,10 @@ async fn emit_timeline_payload(
     snapshot: Option<AgentTaskSnapshot>,
 ) {
     let event = if let Some(registry) = registry {
-        match registry
-            .append_timeline_event(task_id, payload.clone(), snapshot.clone())
+        registry
+            .live_timeline_event(task_id, payload.clone(), snapshot.clone())
             .await
-        {
-            Some(Ok(event)) => event,
-            Some(Err(err)) => {
-                eprintln!("failed to persist timeline event for {task_id}: {err:#}");
-                return;
-            }
-            None => AgentTaskEventPayload::ephemeral(task_id, payload, snapshot),
-        }
+            .unwrap_or_else(|| AgentTaskEventPayload::ephemeral(task_id, payload, snapshot))
     } else {
         AgentTaskEventPayload::ephemeral(task_id, payload, snapshot)
     };
@@ -837,7 +883,12 @@ pub struct DesktopConfig {
 pub fn config_get() -> Result<DesktopConfig, String> {
     let config = socai_core::config::load_config().map_err(|err| format!("{err:#}"))?;
     Ok(DesktopConfig {
-        chrome_source: config.chrome.profile.unwrap_or_default().as_str().to_string(),
+        chrome_source: config
+            .chrome
+            .profile
+            .unwrap_or_default()
+            .as_str()
+            .to_string(),
         chrome_profile_dir: config.chrome.profile_dir.unwrap_or_default(),
         chrome_profile_dir_default: default_managed_profile_dir(),
         output_dir: config.runs.dir.unwrap_or_default(),
@@ -860,7 +911,7 @@ pub fn config_unset(key: String) -> Result<(), String> {
 }
 
 /// Default run-artifact root when `runs.dir` is unset. Mirrors
-/// `socai_core::agent::run_logging::default_runs_root` for the no-config case:
+/// `socai_core::agent::default_runs_root` for the no-config case:
 /// `SOCAI_RUNS_DIR`, then `~/.socai/runs`.
 fn default_runs_root_display() -> String {
     if let Some(dir) = non_empty_env("SOCAI_RUNS_DIR") {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use serde_json::json;
 use socai_core::runtime::{RuntimeBrowserEvent, SocaiRuntime};
 use tasks::AgentTaskRegistry;
-use telemetry::{duration_ms, DesktopTelemetry};
 use tauri::{Emitter, Manager};
+use telemetry::{duration_ms, DesktopTelemetry};
 
 /// macOS traffic-light inset (x, y). With this math the close-button center
 /// lands at `y - 2` px from the window top; the `.is-macos .topbar` header is
@@ -96,6 +96,10 @@ pub fn run() {
                                     handle.abort();
                                 }
                                 let task_id = snapshot.task_id.clone();
+                                commands::record_interrupted_run(
+                                    &snapshot,
+                                    "chrome tab was closed",
+                                );
                                 telemetry.capture(
                                     "socai_agent_task_end",
                                     json!({

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
+use socai_core::agent::{mark_agent_run_status, Session};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::AbortHandle;
 
@@ -38,6 +39,7 @@ pub struct AgentTaskSnapshot {
     pub(crate) finished_at: Option<u64>,
     pub(crate) run_id: Option<String>,
     pub(crate) run_dir: Option<String>,
+    pub(crate) session_dir: Option<String>,
     pub(crate) target_id: Option<String>,
     // Hydrated from `<run_dir>/report.md` for API responses; not persisted in tasks.json.
     pub(crate) final_text: Option<String>,
@@ -57,6 +59,25 @@ impl Default for AgentTaskRegistry {
                 task.finished_at = Some(interrupted_at);
                 task.error = Some("app was closed before this task finished".into());
                 task.target_id = None;
+                if let Some(run_dir) = task.run_dir.as_deref() {
+                    let _ = mark_agent_run_status(
+                        run_dir,
+                        "interrupted",
+                        Some("app was closed before this task finished"),
+                    );
+                }
+                if let (Some(session_dir), Some(run_dir)) =
+                    (task.session_dir.as_deref(), task.run_dir.as_deref())
+                {
+                    if let Ok(mut session) = Session::load(session_dir) {
+                        session.record_run(
+                            &task.task,
+                            "[task interrupted: app was closed before this task finished]",
+                            &PathBuf::from(run_dir),
+                            "interrupted",
+                        );
+                    }
+                }
             }
         }
         let next_seq = tasks.len() as u64;
@@ -83,6 +104,7 @@ impl AgentTaskRegistry {
         provider: Option<String>,
         model: Option<String>,
         run_dir: String,
+        session_dir: String,
     ) -> AgentTaskSnapshot {
         let mut guard = self.inner.lock().await;
         guard.next_seq += 1;
@@ -98,6 +120,7 @@ impl AgentTaskRegistry {
             finished_at: None,
             run_id: None,
             run_dir: Some(run_dir),
+            session_dir: Some(session_dir),
             target_id: None,
             final_text: None,
             error: None,
@@ -230,12 +253,12 @@ impl AgentTaskRegistry {
         Some(timeline::load_task_events(&snapshot))
     }
 
-    pub(crate) async fn append_timeline_event(
+    pub(crate) async fn live_timeline_event(
         &self,
         task_id: &str,
         payload: AgentTaskEventKind,
         snapshot_for_emit: Option<AgentTaskSnapshot>,
-    ) -> Option<anyhow::Result<AgentTaskEventPayload>> {
+    ) -> Option<AgentTaskEventPayload> {
         let (snapshot, timeline_lock) = {
             let mut guard = self.inner.lock().await;
             let snapshot = guard
@@ -252,8 +275,8 @@ impl AgentTaskRegistry {
         };
 
         let _timeline_guard = timeline_lock.lock().await;
-        let sequence = self.next_timeline_sequence(task_id, &snapshot).await;
-        Some(timeline::append_timeline_event(
+        let sequence = self.next_timeline_sequence(task_id).await;
+        Some(timeline::live_timeline_event(
             &snapshot,
             payload,
             snapshot_for_emit,
@@ -261,25 +284,14 @@ impl AgentTaskRegistry {
         ))
     }
 
-    async fn next_timeline_sequence(&self, task_id: &str, snapshot: &AgentTaskSnapshot) -> u64 {
-        {
-            let mut guard = self.inner.lock().await;
-            if let Some(next) = guard.timeline_next_seq.get_mut(task_id) {
-                let sequence = *next;
-                *next = sequence.saturating_add(1);
-                return sequence;
-            }
-        }
-
-        // First append for this task in the current process: scan once to pick
-        // up any existing rows, then cache the next sequence in memory. This
-        // avoids re-reading timeline.jsonl on every streamed event while still
-        // preserving append-after-replay correctness.
-        let sequence = timeline::next_timeline_sequence(snapshot);
+    async fn next_timeline_sequence(&self, task_id: &str) -> u64 {
         let mut guard = self.inner.lock().await;
-        guard
+        let next = guard
             .timeline_next_seq
-            .insert(task_id.to_string(), sequence.saturating_add(1));
+            .entry(task_id.to_string())
+            .or_insert(1);
+        let sequence = *next;
+        *next = sequence.saturating_add(1);
         sequence
     }
 
@@ -305,7 +317,11 @@ impl AgentTaskRegistry {
     /// running→terminal race, or `None` when another path (cancel/interrupt)
     /// already finalized it. This is the single guard that keeps one task from
     /// emitting two terminal events.
-    pub(crate) async fn finalize_if_active<F>(&self, task_id: &str, f: F) -> Option<AgentTaskSnapshot>
+    pub(crate) async fn finalize_if_active<F>(
+        &self,
+        task_id: &str,
+        f: F,
+    ) -> Option<AgentTaskSnapshot>
     where
         F: FnOnce(&mut AgentTaskSnapshot),
     {
@@ -332,10 +348,22 @@ pub(crate) fn now_ms() -> u64 {
 }
 
 fn hydrate_task_snapshot(mut snapshot: AgentTaskSnapshot) -> AgentTaskSnapshot {
-    snapshot.final_text = snapshot
-        .run_dir
-        .as_deref()
-        .and_then(final_text_from_run_dir);
+    if let Some(run_dir) = snapshot.run_dir.as_deref() {
+        snapshot.final_text = final_text_from_run_dir(run_dir);
+        if let Ok(text) = std::fs::read_to_string(PathBuf::from(run_dir).join("run.json")) {
+            if let Ok(run) = serde_json::from_str::<Value>(&text) {
+                snapshot.run_id = run.get("id").and_then(Value::as_str).map(str::to_string);
+                snapshot.error = run.get("error").and_then(Value::as_str).map(str::to_string);
+                snapshot.turns = run
+                    .get("turns")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32);
+                snapshot.input_tokens = run.pointer("/usage/input_tokens").and_then(Value::as_u64);
+                snapshot.output_tokens =
+                    run.pointer("/usage/output_tokens").and_then(Value::as_u64);
+            }
+        }
+    }
     snapshot
 }
 
@@ -379,7 +407,8 @@ fn persist_task_index(tasks: &[AgentTaskSnapshot]) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    // Keep tasks.json as an app index only. Task results live under run_dir.
+    // Keep tasks.json as an app index only. Run id, result, error, usage, and
+    // target state are hydrated from the run or are process-local.
     let records: Vec<Value> = tasks
         .iter()
         .map(|task| {
@@ -392,13 +421,8 @@ fn persist_task_index(tasks: &[AgentTaskSnapshot]) {
                 "created_at": task.created_at,
                 "started_at": task.started_at,
                 "finished_at": task.finished_at,
-                "run_id": &task.run_id,
                 "run_dir": &task.run_dir,
-                "target_id": &task.target_id,
-                "error": &task.error,
-                "turns": task.turns,
-                "input_tokens": task.input_tokens,
-                "output_tokens": task.output_tokens,
+                "session_dir": &task.session_dir,
             })
         })
         .collect();

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -1,15 +1,11 @@
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use socai_core::agent::AgentEvent;
 
 use crate::tasks::{now_ms, AgentTaskSnapshot};
 
-const TIMELINE_FILE: &str = "timeline.jsonl";
 const MAX_EVENT_TEXT_CHARS: usize = 8_000;
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -256,33 +252,26 @@ impl AgentTaskEventKind {
     }
 }
 
-pub(crate) fn append_timeline_event(
+pub(crate) fn live_timeline_event(
     snapshot: &AgentTaskSnapshot,
     payload: AgentTaskEventKind,
     snapshot_for_emit: Option<AgentTaskSnapshot>,
     sequence: u64,
-) -> anyhow::Result<AgentTaskEventPayload> {
-    let path = timeline_path(snapshot).context("task has no run_dir for timeline")?;
-    let mut event = AgentTaskEventPayload {
+) -> AgentTaskEventPayload {
+    AgentTaskEventPayload {
         task_id: snapshot.task_id.clone(),
         payload,
-        snapshot: None,
+        snapshot: snapshot_for_emit,
         sequence,
         created_at: now_ms(),
-    };
-    append_jsonl(&path, &event).with_context(|| format!("write timeline {}", path.display()))?;
-    event.snapshot = snapshot_for_emit;
-    Ok(event)
+    }
 }
 
 pub(crate) fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
-    let mut events = read_timeline_events(snapshot);
-    if events.is_empty() {
-        events = replay_task_events(snapshot);
-        if !events.is_empty() {
-            ensure_started_event(snapshot, &mut events);
-            reindex_replay_events(snapshot, &mut events);
-        }
+    let mut events = replay_task_events(snapshot);
+    if !events.is_empty() {
+        ensure_started_event(snapshot, &mut events);
+        reindex_replay_events(snapshot, &mut events);
     }
     append_terminal_snapshot_events(snapshot, &mut events);
     events.sort_by(compare_events);
@@ -356,10 +345,7 @@ pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind 
     }
 }
 
-/// Human-readable label for a tool name. Computed when an event is written and
-/// baked into timeline.jsonl; the read path never recomputes it. So only current
-/// tool names ever reach here — renamed tools need no legacy aliases, and old
-/// runs keep the labels they were written with.
+/// Human-readable label for a current tool name.
 pub(crate) fn user_label(name: &str) -> String {
     match name {
         "search" => "searched xiaohongshu",
@@ -382,60 +368,6 @@ pub(crate) fn user_label(name: &str) -> String {
     .into()
 }
 
-fn timeline_path(snapshot: &AgentTaskSnapshot) -> Option<PathBuf> {
-    let run_dir = snapshot
-        .run_dir
-        .as_ref()
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|dir| !dir.is_empty())?;
-    Some(PathBuf::from(run_dir).join(TIMELINE_FILE))
-}
-
-fn append_jsonl(path: &Path, event: &AgentTaskEventPayload) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut line = serde_json::to_string(event).map_err(std::io::Error::other)?;
-    line.push('\n');
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-    file.write_all(line.as_bytes())
-}
-
-fn read_timeline_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
-    let Some(path) = timeline_path(snapshot) else {
-        return Vec::new();
-    };
-    let mut events: Vec<AgentTaskEventPayload> = read_jsonl_values(&path)
-        .into_iter()
-        .filter_map(|value| serde_json::from_value::<AgentTaskEventPayload>(value).ok())
-        .map(|mut event| {
-            if event.task_id.is_empty() {
-                event.task_id = snapshot.task_id.clone();
-            }
-            event.snapshot = None;
-            event
-        })
-        .collect();
-    events.sort_by(compare_events);
-    events
-}
-
-pub(crate) fn next_timeline_sequence(snapshot: &AgentTaskSnapshot) -> u64 {
-    timeline_path(snapshot)
-        .map(|path| next_sequence(&path))
-        .unwrap_or(1)
-}
-
-fn next_sequence(path: &Path) -> u64 {
-    read_jsonl_values(path)
-        .into_iter()
-        .filter_map(|value| value.get("sequence").and_then(Value::as_u64))
-        .max()
-        .unwrap_or(0)
-        + 1
-}
-
 fn replay_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
     let Some(run_dir) = snapshot
         .run_dir
@@ -445,48 +377,64 @@ fn replay_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload
         return Vec::new();
     };
     let run_dir = PathBuf::from(run_dir);
-    let mut events = replay_reasoning_log(snapshot, &run_dir, &run_dir.join("reasoning_log.jsonl"));
-    if events.is_empty() {
-        events = replay_run_state_events(snapshot, &run_dir.join("run_state/events.jsonl"));
-    }
-    events
-}
-
-fn replay_reasoning_log(
-    snapshot: &AgentTaskSnapshot,
-    run_dir: &Path,
-    path: &Path,
-) -> Vec<AgentTaskEventPayload> {
+    let Some(run) = read_json(&run_dir.join("run.json")) else {
+        return Vec::new();
+    };
     let mut events = Vec::new();
+    let task = run
+        .get("task")
+        .and_then(Value::as_str)
+        .unwrap_or(&snapshot.task);
+    let model = run
+        .get("model")
+        .and_then(Value::as_str)
+        .or(snapshot.model.as_deref())
+        .unwrap_or("unknown model");
+    let run_id = run
+        .get("id")
+        .and_then(Value::as_str)
+        .or(snapshot.run_id.as_deref())
+        .unwrap_or("");
+    events.push(replay_event(
+        snapshot,
+        AgentTaskEventKind::Started {
+            run_id: run_id.to_string(),
+            task: task.to_string(),
+            model: model.to_string(),
+            text: started_event_text_fields(task, Some(run_id), model),
+        },
+    ));
+
     let mut last_turn = None;
-    for value in read_jsonl_values(path) {
-        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
-        match event_type {
-            "task_start" => {
-                let task = value.get("task").and_then(Value::as_str);
-                let model = value.get("model").and_then(Value::as_str);
-                events.push(replay_event(
-                    snapshot,
-                    AgentTaskEventKind::Started {
-                        run_id: snapshot.run_id.clone().unwrap_or_default(),
-                        task: task.unwrap_or(&snapshot.task).to_string(),
-                        model: model
-                            .or(snapshot.model.as_deref())
-                            .unwrap_or("unknown model")
-                            .to_string(),
-                        text: started_event_text(snapshot, task, model),
-                    },
-                ));
-            }
-            "llm_response" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let text = value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if !text.is_empty() {
+    for (turn, response) in llm_responses(&run_dir) {
+        push_turn_event(snapshot, &mut events, &mut last_turn, turn);
+        if let Some(error) = response.get("error").and_then(Value::as_str) {
+            events.push(replay_event(
+                snapshot,
+                AgentTaskEventKind::ApiError {
+                    turn,
+                    message: error.to_string(),
+                    text: format!("turn {turn}: {error}"),
+                },
+            ));
+            continue;
+        }
+        if let Some(reasoning) = response
+            .get("reasoning_content")
+            .and_then(Value::as_str)
+            .filter(|text| !text.trim().is_empty())
+        {
+            events.push(replay_event(
+                snapshot,
+                AgentTaskEventKind::Reasoning {
+                    turn,
+                    text: truncate_event_text(reasoning),
+                },
+            ));
+        }
+        if let Some(texts) = response.get("text_blocks").and_then(Value::as_array) {
+            for text in texts.iter().filter_map(Value::as_str) {
+                if !text.trim().is_empty() {
                     events.push(replay_event(
                         snapshot,
                         AgentTaskEventKind::Assistant {
@@ -496,188 +444,67 @@ fn replay_reasoning_log(
                     ));
                 }
             }
-            "reasoning" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let text = value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if !text.is_empty() {
-                    events.push(replay_event(
-                        snapshot,
-                        AgentTaskEventKind::Reasoning {
-                            turn,
-                            text: truncate_event_text(text),
-                        },
-                    ));
-                }
-            }
-            "tool_call_start" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let sequence = number_field(&value, "sequence") as u32;
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                let repeat_count = number_field(&value, "repeat_count") as u32;
-                let id = tool_use_id(&value, turn, sequence, tool);
-                events.push(replay_event(
-                    snapshot,
-                    tool_call_event(&id, turn, sequence, tool, input, repeat_count),
-                ));
-            }
-            "tool_result" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let sequence = number_field(&value, "sequence") as u32;
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                let summary = value
-                    .get("result_summary")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let error = value.get("error").and_then(Value::as_str).unwrap_or("");
-                let duration_ms = duration_ms(&value);
-                let result_file = value
-                    .get("result_file")
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
-                let content = value
-                    .get("content")
-                    .cloned()
-                    .or_else(|| {
-                        result_file
-                            .as_deref()
-                            .and_then(|file| load_result_content(run_dir, file))
-                    })
-                    .unwrap_or(Value::Null);
-                let id = tool_use_id(&value, turn, sequence, tool);
-                events.push(replay_event(
-                    snapshot,
-                    tool_result_event(
-                        &id,
-                        turn,
-                        sequence,
-                        tool,
-                        input,
-                        summary,
-                        duration_ms,
-                        if error.trim().is_empty() {
-                            None
-                        } else {
-                            Some(error)
-                        },
-                        &content,
-                        result_file,
-                    ),
-                ));
-            }
-            "api_error" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let message = value
-                    .get("error")
-                    .or_else(|| value.get("message"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("api error");
-                events.push(replay_event(
-                    snapshot,
-                    AgentTaskEventKind::ApiError {
-                        turn,
-                        message: message.to_string(),
-                        text: format!("turn {turn}: {message}"),
-                    },
-                ));
-            }
-            "task_end" => {
-                let turn = number_field(&value, "turn") as u32;
-                events.push(replay_event(
-                    snapshot,
-                    AgentTaskEventKind::Done {
-                        run_id: snapshot.run_id.clone(),
-                        turns: turn,
-                        text: if turn > 0 {
-                            format!("done in {turn} turns")
-                        } else {
-                            "done".into()
-                        },
-                    },
-                ));
-            }
-            _ => {}
+        }
+        let calls = response
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for (index, call) in calls.iter().enumerate() {
+            let sequence = index as u32 + 1;
+            let name = call.get("name").and_then(Value::as_str).unwrap_or("tool");
+            let id = call
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("tool-call");
+            let tool_rel = format!(
+                "tools/turn-{turn:03}-call-{sequence:02}-{}",
+                safe_component(name, "tool")
+            );
+            let tool_dir = run_dir.join(&tool_rel);
+            let manifest = read_json(&tool_dir.join("tool.json")).unwrap_or(Value::Null);
+            let input = manifest
+                .get("input")
+                .or_else(|| call.get("input"))
+                .unwrap_or(&Value::Null);
+            events.push(replay_event(
+                snapshot,
+                tool_call_event(id, turn, sequence, name, input, 0),
+            ));
+            let output = read_json(&tool_dir.join("output.json")).unwrap_or(Value::Null);
+            let error = manifest.get("error").and_then(Value::as_str);
+            let duration = manifest
+                .get("duration_ms")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            let summary = tool_output_summary(&output);
+            events.push(replay_event(
+                snapshot,
+                tool_result_event(
+                    id,
+                    turn,
+                    sequence,
+                    name,
+                    input,
+                    &summary,
+                    duration,
+                    error,
+                    &output,
+                    Some(format!("{tool_rel}/output.json")),
+                ),
+            ));
         }
     }
-    events
-}
-
-fn replay_run_state_events(
-    snapshot: &AgentTaskSnapshot,
-    path: &Path,
-) -> Vec<AgentTaskEventPayload> {
-    let mut events = Vec::new();
-    let mut last_turn = None;
-    for value in read_jsonl_values(path) {
-        let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
-        match event_type {
-            "assistant_turn" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let text = value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if !text.is_empty() {
-                    events.push(replay_event(
-                        snapshot,
-                        AgentTaskEventKind::Assistant {
-                            turn,
-                            text: truncate_event_text(text),
-                        },
-                    ));
-                }
-            }
-            "tool_call" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                let id = tool_use_id(&value, turn, 0, tool);
-                events.push(replay_event(
-                    snapshot,
-                    tool_call_event(&id, turn, 0, tool, input, 0),
-                ));
-            }
-            "tool_result" => {
-                let turn = number_field(&value, "turn") as u32;
-                push_turn_event(snapshot, &mut events, &mut last_turn, turn);
-                let tool = value.get("tool").and_then(Value::as_str).unwrap_or("tool");
-                let input = value.get("input").unwrap_or(&Value::Null);
-                let summary = value
-                    .get("result_summary")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let duration_ms = duration_ms(&value);
-                let id = tool_use_id(&value, turn, 0, tool);
-                events.push(replay_event(
-                    snapshot,
-                    tool_result_event(
-                        &id,
-                        turn,
-                        0,
-                        tool,
-                        input,
-                        summary,
-                        duration_ms,
-                        None,
-                        &Value::Null,
-                        None,
-                    ),
-                ));
-            }
-            _ => {}
-        }
+    let turns = run.get("turns").and_then(Value::as_u64).unwrap_or_default() as u32;
+    if run.get("status").and_then(Value::as_str) == Some("completed") {
+        events.push(replay_event(
+            snapshot,
+            AgentTaskEventKind::Done {
+                run_id: Some(run_id.to_string()),
+                turns,
+                text: format!("done in {turns} turns"),
+            },
+        ));
     }
     events
 }
@@ -968,9 +795,8 @@ fn raw_tool_result_value(content: &Value) -> Option<Value> {
 }
 
 fn normalize_entities(tool: &str, value: &Value) -> Vec<TimelineEntity> {
-    // Like user_label, this runs at write time, so only the current tool name
-    // reaches here. `--preview` yields a `cards` array (-> card grid); the
-    // default full scan yields the aggregated bundle (-> xhs_search).
+    // `--preview` yields a `cards` array (-> card grid); the default full scan
+    // yields the aggregated bundle (-> xhs_search).
     match tool {
         "search" => {
             if let Some(cards) = value.get("cards").and_then(Value::as_array) {
@@ -1030,52 +856,54 @@ fn entity(entity_type: &str, data: Value) -> TimelineEntity {
     }
 }
 
-fn load_result_content(run_dir: &Path, result_file: &str) -> Option<Value> {
-    let path = run_dir.join(result_file);
-    let text = std::fs::read_to_string(path).ok()?;
-    let value = serde_json::from_str::<Value>(&text).ok()?;
-    value.get("content").cloned()
+fn read_json(path: &Path) -> Option<Value> {
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
 }
 
-fn tool_use_id(value: &Value, turn: u32, sequence: u32, tool: &str) -> String {
-    value
-        .get("tool_use_id")
-        .and_then(Value::as_str)
-        .filter(|id| !id.trim().is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| format!("turn:{turn}:sequence:{sequence}:tool:{tool}"))
-}
-
-fn duration_ms(value: &Value) -> u64 {
-    if let Some(ms) = value.get("duration_ms").and_then(Value::as_u64) {
-        return ms;
-    }
-    value
-        .get("duration_s")
-        .and_then(Value::as_f64)
-        .map(|seconds| (seconds * 1000.0).round().max(0.0) as u64)
-        .unwrap_or_default()
-}
-
-fn number_field(value: &Value, field: &str) -> u64 {
-    value
-        .get(field)
-        .and_then(|number| {
-            number
-                .as_u64()
-                .or_else(|| number.as_f64().map(|n| n as u64))
-        })
-        .unwrap_or_default()
-}
-
-fn read_jsonl_values(path: &Path) -> Vec<Value> {
-    let Ok(text) = std::fs::read_to_string(path) else {
+fn llm_responses(run_dir: &Path) -> Vec<(u32, Value)> {
+    let Ok(entries) = std::fs::read_dir(run_dir.join("llm")) else {
         return Vec::new();
     };
-    text.lines()
-        .filter(|line| !line.trim().is_empty())
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .collect()
+    let mut responses: Vec<(u32, Value)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let step = name.strip_suffix(".response.json")?.parse().ok()?;
+            Some((step, read_json(&entry.path())?))
+        })
+        .collect();
+    responses.sort_by_key(|(step, _)| *step);
+    responses
+}
+
+fn tool_output_summary(output: &Value) -> String {
+    let raw = raw_tool_result_value(output).unwrap_or(Value::Null);
+    let text = match raw {
+        Value::String(text) => text,
+        Value::Null => String::new(),
+        value => serde_json::to_string(&value).unwrap_or_default(),
+    };
+    truncate_event_text(&text.chars().take(240).collect::<String>())
+}
+
+fn safe_component(value: &str, fallback: &str) -> String {
+    let cleaned: String = value
+        .trim()
+        .chars()
+        .map(|ch| {
+            if ch.is_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches('_');
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.chars().take(48).collect()
+    }
 }
 
 fn truncate_event_text(text: &str) -> String {

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -619,11 +619,11 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     let page = match runtime.ensure_site_page(site.id, site.home_url).await {
         Ok(page) => page,
         Err(err) => {
-            state.session.record_turn(
+            state.session.record_run(
                 task,
                 &format!("[turn did not run — browser/network error: {err:#}]"),
-                "",
                 &run_dir,
+                "failed",
             );
             return Err(err);
         }
@@ -660,6 +660,7 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
         extra_instructions: agent_instructions(&preamble),
         enabled_sites: vec![site.id.to_string()],
         seed_messages: state.session.chat_messages(),
+        session_id: Some(state.session.id.clone()),
         run_dir: Some(run_dir.clone()),
         ..AgentRunConfig::default()
     };
@@ -672,9 +673,9 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
         outcome = &mut agent => outcome,
         _ = tokio::signal::ctrl_c() => {
             printer.abort();
-            let (run_id, partial) = live
+            let partial = live
                 .lock()
-                .map(|g| (g.run_id.clone(), g.assistant.clone()))
+                .map(|g| g.assistant.clone())
                 .unwrap_or_default();
             let assistant = if partial.trim().is_empty() {
                 "[interrupted by user before producing an answer]".to_string()
@@ -682,7 +683,7 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
                 format!("{}\n\n[interrupted by user]", partial.trim())
             };
             // Record the interrupted turn so a follow-up keeps its context.
-            state.session.record_turn(task, &assistant, &run_id, &run_dir);
+            state.session.record_run(task, &assistant, &run_dir, "interrupted");
             println!("\n[socai] interrupted — recorded; ask a follow-up, or press Ctrl+C at the prompt to exit.");
             return Ok(());
         }
@@ -694,7 +695,7 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
             // Record the failed turn too, so its topic survives for follow-ups.
             state
                 .session
-                .record_turn(task, &format!("[turn failed: {err:#}]"), "", &run_dir);
+                .record_run(task, &format!("[turn failed: {err:#}]"), &run_dir, "failed");
             return Err(err);
         }
     };
@@ -717,9 +718,7 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     } else {
         outcome.final_text.clone()
     };
-    state
-        .session
-        .record_turn(task, &recorded, &outcome.run_id, &outcome.run_dir);
+    state.session.record_turn(task, &recorded, &outcome.run_dir);
     Ok(())
 }
 

--- a/core/src/agent/compaction.rs
+++ b/core/src/agent/compaction.rs
@@ -4,7 +4,7 @@
 //! These are used in two places:
 //! - Agent loop history (keep tool_result bodies bounded so context doesn't
 //!   blow up over many turns).
-//! - RunState/RunDebugLogger (compact entity-like payloads when summarizing
+//! - RunState (compact entity-like payloads when summarizing
 //!   evidence for working_memory.md).
 
 use serde_json::{Map, Value};

--- a/core/src/agent/llm.rs
+++ b/core/src/agent/llm.rs
@@ -107,14 +107,15 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
     pub id: String,
     pub name: String,
     pub input: Value,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum StopReason {
     EndTurn,
     ToolUse,
@@ -122,7 +123,7 @@ pub enum StopReason {
     Other,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LLMResponse {
     pub text_blocks: Vec<String>,
     pub tool_calls: Vec<ToolCall>,
@@ -161,7 +162,7 @@ impl LLMResponse {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolSchema {
     pub name: String,
     pub description: String,
@@ -172,6 +173,24 @@ pub struct ToolSchema {
 pub trait Backend: Send + Sync {
     fn label(&self) -> String;
     fn model(&self) -> &str;
+
+    /// JSON body sent to the provider, excluding authentication headers.
+    /// Production backends override this with their wire-format payload.
+    fn request_payload(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: u32,
+    ) -> anyhow::Result<Value> {
+        Ok(serde_json::json!({
+            "model": self.model(),
+            "system": system,
+            "messages": messages,
+            "tools": tools,
+            "max_tokens": max_tokens,
+        }))
+    }
 
     async fn send(
         &self,

--- a/core/src/agent/llm/anthropic.rs
+++ b/core/src/agent/llm/anthropic.rs
@@ -59,6 +59,50 @@ impl AnthropicBackend {
         self.enable_prompt_caching = enable;
         self
     }
+
+    fn build_request_payload(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: u32,
+    ) -> Value {
+        let wire_messages: Vec<WireMessage> = messages.iter().map(message_to_wire).collect();
+        let system_value = if self.enable_prompt_caching && !system.is_empty() {
+            json!([{
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"},
+            }])
+        } else {
+            json!(system)
+        };
+        let mut wire_tools: Vec<Value> = tools
+            .iter()
+            .map(|tool| {
+                json!({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": tool.input_schema,
+                })
+            })
+            .collect();
+        if self.enable_prompt_caching {
+            if let Some(Value::Object(map)) = wire_tools.last_mut() {
+                map.insert("cache_control".into(), json!({"type": "ephemeral"}));
+            }
+        }
+        json!({
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "system": system_value,
+            "messages": wire_messages.iter().map(|message| json!({
+                "role": message.role,
+                "content": message.content,
+            })).collect::<Vec<_>>(),
+            "tools": wire_tools,
+        })
+    }
 }
 
 fn block_to_wire(block: &Block) -> Option<Value> {
@@ -187,6 +231,16 @@ impl Backend for AnthropicBackend {
         &self.model
     }
 
+    fn request_payload(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: u32,
+    ) -> anyhow::Result<Value> {
+        Ok(self.build_request_payload(system, messages, tools, max_tokens))
+    }
+
     async fn send(
         &self,
         system: &str,
@@ -194,48 +248,7 @@ impl Backend for AnthropicBackend {
         tools: &[ToolSchema],
         max_tokens: u32,
     ) -> anyhow::Result<LLMResponse> {
-        let wire_messages: Vec<WireMessage> = messages.iter().map(message_to_wire).collect();
-
-        // System: pass as a content block when prompt caching is on so we
-        // can attach cache_control; otherwise plain string.
-        let system_value = if self.enable_prompt_caching && !system.is_empty() {
-            json!([{
-                "type": "text",
-                "text": system,
-                "cache_control": {"type": "ephemeral"},
-            }])
-        } else {
-            json!(system)
-        };
-
-        // Tools: drop a cache_control marker on the last one so Anthropic
-        // caches the whole tool-definitions block.
-        let mut wire_tools: Vec<Value> = tools
-            .iter()
-            .map(|t| {
-                json!({
-                    "name": t.name,
-                    "description": t.description,
-                    "input_schema": t.input_schema,
-                })
-            })
-            .collect();
-        if self.enable_prompt_caching {
-            if let Some(Value::Object(map)) = wire_tools.last_mut() {
-                map.insert("cache_control".into(), json!({"type": "ephemeral"}));
-            }
-        }
-
-        let body = json!({
-            "model": self.model,
-            "max_tokens": max_tokens,
-            "system": system_value,
-            "messages": wire_messages.iter().map(|m| json!({
-                "role": m.role,
-                "content": m.content,
-            })).collect::<Vec<_>>(),
-            "tools": wire_tools,
-        });
+        let body = self.build_request_payload(system, messages, tools, max_tokens);
 
         let response = self
             .client

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -104,6 +104,50 @@ impl OpenAICompatBackend {
     fn preserve_reasoning_content(&self) -> bool {
         matches!(self.provider, Provider::Kimi | Provider::Qwen)
     }
+
+    fn build_chat_request(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: u32,
+    ) -> OutgoingRequest {
+        let chat_tools = tools_to_wire(tools);
+        let has_tools = !chat_tools.is_empty();
+        let (max_tokens_field, max_completion_tokens_field) =
+            if matches!(self.provider, Provider::OpenAI) {
+                (None, Some(max_tokens))
+            } else {
+                (Some(max_tokens), None)
+            };
+        OutgoingRequest {
+            model: self.model.clone(),
+            messages: build_chat_messages(system, messages, self.preserve_reasoning_content()),
+            max_tokens: max_tokens_field,
+            max_completion_tokens: max_completion_tokens_field,
+            tools: chat_tools,
+            tool_choice: if has_tools { Some("auto") } else { None },
+            extra: self.extra_body(has_tools),
+        }
+    }
+
+    fn build_responses_request(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+    ) -> ResponsesRequest {
+        ResponsesRequest {
+            model: self.model.clone(),
+            instructions: system.to_string(),
+            input: build_responses_input(messages),
+            tools: responses_tools_to_wire(tools),
+            tool_choice: if tools.is_empty() { None } else { Some("auto") },
+            parallel_tool_calls: true,
+            stream: true,
+            store: false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -599,6 +643,22 @@ impl Backend for OpenAICompatBackend {
         &self.model
     }
 
+    fn request_payload(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: u32,
+    ) -> anyhow::Result<Value> {
+        if matches!(self.credential, Credential::CodexOAuth { .. }) {
+            serde_json::to_value(self.build_responses_request(system, messages, tools))
+                .map_err(Into::into)
+        } else {
+            serde_json::to_value(self.build_chat_request(system, messages, tools, max_tokens))
+                .map_err(Into::into)
+        }
+    }
+
     async fn send(
         &self,
         system: &str,
@@ -610,27 +670,7 @@ impl Backend for OpenAICompatBackend {
             return self.send_codex_responses(system, messages, tools).await;
         }
 
-        let chat_messages =
-            build_chat_messages(system, messages, self.preserve_reasoning_content());
-        let chat_tools = tools_to_wire(tools);
-        let has_tools = !chat_tools.is_empty();
-
-        let (max_tokens_field, max_completion_tokens_field) =
-            if matches!(self.provider, Provider::OpenAI) {
-                (None, Some(max_tokens))
-            } else {
-                (Some(max_tokens), None)
-            };
-
-        let body = OutgoingRequest {
-            model: self.model.clone(),
-            messages: chat_messages,
-            max_tokens: max_tokens_field,
-            max_completion_tokens: max_completion_tokens_field,
-            tools: chat_tools,
-            tool_choice: if has_tools { Some("auto") } else { None },
-            extra: self.extra_body(has_tools),
-        };
+        let body = self.build_chat_request(system, messages, tools, max_tokens);
 
         let response = self
             .client
@@ -702,16 +742,7 @@ impl OpenAICompatBackend {
         messages: &[Message],
         tools: &[ToolSchema],
     ) -> anyhow::Result<LLMResponse> {
-        let body = ResponsesRequest {
-            model: self.model.clone(),
-            instructions: system.to_string(),
-            input: build_responses_input(messages),
-            tools: responses_tools_to_wire(tools),
-            tool_choice: if tools.is_empty() { None } else { Some("auto") },
-            parallel_tool_calls: true,
-            stream: true,
-            store: false,
-        };
+        let body = self.build_responses_request(system, messages, tools);
 
         let response = self.send_codex_responses_once(&body, None).await?;
         self.parse_codex_responses_response(response).await

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -15,7 +15,8 @@
 //! - `memory.rs`    — windowing the message history once it's long
 //! - `report.rs`    — final report enrichment with artifact links
 //! - `compaction.rs` — truncating tool_result bodies for the history budget
-//! - `run_state.rs` / `run_logging.rs` — persisting events + artifacts
+//! - `run_logging.rs` — canonical agent-run / LLM-step / tool-call records
+//! - `run_state.rs` — in-memory context compaction state
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -28,11 +29,11 @@ use tracing::{debug, info, warn};
 
 use crate::agent::compaction::{compress_text_maybe_json, TOOL_RESULT_TEXT_MAX_CHARS};
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, StopReason, ToolCall, ToolResultContent, ToolSchema,
+    Backend, Block, LLMResponse, Message, ToolCall, ToolResultContent, ToolSchema,
 };
 use crate::agent::memory::prepare_messages_for_context;
 use crate::agent::report::report_with_artifacts;
-use crate::agent::run_logging::{make_run_dir, RunDebugLogger};
+use crate::agent::run_logging::{make_run_dir, AgentRunRecorder};
 use crate::agent::run_state::RunState;
 use crate::agent::signature::tool_call_signature;
 use crate::agent::system_prompt::build_system_prompt;
@@ -103,6 +104,8 @@ pub struct AgentOptions {
     /// continue an ongoing multi-turn session. The current task is appended as
     /// the final user message. Empty = a fresh, single-shot run.
     pub seed_messages: Vec<Message>,
+    /// Optional parent conversation identifier.
+    pub session_id: Option<String>,
 }
 
 impl Default for AgentOptions {
@@ -116,6 +119,7 @@ impl Default for AgentOptions {
             keep_recent_messages: 12,
             memory_max_chars: 6000,
             seed_messages: Vec::new(),
+            session_id: None,
         }
     }
 }
@@ -150,8 +154,14 @@ pub async fn run_agent_with_events(
     let run_id = new_run_id();
     let run_dir = options.run_dir.unwrap_or_else(|| make_run_dir(task));
     ensure_dir(&run_dir)?;
-    let run_state = Arc::new(RunState::new(&run_dir, task, backend.model())?);
-    let debug_log = RunDebugLogger::new(&run_dir);
+    let run_state = Arc::new(RunState::new(task));
+    let run_recorder = AgentRunRecorder::start(
+        &run_dir,
+        &run_id,
+        options.session_id.as_deref(),
+        task,
+        backend.model(),
+    )?;
 
     let mut ctx = ToolContext::new(&run_id, &run_dir).with_run_state(Arc::clone(&run_state));
     for site in &options.enabled_sites {
@@ -161,14 +171,6 @@ pub async fn run_agent_with_events(
     let mut messages: Vec<Message> = options.seed_messages.clone();
     messages.push(Message::user(task.to_string()));
 
-    debug_log.event(
-        "task_start",
-        json!({
-            "task": task,
-            "model": backend.model(),
-            "tools": tools.iter().map(|t| t.name()).collect::<Vec<_>>(),
-        }),
-    );
     emit(
         &events,
         AgentEvent::Started {
@@ -185,6 +187,7 @@ pub async fn run_agent_with_events(
     let mut context_memory: Vec<String> = Vec::new();
     let mut tool_call_history: BTreeMap<String, Vec<u32>> = BTreeMap::new();
     let mut completed = false;
+    let mut terminal_error: Option<String> = None;
     let mut last_system: String = build_system_prompt(&[], &options.extra_instructions);
 
     while turn < options.max_turns {
@@ -204,14 +207,30 @@ pub async fn run_agent_with_events(
             options.keep_recent_messages,
             options.memory_max_chars,
         );
+        let request_payload =
+            backend.request_payload(&system, &request_messages, &schemas, options.max_tokens)?;
+        run_recorder.record_llm_request(turn, &request_payload)?;
 
+        let llm_started = Instant::now();
         let response: LLMResponse = match backend
             .send(&system, &request_messages, &schemas, options.max_tokens)
             .await
         {
-            Ok(r) => r,
+            Ok(response) => {
+                run_recorder.record_llm_response(
+                    turn,
+                    &response,
+                    llm_started.elapsed().as_millis() as u64,
+                )?;
+                response
+            }
             Err(e) => {
                 let msg = format!("{e:#}");
+                run_recorder.record_llm_error(
+                    turn,
+                    &msg,
+                    llm_started.elapsed().as_millis() as u64,
+                )?;
                 warn!(turn, error = %msg, "backend error");
                 emit(
                     &events,
@@ -220,8 +239,8 @@ pub async fn run_agent_with_events(
                         message: msg.clone(),
                     },
                 );
-                debug_log.api_error(turn, &msg, false);
                 final_text = format!("API error: {msg}");
+                terminal_error = Some(msg);
                 break;
             }
         };
@@ -246,10 +265,6 @@ pub async fn run_agent_with_events(
                     text: response.reasoning_content.clone(),
                 },
             );
-            debug_log.event(
-                "reasoning",
-                json!({"turn": turn, "text": response.reasoning_content.clone()}),
-            );
         }
         if !thinking_texts.is_empty() {
             let thinking_text = thinking_texts.join("\n");
@@ -260,7 +275,6 @@ pub async fn run_agent_with_events(
                     text: thinking_text.clone(),
                 },
             );
-            debug_log.event("reasoning", json!({"turn": turn, "text": thinking_text}));
         }
 
         // Build the assistant block list manually instead of using
@@ -288,20 +302,6 @@ pub async fn run_agent_with_events(
             .map(|tc| json!({"name": tc.name, "input": tc.input}))
             .collect();
         run_state.note_assistant_turn(turn, &visible_texts.join("\n"), &tool_call_summary);
-        debug_log.event(
-            "llm_response",
-            json!({
-                "turn": turn,
-                "stop_reason": stop_reason_str(response.stop_reason),
-                "text": visible_texts.join("\n"),
-                "tool_calls": tool_call_summary,
-                "usage": {
-                    "input_tokens": response.input_tokens,
-                    "output_tokens": response.output_tokens,
-                },
-            }),
-        );
-
         if response.tool_calls.is_empty() {
             completed = true;
             break;
@@ -318,6 +318,12 @@ pub async fn run_agent_with_events(
             let repeat_count = history.len() as u32;
 
             let sequence = (idx + 1) as u32;
+            let effective_input = find_tool(&tools, name)
+                .map(|tool| tool.effective_input(input))
+                .unwrap_or_else(|| input.clone());
+            let tool_recorder =
+                run_recorder.start_tool_call(turn, sequence, name, &effective_input)?;
+            let tool_ctx = ctx.clone().with_tool_dir(tool_recorder.dir());
             emit(
                 &events,
                 AgentEvent::ToolCall {
@@ -325,27 +331,16 @@ pub async fn run_agent_with_events(
                     turn,
                     sequence,
                     name: name.clone(),
-                    input: input.clone(),
+                    input: effective_input.clone(),
                     repeat_count,
                 },
             );
-            run_state.note_tool_call(turn, name, input);
-            debug_log.event(
-                "tool_call_start",
-                json!({
-                    "turn": turn,
-                    "sequence": sequence,
-                    "tool_use_id": id,
-                    "tool": name,
-                    "input": input,
-                    "repeat_count": repeat_count,
-                }),
-            );
-
+            run_state.note_tool_call(turn, name, &effective_input);
             let started = Instant::now();
-            let (result, error) = dispatch_tool(&tools, name, input, &ctx).await;
+            let (result, error) = dispatch_tool(&tools, name, &effective_input, &tool_ctx).await;
             let duration_ms = started.elapsed().as_millis() as u64;
             let duration_s = (duration_ms as f64) / 1000.0;
+            tool_recorder.finish_blocks(&result.blocks, duration_ms, error.as_deref())?;
 
             let result_content = tool_result_to_content(&result);
             let content = content_for_log(&result_content);
@@ -358,27 +353,14 @@ pub async fn run_agent_with_events(
                     turn,
                     sequence,
                     name: name.clone(),
-                    input: input.clone(),
+                    input: effective_input.clone(),
                     content: content.clone(),
                     summary: summary.clone(),
                     duration_ms,
                     error: error.clone(),
                 },
             );
-            run_state.note_tool_result(turn, name, input, &summary, duration_s);
-            debug_log.tool_result(
-                turn,
-                sequence,
-                id,
-                name,
-                input,
-                &content,
-                duration_s,
-                &summary,
-                repeat_count,
-                error.as_deref().unwrap_or(""),
-            );
-
+            run_state.note_tool_result(turn, name, &effective_input, &summary, duration_s);
             let mut history_content = bound_content_for_history(&result_content);
             // Break tight loops: when the model fires the *same* call with the
             // same args repeatedly, the bare result won't change its mind. Tell
@@ -404,7 +386,10 @@ pub async fn run_agent_with_events(
 
             context_memory.push(format!(
                 "- turn {turn} {name}({}): {summary}",
-                truncate_summary(&serde_json::to_string(input).unwrap_or_default(), 160)
+                truncate_summary(
+                    &serde_json::to_string(&effective_input).unwrap_or_default(),
+                    160,
+                )
             ));
             if context_memory.len() > 80 {
                 let overflow = context_memory.len() - 80;
@@ -413,7 +398,6 @@ pub async fn run_agent_with_events(
             ctx.active_tool_name.clear();
         }
         messages.push(Message::user_blocks(tool_result_blocks));
-        debug_log.event("turn_end", json!({"turn": turn}));
     }
 
     if !completed && turn >= options.max_turns {
@@ -433,11 +417,20 @@ pub async fn run_agent_with_events(
             options.keep_recent_messages,
             options.memory_max_chars,
         );
+        let request_payload =
+            backend.request_payload(&last_system, &request_messages, &[], options.max_tokens)?;
+        run_recorder.record_llm_request(turn + 1, &request_payload)?;
+        let llm_started = Instant::now();
         match backend
             .send(&last_system, &request_messages, &[], options.max_tokens)
             .await
         {
             Ok(response) => {
+                run_recorder.record_llm_response(
+                    turn + 1,
+                    &response,
+                    llm_started.elapsed().as_millis() as u64,
+                )?;
                 total_input_tokens += response.input_tokens;
                 total_output_tokens += response.output_tokens;
                 let (visible_texts, _) = split_thinking(&response.text_blocks);
@@ -451,21 +444,14 @@ pub async fn run_agent_with_events(
                     );
                     final_text = text.clone();
                 }
-                debug_log.event(
-                    "llm_response",
-                    json!({
-                        "turn": turn + 1,
-                        "forced_summary": true,
-                        "text": final_text,
-                        "usage": {
-                            "input_tokens": response.input_tokens,
-                            "output_tokens": response.output_tokens,
-                        },
-                    }),
-                );
             }
             Err(e) => {
                 let msg = format!("{e:#}");
+                run_recorder.record_llm_error(
+                    turn + 1,
+                    &msg,
+                    llm_started.elapsed().as_millis() as u64,
+                )?;
                 warn!(turn = turn + 1, error = %msg, "forced summary error");
                 emit(
                     &events,
@@ -474,7 +460,7 @@ pub async fn run_agent_with_events(
                         message: msg.clone(),
                     },
                 );
-                debug_log.api_error(turn + 1, &msg, true);
+                terminal_error = Some(msg);
             }
         }
     }
@@ -491,23 +477,17 @@ pub async fn run_agent_with_events(
     let enriched_report = report_with_artifacts(&final_text, Some(&run_state));
     let _ = std::fs::write(run_dir.join("report.md"), &enriched_report);
 
-    let serialized_messages = serde_json::to_value(&messages).unwrap_or(Value::Null);
-    debug_log.write_conversation(&last_system, &serialized_messages);
-
-    let summary = json!({
-        "task": task,
-        "model": backend.label(),
-        "turns": turn,
-        "run_dir": run_dir.to_string_lossy(),
-        "input_tokens": total_input_tokens,
-        "output_tokens": total_output_tokens,
-        "reasoning_log_file": "reasoning_log.jsonl",
-        "conversation_file": "conversation.json",
-        "report_file": "report.md",
-        "tool_results_dir": "tool_results",
-    });
-    debug_log.write_agent_summary(&summary);
-    debug_log.event("task_end", json!({"turn": turn, "completed": completed}));
+    run_recorder.finish(
+        if terminal_error.is_some() {
+            "failed"
+        } else {
+            "completed"
+        },
+        turn,
+        total_input_tokens,
+        total_output_tokens,
+        terminal_error.as_deref(),
+    )?;
 
     Ok(AgentOutcome {
         run_id,
@@ -554,15 +534,6 @@ fn find_tool<'a>(tools: &'a [SharedTool], name: &str) -> Option<&'a SharedTool> 
 
 fn emit(events: &broadcast::Sender<AgentEvent>, event: AgentEvent) {
     let _ = events.send(event);
-}
-
-fn stop_reason_str(reason: StopReason) -> &'static str {
-    match reason {
-        StopReason::EndTurn => "end_turn",
-        StopReason::ToolUse => "tool_use",
-        StopReason::MaxTokens => "max_tokens",
-        StopReason::Other => "other",
-    }
 }
 
 async fn dispatch_tool(
@@ -614,8 +585,8 @@ fn tool_result_to_content(result: &ToolResult) -> Vec<ToolResultContent> {
 ///   model can still cite it in the final report.
 ///
 /// Returns a single Text block (or `(empty result)` when nothing usable
-/// remained). The raw bodies still hit disk via tool_results/*.json, so
-/// nothing is lost — we just keep the chat-history budget bounded.
+/// remained). The raw bodies are preserved by the tool-call recorder, so the
+/// chat-history budget can stay bounded without losing debug data.
 fn bound_content_for_history(content: &[ToolResultContent]) -> Vec<ToolResultContent> {
     let mut screenshot_path: Option<String> = None;
     let mut parts: Vec<String> = Vec::new();
@@ -664,9 +635,8 @@ fn extract_screenshot_hint(text: &str) -> Option<String> {
     }
 }
 
-/// Render tool-result content as a JSON value suitable for the
-/// `reasoning_log.jsonl` debug stream (images are mentioned but bodies
-/// omitted — same convention as `json_safe_for_log`).
+/// Render tool-result content for the live UI event stream. Image bodies stay
+/// in the canonical tool output and are omitted from the event payload.
 fn content_for_log(content: &[ToolResultContent]) -> Value {
     let array: Vec<Value> = content
         .iter()

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -27,13 +27,14 @@ pub use self::llm::{
 pub use self::provider::{
     catalog_model_display_name, catalog_models_for, config_for, configured_default_model_for,
     configured_default_provider, default_model_for, list_available_providers, load_api_key,
-    load_openai_credential,
-    load_provider_credential, provider_credential_kind, resolve_provider, save_api_key,
-    save_default_model, Credential, CredentialKind, ModelCatalogEntry, Provider, ProviderConfig,
-    PROVIDERS,
+    load_openai_credential, load_provider_credential, provider_credential_kind, resolve_provider,
+    save_api_key, save_default_model, Credential, CredentialKind, ModelCatalogEntry, Provider,
+    ProviderConfig, PROVIDERS,
 };
 pub use self::r#loop::{run_agent, run_agent_with_events, AgentEvent, AgentOptions, AgentOutcome};
-pub use self::run_logging::{make_run_dir, RunDebugLogger};
+pub use self::run_logging::{
+    default_runs_root, make_run_dir, mark_agent_run_status, AgentRunRecorder, ToolCallRecorder,
+};
 pub use self::run_state::{ArtifactRecord, RunState};
 pub use self::session::{default_sessions_root, Session, Turn};
 pub use self::tool::{

--- a/core/src/agent/run_logging.rs
+++ b/core/src/agent/run_logging.rs
@@ -1,31 +1,35 @@
-//! Persistent debug logging for one agent run.
+//! Minimal persistence for agent runs and tool calls.
 //!
-//! Writes (under the run dir):
-//! - `reasoning_log.jsonl`       — append-only event timeline
-//! - `conversation.json`         — final system + messages snapshot
-//! - `agent_log.json`            — run summary (turns, run_dir, durations, …)
-//! - `tool_results/<turn>_<seq>_<tool>.json` — full tool result body per call
+//! Each fact has one owner:
+//! - `run.json` owns agent-run metadata and aggregate usage.
+//! - `llm/NNN.request.json` and `llm/NNN.response.json` own exact LLM I/O.
+//! - `tools/turn-NNN-call-NN-name/tool.json` owns tool input and lifecycle.
+//! - tool `output.json` owns the raw tool result.
+//! - standalone tool `tool.json` additionally owns its input because there is
+//!   no parent LLM response.
 
-// tool_result takes many fields (turn, sequence, tool_use_id, tool, input,
-// content, duration_s, result_summary, repeat_count, error). Plain function
-// args match the persisted debug payload directly.
-#![allow(clippy::too_many_arguments)]
+#![allow(clippy::expect_used)]
 
-use std::{
-    ffi::OsString,
-    path::{Path, PathBuf},
-};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
 
-use chrono::Local;
-use serde_json::{json, Map, Value};
+use chrono::{Local, Utc};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::agent::llm::LLMResponse;
+use crate::agent::tool::ToolResultBlock;
 
 fn timestamp() -> String {
-    Local::now().to_rfc3339()
+    Utc::now().to_rfc3339()
 }
 
-fn safe_slug(text: &str, max_chars: usize) -> String {
-    let raw = text.trim().replace('/', " ");
-    let mut acc: String = raw
+fn safe_component(value: &str, fallback: &str) -> String {
+    let cleaned: String = value
+        .trim()
         .chars()
         .map(|ch| {
             if ch.is_alphanumeric() || ch == '_' || ch == '-' {
@@ -35,16 +39,47 @@ fn safe_slug(text: &str, max_chars: usize) -> String {
             }
         })
         .collect();
-    while acc.contains("__") {
-        acc = acc.replace("__", "_");
-    }
-    let trimmed: String = acc.trim_matches('_').to_string();
-    let final_slug = if trimmed.is_empty() {
-        "agent".to_string()
+    let trimmed = cleaned.trim_matches('_');
+    if trimmed.is_empty() {
+        fallback.to_string()
     } else {
-        trimmed
-    };
-    final_slug.chars().take(max_chars).collect()
+        trimmed.chars().take(48).collect()
+    }
+}
+
+fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(value).map_err(std::io::Error::other)?;
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("record.json");
+    let temp = path.with_file_name(format!(".{name}.{}.tmp", Uuid::new_v4()));
+    std::fs::write(&temp, bytes)?;
+    if std::fs::rename(&temp, path).is_err() {
+        let _ = std::fs::remove_file(path);
+        std::fs::rename(temp, path)?;
+    }
+    Ok(())
+}
+
+fn env_runs_root(value: Option<OsString>) -> Option<PathBuf> {
+    let value = value?;
+    let value = value.to_string_lossy().trim().to_string();
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
+
+fn default_runs_root_from_parts(
+    env_root: Option<OsString>,
+    config_root: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> PathBuf {
+    env_runs_root(env_root)
+        .or(config_root)
+        .or_else(|| home.map(|path| path.join(".socai/runs")))
+        .unwrap_or_else(|| PathBuf::from(".socai/runs"))
 }
 
 /// Root for generated run directories. Precedence: `SOCAI_RUNS_DIR`, then
@@ -55,61 +90,34 @@ pub fn default_runs_root() -> PathBuf {
     }
     let config_root = match crate::config::load_config() {
         Ok(config) => config.runs_root(),
-        Err(err) => {
-            tracing::warn!(error = %err, "failed to load socai config for runs.dir; using default runs root");
+        Err(error) => {
+            tracing::warn!(%error, "failed to load runs.dir; using the default");
             None
         }
     };
     default_runs_root_from_parts(None, config_root, dirs::home_dir())
 }
 
-fn env_runs_root(value: Option<OsString>) -> Option<PathBuf> {
-    let value = value?;
-    let trimmed = value.to_string_lossy().trim().to_string();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(trimmed))
-    }
+/// Allocate `<timestamp>_<label>`, adding a numeric suffix on collision.
+pub fn make_run_dir(label: &str) -> PathBuf {
+    make_run_dir_in_root(default_runs_root(), label)
 }
 
-fn default_runs_root_from_parts(
-    env_root: Option<OsString>,
-    config_root: Option<PathBuf>,
-    home: Option<PathBuf>,
-) -> PathBuf {
-    if let Some(root) = env_runs_root(env_root) {
-        return root;
-    }
-    if let Some(root) = config_root {
-        return root;
-    }
-    if let Some(home) = home {
-        return home.join(".socai/runs");
-    }
-    PathBuf::from(".socai/runs")
-}
-
-/// Allocate a unique run directory for the given task:
-/// `<YYYYMMDD_HHMMSS>_<slug>` with a numeric suffix if that name already
-/// exists. The timestamp is local time, matching the per-frame snapshot
-/// folder names.
-pub fn make_run_dir(task: &str) -> PathBuf {
-    make_run_dir_in_root(default_runs_root(), task)
-}
-
-fn make_run_dir_in_root(root: impl AsRef<Path>, task: &str) -> PathBuf {
-    let ts = Local::now().format("%Y%m%d_%H%M%S").to_string();
-    let slug = safe_slug(task, 48);
-    let base = root.as_ref().join(format!("{ts}_{slug}"));
+fn make_run_dir_in_root(root: impl AsRef<Path>, label: &str) -> PathBuf {
+    let base = root.as_ref().join(format!(
+        "{}_{}",
+        Local::now().format("%Y%m%d_%H%M%S"),
+        safe_component(label, "run")
+    ));
     if !base.exists() {
         return base;
     }
     for suffix in 2u32.. {
         let candidate = base.with_file_name(format!(
-            "{}_{}",
-            base.file_name().and_then(|s| s.to_str()).unwrap_or("run"),
-            suffix
+            "{}_{suffix}",
+            base.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("run")
         ));
         if !candidate.exists() {
             return candidate;
@@ -118,248 +126,283 @@ fn make_run_dir_in_root(root: impl AsRef<Path>, task: &str) -> PathBuf {
     base
 }
 
-/// Strip images / huge strings out of a value before logging it. Keeps
-/// reasoning_log lean even when tool outputs are sprawling.
-pub fn json_safe_for_log(value: &Value, max_string_chars: usize) -> Value {
-    match value {
-        Value::String(s) => {
-            if s.chars().count() <= max_string_chars {
-                Value::String(s.clone())
-            } else {
-                let kept: String = s.chars().take(max_string_chars).collect();
-                Value::String(format!(
-                    "{}\n... [truncated {} chars]",
-                    kept,
-                    s.chars().count() - max_string_chars
-                ))
-            }
-        }
-        Value::Object(map) => {
-            if map.get("type").and_then(Value::as_str) == Some("image") {
-                return json!({
-                    "type": "image",
-                    "omitted": true,
-                    "note": "Image data omitted from debug log; use the saved artifact path if present.",
-                });
-            }
-            let mut out = Map::new();
-            for (k, v) in map {
-                out.insert(k.clone(), json_safe_for_log(v, max_string_chars));
-            }
-            Value::Object(out)
-        }
-        Value::Array(arr) => Value::Array(
-            arr.iter()
-                .map(|v| json_safe_for_log(v, max_string_chars))
-                .collect(),
-        ),
-        other => other.clone(),
-    }
+pub struct AgentRunRecorder {
+    run_dir: PathBuf,
+    manifest_path: PathBuf,
+    manifest: Mutex<Value>,
+    started: Instant,
+    finalized: AtomicBool,
 }
 
-fn write_json(path: &Path, payload: &Value) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let safe = json_safe_for_log(payload, 100_000);
-    let rendered = serde_json::to_string_pretty(&safe).map_err(std::io::Error::other)?;
-    std::fs::write(path, rendered)
-}
-
-fn append_jsonl(path: &Path, entry: &Value) -> std::io::Result<()> {
-    use std::io::Write;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let safe = json_safe_for_log(entry, 100_000);
-    let line = serde_json::to_string(&safe).map_err(std::io::Error::other)?;
-    let mut handle = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
-    handle.write_all(line.as_bytes())?;
-    handle.write_all(b"\n")
-}
-
-#[derive(Debug, Clone)]
-pub struct RunDebugLogger {
-    pub run_dir: PathBuf,
-    pub reasoning_log_path: PathBuf,
-    pub tool_results_dir: PathBuf,
-    pub conversation_path: PathBuf,
-    pub agent_log_path: PathBuf,
-}
-
-impl RunDebugLogger {
-    pub fn new(run_dir: impl AsRef<Path>) -> Self {
+impl AgentRunRecorder {
+    pub fn start(
+        run_dir: impl AsRef<Path>,
+        run_id: &str,
+        session_id: Option<&str>,
+        task: &str,
+        model: &str,
+    ) -> std::io::Result<Self> {
         let run_dir = run_dir.as_ref().to_path_buf();
-        Self {
-            reasoning_log_path: run_dir.join("reasoning_log.jsonl"),
-            tool_results_dir: run_dir.join("tool_results"),
-            conversation_path: run_dir.join("conversation.json"),
-            agent_log_path: run_dir.join("agent_log.json"),
-            run_dir,
-        }
-    }
-
-    pub fn event(&self, event_type: &str, mut payload: Value) {
-        if let Value::Object(map) = &mut payload {
-            map.insert("type".into(), Value::String(event_type.to_string()));
-            map.insert("timestamp".into(), Value::String(timestamp()));
-        } else {
-            payload = json!({"type": event_type, "timestamp": timestamp(), "value": payload});
-        }
-        let _ = append_jsonl(&self.reasoning_log_path, &payload);
-    }
-
-    pub fn api_error(&self, turn: u32, error: &str, forced_summary: bool) {
-        let mut payload = json!({
-            "turn": turn,
-            "error": error,
+        std::fs::create_dir_all(run_dir.join("llm"))?;
+        let manifest_path = run_dir.join("run.json");
+        let mut manifest = json!({
+            "id": run_id,
+            "task": task,
+            "model": model,
+            "status": "running",
+            "started_at": timestamp(),
         });
-        if forced_summary {
-            payload
-                .as_object_mut()
-                .map(|m| m.insert("forced_summary".into(), Value::Bool(true)));
+        if let Some(session_id) = session_id {
+            manifest["session_id"] = json!(session_id);
         }
-        self.event("api_error", payload);
+        write_json_atomic(&manifest_path, &manifest)?;
+        Ok(Self {
+            run_dir,
+            manifest_path,
+            manifest: Mutex::new(manifest),
+            started: Instant::now(),
+            finalized: AtomicBool::new(false),
+        })
     }
 
-    pub fn tool_result(
+    pub fn record_llm_request(&self, step: u32, payload: &Value) -> std::io::Result<()> {
+        write_json_atomic(
+            &self.run_dir.join(format!("llm/{step:03}.request.json")),
+            payload,
+        )
+    }
+
+    pub fn record_llm_response(
+        &self,
+        step: u32,
+        response: &LLMResponse,
+        duration_ms: u64,
+    ) -> std::io::Result<()> {
+        let mut value = serde_json::to_value(response).map_err(std::io::Error::other)?;
+        value["duration_ms"] = json!(duration_ms);
+        value["completed_at"] = json!(timestamp());
+        write_json_atomic(
+            &self.run_dir.join(format!("llm/{step:03}.response.json")),
+            &value,
+        )
+    }
+
+    pub fn record_llm_error(
+        &self,
+        step: u32,
+        error: &str,
+        duration_ms: u64,
+    ) -> std::io::Result<()> {
+        write_json_atomic(
+            &self.run_dir.join(format!("llm/{step:03}.response.json")),
+            &json!({
+                "duration_ms": duration_ms,
+                "completed_at": timestamp(),
+                "error": error,
+            }),
+        )
+    }
+
+    pub fn start_tool_call(
         &self,
         turn: u32,
         sequence: u32,
-        tool_use_id: &str,
         tool_name: &str,
-        tool_input: &Value,
-        content: &Value,
-        duration_s: f64,
-        result_summary: &str,
-        repeat_count: u32,
-        error: &str,
-    ) -> String {
-        let file_name = format!(
-            "{:03}_{:02}_{}.json",
-            turn,
-            sequence,
-            safe_slug(tool_name, 32)
-        );
-        let path = self.tool_results_dir.join(&file_name);
-        let payload = json!({
-            "type": "tool_result",
-            "timestamp": timestamp(),
-            "turn": turn,
-            "sequence": sequence,
-            "tool_use_id": tool_use_id,
-            "tool": tool_name,
-            "input": tool_input,
-            "duration_s": duration_s,
-            "error": error,
-            "content": content,
+        input: &Value,
+    ) -> std::io::Result<ToolCallRecorder> {
+        let dir = self.run_dir.join("tools").join(format!(
+            "turn-{turn:03}-call-{sequence:02}-{}",
+            safe_component(tool_name, "tool")
+        ));
+        ToolCallRecorder::start_agent(dir, tool_name, input)
+    }
+
+    pub fn finish(
+        &self,
+        status: &str,
+        turns: u32,
+        input_tokens: u64,
+        output_tokens: u64,
+        error: Option<&str>,
+    ) -> std::io::Result<()> {
+        let mut manifest = self.manifest.lock().expect("poisoned");
+        manifest["status"] = json!(status);
+        manifest["duration_ms"] = json!(self.started.elapsed().as_millis() as u64);
+        manifest["turns"] = json!(turns);
+        manifest["usage"] = json!({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
         });
-        let _ = write_json(&path, &payload);
-        let relative = path
-            .strip_prefix(&self.run_dir)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| file_name.clone());
-
-        self.event(
-            "tool_result",
-            json!({
-                "turn": turn,
-                "sequence": sequence,
-                "tool_use_id": tool_use_id,
-                "tool": tool_name,
-                "input": tool_input,
-                "duration_s": duration_s,
-                "result_summary": result_summary,
-                "result_file": relative,
-                "error": error,
-                "repeat_count": repeat_count,
-            }),
-        );
-        relative
-    }
-
-    pub fn write_conversation(&self, system_prompt: &str, messages: &Value) -> PathBuf {
-        let _ = write_json(
-            &self.conversation_path,
-            &json!({"system": system_prompt, "messages": messages}),
-        );
-        self.conversation_path.clone()
-    }
-
-    pub fn write_agent_summary(&self, summary: &Value) {
-        let _ = write_json(&self.agent_log_path, summary);
+        if let Some(error) = error {
+            manifest["error"] = json!(error);
+        }
+        write_json_atomic(&self.manifest_path, &manifest)?;
+        self.finalized.store(true, Ordering::Release);
+        Ok(())
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl Drop for AgentRunRecorder {
+    fn drop(&mut self) {
+        if self.finalized.load(Ordering::Acquire) {
+            return;
+        }
+        if let Ok(mut manifest) = self.manifest.lock() {
+            manifest["status"] = json!("interrupted");
+            manifest["duration_ms"] = json!(self.started.elapsed().as_millis() as u64);
+            let _ = write_json_atomic(&self.manifest_path, &manifest);
+        }
+    }
+}
 
-    #[test]
-    fn slug_replaces_punctuation() {
-        assert_eq!(safe_slug("hello, world!", 64), "hello_world");
+pub struct ToolCallRecorder {
+    tool_dir: PathBuf,
+    manifest_path: PathBuf,
+    manifest: Mutex<Value>,
+    started: Instant,
+    finalized: AtomicBool,
+}
+
+impl ToolCallRecorder {
+    fn start_agent(tool_dir: PathBuf, tool_name: &str, input: &Value) -> std::io::Result<Self> {
+        Self::start(
+            tool_dir,
+            json!({
+                "tool": tool_name,
+                "input": input,
+                "status": "running",
+                "started_at": timestamp(),
+            }),
+        )
     }
 
-    #[test]
-    fn slug_fallback_when_empty() {
-        assert_eq!(safe_slug("!!!", 64), "agent");
+    pub fn start_standalone(
+        tool_dir: impl AsRef<Path>,
+        site_id: &str,
+        command_name: &str,
+        implementation_name: &str,
+        input: &Value,
+    ) -> std::io::Result<Self> {
+        let public_name = format!("{site_id}.{command_name}");
+        let mut manifest = json!({
+            "tool": public_name,
+            "input": input,
+            "status": "running",
+            "started_at": timestamp(),
+        });
+        if implementation_name != command_name {
+            manifest["implementation"] = json!(implementation_name);
+        }
+        Self::start(tool_dir.as_ref().to_path_buf(), manifest)
     }
 
-    #[test]
-    fn json_safe_omits_images() {
-        let v = json!({"type": "image", "source": {"data": "aGVsbG8="}});
-        let safe = json_safe_for_log(&v, 1000);
-        assert_eq!(safe.get("omitted"), Some(&Value::Bool(true)));
+    fn start(tool_dir: PathBuf, manifest: Value) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&tool_dir)?;
+        let manifest_path = tool_dir.join("tool.json");
+        write_json_atomic(&manifest_path, &manifest)?;
+        Ok(Self {
+            tool_dir,
+            manifest_path,
+            manifest: Mutex::new(manifest),
+            started: Instant::now(),
+            finalized: AtomicBool::new(false),
+        })
     }
 
-    #[test]
-    fn default_runs_root_uses_configured_runs_dir() {
-        let home = PathBuf::from("/tmp/socai-home");
-        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
-
-        assert_eq!(
-            default_runs_root_from_parts(None, Some(configured_runs_dir.clone()), Some(home)),
-            configured_runs_dir
-        );
-        let run_dir = make_run_dir_in_root(&configured_runs_dir, "author scan");
-        assert!(run_dir.starts_with(&configured_runs_dir));
-        let file_name = run_dir.file_name().and_then(|name| name.to_str()).unwrap();
-        assert!(file_name.ends_with("author_scan"));
+    pub fn dir(&self) -> &Path {
+        &self.tool_dir
     }
 
-    #[test]
-    fn default_runs_root_prefers_env_over_configured_runs_dir() {
-        let home = PathBuf::from("/tmp/socai-home");
-        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
-        let env_runs_dir = PathBuf::from("/tmp/socai-env-runs");
-
-        assert_eq!(
-            default_runs_root_from_parts(
-                Some(OsString::from(env_runs_dir.to_string_lossy().to_string())),
-                Some(configured_runs_dir),
-                Some(home),
-            ),
-            env_runs_dir
-        );
-        let run_dir = make_run_dir_in_root(&env_runs_dir, "topic scan");
-        assert!(run_dir.starts_with(&env_runs_dir));
+    pub fn finish_blocks(
+        &self,
+        blocks: &[ToolResultBlock],
+        duration_ms: u64,
+        error: Option<&str>,
+    ) -> std::io::Result<()> {
+        self.finish_output(
+            &serde_json::to_value(blocks).map_err(std::io::Error::other)?,
+            duration_ms,
+            error,
+        )
     }
 
-    #[test]
-    fn default_runs_root_ignores_empty_env_override() {
-        let home = PathBuf::from("/tmp/socai-home");
-        let configured_runs_dir = PathBuf::from("/tmp/socai-configured-runs");
-
-        assert_eq!(
-            default_runs_root_from_parts(
-                Some(OsString::from("  \t  ")),
-                Some(configured_runs_dir.clone()),
-                Some(home),
-            ),
-            configured_runs_dir
-        );
+    pub fn finish_value(
+        &self,
+        output: &Value,
+        duration_ms: u64,
+        error: Option<&str>,
+    ) -> std::io::Result<()> {
+        self.finish_output(output, duration_ms, error)
     }
+
+    pub fn finish_error(&self, duration_ms: u64, error: &str) -> std::io::Result<()> {
+        self.finish_manifest(duration_ms, Some(error))
+    }
+
+    fn finish_output(
+        &self,
+        output: &Value,
+        duration_ms: u64,
+        error: Option<&str>,
+    ) -> std::io::Result<()> {
+        write_json_atomic(&self.tool_dir.join("output.json"), output)?;
+        self.finish_manifest(duration_ms, error)
+    }
+
+    fn finish_manifest(&self, duration_ms: u64, error: Option<&str>) -> std::io::Result<()> {
+        let mut manifest = self.manifest.lock().expect("poisoned");
+        manifest["status"] = json!(if error.is_some() {
+            "failed"
+        } else {
+            "completed"
+        });
+        manifest["duration_ms"] = json!(duration_ms);
+        if let Some(error) = error {
+            manifest["error"] = json!(error);
+        }
+        write_json_atomic(&self.manifest_path, &manifest)?;
+        self.finalized.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+impl Drop for ToolCallRecorder {
+    fn drop(&mut self) {
+        if self.finalized.load(Ordering::Acquire) {
+            return;
+        }
+        if let Ok(mut manifest) = self.manifest.lock() {
+            manifest["status"] = json!("interrupted");
+            manifest["duration_ms"] = json!(self.started.elapsed().as_millis() as u64);
+            let _ = write_json_atomic(&self.manifest_path, &manifest);
+        }
+    }
+}
+
+/// Best-effort terminal update when an entrypoint cancels the agent future.
+pub fn mark_agent_run_status(
+    run_dir: impl AsRef<Path>,
+    status: &str,
+    error: Option<&str>,
+) -> std::io::Result<()> {
+    let path = run_dir.as_ref().join("run.json");
+    let mut manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(&path)?).map_err(std::io::Error::other)?;
+    let duration_ms = manifest
+        .get("started_at")
+        .and_then(Value::as_str)
+        .and_then(|started| chrono::DateTime::parse_from_rfc3339(started).ok())
+        .map(|started| {
+            (Utc::now() - started.with_timezone(&Utc))
+                .num_milliseconds()
+                .max(0) as u64
+        });
+    manifest["status"] = json!(status);
+    if let Some(duration_ms) = duration_ms {
+        manifest["duration_ms"] = json!(duration_ms);
+    }
+    if let Some(error) = error {
+        manifest["error"] = json!(error);
+    }
+    write_json_atomic(&path, &manifest)
 }

--- a/core/src/agent/run_state.rs
+++ b/core/src/agent/run_state.rs
@@ -1,65 +1,18 @@
-//! Persistent per-run state for the agent loop.
+//! In-memory working state used for context compaction and report enrichment.
 //!
-//! Persists a stable file layout under `<run_dir>/run_state/`, so a run
-//! produced by the Rust agent can be inspected with tooling that understands
-//! the JSON shape.
-//!
-//! Files written:
-//! - `task.json`            — task + model + created_at
-//! - `plan.json`            — optional step list
-//! - `artifacts.json`       — registry of all saved artifacts (screenshots, JSON dumps)
-//! - `evidence.json`        — entity-like extracts surfaced from tool results
-//! - `events.jsonl`         — append-only timeline of assistant turns, tool calls, results
-//! - `working_memory.md`    — human-readable summary regenerated on every event
-//!
-//! All methods are sync-friendly: `RunState` owns a `Mutex` internally so
-//! it can be shared across async tasks without `await`-holding a lock.
+//! This is deliberately not persisted: exact LLM and tool records already own
+//! the durable execution history.
 
-// `expect("poisoned")` is the idiomatic pattern for `Mutex::lock` failures —
-// poisoning here would mean a panic in another thread while holding the
-// lock, which we treat as fatal anyway.
 #![allow(clippy::expect_used)]
-// `record_artifact` and `write_json_artifact` legitimately need 8–10 fields
-// (path, label, kind, source_tool, turn, summary, metadata, payload). A
-// builder would just hide the same parameters behind more code.
 #![allow(clippy::too_many_arguments)]
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 use crate::agent::compaction::{compact_value, truncate};
-
-fn utc_now() -> String {
-    let now: DateTime<Utc> = Utc::now();
-    now.to_rfc3339()
-}
-
-fn write_json(path: &Path, payload: &Value) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let text = serde_json::to_string_pretty(payload).map_err(std::io::Error::other)?;
-    std::fs::write(path, text)
-}
-
-fn append_jsonl(path: &Path, entry: &Value) -> std::io::Result<()> {
-    use std::io::Write;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut handle = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
-    let line = serde_json::to_string(entry).map_err(std::io::Error::other)?;
-    handle.write_all(line.as_bytes())?;
-    handle.write_all(b"\n")
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ArtifactRecord {
@@ -75,14 +28,11 @@ pub struct ArtifactRecord {
 
 #[derive(Debug)]
 struct Inner {
-    run_dir: PathBuf,
-    state_dir: PathBuf,
     task: String,
-    plan: Value,
+    plan: Vec<Value>,
     artifacts: BTreeMap<String, ArtifactRecord>,
     evidence: BTreeMap<String, Value>,
     recent_events: Vec<Value>,
-    max_recent_events: usize,
 }
 
 #[derive(Debug)]
@@ -91,86 +41,23 @@ pub struct RunState {
 }
 
 impl RunState {
-    pub fn new(
-        run_dir: impl AsRef<Path>,
-        task: impl Into<String>,
-        model: impl Into<String>,
-    ) -> std::io::Result<Self> {
-        let run_dir = run_dir.as_ref().to_path_buf();
-        let state_dir = run_dir.join("run_state");
-        std::fs::create_dir_all(&state_dir)?;
-        let task = task.into().trim().to_string();
-        let model = model.into().trim().to_string();
-        let inner = Inner {
-            run_dir: run_dir.clone(),
-            state_dir: state_dir.clone(),
-            task: task.clone(),
-            plan: json!({
-                "task": task,
-                "updated_at": utc_now(),
-                "steps": [],
-                "notes": [],
+    pub fn new(task: impl Into<String>) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                task: task.into().trim().to_string(),
+                plan: Vec::new(),
+                artifacts: BTreeMap::new(),
+                evidence: BTreeMap::new(),
+                recent_events: Vec::new(),
             }),
-            artifacts: BTreeMap::new(),
-            evidence: BTreeMap::new(),
-            recent_events: Vec::new(),
-            max_recent_events: 80,
-        };
-
-        write_json(
-            &state_dir.join("task.json"),
-            &json!({
-                "task": task,
-                "model": model,
-                "created_at": utc_now(),
-                "run_dir": run_dir.to_string_lossy(),
-            }),
-        )?;
-        write_json(&state_dir.join("plan.json"), &inner.plan)?;
-        write_json(
-            &state_dir.join("artifacts.json"),
-            &json!({"count": 0, "items": []}),
-        )?;
-        write_json(
-            &state_dir.join("evidence.json"),
-            &json!({"count": 0, "items": []}),
-        )?;
-
-        let state = Self {
-            inner: Mutex::new(inner),
-        };
-        state.flush_working_memory();
-        Ok(state)
-    }
-
-    pub fn state_dir(&self) -> PathBuf {
-        self.inner.lock().expect("poisoned").state_dir.clone()
-    }
-
-    pub fn run_dir(&self) -> PathBuf {
-        self.inner.lock().expect("poisoned").run_dir.clone()
+        }
     }
 
     fn append_event(&self, event: Value) {
-        let mut event_obj = match event {
-            Value::Object(m) => m,
-            other => {
-                let mut m = Map::new();
-                m.insert("value".into(), other);
-                m
-            }
-        };
-        event_obj.insert("timestamp".into(), Value::String(utc_now()));
-        let enriched = Value::Object(event_obj);
-
         let mut guard = self.inner.lock().expect("poisoned");
-        let path = guard.state_dir.join("events.jsonl");
-        let _ = append_jsonl(&path, &enriched);
-        guard.recent_events.push(enriched);
-        if guard.recent_events.len() > guard.max_recent_events {
-            let overflow = guard.recent_events.len() - guard.max_recent_events;
-            guard.recent_events.drain(0..overflow);
-        }
+        guard.recent_events.push(event);
+        let overflow = guard.recent_events.len().saturating_sub(80);
+        guard.recent_events.drain(0..overflow);
     }
 
     pub fn note_assistant_turn(&self, turn: u32, text: &str, tool_calls: &[Value]) {
@@ -180,7 +67,6 @@ impl RunState {
             "text": truncate(text, 800),
             "tool_calls": tool_calls,
         }));
-        self.flush_working_memory();
     }
 
     pub fn note_tool_call(&self, turn: u32, tool_name: &str, tool_input: &Value) {
@@ -190,7 +76,6 @@ impl RunState {
             "tool": tool_name,
             "input": compact_value(tool_input),
         }));
-        self.flush_working_memory();
     }
 
     pub fn note_tool_result(
@@ -209,7 +94,6 @@ impl RunState {
             "result_summary": truncate(result_summary, 800),
             "duration_s": duration_s,
         }));
-        self.flush_working_memory();
     }
 
     pub fn record_artifact(
@@ -223,75 +107,49 @@ impl RunState {
         metadata: Value,
         payload: Option<&Value>,
     ) {
-        let record = ArtifactRecord {
-            key: format!("{:03}_{label}", {
-                let g = self.inner.lock().expect("poisoned");
-                let next = g.artifacts.len() + 1;
-                drop(g);
-                next
-            }),
-            path: relative_path.to_string(),
-            label: label.to_string(),
-            kind: kind.to_string(),
-            source_tool: source_tool.to_string(),
-            turn,
-            summary: summary.to_string(),
-            metadata: metadata.clone(),
-        };
         {
             let mut guard = self.inner.lock().expect("poisoned");
-            guard.artifacts.insert(record.key.clone(), record.clone());
-            let items: Vec<&ArtifactRecord> = guard.artifacts.values().collect();
-            let _ = write_json(
-                &guard.state_dir.join("artifacts.json"),
-                &json!({"count": items.len(), "items": items}),
+            let key = format!("{:03}_{label}", guard.artifacts.len() + 1);
+            guard.artifacts.insert(
+                key.clone(),
+                ArtifactRecord {
+                    key,
+                    path: relative_path.to_string(),
+                    label: label.to_string(),
+                    kind: kind.to_string(),
+                    source_tool: source_tool.to_string(),
+                    turn,
+                    summary: summary.to_string(),
+                    metadata,
+                },
             );
         }
-
-        // Best-effort evidence ingest when the artifact carries entity-like data.
         if let Some(payload) = payload {
             self.ingest_evidence(payload, relative_path, turn);
         }
-
         self.append_event(json!({
             "type": "artifact_recorded",
             "turn": turn,
             "path": relative_path,
-            "label": label,
-            "kind": kind,
-            "source_tool": source_tool,
         }));
-        self.flush_working_memory();
     }
 
     fn ingest_evidence(&self, payload: &Value, artifact_path: &str, turn: Option<u32>) {
-        let candidate = match payload {
-            Value::Object(map) => Some(map.clone()),
-            _ => None,
-        };
-        let Some(map) = candidate else { return };
-        let interesting = [
+        let Value::Object(map) = payload else { return };
+        let signal_keys = [
             "id",
             "entity_id",
             "note_id",
             "url",
-            "resolved_url",
             "title",
             "author",
             "content",
-            "content_summary",
             "summary",
-            "screenshot",
         ];
-        let has_signal = interesting.iter().any(|k| {
-            map.get(*k)
-                .map(|v| {
-                    !matches!(v, Value::Null) && !v.is_string()
-                        || v.as_str().is_some_and(|s| !s.is_empty())
-                })
-                .unwrap_or(false)
-        });
-        if !has_signal {
+        if !signal_keys.iter().any(|key| {
+            map.get(*key)
+                .is_some_and(|value| !value.is_null() && value.as_str() != Some(""))
+        }) {
             return;
         }
         let key = map
@@ -300,201 +158,95 @@ impl RunState {
             .or_else(|| map.get("id"))
             .or_else(|| map.get("url"))
             .and_then(Value::as_str)
-            .map(str::to_string)
-            .unwrap_or_else(|| artifact_path.to_string());
-
+            .unwrap_or(artifact_path)
+            .to_string();
         let mut compact = match compact_value(&Value::Object(map.clone())) {
-            Value::Object(m) => m,
+            Value::Object(value) => value,
             _ => Map::new(),
         };
-        compact.insert("key".into(), Value::String(key.clone()));
-        compact.insert(
-            "artifact_path".into(),
-            Value::String(artifact_path.to_string()),
-        );
+        compact.insert("key".into(), json!(key));
+        compact.insert("artifact_path".into(), json!(artifact_path));
         if let Some(turn) = turn {
             compact.insert("turn".into(), json!(turn));
         }
-
-        let mut guard = self.inner.lock().expect("poisoned");
-        guard.evidence.insert(key, Value::Object(compact));
-        let items: Vec<&Value> = guard.evidence.values().collect();
-        let _ = write_json(
-            &guard.state_dir.join("evidence.json"),
-            &json!({"count": items.len(), "items": items}),
-        );
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .evidence
+            .insert(key, Value::Object(compact));
     }
 
     pub fn update_plan_steps(&self, steps: Vec<Value>) {
-        let mut guard = self.inner.lock().expect("poisoned");
-        let plan = guard.plan.as_object_mut().expect("plan is always object");
-        plan.insert("steps".into(), Value::Array(steps));
-        plan.insert("updated_at".into(), Value::String(utc_now()));
-        let snapshot = guard.plan.clone();
-        let _ = write_json(&guard.state_dir.join("plan.json"), &snapshot);
-        drop(guard);
+        self.inner.lock().expect("poisoned").plan = steps;
         self.append_event(json!({"type": "plan_update"}));
-        self.flush_working_memory();
-    }
-
-    fn flush_working_memory(&self) {
-        let text = self.render_working_memory(10, 8);
-        let path = {
-            let guard = self.inner.lock().expect("poisoned");
-            guard.state_dir.join("working_memory.md")
-        };
-        let _ = std::fs::write(path, text);
     }
 
     pub fn render_working_memory(&self, max_recent_events: usize, max_evidence: usize) -> String {
         let guard = self.inner.lock().expect("poisoned");
-        let mut out = String::new();
-        out.push_str("# Task\n");
-        if guard.task.is_empty() {
-            out.push_str("(empty task)\n");
-        } else {
-            out.push_str(&guard.task);
-            out.push('\n');
-        }
-        out.push_str("\n# Plan\n");
-        let steps = guard
-            .plan
-            .get("steps")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        if steps.is_empty() {
+        let mut out = format!("# Task\n{}\n\n# Plan\n", guard.task);
+        if guard.plan.is_empty() {
             out.push_str("- No explicit plan has been recorded yet.\n");
-        } else {
-            for step in &steps {
-                let status = step
-                    .get("status")
-                    .and_then(Value::as_str)
-                    .unwrap_or("pending");
-                let title = step
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                let details = step
-                    .get("details")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                if details.is_empty() {
-                    out.push_str(&format!("- [{status}] {title}\n"));
-                } else {
-                    out.push_str(&format!("- [{status}] {title} — {details}\n"));
-                }
-            }
+        }
+        for step in &guard.plan {
+            let status = step
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("pending");
+            let title = step.get("title").and_then(Value::as_str).unwrap_or("");
+            out.push_str(&format!("- [{status}] {title}\n"));
         }
         out.push_str(&format!(
             "\n# Current State\n- Saved artifacts: {}\n- Evidence records: {}\n",
             guard.artifacts.len(),
             guard.evidence.len()
         ));
-        let latest_result = guard
-            .recent_events
-            .iter()
-            .rev()
-            .find(|e| e.get("type").and_then(Value::as_str) == Some("tool_result"));
-        if let Some(event) = latest_result {
-            let turn = event.get("turn").and_then(Value::as_u64).unwrap_or(0);
-            let tool = event.get("tool").and_then(Value::as_str).unwrap_or("");
-            let summary = event
-                .get("result_summary")
-                .and_then(Value::as_str)
-                .unwrap_or("");
-            out.push_str(&format!(
-                "- Latest tool result: turn {turn} {tool} — {}\n",
-                truncate(summary, 200)
-            ));
-        }
         out.push_str("\n# Recent Activity\n");
-        let recent: Vec<&Value> = guard
+        for event in guard
             .recent_events
             .iter()
             .rev()
             .take(max_recent_events)
-            .collect();
-        if recent.is_empty() {
-            out.push_str("- No activity has been recorded yet.\n");
-        } else {
-            for event in recent.iter().rev() {
-                let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
-                let turn = event.get("turn").and_then(Value::as_u64).unwrap_or(0);
-                match kind {
-                    "assistant_turn" => {
-                        let text = event.get("text").and_then(Value::as_str).unwrap_or("");
-                        out.push_str(&format!(
-                            "- turn {turn} assistant: {}\n",
-                            truncate(text, 160)
-                        ));
-                    }
-                    "tool_call" => {
-                        let tool = event.get("tool").and_then(Value::as_str).unwrap_or("");
-                        out.push_str(&format!("- turn {turn} tool_call {tool}\n"));
-                    }
-                    "tool_result" => {
-                        let tool = event.get("tool").and_then(Value::as_str).unwrap_or("");
-                        let summary = event
+            .rev()
+        {
+            let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
+            let turn = event.get("turn").and_then(Value::as_u64).unwrap_or(0);
+            match kind {
+                "assistant_turn" => out.push_str(&format!(
+                    "- turn {turn} assistant: {}\n",
+                    truncate(event.get("text").and_then(Value::as_str).unwrap_or(""), 160)
+                )),
+                "tool_call" => out.push_str(&format!(
+                    "- turn {turn} tool_call {}\n",
+                    event.get("tool").and_then(Value::as_str).unwrap_or("")
+                )),
+                "tool_result" => out.push_str(&format!(
+                    "- turn {turn} tool_result {}: {}\n",
+                    event.get("tool").and_then(Value::as_str).unwrap_or(""),
+                    truncate(
+                        event
                             .get("result_summary")
                             .and_then(Value::as_str)
-                            .unwrap_or("");
-                        out.push_str(&format!(
-                            "- turn {turn} tool_result {tool}: {}\n",
-                            truncate(summary, 160)
-                        ));
-                    }
-                    "plan_update" => {
-                        out.push_str(&format!("- turn {turn} plan updated\n"));
-                    }
-                    "artifact_recorded" => {
-                        let path = event.get("path").and_then(Value::as_str).unwrap_or("");
-                        out.push_str(&format!("- turn {turn} saved {path}\n"));
-                    }
-                    _ => {}
-                }
+                            .unwrap_or(""),
+                        160
+                    )
+                )),
+                "artifact_recorded" => out.push_str(&format!(
+                    "- turn {turn} saved {}\n",
+                    event.get("path").and_then(Value::as_str).unwrap_or("")
+                )),
+                _ => {}
             }
         }
         out.push_str("\n# Key Evidence\n");
-        let evidence_items: Vec<&Value> =
-            guard.evidence.values().rev().take(max_evidence).collect();
-        if evidence_items.is_empty() {
-            out.push_str("- No structured evidence has been extracted yet.\n");
-        } else {
-            for item in evidence_items.iter().rev() {
-                let title = item
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .or_else(|| item.get("key").and_then(Value::as_str))
-                    .unwrap_or("");
-                let author = item
-                    .get("author")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                let summary = item
-                    .get("summary")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .trim();
-                let mut line = format!("- {title}");
-                if !author.is_empty() {
-                    line.push_str(&format!(" — {author}"));
-                }
-                if !summary.is_empty() {
-                    line.push_str(&format!(" | {}", truncate(summary, 180)));
-                }
-                line.push('\n');
-                out.push_str(&line);
-            }
+        for item in guard.evidence.values().rev().take(max_evidence).rev() {
+            let title = item
+                .get("title")
+                .or_else(|| item.get("key"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let summary = item.get("summary").and_then(Value::as_str).unwrap_or("");
+            out.push_str(&format!("- {title}: {}\n", truncate(summary, 180)));
         }
-        out.push_str(
-            "\n# Retrieval\n\
-- Use a task-plan tool, if one is registered, to keep a live checklist for complex tasks.\n\
-- Use run-state or artifact-reading tools, if registered by the host, to revisit earlier findings.\n",
-        );
         out
     }
 
@@ -504,35 +256,16 @@ impl RunState {
 
     pub fn has_structured_state(&self) -> bool {
         let guard = self.inner.lock().expect("poisoned");
-        if guard
-            .plan
-            .get("steps")
-            .and_then(Value::as_array)
-            .map(|a| !a.is_empty())
-            .unwrap_or(false)
-        {
-            return true;
-        }
-        if !guard.evidence.is_empty() {
-            return true;
-        }
-        for artifact in guard.artifacts.values() {
-            let kind = artifact.kind.to_ascii_lowercase();
-            let metadata = artifact.metadata.as_object();
-            let is_screenshot = kind == "image"
-                && metadata
-                    .and_then(|m| m.get("category"))
-                    .and_then(Value::as_str)
-                    == Some("screenshot");
-            if !is_screenshot {
-                return true;
-            }
-        }
-        false
+        !guard.plan.is_empty() || !guard.evidence.is_empty() || !guard.artifacts.is_empty()
     }
 
     pub fn artifact_records(&self) -> Vec<ArtifactRecord> {
-        let guard = self.inner.lock().expect("poisoned");
-        guard.artifacts.values().cloned().collect()
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .artifacts
+            .values()
+            .cloned()
+            .collect()
     }
 }

--- a/core/src/agent/session.rs
+++ b/core/src/agent/session.rs
@@ -1,35 +1,30 @@
-//! Chat session: a persistent multi-turn conversation built on top of runs.
+//! Persistent multi-turn conversation index.
 //!
-//! Each session is one folder under `~/.socai/sessions/<id>/` (override with
-//! `SOCAI_SESSIONS_DIR`) holding `session.json` — the structured turns
-//! (user / assistant / run pointers), which is also the seed source.
-//!
-//! Run-dir granularity is unchanged: every user turn still produces its own
-//! run dir. The session only records *pointers* to those run dirs plus the
-//! chat-level text, so the agent can refer back to earlier artifacts (via the
-//! local environment tools) without bloating the seed.
-//!
-//! This lives in core so any entrypoint (TUI today, desktop later) can reuse
-//! it. Nothing constructs a `Session` implicitly — entrypoints opt in.
+//! A session owns user-message order and references to L2 agent runs. Assistant
+//! output is read from each run's `report.md`; an inline fallback is stored
+//! only when a run did not produce a report.
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::agent::llm::{Block, Message};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Turn {
     pub user: String,
-    pub assistant: String,
-    pub run_id: String,
     pub run_dir: String,
-    pub ts_ms: u64,
+    pub status: String,
+    pub timestamp_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assistant_fallback: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Session {
+    #[serde(skip)]
     pub id: String,
     #[serde(skip)]
     pub dir: PathBuf,
@@ -40,10 +35,12 @@ pub struct Session {
 }
 
 impl Session {
-    /// Create a fresh session folder and persist its (empty) index.
     pub fn new(model: Option<String>) -> std::io::Result<Self> {
         let now = now_ms();
-        let id = format!("session-{now}");
+        let id = format!(
+            "session-{now}-{}",
+            &Uuid::new_v4().simple().to_string()[..8]
+        );
         let dir = default_sessions_root().join(&id);
         std::fs::create_dir_all(&dir)?;
         let session = Self {
@@ -58,53 +55,64 @@ impl Session {
         Ok(session)
     }
 
-    /// Record a completed turn and flush to disk.
-    pub fn record_turn(&mut self, user: &str, assistant: &str, run_id: &str, run_dir: &Path) {
+    pub fn load(dir: impl AsRef<Path>) -> std::io::Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        let mut session: Self =
+            serde_json::from_str(&std::fs::read_to_string(dir.join("session.json"))?)
+                .map_err(std::io::Error::other)?;
+        session.id = dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("session")
+            .to_string();
+        session.dir = dir;
+        Ok(session)
+    }
+
+    pub fn record_turn(&mut self, user: &str, assistant: &str, run_dir: &Path) {
+        self.record_run(user, assistant, run_dir, "completed");
+    }
+
+    pub fn record_run(&mut self, user: &str, assistant: &str, run_dir: &Path, status: &str) {
+        let assistant_fallback = (!run_dir.join("report.md").is_file())
+            .then(|| assistant.to_string())
+            .filter(|value| !value.is_empty());
         self.turns.push(Turn {
             user: user.to_string(),
-            assistant: assistant.to_string(),
-            run_id: run_id.to_string(),
             run_dir: run_dir.to_string_lossy().to_string(),
-            ts_ms: now_ms(),
+            status: status.to_string(),
+            timestamp_ms: now_ms(),
+            assistant_fallback,
         });
         self.updated_at_ms = now_ms();
         self.persist();
     }
 
-    /// Chat-level seed messages (prior user inputs + assistant answers) used to
-    /// continue the conversation on the next turn.
     pub fn chat_messages(&self) -> Vec<Message> {
-        let mut out = Vec::with_capacity(self.turns.len() * 2);
+        let mut messages = Vec::with_capacity(self.turns.len() * 2);
         for turn in &self.turns {
-            out.push(Message::user(turn.user.clone()));
-            out.push(Message::assistant_blocks(vec![Block::Text {
-                text: turn.assistant.clone(),
+            messages.push(Message::user(turn.user.clone()));
+            let report = std::fs::read_to_string(Path::new(&turn.run_dir).join("report.md"))
+                .ok()
+                .or_else(|| turn.assistant_fallback.clone())
+                .unwrap_or_default();
+            messages.push(Message::assistant_blocks(vec![Block::Text {
+                text: report,
             }]));
         }
-        out
+        messages
     }
 
-    /// A short note for the agent instructions so it knows which run dirs
-    /// belong to this session and can read their artifacts on demand.
     pub fn context_note(&self) -> String {
-        if self.turns.is_empty() {
-            return format!(
-                "This is an ongoing chat session. Session dir: {}. \
-                 Use the local environment tools (read_file, bash) when the user asks \
-                 to inspect earlier results or produce output files.",
-                self.dir.display()
-            );
-        }
         let mut lines = vec![format!(
-            "This is an ongoing chat session (session dir: {}). Earlier turns saved \
-             artifacts under these run dirs — inspect them with read_file/bash when \
-             the user refers back to them:",
+            "This is an ongoing chat session (session dir: {}). Earlier turns have \
+             their full records in these run dirs:",
             self.dir.display()
         )];
-        for (i, turn) in self.turns.iter().enumerate() {
+        for (index, turn) in self.turns.iter().enumerate() {
             lines.push(format!(
                 "  {}. {} — {}",
-                i + 1,
+                index + 1,
                 turn.run_dir,
                 preview(&turn.user)
             ));
@@ -119,23 +127,22 @@ impl Session {
     }
 }
 
-/// Root directory for chat sessions: `$SOCAI_SESSIONS_DIR` or
-/// `~/.socai/sessions`. Mirrors [`crate::agent::run_logging::default_runs_root`].
 pub fn default_sessions_root() -> PathBuf {
-    if let Ok(env) = std::env::var("SOCAI_SESSIONS_DIR") {
-        return PathBuf::from(env);
+    if let Ok(path) = std::env::var("SOCAI_SESSIONS_DIR") {
+        return PathBuf::from(path);
     }
-    if let Some(home) = dirs::home_dir() {
-        return home.join(".socai/sessions");
+    if let Ok(home) = std::env::var("SOCAI_HOME") {
+        return PathBuf::from(home).join("sessions");
     }
-    PathBuf::from(".socai/sessions")
+    dirs::home_dir()
+        .map(|home| home.join(".socai/sessions"))
+        .unwrap_or_else(|| PathBuf::from(".socai/sessions"))
 }
 
 fn preview(text: &str) -> String {
     let line = text.trim().lines().next().unwrap_or("").trim();
     if line.chars().count() > 60 {
-        let s: String = line.chars().take(60).collect();
-        format!("{s}…")
+        format!("{}…", line.chars().take(60).collect::<String>())
     } else {
         line.to_string()
     }
@@ -144,6 +151,6 @@ fn preview(text: &str) -> String {
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
+        .map(|duration| duration.as_millis() as u64)
         .unwrap_or_default()
 }

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -145,6 +145,7 @@ pub struct ToolContext {
     pub turn: u32,
     pub active_tool_name: String,
     pub run_state: Option<Arc<RunState>>,
+    tool_dir: Option<PathBuf>,
     pub enabled_sites: Arc<Mutex<BTreeSet<String>>>,
     progress: Option<ToolProgressSender>,
     counters: Arc<Mutex<Counters>>,
@@ -190,6 +191,7 @@ impl ToolContext {
             turn: 0,
             active_tool_name: String::new(),
             run_state: None,
+            tool_dir: None,
             enabled_sites: Arc::new(Mutex::new(BTreeSet::new())),
             progress: None,
             counters: Arc::new(Mutex::new(Counters::default())),
@@ -295,6 +297,19 @@ impl ToolContext {
         self
     }
 
+    pub fn with_tool_dir(mut self, tool_dir: impl AsRef<Path>) -> Self {
+        self.tool_dir = Some(tool_dir.as_ref().to_path_buf());
+        self.counters = Arc::new(Mutex::new(Counters::default()));
+        self
+    }
+
+    /// Root owned by the current tool invocation. For standalone CLI calls it
+    /// is the run directory itself; for agent calls it is
+    /// `<run_dir>/tools/<tool-call>/`.
+    pub fn output_dir(&self) -> &Path {
+        self.tool_dir.as_deref().unwrap_or(&self.run_dir)
+    }
+
     pub fn enable_site(&self, site: impl Into<String>) {
         if let Ok(mut guard) = self.enabled_sites.lock() {
             guard.insert(site.into());
@@ -314,7 +329,7 @@ impl ToolContext {
         guard.screenshot += 1;
         let label = sanitize_label(label, "screenshot");
         let path = self
-            .run_dir
+            .output_dir()
             .join(format!("{:03}_{label}.png", guard.screenshot));
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -327,7 +342,7 @@ impl ToolContext {
         let mut guard = self.counters.lock().expect("poisoned");
         guard.artifact += 1;
         let label = sanitize_label(label, "artifact");
-        let dir = self.run_dir.join(subdir);
+        let dir = self.output_dir().join(subdir);
         let _ = std::fs::create_dir_all(&dir);
         dir.join(format!("{:03}_{label}{suffix}", guard.artifact))
     }
@@ -448,6 +463,12 @@ pub trait Tool: Send + Sync {
             return true;
         }
         ctx.site_enabled(site)
+    }
+
+    /// Input after tool-specific defaults or forced runtime options are
+    /// applied. This is what gets executed and persisted in `tool.json`.
+    fn effective_input(&self, input: &Value) -> Value {
+        input.clone()
     }
 
     async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult>;

--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -7,7 +7,7 @@ use base64::Engine;
 use futures::StreamExt;
 use serde_json::Value;
 
-use crate::media::common::{detect_media_type, insert_string, short, url_suffix, MediaUnavailable};
+use crate::media::common::{detect_media_type, insert_string, url_suffix, MediaUnavailable};
 use crate::media::md5;
 use crate::media::processor::MediaProcessor;
 
@@ -84,7 +84,7 @@ impl MediaProcessor {
             };
             match result {
                 Ok(text) if !text.trim().is_empty() => {
-                    insert_string(item, "ocr_text", short(&text, 1200));
+                    insert_string(item, "ocr_text", text);
                 }
                 Ok(_) => {}
                 Err(err) => insert_string(item, "ocr_error", err),
@@ -99,7 +99,11 @@ impl MediaProcessor {
     /// one batch, and attaches `ocr_text` (or `ocr_error`) to the card in place;
     /// the downloaded bytes are dropped (nothing written to the run dir). Returns
     /// the batch inference time.
-    pub async fn ocr_cover_images(&self, cards: &mut [Value], referer: &str) -> std::time::Duration {
+    pub async fn ocr_cover_images(
+        &self,
+        cards: &mut [Value],
+        referer: &str,
+    ) -> std::time::Duration {
         if !self.config.use_ocr || cards.is_empty() {
             return std::time::Duration::ZERO;
         }
@@ -138,7 +142,8 @@ impl MediaProcessor {
             .filter(|(_, bytes)| futures::future::ready(!bytes.is_empty()))
             .collect()
             .await;
-        self.timing.record("ocr_cover_download_batch", t_dl.elapsed());
+        self.timing
+            .record("ocr_cover_download_batch", t_dl.elapsed());
 
         let batch =
             tokio::task::spawn_blocking(move || crate::media::ocr::ocr_images_bytes(fetched)).await;
@@ -153,7 +158,7 @@ impl MediaProcessor {
             };
             match result {
                 Ok(text) if !text.trim().is_empty() => {
-                    insert_string(card, "ocr_text", short(&text, 1200));
+                    insert_string(card, "ocr_text", text);
                 }
                 Ok(_) => {}
                 Err(err) => insert_string(card, "ocr_error", err),
@@ -399,7 +404,7 @@ impl MediaProcessor {
             if !payload.is_empty() && self.config.use_ocr && item.get("ocr_text").is_none() {
                 match self.ocr_image(payload) {
                     Ok(text) if !text.trim().is_empty() => {
-                        insert_string(item, "ocr_text", short(&text, 800));
+                        insert_string(item, "ocr_text", text);
                     }
                     Ok(_) => {}
                     Err(err) => insert_string(item, "ocr_error", format!("{err:#}")),

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -307,6 +307,7 @@ pub struct AgentRunConfig {
     pub run_dir: Option<PathBuf>,
     /// Prior chat-level messages to continue a multi-turn session from.
     pub seed_messages: Vec<Message>,
+    pub session_id: Option<String>,
 }
 
 impl Default for AgentRunConfig {
@@ -320,6 +321,7 @@ impl Default for AgentRunConfig {
             enabled_sites: Vec::new(),
             run_dir: None,
             seed_messages: Vec::new(),
+            session_id: None,
         }
     }
 }
@@ -344,6 +346,7 @@ pub async fn run_agent_task(
         keep_recent_messages: config.keep_recent_messages,
         memory_max_chars: config.memory_max_chars,
         seed_messages: config.seed_messages,
+        session_id: config.session_id,
     };
     run_agent_with_events(task, llm_provider, tools, options, events_tx).await
 }

--- a/core/src/sites/runner.rs
+++ b/core/src/sites/runner.rs
@@ -1,18 +1,18 @@
 //! Shared one-shot command runner for site commands.
 //!
 //! Every site command (CLI `socai <site> <tool>` / daemon dispatch) needs the
-//! same scaffolding: allocate a run dir, persist the invocation, wrap the
+//! same scaffolding: allocate a run dir, record the invocation, wrap the
 //! whole command in optional snapshot recording, invoke one agent tool by
 //! name, and return the `{command, run_dir, input, data}` envelope. Site
 //! modules supply only the tool set and optional page-state hooks — do not
 //! copy this scaffolding into a site folder.
 
-use std::{path::Path, sync::Arc};
+use std::{path::Path, sync::Arc, time::Instant};
 
 use serde_json::{json, Value};
 
 use crate::agent::tool::ToolProgressSender;
-use crate::agent::{make_run_dir, Tool, ToolContext, ToolResult};
+use crate::agent::{make_run_dir, Tool, ToolCallRecorder, ToolContext, ToolResult};
 use crate::cdp::{with_snapshot_recording, PageSession};
 use crate::sites::registry::BoxFuture;
 
@@ -58,42 +58,57 @@ pub async fn run_tool_command(
         }
     }
     let (run_dir, ctx) = command_context_for_label(cmd.site_id, &label, progress);
-    // Persist the full command input up front (best-effort) so a run is
-    // debuggable from its dir alone — including the exact args — even when the
-    // tool errors out partway.
-    let invocation = json!({
-        "command": cmd.command_name,
-        "tool": cmd.tool_name,
-        "input": input.clone(),
-    });
-    let _ = std::fs::create_dir_all(&ctx.run_dir);
-    if let Ok(bytes) = serde_json::to_vec_pretty(&invocation) {
-        let _ = std::fs::write(ctx.run_dir.join("command_input.json"), bytes);
-    }
+    let effective_input = tools
+        .iter()
+        .find(|tool| tool.name() == cmd.tool_name)
+        .ok_or_else(|| anyhow::anyhow!("site tool not found: {}", cmd.tool_name))?
+        .effective_input(&input);
+    let tool_recorder = ToolCallRecorder::start_standalone(
+        &ctx.run_dir,
+        cmd.site_id,
+        cmd.command_name,
+        cmd.tool_name,
+        &effective_input,
+    )?;
+    let response_input = input.clone();
+    let ctx = ctx.with_tool_dir(tool_recorder.dir());
     // Snapshot recording (when `--debug-snapshot` is on) wraps the whole
     // command — setup navigation, the tool's clicks/scrolls, and teardown. All
     // recorder machinery lives in the generic CDP layer; this is the only hook
     // a site command runner needs.
-    let data = with_snapshot_recording(&page, &ctx.run_dir, debug_snapshot, async {
+    let started = Instant::now();
+    let result = with_snapshot_recording(&page, ctx.output_dir(), debug_snapshot, async {
         if let Some(hook) = cmd.before {
             hook(page.clone()).await?;
         }
-        let data = call_site_tool(tools, cmd.tool_name, input, &ctx).await?;
+        let data = call_site_tool(tools, cmd.tool_name, effective_input, &ctx).await?;
         if let Some(hook) = cmd.after {
             hook(page.clone()).await?;
         }
         Ok::<Value, anyhow::Error>(data)
     })
-    .await?;
+    .await;
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let data = match result {
+        Ok(data) => {
+            tool_recorder.finish_value(&data, duration_ms, None)?;
+            data
+        }
+        Err(err) => {
+            let message = format!("{err:#}");
+            tool_recorder.finish_error(duration_ms, &message)?;
+            return Err(err);
+        }
+    };
 
     let mut response = json!({
         "command": cmd.command_name,
         "run_dir": run_dir,
-        "input": invocation.get("input").cloned().unwrap_or(Value::Null),
+        "input": response_input.clone(),
         "data": data,
     });
     if cmd.include_run_metadata {
-        let run = run_metadata(&ctx, input_downloads_media(&invocation["input"]));
+        let run = run_metadata(&ctx, input_downloads_media(&response_input));
         response["run"] = run.clone();
         response["data"] = attach_run_metadata(response["data"].take(), &run);
     }
@@ -132,7 +147,10 @@ pub fn run_metadata(ctx: &ToolContext, include_media_dir: bool) -> Value {
         "dir": path_string(&ctx.run_dir),
     });
     if include_media_dir {
-        run["media_dir"] = json!(path_string(&ctx.run_dir.join("site_media")));
+        run["media_dir"] = json!(path_string(&ctx.output_dir().join("site_media")));
+    }
+    if ctx.output_dir() != ctx.run_dir {
+        run["tool_dir"] = json!(path_string(ctx.output_dir()));
     }
     run
 }

--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -15,8 +15,8 @@ pub(super) fn write_media_manifest_file(
     ctx: &ToolContext,
     manifest: &Value,
 ) -> std::io::Result<String> {
-    std::fs::create_dir_all(&ctx.run_dir)?;
-    let path = ctx.run_dir.join("media_manifest.json");
+    std::fs::create_dir_all(ctx.output_dir())?;
+    let path = ctx.output_dir().join("media_manifest.json");
     let rendered = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
     std::fs::write(&path, rendered)?;
     let _ = ctx.register_artifact(

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -8,6 +8,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use crate::agent::compaction::truncate;
 use crate::agent::tool::{
     ToolProgressEvent, ToolProgressPhase, ToolProgressSender, ToolProgressStatus,
 };
@@ -21,8 +22,8 @@ use crate::sites::registry::{
     required_string, ArgKind, BoxFuture, CommandArg, SiteCommand, SiteSpec, SlowWhen,
 };
 use crate::sites::runner::{
-    get_bool, get_f64, get_i64, get_str, json_result, run_metadata, run_tool_command,
-    trimmed_required, PageHook, ToolCommand,
+    get_bool, get_f64, get_i64, get_str, json_result, run_tool_command, trimmed_required, PageHook,
+    ToolCommand,
 };
 use crate::sites::xhs::media_manifest::{
     ensure_entity_note_id, search_media_manifest, write_media_manifest_file,
@@ -625,7 +626,7 @@ fn media_for(
 ) -> anyhow::Result<Option<MediaProcessor>> {
     if include_media {
         Ok(Some(MediaProcessor::for_run_dir(
-            &ctx.run_dir,
+            ctx.output_dir(),
             llm_provider,
         )?))
     } else {
@@ -1174,8 +1175,8 @@ fn attach_note_ocr_summary(entity: &mut Value) {
             let text = image
                 .get("ocr_text")
                 .and_then(Value::as_str)
-                .unwrap_or("")
-                .to_string();
+                .map(|text| truncate(text, 1200))
+                .unwrap_or_default();
             Value::String(text)
         })
         .collect();
@@ -1191,7 +1192,7 @@ fn attach_note_ocr_summary(entity: &mut Value) {
 }
 
 /// OCR performance/debug record, written to a separate file
-/// (`statistics/ocr_perf.json` in the run dir) rather than the LLM-facing JSON
+/// (`stats/ocr.json` in the tool-call dir) rather than the LLM-facing JSON
 /// artifact. OCR runs as one batched `predict` per note (fast, multi-core), so
 /// timing is per note/batch, not per image. The recognized `ocr_text` stays on
 /// the images for the LLM; only timing lives here.
@@ -1301,23 +1302,20 @@ fn write_cover_ocr_perf(
     write_run_perf_file(ctx, &perf);
 }
 
-/// Write an OCR perf record to `<run_dir>/statistics/ocr_perf.json`. Unlike
-/// artifacts, this is a plain debug file under a dedicated `statistics/` subdir —
-/// not registered, so it isn't surfaced to the LLM. Best-effort: write failures
-/// are ignored (perf logging must never fail a scan).
+/// Write the tool-specific OCR record under the current tool call's `stats/`.
 fn write_run_perf_file(ctx: &ToolContext, perf: &Value) {
-    let dir = ctx.run_dir.join("statistics");
-    if std::fs::create_dir_all(&dir).is_err() {
+    let stats_dir = ctx.output_dir().join("stats");
+    if std::fs::create_dir_all(&stats_dir).is_err() {
         return;
     }
     if let Ok(rendered) = serde_json::to_string_pretty(perf) {
-        let _ = std::fs::write(dir.join("ocr_perf.json"), rendered);
+        let _ = std::fs::write(stats_dir.join("ocr.json"), rendered);
     }
 }
 
 /// Remove OCR timing keys from the media-timing summary so the JSON artifact's
 /// `timing.media` carries only non-OCR (download) timings; OCR timing lives in
-/// the dedicated `ocr_perf.json`.
+/// the dedicated `stats/ocr.json`.
 fn strip_ocr_timing(media_timing: &mut Value) {
     if let Some(map) = media_timing.as_object_mut() {
         map.retain(|key, _| !key.starts_with("ocr"));
@@ -1401,6 +1399,9 @@ fn lean_preview_cards(payload: &mut Value) {
         let Some(obj) = card.as_object_mut() else {
             continue;
         };
+        if let Some(text) = obj.get("ocr_text").and_then(Value::as_str) {
+            obj.insert("ocr_text".into(), json!(truncate(text, 1200)));
+        }
         if let Some(link) = obj.remove("link") {
             obj.insert("url".into(), link);
         }
@@ -1934,6 +1935,33 @@ pub struct SearchTool {
     always_ocr: bool,
 }
 
+fn effective_macro_input(
+    input: &Value,
+    default_num_notes: Option<i64>,
+    always_download_media: bool,
+    always_ocr: bool,
+) -> Value {
+    let mut effective = input.clone();
+    let preview = get_bool(&effective, "preview", false);
+    if effective.get("num_notes").is_none() {
+        if let Some(default) = default_num_notes {
+            effective["num_notes"] = json!(default);
+        }
+    }
+    let ocr = always_ocr || get_bool(&effective, "ocr", false);
+    if ocr {
+        effective["ocr"] = json!(true);
+    }
+    if preview {
+        if let Some(object) = effective.as_object_mut() {
+            object.remove("download_media");
+        }
+    } else if always_download_media || ocr || get_bool(&effective, "download_media", false) {
+        effective["download_media"] = json!(true);
+    }
+    effective
+}
+
 #[async_trait]
 impl Tool for SearchTool {
     fn name(&self) -> &str {
@@ -1989,6 +2017,15 @@ impl Tool for SearchTool {
         })
     }
 
+    fn effective_input(&self, input: &Value) -> Value {
+        effective_macro_input(
+            input,
+            Some(DEFAULT_NUM_NOTES),
+            self.always_download_media,
+            self.always_ocr,
+        )
+    }
+
     async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
@@ -2033,7 +2070,7 @@ impl Tool for SearchTool {
                         None,
                         None,
                     );
-                    let media = MediaProcessor::for_run_dir(&ctx.run_dir, None)?;
+                    let media = MediaProcessor::for_run_dir(ctx.output_dir(), None)?;
                     let cover_t0 = std::time::Instant::now();
                     let predict = media.ocr_cover_images(cards, XHS_HOME_URL).await;
                     let wall = cover_t0.elapsed();
@@ -2290,7 +2327,7 @@ impl Tool for SearchTool {
         }
 
         let media_manifest_metadata = if download_media {
-            let media_manifest = search_media_manifest(&notes, &ctx.run_dir);
+            let media_manifest = search_media_manifest(&notes, ctx.output_dir());
             let media_manifest_count = media_manifest.as_array().map(Vec::len).unwrap_or_default();
             let (media_manifest_path, media_manifest_error) =
                 match write_media_manifest_file(ctx, &media_manifest) {
@@ -2309,7 +2346,6 @@ impl Tool for SearchTool {
         let mut payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
             "query": query,
-            "run": run_metadata(ctx, download_media),
             "filters": filter_result,
             "search": search,
             "notes": notes,
@@ -2326,7 +2362,7 @@ impl Tool for SearchTool {
             }
         });
         // OCR perf (model / EP / machine / per-image timing) is written to
-        // `ocr_perf.json` (see write_note_ocr_perf above), not the JSON artifact.
+        // `stats/ocr.json` (see write_note_ocr_perf above), not the JSON artifact.
         if let Some((media_manifest_count, media_manifest_path, media_manifest_error)) =
             media_manifest_metadata
         {
@@ -2445,6 +2481,10 @@ impl Tool for AuthorScanTool {
             },
             "required": ["author_id"]
         })
+    }
+
+    fn effective_input(&self, input: &Value) -> Value {
+        effective_macro_input(input, None, self.always_download_media, self.always_ocr)
     }
 
     async fn call(&self, input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
@@ -2610,7 +2650,7 @@ impl Tool for AuthorScanTool {
                     None,
                     None,
                 );
-                let cover_media = MediaProcessor::for_run_dir(&ctx.run_dir, None)?;
+                let cover_media = MediaProcessor::for_run_dir(ctx.output_dir(), None)?;
                 let covers = cards_value.len();
                 let cover_t0 = std::time::Instant::now();
                 let predict = cover_media
@@ -2637,7 +2677,7 @@ impl Tool for AuthorScanTool {
 
         // Build the media manifest from `notes` before they move into payload.
         let media_manifest_metadata = if download_media {
-            let media_manifest = search_media_manifest(&notes, &ctx.run_dir);
+            let media_manifest = search_media_manifest(&notes, ctx.output_dir());
             let media_manifest_count = media_manifest.as_array().map(Vec::len).unwrap_or_default();
             let (path, error) = match write_media_manifest_file(ctx, &media_manifest) {
                 Ok(path) => (Some(path), None),
@@ -2664,7 +2704,7 @@ impl Tool for AuthorScanTool {
             "timing": { "media": media_timing },
         });
 
-        // OCR perf is written to `ocr_perf.json` (see above), not the artifact.
+        // OCR perf is written to `stats/ocr.json` (see above), not the artifact.
 
         if let Some((count, path, error)) = media_manifest_metadata {
             if let Some(map) = payload.as_object_mut() {
@@ -2772,12 +2812,12 @@ mod tests {
     fn run_metadata_includes_media_dir_only_when_requested() {
         let ctx = ToolContext::new("run-1", "/tmp/socai-run");
 
-        let without_media = run_metadata(&ctx, false);
+        let without_media = crate::sites::runner::run_metadata(&ctx, false);
         assert_eq!(without_media["id"], json!("run-1"));
         assert_eq!(without_media["dir"], json!("/tmp/socai-run"));
         assert!(without_media.get("media_dir").is_none());
 
-        let with_media = run_metadata(&ctx, true);
+        let with_media = crate::sites::runner::run_metadata(&ctx, true);
         assert_eq!(with_media["media_dir"], json!("/tmp/socai-run/site_media"));
     }
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,229 +1,165 @@
-# socai data model
+# socai persisted execution model
 
-This document describes the persisted data that backs agent runs and the desktop
-app task history. Keep this current when changing run artifacts, task state, or
-history replay.
+Socai stores execution data in three ownership layers. The rule is simple:
+persist a fact once, in the lowest layer that owns it. Parent layers keep
+references instead of copying child records.
 
-## Guiding rule
+## L1: conversation session
 
-`~/.socai/runs/...` (or the root configured by `runs.dir` / `SOCAI_RUNS_DIR`)
-is the source of truth for task results.
-
-The desktop app may keep an index in `~/.socai/app/tasks.json`, but it should not
-persist duplicate task result payloads such as final answers or event timelines.
-The app can hydrate those fields from the run directory when serving the UI.
-
-## Locations
-
-| Data | Default path | Override | Owner |
-| --- | --- | --- | --- |
-| Core run artifacts | `~/.socai/runs/<timestamp>_<task-slug>/` | `SOCAI_RUNS_DIR`, else `socai config set runs.dir <path>` | `socai-core` |
-| Desktop task index | `~/.socai/app/tasks.json` | `SOCAI_HOME` (`$SOCAI_HOME/app/tasks.json`) | Tauri app |
-
-Do not add a second persistent task-result store under `~/.socai/app/`. If the
-UI needs result data after restart, derive it from the task's `run_dir`.
-
-## Identifiers
-
-### `task_id`
-
-Created by the desktop app task registry before the agent starts.
-
-Example:
-
-```txt
-task-1790000000000-1
+```text
+~/.socai/sessions/<session-id>/
+└── session.json
 ```
 
-Used for desktop UI state: task list rows, selected task, cancellation, and
-mapping an app task to a core run.
+`session.json` is the ordered conversation index. It stores the selected model,
+timestamps, and one entry per user interaction:
 
-### `run_id`
+- user text;
+- L2 run directory;
+- interaction status;
+- an assistant fallback only if the run produced no `report.md`.
 
-Created inside `socai-core` when the agent loop starts.
+The session id comes from the directory name. The final answer is read from the
+referenced run's `report.md`; the effective system prompt is in that run's
+first LLM request. Neither is copied into `session.json`.
 
-Example:
+The TUI can append multiple interactions to one session. Desktop currently
+creates one session per task, but uses the same format so it can add follow-up
+interactions later.
 
-```txt
-20260518-142233-123456
+The session root is `SOCAI_SESSIONS_DIR`, then `SOCAI_HOME/sessions`, then
+`~/.socai/sessions`.
+
+## L2: one agent execution
+
+```text
+~/.socai/runs/<timestamp>_<task>/
+├── run.json
+├── report.md
+├── llm/
+│   ├── 001.request.json
+│   ├── 001.response.json
+│   └── ...
+└── tools/
+    ├── turn-001-call-01-search/
+    └── ...
 ```
 
-Used by the core agent run and persisted in run artifacts / task index once the
-run exists.
+`run.json` owns only run-level facts:
 
-### `run_dir`
+- run id and optional parent session id;
+- task and model;
+- status, start time, and total duration;
+- turn count and aggregate token usage;
+- an error only for failed/interrupted runs.
 
-Created before starting the core run and passed into `socai-core`.
+`report.md` is the single durable copy of the final user-facing answer.
 
-Example:
+Each `llm/NNN.request.json` is the actual JSON body sent after context
+preparation and provider-specific translation, excluding authentication
+headers. Its shape therefore follows the active API (Anthropic Messages,
+OpenAI-compatible Chat Completions, or Responses).
 
-```txt
-~/.socai/runs/20260518_142233_find_xhs_coffee_notes
+The matching response contains text, exposed reasoning, tool calls, stop
+reason, token usage, request duration, and completion time. An unsuccessful
+request contains its duration, completion time, and error. Authentication
+headers, credentials, and raw response bytes are not recorded.
+
+The LLM files are also the canonical ordered execution trace. Socai does not
+write a parallel event log or span log: LLM duration lives on the response,
+tool duration lives on the tool manifest, and total duration lives on
+`run.json`.
+
+The run root is `SOCAI_RUNS_DIR`, then `socai config get runs.dir`, then
+`~/.socai/runs`.
+
+## L3: one tool invocation
+
+An agent tool call is nested under its L2 run:
+
+```text
+tools/turn-001-call-01-search/
+├── tool.json
+├── output.json          # only when the invocation returned a value
+├── artifacts/          # only when the tool saves full domain data
+├── site_media/         # only when media is downloaded
+├── media_manifest.json # only when media needs a registry
+├── stats/
+│   └── ocr.json        # only when OCR ran
+└── snapshots/          # only with debug snapshots enabled
 ```
 
-This directory is the source of truth for final answer and timeline replay.
+The directory name makes the LLM turn, call sequence within that turn, and tool
+name visible. `tool.json` owns the tool name, effective input after
+tool-specific defaults/forced options, lifecycle status, start time, duration,
+and an error when present. The parent LLM response retains the input originally
+requested by the model; when defaults are involved these two values are
+intentionally different.
 
-`task_id` and `run_id` are intentionally different. `task_id` is an app/workflow
-identifier; `run_id` is a core agent-run identifier.
+`output.json` is the raw `ToolResultBlock[]` returned to the agent. It is not
+wrapped with tool names, ids, timestamps, durations, or another `output` field.
 
-## Core run directory
+Artifacts contain full, untrimmed domain results when the model/CLI-facing
+output is intentionally lean. Downloaded media, its manifest, tool-specific
+statistics, and debug snapshots all stay inside the same tool directory.
+There is no artifact index: a consumer can enumerate `artifacts/`, while the
+tool output points to any artifact it expects a caller to use.
 
-Each agent run writes files under `run_dir`.
+## Standalone CLI tool invocation
 
-| Path | Purpose | Notes |
-| --- | --- | --- |
-| `report.md` | Final answer shown by the desktop app | Source of truth for completed task output. May include appended artifact markdown. |
-| `timeline.jsonl` | Canonical typed task timeline | Source of truth for live and historical desktop timeline rows for new runs. |
-| `reasoning_log.jsonl` | Append-only debug/event log | Debug log and legacy fallback source for historical timeline replay. |
-| `conversation.json` | Final system prompt and message history snapshot | Useful for debugging/model replay. |
-| `agent_log.json` | Run summary | Includes task, model, turns, token counts, paths to run files. |
-| `tool_results/<turn>_<seq>_<tool>.json` | Full tool result bodies | `reasoning_log.jsonl` only stores compact summaries. |
-| `run_state/events.jsonl` | Compact run-state timeline | Fallback source for historical timeline replay. |
-| `run_state/working_memory.md` | Rendered working memory | Used by the agent context/memory path. |
-| `run_state/artifacts.json` | Artifact registry | Screenshots/media/other artifacts saved by tools. |
-| `run_state/evidence.json` | Extracted evidence records | Populated from entity-like tool artifacts. |
-| `run_state/plan.json` | Current plan state | Updated by plan tools when used. |
+A site CLI command is already one tool invocation, so its run directory is
+directly L3:
 
-### `reasoning_log.jsonl`
-
-One JSON object per line. Current important event types include:
-
-- `task_start`
-- `llm_response`
-- `reasoning`
-- `tool_call_start`
-- `tool_result`
-- `api_error`
-- `turn_end`
-- `task_end`
-
-For new runs, the desktop app replays timeline rows from `timeline.jsonl` first.
-If `timeline.jsonl` is absent or empty, the app falls back to this file and then
-to `run_state/events.jsonl` for legacy runs.
-
-## Desktop task index: `tasks.json`
-
-`tasks.json` is an app index, not a task result store. It is an array of task
-snapshots with fields like:
-
-```json
-{
-  "task_id": "task-1790000000000-1",
-  "task": "find popular xhs coffee notes",
-  "model": "claude-sonnet-4-5-20250929",
-  "status": "completed",
-  "created_at": 1790000000000,
-  "started_at": 1790000000200,
-  "finished_at": 1790000060000,
-  "run_id": "20260518-142233-123456",
-  "run_dir": "/Users/alice/.socai/runs/20260518_142233_find_popular_xhs_coffee_notes",
-  "target_id": null,
-  "error": null,
-  "turns": 4,
-  "input_tokens": 12345,
-  "output_tokens": 2345
-}
+```text
+~/.socai/runs/<timestamp>_<site>_<command>_<identifier>/
+├── tool.json
+├── output.json          # only when the invocation returned a value
+├── artifacts/
+├── site_media/
+├── media_manifest.json
+├── stats/
+│   └── ocr.json
+└── snapshots/
 ```
 
-Rules:
+There is no parent LLM response, so standalone `tool.json` additionally owns
+the public tool name and effective input. It includes `implementation` only when
+the CLI command and internal tool names differ. `output.json` is the raw tool
+value.
 
-- `final_text` is not persisted in `tasks.json`.
-- If old `tasks.json` files contain `final_text`, the app ignores it on load and
-  omits it the next time the index is written.
-- API responses may still include `final_text`, but it is hydrated from
-  `<run_dir>/report.md`.
-- `error` is status metadata for failed/interrupted tasks; it is not a final
-  answer.
-- Queued/running tasks are marked `interrupted` on app startup because their
-  in-process runner and browser tab no longer exist.
+Optional directories and files are created lazily. A normal search without
+media, OCR, or snapshots should not contain empty `stats/`, `site_media/`, or
+`snapshots/` directories.
 
-## Desktop timeline state
+## Desktop task history
 
-New task timeline rows are appended to `<run_dir>/timeline.jsonl` before they are
-emitted to the webview. The Tauri `agent_task:event` stream is a live delivery
-mechanism for already-persisted rows; frontend memory is only a view cache.
+`~/.socai/app/tasks.json` is a lightweight UI index, not a fourth logging
+layer. It stores task lookup/status fields plus run and session directories.
+Run id, errors, answer text, turn count, and usage are hydrated from
+`run.json` and `report.md`.
 
-Timeline rows use a typed discriminated shape with `kind` at the top level. For
-example:
+Live desktop events exist only in memory. After restart, the desktop rebuilds
+its typed timeline from `run.json`, `llm/*.response.json`, and each referenced
+tool's `tool.json` and `output.json`. It does not persist a duplicate
+`timeline.jsonl`.
 
-```json
-{
-  "task_id": "task-1790000000000-1",
-  "kind": "tool_call",
-  "id": "toolu_123",
-  "turn": 1,
-  "sequence_in_turn": 1,
-  "name": "search",
-  "label": "searched xiaohongshu",
-  "args": { "query": "..." },
-  "repeat_count": 1,
-  "text": "search({\"query\":\"...\"})",
-  "sequence": 4,
-  "created_at": 1790000005000
-}
-```
+## Ownership table
 
-Tool results can additionally carry normalized inline entities:
+| Fact | Single durable owner |
+| --- | --- |
+| Conversation order and user interactions | L1 `session.json` |
+| Run task, model, status, totals | L2 `run.json` |
+| Final answer | L2 `report.md` |
+| Exact LLM request and response | L2 `llm/` pair |
+| Agent tool input | L3 `tool.json` |
+| Provider tool call id | Parent LLM response |
+| Standalone tool input | L3 `tool.json` |
+| Tool status, duration, error | L3 `tool.json` |
+| Tool result | L3 `output.json` |
+| Full domain artifact | L3 `artifacts/` |
+| Downloaded media and registry | L3 `site_media/`, `media_manifest.json` |
+| OCR details | L3 `stats/ocr.json` |
+| Debug browser state | L3 `snapshots/` |
 
-```json
-{
-  "task_id": "task-1790000000000-1",
-  "kind": "tool_result",
-  "id": "toolu_123",
-  "name": "search",
-  "label": "searched xiaohongshu",
-  "ok": true,
-  "duration_ms": 1400,
-  "entities": [{ "type": "xhs_note_card_grid", "data": [] }],
-  "text": "search (1400ms): ...",
-  "sequence": 5,
-  "created_at": 1790000006500
-}
-```
-
-After restart or webview reload, the app does not read a separate app event
-cache. Instead, `agent_task_events(task_id)` reads rows from the task's
-`run_dir`:
-
-1. `<run_dir>/timeline.jsonl`
-2. legacy fallback: `<run_dir>/reasoning_log.jsonl` plus `tool_results/*.json`
-3. legacy fallback: `<run_dir>/run_state/events.jsonl`
-4. terminal status metadata from `tasks.json` when applicable
-
-This keeps timeline and final answer data rooted in the run directory.
-
-## Realtime event stream vs `timeline.jsonl` / `reasoning_log.jsonl`
-
-For new runs, `timeline.jsonl` is the canonical source for both realtime and
-historical timeline rows. The live UI receives rows only after they have been
-written to that file.
-
-The live UI receives two classes of events:
-
-1. App lifecycle/status events emitted by Tauri: `queued`, `running`, `tab`,
-   `completed`, `failed`, `cancelled`, `interrupted`.
-2. Core agent events emitted by `socai-core`: `started`, `turn`, `assistant`,
-   `reasoning`, `tool_call`, `tool_result`, `tool_error`, `api_error`, `done`.
-
-`reasoning_log.jsonl` remains a persistent core debug log and legacy replay
-fallback. It is not an exact byte-for-byte copy of what the user sees in
-realtime.
-
-| UI row | New-run source | Legacy fallback source | Replay behavior |
-| --- | --- | --- | --- |
-| `queued` | `timeline.jsonl` | Not logged | Replayed for new runs. |
-| `running` | `timeline.jsonl` | Not logged | Replayed for new runs. |
-| `tab` | `timeline.jsonl` | Not logged | Replayed for new runs. |
-| `started` | `timeline.jsonl` | `task_start` | Replayed. |
-| `turn` | `timeline.jsonl` | inferred from `turn` fields | Replayed/reconstructed. |
-| `assistant` | `timeline.jsonl` | `llm_response.text` | Replayed. |
-| `reasoning` | `timeline.jsonl` | `reasoning` when present | Replayed for new runs. |
-| `tool_call` | `timeline.jsonl` | `tool_call_start` | Replayed. |
-| `tool_result` / `tool_error` | `timeline.jsonl` | `tool_result` + `tool_results/*.json` | Replayed with normalized entities when possible. |
-| `api_error` | `timeline.jsonl` | `api_error` | Replayed. |
-| `done` | `timeline.jsonl` | `task_end` | Replayed. |
-| terminal app status | `timeline.jsonl` | `tasks.json` status metadata | Replayed/reconstructed. |
-
-New runs persist the typed desktop timeline directly in `timeline.jsonl` under
-`run_dir`. `tasks.json` remains an index and must not grow a duplicate timeline
-cache.
+These local files currently have no external schema consumer or migration
+reader, so they intentionally do not carry a `schema_version` field.


### PR DESCRIPTION
## Summary

Refactor persisted execution output around three ownership layers:

1. conversation session;
2. one agent execution;
3. one tool invocation.

Each fact now has one durable owner. Agent runs keep exact LLM I/O and nest
tool-owned data under the corresponding call. A standalone CLI command is
already one tool invocation, so its run directory is directly an L3 record.

This removes the legacy flat format rather than maintaining compatibility
readers or a feature flag.

## Why

The old desktop run directory mixed conversation state, agent state, UI events,
tool results, artifacts, media, and performance data at the same level. Several
files recorded the same facts in different shapes, while exact provider
requests and responses were not preserved consistently.

That made debugging ambiguous:

- `agent_log.json`, `conversation.json`, `reasoning_log.jsonl`,
  `timeline.jsonl`, and `run_state/*` overlapped;
- tool output and tool metadata were wrapped together in `tool_results/*`;
- artifacts, media, OCR statistics, and debug state were stored at run scope
  even though they belonged to one tool invocation;
- parallel event, trace, and performance files could disagree about timing or
  lifecycle state.

## New persisted layout

### L1: conversation session

```text
~/.socai/sessions/<session-id>/
└── session.json
```

`session.json` is only the ordered interaction index: model, timestamps, user
text, L2 run reference, and status. It does not copy the system prompt or final
answer. TUI sessions can contain multiple interactions; desktop currently
creates one session per task using the same format.

### L2: one agent execution

```text
~/.socai/runs/<timestamp>_<task>/
├── run.json
├── report.md
├── llm/
│   ├── 001.request.json
│   ├── 001.response.json
│   └── ...
└── tools/
    ├── turn-001-call-01-search/
    └── ...
```

- `run.json` owns run identity, task/model, status, timing, turn count, and
  aggregate token usage.
- `report.md` remains the single durable final answer.
- `llm/NNN.request.json` stores the actual provider request body after context
  preparation and provider translation, without authentication headers.
- `llm/NNN.response.json` stores text, exposed reasoning, tool calls, stop
  reason, usage, duration, and completion/error state.
- The LLM files are the ordered execution trace; there is no parallel persisted
  event or span log.

One LLM turn may return multiple tool calls. In
`turn-001-call-01-search`, `001` is the LLM turn and `01` is the call sequence
within that response.

### L3: one tool invocation

```text
tools/turn-001-call-01-search/
├── tool.json
├── output.json
├── artifacts/
├── site_media/
├── media_manifest.json
├── stats/
│   └── ocr.json
└── snapshots/
```

- `tool.json` owns the tool name, effective input, lifecycle status, start
  time, duration, and error.
- `output.json` is the raw result returned to the agent, without another
  metadata wrapper.
- Full untrimmed domain data remains in `artifacts/` when the model-facing
  result is intentionally lean.
- Media, OCR details, and debug snapshots stay with the tool call that produced
  them.
- Optional files and directories are created lazily.

### Standalone CLI tool invocation

```text
~/.socai/runs/<timestamp>_<site>_<command>_<identifier>/
├── tool.json
├── output.json
├── artifacts/
├── site_media/
├── media_manifest.json
├── stats/
│   └── ocr.json
└── snapshots/
```

There is no synthetic L1 or L2 wrapper. `tool.json` additionally owns the
public CLI tool name and effective command input.

## Old versus new files

| Old path | Old role/problem | New owner |
| --- | --- | --- |
| `agent_log.json` | Run summary plus paths to other records; repeated task, model, usage, and layout knowledge | `run.json` stores only L2 facts; directory structure is not repeated as path metadata |
| `conversation.json` | Copied system prompt and accumulated messages into a final run snapshot | Exact provider inputs live in `llm/*.request.json`; L1 `session.json` stores only interaction order and run references |
| `reasoning_log.jsonl` | Parallel reasoning/tool lifecycle event stream | Reasoning and tool calls live in `llm/*.response.json`; tool lifecycle lives in `tool.json` |
| `timeline.jsonl` | Second UI-oriented event stream overlapping the reasoning log | Desktop keeps live events in memory and reconstructs history from canonical L2/L3 files |
| `run_state/task.json` | Repeated task/run status | `run.json` |
| `run_state/plan.json` | Internal mutable plan snapshot | Runtime memory only; no additional persisted source of truth |
| `run_state/working_memory.md` | Internal mutable working-memory snapshot | Runtime memory only |
| `run_state/events.jsonl` | Third lifecycle/event stream | Removed; replay uses L2/L3 records |
| `run_state/evidence.json` | Derived evidence index | Removed; canonical tool output/artifacts remain available |
| `run_state/artifacts.json` | Artifact registry duplicating filesystem contents | Removed; enumerate the owning tool's `artifacts/` directory |
| `tool_results/001_01_search.json` | Wrapped tool input, output, ids, timing, summaries, and errors together | `tools/turn-001-call-01-search/tool.json` owns input/lifecycle; `output.json` owns only the raw result; provider call id stays in the parent LLM response |
| run-root `artifacts/*` | Full domain output detached from the producing call | `tools/<call>/artifacts/*` |
| run-root `site_media/*` | Downloaded media detached from the producing call | `tools/<call>/site_media/*` |
| run-root `media_manifest.json` | Media registry detached from the producing call | `tools/<call>/media_manifest.json` |
| `statistics/ocr_perf.json` | OCR timing at run scope | `tools/<call>/stats/ocr.json` |
| run-root debug snapshots | Browser/debug state detached from the producing call | `tools/<call>/snapshots/*` |
| `report.md` | Final user-facing answer | Retained as the single L2 answer |
| no exact request/response pair | Provider payloads could only be inferred from snapshots/events | `llm/NNN.request.json` and `llm/NNN.response.json` preserve exact LLM I/O |
| no conversation index | A run snapshot acted as both execution log and conversation state | L1 `session.json` indexes interactions and references L2 runs |

## Deliberately omitted

- no `artifacts/index.json`: the directory is already the index;
- no separate `stats/perf.json` or `trace/spans.jsonl`: durations belong to
  `run.json`, LLM responses, and `tool.json`;
- no copied tool name/call id in `output.json`;
- no `schema_version`: these files currently have no external schema consumer
  or migration reader;
- no legacy-format writer, reader, or `SOCAI_LEGACY_RUN_LOGS` switch.

## Desktop and CLI impact

- Desktop task history remains a lightweight UI index and hydrates canonical
  run fields from `run.json` and `report.md`.
- Desktop timeline replay now reads `run.json`, LLM responses, and tool records
  instead of persisting another timeline.
- TUI sessions retain multi-interaction context through L1 session records.
- CLI commands emit the same user-facing result while persisting one concise
  L3 record.
- Full artifact and OCR data are not truncated during persistence. Any lean
  result sent to the model remains a deliberate tool-output contract, with the
  full domain record stored alongside it.

## Validation

- `cargo check --workspace`
- `pnpm run build` in `app/`
- `rustfmt --edition 2021 --check` for all modified Rust files
- `git diff --check`

No new Rust tests are included, following the repository guidance added in this
change.
