### PR TITLE
feat(app): Windows desktop support — NSIS installer, CI build, windows-safe paths

### DIFF
--- a/.claude/skills/socai-release/SKILL.md
+++ b/.claude/skills/socai-release/SKILL.md
@@ -27,7 +27,7 @@ A helper script wraps this command, finds the created run, watches it, and print
 - Production ref: `main`
 - Test ref: `fix/release-*` branches only; build runs but publish job is skipped
 - Version source: latest strict semver tag matching `vMAJOR.MINOR.PATCH`; if no tag exists, app version from `app/src-tauri/tauri.conf.json`
-- Desktop artifacts: `socai-macos-universal.dmg`, plus the auto-updater set `socai-macos-universal.app.tar.gz` + `.sig` + `latest.json`
+- Desktop artifacts: `socai-macos-universal.dmg` and `socai-windows-x86_64-setup.exe`, plus the auto-updater set `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json` (darwin + windows platforms)
 - Production publish steps on `main`:
   1. Build universal macOS app + DMG on GitHub Actions.
   2. Require Developer ID signing + notarization secrets, and the updater minisign keypair (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`).
@@ -205,7 +205,7 @@ Expected:
 
 - `isDraft: false`
 - `isPrerelease: false`
-- Asset list includes `socai-macos-universal.dmg`, `socai-macos-universal.app.tar.gz`, `socai-macos-universal.app.tar.gz.sig`, and `latest.json`
+- Asset list includes `socai-macos-universal.dmg`, `socai-macos-universal.app.tar.gz`, `socai-macos-universal.app.tar.gz.sig`, `socai-windows-x86_64-setup.exe`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json`
 
 Verify download redirects:
 
@@ -239,7 +239,7 @@ Include:
 - Ref used (`main` for production)
 - GitHub Actions run URL and conclusion
 - Published tag/version and release URL
-- Asset presence (`socai-macos-universal.dmg`, plus updater `socai-macos-universal.app.tar.gz` + `.sig` + `latest.json`)
+- Asset presence (`socai-macos-universal.dmg` + `socai-windows-x86_64-setup.exe`, plus updater `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json`)
 - `/download` verification summary
 - `socai.io` site verification summary (mandatory): live visible version equals `X.Y.Z`, and `/`, `www`, `/download`, `/github` all behave as expected
 - Whether the Git-integration auto-deploy was sufficient, or a manual `socai-site-deployment` redeploy fallback was needed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -885,6 +885,9 @@ jobs:
 
           $installer = Get-ChildItem -Path $bundleDir -Filter '*-setup.exe' -File | Select-Object -First 1
           if (-not $installer) { throw "no NSIS installer found in $bundleDir" }
+          if ($installer.Name -notlike "*$env:VERSION*") {
+            throw "expected installer name to contain version $env:VERSION, got: $($installer.Name)"
+          }
           $assetRel = Join-Path $dist 'socai-windows-x86_64-setup.exe'
           $assetFull = Join-Path $env:GITHUB_WORKSPACE $assetRel
           Copy-Item $installer.FullName $assetFull
@@ -896,10 +899,11 @@ jobs:
           if ($env:TAURI_SIGNING_PRIVATE_KEY -and $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD) {
             Push-Location app
             try {
-              pnpm exec tauri signer sign `
-                --private-key "$env:TAURI_SIGNING_PRIVATE_KEY" `
-                --password "$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD" `
-                "$assetFull"
+              # The CLI reads the key and password from the TAURI_SIGNING_* env
+              # vars already set on this step, so the multi-line minisign key
+              # never crosses the pwsh -> pnpm -> node command-line round-trip.
+              pnpm exec tauri signer sign "$assetFull"
+              if ($LASTEXITCODE -ne 0) { throw "tauri signer sign exited with status $LASTEXITCODE" }
             } finally {
               Pop-Location
             }
@@ -1077,10 +1081,10 @@ jobs:
           - [universal mac dmg](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-macos-universal.dmg) — supports Apple Silicon and Intel Macs.
           - [windows app installer (.exe)](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-windows-x86_64-setup.exe) — desktop app for Windows 10/11 (x64).
           - [macOS CLI installer](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/install.sh) — one-command macOS CLI install.
-          - [universal mac CLI tarball](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz) — standalone `socai` CLI.
+          - [universal mac CLI tarball](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz) — standalone \`socai\` CLI.
           - [macOS CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz.sha256)
           - [Windows CLI installer](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/install.ps1) — one-command Windows CLI install.
-          - [Windows CLI zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-windows-x86_64.zip) — standalone `socai.exe` CLI.
+          - [Windows CLI zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-windows-x86_64.zip) — standalone \`socai.exe\` CLI.
           - [Windows CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-windows-x86_64.zip.sha256)
 
           The macOS app build is signed and notarized. The Windows app installer is not yet code-signed, so SmartScreen may warn on first run — choose "More info" then "Run anyway".
@@ -1205,6 +1209,64 @@ jobs:
           }
           & $socai --help | Out-Null
           & $socai version --no-check
+
+  verify-windows-desktop-installer:
+    name: verify latest windows desktop installer
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - prepare
+      - release
+    runs-on: windows-latest
+
+    steps:
+      - name: install desktop app from latest release
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $setupUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/latest/download/socai-windows-x86_64-setup.exe"
+          $setup = Join-Path $env:RUNNER_TEMP 'socai-setup.exe'
+          Remove-Item -Force $setup -ErrorAction SilentlyContinue
+
+          $downloaded = $false
+          for ($attempt = 1; $attempt -le 12; $attempt++) {
+            Write-Host "download attempt ${attempt}: $setupUrl"
+            try {
+              Invoke-WebRequest -UseBasicParsing -Uri $setupUrl -OutFile $setup
+              $downloaded = $true
+              break
+            } catch {
+              Write-Warning $_
+              Start-Sleep -Seconds 10
+            }
+          }
+          if (-not $downloaded) {
+            throw 'failed to download socai desktop installer from latest release'
+          }
+
+          Unblock-File $setup
+          $install = Start-Process -FilePath $setup -ArgumentList '/S' -PassThru -Wait
+          if ($install.ExitCode -ne 0) {
+            throw "silent install exited with status $($install.ExitCode)"
+          }
+
+          # NSIS installMode currentUser installs under LOCALAPPDATA; check
+          # Program Files too in case the install mode ever changes.
+          $candidates = @(
+            (Join-Path $env:LOCALAPPDATA 'socai\socai.exe'),
+            (Join-Path $env:ProgramFiles 'socai\socai.exe')
+          )
+          $app = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $app) {
+            throw "socai.exe not found after install; checked: $($candidates -join ', ')"
+          }
+
+          $productVersion = (Get-Item $app).VersionInfo.ProductVersion
+          Write-Host "installed ${app} (ProductVersion=$productVersion)"
+          if ($productVersion -notmatch "^$([regex]::Escape($env:VERSION))") {
+            throw "expected installed app version to start with $env:VERSION, got: $productVersion"
+          }
 
   verify-desktop-updater:
     name: verify desktop updater manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,6 +800,135 @@ jobs:
           path: dist-artifacts/*
           if-no-files-found: error
 
+  build-windows-app:
+    name: build windows app installer
+    needs: prepare
+    runs-on: windows-latest
+
+    steps:
+      - name: checkout release base commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+
+      - name: apply release version
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python .github/scripts/set-app-version.py $env:VERSION
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add Cargo.toml app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.lock
+          git commit -m "chore: release socai v$env:VERSION"
+          $versionedSha = git rev-parse HEAD
+          "SOCAI_BUILD_SHA=$versionedSha" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "versioned build tree $versionedSha"
+
+      - name: set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+          run_install: false
+
+      - name: set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: set up rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cache rust build outputs
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          key: windows-app
+
+      - name: clear stale bundle outputs
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Remove-Item -Recurse -Force target\release\bundle -ErrorAction SilentlyContinue
+
+      - name: build app installer
+        working-directory: app
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # NSIS only (the user-selected installer). Authenticode code signing is
+          # intentionally not configured yet, so the installer ships unsigned and
+          # SmartScreen will warn — updater signing below is independent of this.
+          pnpm exec tauri build --ci --bundles nsis
+
+      - name: collect and sign updater artifact
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $bundleDir = 'target\release\bundle\nsis'
+          $dist = 'dist-artifacts'
+          Remove-Item -Recurse -Force $dist -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+
+          $installer = Get-ChildItem -Path $bundleDir -Filter '*-setup.exe' -File | Select-Object -First 1
+          if (-not $installer) { throw "no NSIS installer found in $bundleDir" }
+          $assetRel = Join-Path $dist 'socai-windows-x86_64-setup.exe'
+          $assetFull = Join-Path $env:GITHUB_WORKSPACE $assetRel
+          Copy-Item $installer.FullName $assetFull
+          "collected $($installer.Name) -> $assetRel"
+
+          # Desktop auto-updater signing (minisign) — independent of Authenticode.
+          # The updater verifies each release against the pubkey baked into
+          # tauri.conf.json, so the matching private key must sign the installer.
+          if ($env:TAURI_SIGNING_PRIVATE_KEY -and $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD) {
+            Push-Location app
+            try {
+              pnpm exec tauri signer sign `
+                --private-key $env:TAURI_SIGNING_PRIVATE_KEY `
+                --password $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD `
+                $assetFull
+            } finally {
+              Pop-Location
+            }
+            $sigFull = "$assetFull.sig"
+            if (-not (Test-Path $sigFull)) { throw "expected $sigFull from tauri signer sign" }
+            $signature = (Get-Content -Raw $sigFull).Trim()
+            $downloadUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/v$($env:VERSION)/socai-windows-x86_64-setup.exe"
+            # Partial updater manifest merged into latest.json by the publish job,
+            # so the macOS-produced darwin keys are not clobbered.
+            [ordered]@{
+              'windows-x86_64' = [ordered]@{ signature = $signature; url = $downloadUrl }
+            } | ConvertTo-Json -Depth 5 | Set-Content -Encoding utf8NoBOM (Join-Path $dist 'latest-windows-x86_64.json')
+            "generated windows updater fragment:"
+            Get-Content (Join-Path $dist 'latest-windows-x86_64.json')
+          } elseif ($env:GITHUB_REF -eq 'refs/heads/main') {
+            throw 'main releases require TAURI_SIGNING_PRIVATE_KEY and TAURI_SIGNING_PRIVATE_KEY_PASSWORD secrets for the desktop auto-updater'
+          } else {
+            "no updater signing key for this branch build; skipping installer signature and updater fragment"
+          }
+
+          Get-ChildItem $dist
+
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: socai-${{ needs.prepare.outputs.version }}-windows-app
+          path: dist-artifacts/*
+          if-no-files-found: error
+
   release:
     name: publish github release
     if: github.ref == 'refs/heads/main'
@@ -808,6 +937,7 @@ jobs:
       - build-macos-app-dmg
       - build-macos-cli
       - build-windows-cli
+      - build-windows-app
     runs-on: ubuntu-latest
 
     steps:
@@ -823,6 +953,45 @@ jobs:
           pattern: socai-${{ needs.prepare.outputs.version }}-*
           merge-multiple: true
           path: dist-artifacts
+
+      - name: merge windows entry into updater manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The macOS app job produces latest.json with only the darwin-* keys;
+          # the windows app job produces a windows-x86_64 fragment. Merge the
+          # fragment into the canonical manifest here (rather than letting two
+          # latest.json files collide under merge-multiple), then drop the
+          # fragment so it is not published as a release asset.
+          manifest="dist-artifacts/latest.json"
+          fragment="dist-artifacts/latest-windows-x86_64.json"
+
+          if [ ! -f "${manifest}" ]; then
+            echo "missing ${manifest} (expected from the macOS app job)" >&2
+            exit 1
+          fi
+          if [ ! -f "${fragment}" ]; then
+            echo "missing ${fragment} (expected from the windows app job)" >&2
+            exit 1
+          fi
+
+          python3 - "${manifest}" "${fragment}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          manifest_path, fragment_path = sys.argv[1], sys.argv[2]
+          manifest = json.loads(Path(manifest_path).read_text())
+          fragment = json.loads(Path(fragment_path).read_text())
+          manifest.setdefault("platforms", {}).update(fragment)
+          Path(manifest_path).write_text(json.dumps(manifest, indent=2) + "\n")
+          PY
+
+          rm -f "${fragment}"
+
+          echo "merged latest.json:"
+          cat "${manifest}"
 
       - name: publish release
         shell: bash
@@ -854,6 +1023,8 @@ jobs:
             dist-artifacts/socai-cli-windows-x86_64.zip
             dist-artifacts/socai-cli-windows-x86_64.zip.sha256
             dist-artifacts/install.ps1
+            dist-artifacts/socai-windows-x86_64-setup.exe
+            dist-artifacts/socai-windows-x86_64-setup.exe.sig
           )
           for artifact in "${required_artifacts[@]}"; do
             if [ ! -f "${artifact}" ]; then
@@ -904,6 +1075,7 @@ jobs:
           ## downloads
 
           - [universal mac dmg](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-macos-universal.dmg) — supports Apple Silicon and Intel Macs.
+          - [windows app installer (.exe)](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-windows-x86_64-setup.exe) — desktop app for Windows 10/11 (x64).
           - [macOS CLI installer](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/install.sh) — one-command macOS CLI install.
           - [universal mac CLI tarball](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz) — standalone `socai` CLI.
           - [macOS CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-macos-universal.tar.gz.sha256)
@@ -911,7 +1083,7 @@ jobs:
           - [Windows CLI zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-windows-x86_64.zip) — standalone `socai.exe` CLI.
           - [Windows CLI checksum](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-cli-windows-x86_64.zip.sha256)
 
-          The macOS app build is signed and notarized.
+          The macOS app build is signed and notarized. The Windows app installer is not yet code-signed, so SmartScreen may warn on first run — choose "More info" then "Run anyway".
 
           ## changes
 
@@ -1075,13 +1247,13 @@ jobs:
             exit 1
           fi
 
-          for arch in darwin-aarch64 darwin-x86_64; do
-            tarball_url="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['url'])")"
+          for arch in darwin-aarch64 darwin-x86_64 windows-x86_64; do
+            asset_url="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['url'])")"
             signature="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['signature'])")"
             if [ -z "${signature}" ]; then
               echo "latest.json ${arch} signature is empty" >&2
               exit 1
             fi
-            echo "checking ${arch} updater tarball: ${tarball_url}"
-            curl -fsSL -I "${tarball_url}" > /dev/null
+            echo "checking ${arch} updater asset: ${asset_url}"
+            curl -fsSL -I "${asset_url}" > /dev/null
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -897,9 +897,9 @@ jobs:
             Push-Location app
             try {
               pnpm exec tauri signer sign `
-                --private-key $env:TAURI_SIGNING_PRIVATE_KEY `
-                --password $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD `
-                $assetFull
+                --private-key "$env:TAURI_SIGNING_PRIVATE_KEY" `
+                --password "$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD" `
+                "$assetFull"
             } finally {
               Pop-Location
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -796,7 +796,7 @@ jobs:
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: socai-${{ needs.prepare.outputs.version }}-windows-x86_64
+          name: socai-${{ needs.prepare.outputs.version }}-windows-cli
           path: dist-artifacts/*
           if-no-files-found: error
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,6 +5040,7 @@ name = "socai_app"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "dirs 5.0.1",
  "objc2",
  "objc2-app-kit",
  "serde",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true }
 anyhow.workspace = true
+dirs = "5"
 socai-core.workspace = true
 
 # macOS-only: attach an empty unified toolbar so AppKit centers the native

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1007,11 +1007,11 @@ fn non_empty_env(key: &str) -> Option<String> {
 }
 
 fn join_home(relative: &str) -> String {
-    match std::env::var_os("HOME").filter(|home| !home.is_empty()) {
-        Some(home) => PathBuf::from(home)
-            .join(relative)
-            .to_string_lossy()
-            .into_owned(),
+    // `dirs::home_dir()` resolves `%USERPROFILE%` on Windows and `$HOME` on
+    // unix, so the settings-UI placeholder shows the real `~/.socai/...` path on
+    // every platform instead of a bare relative string on Windows.
+    match dirs::home_dir() {
+        Some(home) => home.join(relative).to_string_lossy().into_owned(),
         None => relative.to_string(),
     }
 }

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -1,3 +1,8 @@
+// Hide the extra console window Windows would otherwise open alongside the GUI in
+// release builds. No-op on macOS/Linux; debug builds keep the console so `tauri dev`
+// stderr logging stays visible.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 fn main() {
     socai_app_lib::run()
 }

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -402,8 +402,13 @@ pub(crate) fn app_data_dir() -> PathBuf {
     if let Ok(home) = std::env::var("SOCAI_HOME") {
         return PathBuf::from(home).join("app");
     }
-    if let Ok(home) = std::env::var("HOME") {
-        return PathBuf::from(home).join(".socai/app");
+    // `dirs::home_dir()` resolves `%USERPROFILE%` on Windows (where `HOME` is
+    // usually unset) and `$HOME` on unix — keeping the `~/.socai/app` layout on
+    // every platform. The bare relative path is a last resort that should never
+    // be hit once a home dir resolves; falling back to it on Windows would
+    // scatter `tasks.json` into the CWD and lose it across launches.
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".socai/app");
     }
     PathBuf::from(".socai/app")
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -43,7 +43,15 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      },
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/core/src/util/machine.rs
+++ b/core/src/util/machine.rs
@@ -68,6 +68,29 @@ fn cpu_model() -> String {
     }
     #[cfg(target_os = "windows")]
     {
+        // The marketing name ("AMD Ryzen 7 7840H …") lives in the registry —
+        // the same thing macOS exposes as machdep.cpu.brand_string. The
+        // PROCESSOR_IDENTIFIER env var only carries the CPUID family/model/
+        // stepping tuple ("AMD64 Family 25 Model 116 …"), so it's the fallback.
+        let out = command_output(
+            "reg",
+            &[
+                "query",
+                r"HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0",
+                "/v",
+                "ProcessorNameString",
+            ],
+        );
+        if let Some(idx) = out.find("REG_SZ") {
+            let s = out[idx + "REG_SZ".len()..]
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim();
+            if !s.is_empty() {
+                return s.to_string();
+            }
+        }
         if let Ok(v) = std::env::var("PROCESSOR_IDENTIFIER") {
             let s = v.trim().to_string();
             if !s.is_empty() {
@@ -155,7 +178,46 @@ fn memory_total_mb() -> Option<u64> {
     None
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(target_os = "windows")]
+fn memory_total_mb() -> Option<u64> {
+    // GlobalMemoryStatusEx is the canonical total-RAM query. Hand-declared FFI
+    // (like the macOS sysctl path above) so core doesn't grow a windows-sys
+    // dependency for a single call.
+    #[repr(C)]
+    struct MemoryStatusEx {
+        dw_length: u32,
+        dw_memory_load: u32,
+        ull_total_phys: u64,
+        ull_avail_phys: u64,
+        ull_total_page_file: u64,
+        ull_avail_page_file: u64,
+        ull_total_virtual: u64,
+        ull_avail_virtual: u64,
+        ull_avail_extended_virtual: u64,
+    }
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GlobalMemoryStatusEx(buffer: *mut MemoryStatusEx) -> i32;
+    }
+    let mut status = MemoryStatusEx {
+        dw_length: std::mem::size_of::<MemoryStatusEx>() as u32,
+        dw_memory_load: 0,
+        ull_total_phys: 0,
+        ull_avail_phys: 0,
+        ull_total_page_file: 0,
+        ull_avail_page_file: 0,
+        ull_total_virtual: 0,
+        ull_avail_virtual: 0,
+        ull_avail_extended_virtual: 0,
+    };
+    if unsafe { GlobalMemoryStatusEx(&mut status) } != 0 {
+        Some(status.ull_total_phys / 1024 / 1024)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn memory_total_mb() -> Option<u64> {
     None
 }


### PR DESCRIPTION
## Summary

Adds Windows desktop support for the Tauri app: CI now produces a signed, auto-updating **NSIS installer** on `windows-latest`, and the app crate's data paths are fixed to resolve correctly on Windows. This is the first shippable slice — the app installs, launches, stores its data correctly, and auto-updates on Windows.

The two hardest layers were already cross-platform (CDP/Chrome discovery+launch, daemon IPC via TCP, and the shell compiles on `windows-msvc` with macOS deps `cfg`-gated), so this change is at the edges: packaging, data paths, and the console-window gotcha.

## What changed

**Data-path safety (fixes silent data loss on Windows)**
- `app/src-tauri/src/tasks.rs` (`app_data_dir`) and `commands.rs` (`join_home`) read the raw `HOME` env var, which is usually **unset on Windows**, then fell back to a *relative* `.socai/` path — scattering `tasks.json`/telemetry into the working directory. Switched both to `dirs::home_dir()` (the convention already used throughout `core/`), which resolves `%USERPROFILE%` on Windows.
- **Non-breaking:** the `~/.socai` layout is preserved on every platform. Deliberately *not* switched to `%APPDATA%`/`ProjectDirs`, which would orphan existing macOS/Linux users' data.
- Added `dirs = "5"` to the app crate (already in the tree via `core`).

**Windows installer + auto-update (CI)**
- `tauri.conf.json`: new `bundle.windows` — `webviewInstallMode: downloadBootstrapper` and NSIS `installMode: currentUser` (installs to `%LOCALAPPDATA%`, **no admin/UAC**).
- `.github/workflows/release.yml`: new `build-windows-app` job on `windows-latest` mirroring the proven `build-macos-app-dmg` job — `tauri build --bundles nsis`, then minisign-signs the installer with the **existing** `TAURI_SIGNING_PRIVATE_KEY` secret and emits a `windows-x86_64` updater fragment.
- The publish job **merges** that fragment into the darwin-only `latest.json` (so the two jobs don't collide under `merge-multiple`), requires the new artifacts, and `verify-desktop-updater` now checks the `windows-x86_64` entry too.

**Console-window fix**
- `app/src-tauri/src/main.rs` lacked `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]`, so the release `.exe` ran in the console subsystem and Windows opened a terminal beside the GUI. Added it, gated on `not(debug_assertions)` so `tauri dev` keeps its console.

## Reviewer notes

- **Installer ships unsigned (Authenticode).** Intentional for this first release — SmartScreen will warn once ("More info → Run anyway"). The release notes disclose this. Updater signing (minisign) is separate and **is** in place, so auto-update works.
- **Updater coordination:** macOS writes `latest.json` (darwin keys); Windows writes a `latest-windows-x86_64.json` fragment; publish merges + removes the fragment before `gh release create`. On `main`, both are guaranteed present (signing is mandatory there).
- The NSIS bundler auto-downloads NSIS on the runner (no pre-install); with no `--target`, output lands in `target/release/bundle/nsis/`.

## Testing

- `cargo check -p socai_app` passes; `release.yml` parses; an independent adversarial review of the workflow found no correctness issues across 8 scrutiny points.
- **CI test build** (`fix/release-windows-test`, publish skipped) went green end-to-end on `windows-latest` and produced a signed `socai-windows-x86_64-setup.exe` (~4.9 MB) + valid `.sig` + updater fragment.
- **Installed and launched on a real Windows machine.** Confirmed per-user install (no UAC) and correct data-path behavior. Console-window fix built and delivered; native window chrome renders fine.

## Follow-ups (not in this PR)

- **Authenticode code signing** once a cert is available (wire `signtool` + secrets into the Windows job).
- **M4 titlebar polish** — Windows currently shows a native title bar above socai's custom header (redundant but functional; deemed acceptable for now).
- **M5 site download** — OS detection + `/download/windows` route so Windows users land on the installer; README desktop section.
- Port or disable `find_codex_binary()` on Windows (currently unix-only paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
