### PR TITLE
feat(xhs): load arbitrary comment counts with nested replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,11 @@ and in DEVELOPMENT.md instead.
 
 ## Engineering rules
 
-- Generally do not add new tests to Rust code. Add them only when the user
-  explicitly asks for tests.
+- **Do NOT add new tests to Rust code unless the user explicitly asks.** This
+  applies even when you add a new function or change behavior — ship the change
+  without a test. It is fine (and expected) to *update* an existing test when you
+  change an API it already covers, but do not create new `#[test]` functions or
+  grow `mod tests` on your own initiative.
 
 ## Rust core — `core/`
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Options:
   `publish_time` (不限/一天内/一周内/半年内), `search_scope` (不限/已看过/未看过/已关注),
   `distance` (不限/同城/附近). 不写则按默认.
   e.g. `--filter publish_time=一天内 --filter note_type=图文`
-- `--num-notes <N>` — 返回多少个帖子。如果设置的数量大，socai 会自动往下翻页，获取更多帖子。
+- `--num-notes <N>` — 返回多少个帖子。默认10个。如果设置的数量大，socai 会自动往下翻页，获取更多帖子。
+- `--num-comments <N>` — 每个帖子返回多少条评论。默认8条。如果设置的数量大，socai 会自动下滑评论区，获取更多评论。
 - `--preview` — 只拿帖子概要（标题、封面等等），不逐个打开帖子拿详情。
 - `--download-media` — 打开每篇帖子的时候 (不加`--preview`时): 把图像和视频下载到 `run_dir`
   (`site_media/`), 输出 top-level `run` (`id`, `dir`, `media_dir`), 并创建列表

--- a/core/src/sites/creation/SKILL.md
+++ b/core/src/sites/creation/SKILL.md
@@ -6,7 +6,7 @@ socai总是用模拟人的方式，通过CDP和DOM进行每一步的网页操作
 
 每个网站目录包含以下几类文件：
 - tools.rs：定义了网站的工具函数，接口层，可以是偏底层的原子操作，也可以有偏工作流的连续操作，便于完成用户高频流程。工具实现 `Tool` trait（`core/src/agent/tool.rs`）：`name`/`description`/`input_schema`/`call`，返回 JSON 文本。description 里写清楚成本与耗时（是否打开页面、是否耗 token/需要本地 ASR 等），agent 靠它做性价比决策。命令包装一律复用共享 runner（`core/src/sites/runner.rs` 的 `run_tool_command`/`ToolCommand`，输入小工具 `get_*`/`trimmed_required`/`json_result` 也从那里 import，参考 xhs 的 `run_xhs_tool_command`）——**不要把 run_dir/快照/工具分发这套脚手架复制进站点文件夹**。
-- page.rs：tools背后的实现，包含业务逻辑和 CDP 操作编排。选择器尽量稳定，优先结构性选择器、`data-*`、aria 属性；不要依赖构建生成的 hash class。
+- page.rs：tools背后的实现，包含业务逻辑和 CDP 操作编排。选择器尽量稳定，优先结构性选择器、`data-*`、aria 属性；不要依赖构建生成的 hash class。**只用 snapshot DOM 里真实见过的元素/类名写选择器，绝不凭猜测。**
 - page_scripts.js：页面内 DOM 逻辑，每次 `run_script()` 时注入页面执行。JS 只做提取，返回 JSON。page_scripts.js 是一个 IIFE，在 window 上挂一个命名函数表（参考 xhs 的 `SocaiXhsPageScripts`）。每个函数接收一个 JSON 参数、返回可序列化的 JSON——不返回 DOM 节点、不在 JS 里做多步编排。点击/滚动/等待等编排都在 Rust 侧（page.rs），通过 `run_script(name, arg)` 注入调用并校验结果。
 - entities.rs：定义网站数据类型
 - knowledge.md：关于这个网站的know-hows，包括工具信息、网页功能、布局、页面动态、跳转、登录、风控等信息，便于后续agent快速上手
@@ -23,34 +23,23 @@ socai总是用模拟人的方式，通过CDP和DOM进行每一步的网页操作
 
 当用户想要增加新网站或新能力时，**严格**遵循以下步骤，逐步执行：
 
-1. 首先，不能直接开始写实现代码，而是先让用户尽可能详细地描述如下信息：
+### 1. 确认需求
+首先，不能直接开始写实现代码，而是先让用户尽可能详细地描述如下信息：
   1) 目标网页 URL / 入口页。
   2) 用户想完成的具体流程，用自然语言。
   3) 详细描述每一步预期的人类操作方式，例如点击、输入、滚动、悬浮、快捷键。比如点击还是悬浮鼠标、在哪个区域上下滑滚轮，是否有键盘按键能更准确地操作（比如上下左右键切换帖子、esc键退出当前页面等等）。
   4) 目标输出的数据结构或至少要抽取哪些字段。
   5) 是否需要登录，以及当前账号/浏览器是否已经处于可用状态。
   
-2. 详细了解以上的用户回答后，如果sites目录下面还没有关于这个网站的文件夹，则增加一个，然后按照上面的代码准则scaffold出所需文件，并构建出接口。注意，先不实现具体工具逻辑。如果已有这个网站的文件夹，则可按需看是否需要增加文件或接口。新增的site_id和文件夹名保持一致，都用简写，比如小红书 `xhs`、抖音 `dy`。
+  
+### 2. Scaffold代码
+详细了解以上的用户回答后，如果sites目录下面还没有关于这个网站的文件夹，则增加一个，然后按照上面的代码准则scaffold出所需文件，并构建出接口。注意，先不实现具体工具逻辑。如果已有这个网站的文件夹，则可按需看是否需要增加文件或接口。新增的site_id和文件夹名保持一致，都用简写，比如小红书 `xhs`、抖音 `dy`。
 
-3. 然后，按以下的3步流程逐步执行，并且不断循环这3步流程，一步一步地添加：
+### 3. （核心）开发Loop
+然后，按以下的3步流程逐步执行，并且不断循环这3步流程，一步一步地添加：
   1) 首先，添加下一步单点操作的代码。代码结构要符合上面的代码准则。如果是刚开始实现第一步，则新增一个打开网页的操作；如果是后面的步骤，则是新增一个鼠标或键盘操作或页面js操作等等，你需要基于上一个循环中对snapshot理解，去准确写出代码。避免猜测页面元素，总是根据上一个循环中的实际DOM信息来写代码。确保新增的工具函数里支持--debug-snapshot参数，确保每执行一个动作都能保存下来变化的snapshots。
   2) 然后，你调用目前代码已有的半成品工具函数，比如 `cargo run -p socai-cli -- <site_id> <command> ... --debug-snapshot`。此时cli会开始操作Chrome，每次命令在 stderr 打印 `run_dir`（目录名形如 `<本地时间>_<site_id>_<command>[_<搜索词>]`，位于 ~/.socai/runs/ 下），snapshots 保存在 `<run_dir>/snapshots/`。
 
-**开发前先把 Chrome 切到 managed profile，避免反复弹 allow-debugging。** socai 默认复用用户日常 Chrome，每次 rebuild 重启 daemon 后首次连接都会弹一次 allow-debugging；开发时反复 rebuild 会很烦。所以在开始这一轮自我创建开发前，先执行一次：
-
-```bash
-cargo run -p socai-cli -- config set chrome.profile managed
-cargo run -p socai-cli -- stop   # 让 daemon 下次用新 profile
-```
-
-之后 socai 会拉起一个它自己管理的独立 Chrome（profile 目录 `~/.socai/chrome-profile`），不碰用户日常浏览器，**不再弹 allow-debugging**，daemon 反复重启也不会。代价是这个独立 Chrome 是干净 profile：首次运行时请提醒用户在弹出的 Chrome 窗口里手动登录一次目标网站（如小红书），登录态会持久化在该 profile 目录里，后续重建无需再登录。
-
-开发全部完成后，把 profile 改回去，恢复日常使用默认 Chrome 的行为：
-
-```bash
-cargo run -p socai-cli -- config unset chrome.profile
-cargo run -p socai-cli -- stop
-```
   3) 这步工具运行完成后，你需要查看最新一步的增量snapshot。每帧目录包含：`screenshot.jpg`（用户视窗）、`screenshot_full.jpg`（全页截图，和DOM范围对应）、`a11y.json`（精简无障碍树）、`dom.html`（精简DOM）、`dom.raw.html`（原始DOM，很大，一般不需要）。你每次先用多模态能力看两张截图来理解页面，再读 `a11y.json` 理解页面区块与状态，然后重点从 `dom.html` 里面来确认元素。确认当前操作是否符合预期。由于你是一步一步添加操作的，这时候的工具结果只是中间结果，你要检验的是so far这个中间结果是否符合预期。如果符合预期，则基于这一步snapshot的结果，继续实现下一步的代码。如果结果不符合预期，说明上一步的代码有问题，你排查snapshot，修改上一步的代码。
 重复以上3步循环，直到新加的工具完整执行每一步，能完成用户的需求。总是按照上面的三部曲，每一步都要确认snapshot再添加下一步的代码，避免跳步。如果再开发过程中发现有和用户描述不符或者一开始用户没有描述清楚的地方，这时你应该用户再次交互对话，来理清楚操作细节。
 代码实现过程中，多参考sites目录下已有的其他网站代码。
@@ -65,8 +54,29 @@ cargo run -p socai-cli -- stop
 - 第六轮，上一轮的成功运行结果中，snapshot应该已经显示出了搜索结果页的帖子信息是什么样的结构，因此，这一步在工具函数中增加“从搜索结果页中获取帖子信息并返回”的操作，然后和前面所有轮次类似，做运行、查看、验证。
 - 如果用户有更详细的需求，比如逐个点开帖子拿详细内容或评论、或者需要传入能拿的帖子数因而需要滚动页面，等等，则根据具体的需求修改，原理和步骤都和上面类似。
 
-4. 新工具能力实现之后，运行3-5组不同参数，来全面测试新能力。如果遇到问题，返回上一步的流程进行修复。
+#### 开发前先把 Chrome 切到 managed profile，避免反复弹 allow-debugging。
+socai 默认复用用户日常 Chrome，每次 rebuild 重启 daemon 后首次连接都会弹一次 allow-debugging；开发时反复 rebuild 会很烦。所以在开始这一轮自我创建开发前，先执行一次：
 
-5. 代码完成后，把新增的工具信息和发现的有价值的网站知识写到knowledge.md。不要一上来先写knowledge.md，而是在代码全部实现完成后再写。
+```bash
+cargo run -p socai-cli -- config set chrome.profile managed
+cargo run -p socai-cli -- stop   # 让 daemon 下次用新 profile
+```
 
-完成后，向用户汇报上面的结果，并把上面的3-5次不同参数的运行结果汇报给用户。
+之后 socai 会拉起一个它自己管理的独立 Chrome（profile 目录 `~/.socai/chrome-profile`），不碰用户日常浏览器，不再弹 allow-debugging，daemon 反复重启也不会。代价是这个独立 Chrome 是干净 profile：首次运行时请提醒用户在弹出的 Chrome 窗口里手动登录一次目标网站（如小红书），登录态会持久化在该 profile 目录里，后续重建无需再登录。
+
+开发全部完成后，把 profile 改回去，恢复日常使用默认 Chrome 的行为：
+
+```bash
+cargo run -p socai-cli -- config unset chrome.profile
+cargo run -p socai-cli -- stop
+```
+
+### 4. 测试
+新工具能力实现之后，运行3-5组不同参数，来全面测试新能力。如果遇到问题，返回上一步的流程进行修复。
+
+### 5. 更新知识
+代码完成后，把新增的工具信息和发现的有价值的网站知识写到knowledge.md。不要一上来先写knowledge.md，而是在代码全部实现完成后再写。
+
+
+
+以上流程都完成后，向用户汇报上面的结果，并把上面的3-5次不同参数的运行结果汇报给用户。

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -43,6 +43,16 @@ pub struct HistoryEntry {
     /// True once any past read ran OCR (the entity carries `ocr_text`).
     #[serde(default)]
     pub ocr: bool,
+    /// Most comments (primary + replies) ever cached for this note. Lets a later
+    /// scan asking for more comments than we have re-read instead of short-
+    /// circuiting on the stale, smaller set.
+    #[serde(default)]
+    pub comments_loaded: u32,
+    /// The note's own total comment count (from `comments_count`, includes
+    /// replies) as last seen. When `comments_loaded` reaches this we've captured
+    /// everything, so a bigger request is still satisfied. `0` when unknown.
+    #[serde(default)]
+    pub comments_total: u32,
     #[serde(default)]
     pub analysis_count: u32,
     #[serde(default)]
@@ -132,6 +142,7 @@ impl XhsHistoryStore {
         include_media: bool,
         download_media: bool,
         ocr: bool,
+        min_comments: i64,
     ) -> bool {
         let Some(prev) = self.get(note_id) else {
             return false;
@@ -146,6 +157,15 @@ impl XhsHistoryStore {
             return false;
         }
         if ocr && !prev.ocr {
+            return false;
+        }
+        // A request for more comments than we cached forces a re-read — unless we
+        // already captured the whole thread (loaded >= the note's own total), in
+        // which case there is nothing more to fetch.
+        if min_comments > 0
+            && (prev.comments_loaded as i64) < min_comments
+            && (prev.comments_total == 0 || prev.comments_loaded < prev.comments_total)
+        {
             return false;
         }
         true
@@ -227,6 +247,16 @@ impl XhsHistoryStore {
             if entity_has_ocr(entity) {
                 entry.ocr = true;
             }
+            // Track comment coverage (primary + replies) so a later, larger
+            // request re-reads instead of reusing a smaller cached set.
+            let loaded = entity_comment_count(entity);
+            if loaded > entry.comments_loaded {
+                entry.comments_loaded = loaded;
+            }
+            let total = entity_comment_total(entity);
+            if total > entry.comments_total {
+                entry.comments_total = total;
+            }
             // Cache the full entity so a later reuse returns complete data.
             entry.entity = Some(entity.clone());
             entry.analysis_count = entry.analysis_count.saturating_add(1);
@@ -292,6 +322,55 @@ fn string_field(value: &Value, key: &str) -> String {
         .to_string()
 }
 
+/// Count the comments cached on an entity: primary comments plus their replies.
+/// `top_comments` may be full objects (with `sub_comments`) or already-leaned
+/// (a string, or `{text, replies}`), so cover both shapes.
+fn entity_comment_count(entity: &Value) -> u32 {
+    let Some(comments) = entity.get("top_comments").and_then(Value::as_array) else {
+        return 0;
+    };
+    let mut count = 0u32;
+    for comment in comments {
+        count += 1;
+        let replies = comment
+            .get("sub_comments")
+            .or_else(|| comment.get("replies"))
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        count += replies as u32;
+    }
+    count
+}
+
+/// Parse the note's own total comment count from `comments_count` (e.g. "170",
+/// "1.2万", "3,456"). `0` when absent or unparseable.
+fn entity_comment_total(entity: &Value) -> u32 {
+    let raw = entity
+        .get("comments_count")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    if raw.is_empty() {
+        return 0;
+    }
+    let cleaned: String = raw.chars().filter(|c| !matches!(c, ',' | '+' | ' ')).collect();
+    let digits: String = cleaned
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    let Ok(base) = digits.parse::<f64>() else {
+        return 0;
+    };
+    let mult = if cleaned.contains('万') || cleaned.contains('w') || cleaned.contains('W') {
+        10_000.0
+    } else if cleaned.contains('k') || cleaned.contains('K') {
+        1_000.0
+    } else {
+        1.0
+    };
+    (base * mult).round() as u32
+}
+
 /// True when the entity carries OCR output: a non-empty note-level `ocr_text`
 /// array, or any image with a non-empty per-image `ocr_text`.
 fn entity_has_ocr(entity: &Value) -> bool {
@@ -349,6 +428,8 @@ fn save_file(path: &Path, data: &HistoryFile) -> std::io::Result<()> {
     Ok(())
 }
 
+// AGENTS.md: do NOT add new Rust tests unless the user explicitly asks. Update
+// the existing ones when an API they cover changes; don't grow this module.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,14 +477,14 @@ mod tests {
         let store = XhsHistoryStore::open(dir.path().join("h.json"));
         store.record(&json!({"note_id": "n1"}), "lite", false);
 
-        assert!(store.is_satisfied_by("n1", "card", false, false, false));
-        assert!(store.is_satisfied_by("n1", "lite", false, false, false));
-        assert!(!store.is_satisfied_by("n1", "deep", false, false, false));
-        assert!(!store.is_satisfied_by("n1", "lite", true, false, false));
-        assert!(!store.is_satisfied_by("unknown", "card", false, false, false));
+        assert!(store.is_satisfied_by("n1", "card", false, false, false, 0));
+        assert!(store.is_satisfied_by("n1", "lite", false, false, false, 0));
+        assert!(!store.is_satisfied_by("n1", "deep", false, false, false, 0));
+        assert!(!store.is_satisfied_by("n1", "lite", true, false, false, 0));
+        assert!(!store.is_satisfied_by("unknown", "card", false, false, false, 0));
         // download / ocr dimensions: a plain read doesn't satisfy them.
-        assert!(!store.is_satisfied_by("n1", "lite", false, true, false));
-        assert!(!store.is_satisfied_by("n1", "lite", false, false, true));
+        assert!(!store.is_satisfied_by("n1", "lite", false, true, false, 0));
+        assert!(!store.is_satisfied_by("n1", "lite", false, false, true, 0));
     }
 
     #[test]
@@ -420,7 +501,7 @@ mod tests {
             false,
         );
 
-        assert!(store.is_satisfied_by("n2", "deep", false, true, true));
+        assert!(store.is_satisfied_by("n2", "deep", false, true, true, 0));
         let entry = store.get("n2").unwrap();
         assert!(entry.downloaded);
         assert!(entry.ocr);

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -57,8 +57,14 @@ artifacts, and return a compact bundle. They differ only in where they enter:
 
 Shared options (same meaning for both):
 
-- `num_notes=N` — how many notes to collect. Modest default; raise only when the
+- `num_notes=N` — how many notes to collect (default 10); raise only when the
   question needs broader evidence.
+- `num_comments=N` — how many comments to load per note (default 8). The comment
+  area is scrolled and reply threads ("展开 N 条回复") are expanded until the count
+  is reached or the thread ends; **replies count toward N**. Each parent keeps its
+  replies as a nested `sub_comments`/`replies` array. Raising this adds latency per
+  note (more scroll + expand rounds), so lift it only when the question is about
+  the discussion itself. `0` skips comments. Ignored in `preview` mode. 
 - `preview=true` — fast cards-only pass (titles/likes/covers), without opening
   any note. `download_media` is ignored in this mode.
 - `download_media=true` — download note images/videos into the run dir; use when

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -34,6 +34,8 @@ const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "noteOpen",
     "comments",
     "commentsWithWait",
+    "commentAreaState",
+    "expandCommentReplies",
     "scrollFeed",
     "scrollInNote",
     "carouselImages",
@@ -670,6 +672,107 @@ impl<'a> XhsPageRuntime<'a> {
             })),
         )
         .await
+    }
+
+    /// Load up to `max_total` comments on the currently open note by driving the
+    /// page like a human: wait for the list to hydrate, then loop
+    /// scroll-comment-area → click "展开 N 条回复" → re-measure until the budget is
+    /// met, the "- THE END -" sentinel shows with no reply buttons left, growth
+    /// stalls, or the timeout hits. `max_total` counts primary comments *and*
+    /// their replies together; `0`/negative means "load everything available".
+    /// The returned `comments` array is hot-sorted and trimmed so primary + reply
+    /// count does not exceed the budget.
+    pub async fn load_comments(&self, max_total: i64, timeout_seconds: f64) -> Result<Value> {
+        self.ensure_xhs(false).await?;
+        // Let the (slow) comment list hydrate before the first measurement.
+        let first = self.extract_comments_with_wait(0, 5.0).await.ok();
+
+        let deadline = Instant::now() + Duration::from_secs_f64(timeout_seconds.max(2.0));
+        let mut last_total: i64 = -1;
+        let mut stale_rounds = 0;
+        let mut rounds = 0;
+        let stop_reason;
+        loop {
+            let state = self
+                .expect_object("commentAreaState", None)
+                .await
+                .unwrap_or_else(|_| json!({}));
+            let loaded_total = state.get("loaded_total").and_then(Value::as_i64).unwrap_or(0);
+            let pending = state
+                .get("pending_show_more")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            let has_end = state.get("has_end").and_then(Value::as_bool).unwrap_or(false);
+
+            // Budget reached — no need to load more.
+            if max_total > 0 && loaded_total >= max_total {
+                stop_reason = "budget_reached";
+                break;
+            }
+            // Everything that exists is loaded and expanded: the end sentinel is
+            // showing, no reply threads are left to expand, and the count has
+            // settled.
+            if has_end && pending == 0 && loaded_total == last_total {
+                stop_reason = "exhausted";
+                break;
+            }
+            if loaded_total == last_total {
+                stale_rounds += 1;
+            } else {
+                stale_rounds = 0;
+            }
+            // No growth across several rounds despite scrolling/expanding.
+            if stale_rounds >= 3 {
+                stop_reason = "stalled";
+                break;
+            }
+            if Instant::now() >= deadline {
+                stop_reason = "timeout";
+                break;
+            }
+            last_total = loaded_total;
+            rounds += 1;
+
+            // Expand any visible reply buttons first (cheap, surfaces sub-comments
+            // that count toward the budget), then scroll for more parents.
+            if pending > 0 {
+                let _ = self.expect_object("expandCommentReplies", None).await;
+                sleep_ms(500).await;
+            }
+            if !has_end {
+                let _ = self.scroll_in_note(1200).await;
+            }
+            sleep_ms(500).await;
+        }
+
+        let all = self.extract_comments(0).await.unwrap_or_default();
+        let loaded_primary = all.len() as i64;
+        let loaded_total: i64 = loaded_primary
+            + all
+                .iter()
+                .map(|c| c.get("sub_comments").and_then(Value::as_array).map_or(0, Vec::len) as i64)
+                .sum::<i64>();
+        let comments = trim_comments_to_budget(all, max_total);
+        let returned_total: i64 = comments.len() as i64
+            + comments
+                .iter()
+                .map(|c| c.get("sub_comments").and_then(Value::as_array).map_or(0, Vec::len) as i64)
+                .sum::<i64>();
+
+        Ok(json!({
+            "ok": true,
+            "comments": comments,
+            "loaded_primary": loaded_primary,
+            "loaded_total": loaded_total,
+            "returned_total": returned_total,
+            "rounds": rounds,
+            "stop_reason": stop_reason,
+            "ready": first
+                .as_ref()
+                .and_then(|v| v.get("ready"))
+                .and_then(Value::as_bool)
+                .unwrap_or(loaded_total > 0),
+        }))
     }
 
     pub async fn collect_carousel_images(&self, max_images: i64) -> Result<Vec<String>> {
@@ -1649,6 +1752,36 @@ async fn sleep_ms(ms: u64) {
     tokio::time::sleep(Duration::from_millis(ms)).await;
 }
 
+/// Trim a hot-sorted comment list so primary comments plus their replies do not
+/// exceed `max_total`. Each parent counts as one; its `sub_comments` are then
+/// truncated to whatever budget remains. `max_total <= 0` keeps everything.
+fn trim_comments_to_budget(comments: Vec<Value>, max_total: i64) -> Vec<Value> {
+    if max_total <= 0 {
+        return comments;
+    }
+    let mut out = Vec::new();
+    let mut count: i64 = 0;
+    for mut comment in comments {
+        if count >= max_total {
+            break;
+        }
+        count += 1; // the parent comment itself
+        let remaining = max_total - count;
+        if let Some(subs) = comment.get_mut("sub_comments").and_then(Value::as_array_mut) {
+            if remaining <= 0 {
+                subs.clear();
+            } else if subs.len() as i64 > remaining {
+                subs.truncate(remaining as usize);
+            }
+            count += subs.len() as i64;
+        }
+        out.push(comment);
+    }
+    out
+}
+
+// AGENTS.md: do NOT add new Rust tests unless the user explicitly asks. Update
+// the existing ones when an API they cover changes; don't grow this module.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -988,7 +988,14 @@ const SocaiXhsPageScripts = (() => {
 
   // ── comments ─────────────────────────────────────────────────
   const COMMENT_ROOT_SELECTOR = '.comment-item, .parent-comment, .comment-inner, .comments-container .comment-item-inner, .comment-wrapper';
-  const SUB_COMMENT_SELECTOR = '.reply-item, .sub-comment-item, .child-comment-item, .reply-comment-item';
+  // All three verified against the live note DOM (image + video notes):
+  //   `.comment-item-sub` — a reply node, inside `.parent-comment > .reply-container`.
+  //   `.show-more`        — the "展开 N 条回复 / 展开更多回复" reply-pagination button.
+  //   `.end-container`    — the " - THE END - " sentinel, present once every parent
+  //                          comment is loaded.
+  const SUB_COMMENT_SELECTOR = '.comment-item-sub';
+  const SHOW_MORE_SELECTOR = '.show-more';
+  const COMMENT_END_SELECTOR = '.end-container';
 
   function parseCount(raw) {
     const v = String(raw || '').trim().toLowerCase().replace(/,/g, '').replace(/\+/g, '');
@@ -1112,6 +1119,45 @@ const SocaiXhsPageScripts = (() => {
       };
       tick();
     });
+  }
+
+  // Snapshot of the comment area used by the Rust-side load loop to decide when
+  // to stop scrolling/expanding: how many primary + reply comments are currently
+  // in the DOM, whether unexpanded reply buttons remain, and whether the
+  // "- THE END -" sentinel (all parent comments loaded) is present.
+  function commentAreaState() {
+    const root = getNoteRoot();
+    const scope = $('.comments-el', root) || root;
+    const items = comments({ prefer_hot: false, max_comments: 0 });
+    const subs = items.reduce((n, c) => n + ((c.sub_comments && c.sub_comments.length) || 0), 0);
+    const totalText = firstText(['.total'], scope);
+    const pending = $$(SHOW_MORE_SELECTOR, scope)
+      .filter((b) => isVisible(b) && !/收起/.test(text(b)));
+    return {
+      ok: true,
+      total: parseCount(totalText),
+      loaded_primary: items.length,
+      loaded_total: items.length + subs,
+      pending_show_more: pending.length,
+      has_end: !!$(COMMENT_END_SELECTOR, scope),
+    };
+  }
+
+  // Click every visible "展开 N 条回复 / 展开更多回复" button to load the next batch
+  // of replies. These are Vue-bound divs, so a synthetic .click() drives the same
+  // handler a human click would. Skips "收起" (collapse). Returns how many fired.
+  function expandCommentReplies(opts = {}) {
+    const root = getNoteRoot();
+    const scope = $('.comments-el', root) || root;
+    const max = Number(opts.max_clicks) || 60;
+    const buttons = $$(SHOW_MORE_SELECTOR, scope)
+      .filter((b) => isVisible(b) && !/收起/.test(text(b)));
+    let clicked = 0;
+    for (const b of buttons) {
+      if (clicked >= max) break;
+      try { b.click(); clicked += 1; } catch (e) { /* ignore */ }
+    }
+    return { ok: true, clicked, remaining: Math.max(0, buttons.length - clicked) };
   }
 
   // ── search/feed scroll ───────────────────────────────────────
@@ -1246,6 +1292,8 @@ const SocaiXhsPageScripts = (() => {
     noteOpen,
     comments,
     commentsWithWait,
+    commentAreaState,
+    expandCommentReplies,
     scrollFeed,
     scrollInNote,
     carouselImages,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -43,7 +43,7 @@ const SEARCH_WAIT_SECONDS: f64 = 2.0;
 /// Top comments attached to every note read (read_note, extract_note,
 /// search, author_scan). Comments are read from the already-open note's DOM
 /// (one extra JS read, no extra navigation), so every note read includes them.
-const TOP_COMMENTS_PER_NOTE: i64 = 12;
+const TOP_COMMENTS_PER_NOTE: i64 = 8;
 
 /// XHS macro-agent playbook for the single app/TUI agent interface. Embedded
 /// at compile time so the agent prompt always carries the latest copy.
@@ -199,6 +199,16 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     kind: ArgKind::Int,
                 },
                 CommandArg {
+                    key: "num_comments",
+                    long: Some("num-comments"),
+                    value_name: "N",
+                    help: "Comments to load per note, scrolling the comment area and expanding \
+                           reply threads to reach it (replies count toward N). Default 8; \
+                           ignored with --preview.",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+                CommandArg {
                     key: "download_media",
                     long: Some("download-media"),
                     value_name: "DOWNLOAD_MEDIA",
@@ -251,6 +261,16 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("num-notes"),
                     value_name: "N",
                     help: "Scroll the profile grid to collect this many notes (default 10).",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+                CommandArg {
+                    key: "num_comments",
+                    long: Some("num-comments"),
+                    value_name: "N",
+                    help: "Comments to load per note, scrolling the comment area and expanding \
+                           reply threads to reach it (replies count toward N). Default 8; \
+                           ignored with --preview.",
                     required: false,
                     kind: ArgKind::Int,
                 },
@@ -309,6 +329,7 @@ fn run_search(
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
+        let num_comments = args.get("num_comments").and_then(Value::as_i64);
         let preview = args
             .get("preview")
             .and_then(Value::as_bool)
@@ -331,6 +352,7 @@ fn run_search(
             &query,
             filters.as_ref(),
             num_notes,
+            num_comments,
             download_media,
             ocr,
             preview,
@@ -355,6 +377,7 @@ fn run_author_scan(
             .get("num_notes")
             .and_then(Value::as_i64)
             .or(Some(DEFAULT_NUM_NOTES));
+        let num_comments = args.get("num_comments").and_then(Value::as_i64);
         // Default opens each note; --preview returns cards only.
         let preview = args
             .get("preview")
@@ -375,6 +398,7 @@ fn run_author_scan(
             page,
             &author_id,
             num_notes,
+            num_comments,
             preview,
             download_media,
             ocr,
@@ -420,12 +444,14 @@ const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
 };
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub async fn search_command(
     page: Arc<PageSession>,
     command_name: &'static str,
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
+    num_comments: Option<i64>,
     download_media: bool,
     ocr: bool,
     preview: bool,
@@ -442,7 +468,15 @@ pub async fn search_command(
     run_xhs_tool_command(
         page,
         spec,
-        search_input(query, filters, num_notes, download_media, ocr, preview)?,
+        search_input(
+            query,
+            filters,
+            num_notes,
+            num_comments,
+            download_media,
+            ocr,
+            preview,
+        )?,
         debug_snapshot,
         progress,
     )
@@ -454,6 +488,7 @@ pub async fn author_scan_command(
     page: Arc<PageSession>,
     author_id: &str,
     num_notes: Option<i64>,
+    num_comments: Option<i64>,
     preview: bool,
     download_media: bool,
     ocr: bool,
@@ -463,17 +498,19 @@ pub async fn author_scan_command(
     run_xhs_tool_command(
         page,
         AUTHOR_SCAN_COMMAND,
-        author_scan_input(author_id, num_notes, preview, download_media, ocr)?,
+        author_scan_input(author_id, num_notes, num_comments, preview, download_media, ocr)?,
         debug_snapshot,
         progress,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 fn search_input(
     query: &str,
     filters: Option<&Value>,
     num_notes: Option<i64>,
+    num_comments: Option<i64>,
     download_media: bool,
     ocr: bool,
     preview: bool,
@@ -486,6 +523,9 @@ fn search_input(
     }
     if let Some(n) = num_notes {
         input["num_notes"] = json!(n.max(1));
+    }
+    if let Some(n) = num_comments {
+        input["num_comments"] = json!(n.max(0));
     }
     if download_media {
         input["download_media"] = json!(true);
@@ -502,6 +542,7 @@ fn search_input(
 fn author_scan_input(
     author_id: &str,
     num_notes: Option<i64>,
+    num_comments: Option<i64>,
     preview: bool,
     download_media: bool,
     ocr: bool,
@@ -511,6 +552,9 @@ fn author_scan_input(
     });
     if let Some(n) = num_notes {
         input["num_notes"] = json!(n.max(1));
+    }
+    if let Some(n) = num_comments {
+        input["num_comments"] = json!(n.max(0));
     }
     if preview {
         input["preview"] = json!(true);
@@ -634,12 +678,20 @@ fn media_for(
     }
 }
 
-/// Read up to `TOP_COMMENTS_PER_NOTE` top comments from the currently open note
+/// Wall-clock safety net for the comment load loop, per note. The loop's real
+/// stop conditions are the budget being met, the thread being exhausted, or
+/// growth stalling; this only exists so a pathological page (DOM that keeps
+/// "growing" a sliver each round, or a hang) can't loop forever. It is a fixed
+/// generous cap on purpose — scaling it with the requested count would truncate a
+/// large request that is still legitimately loading.
+const COMMENT_LOAD_TIMEOUT_S: f64 = 120.0;
+
+/// Load up to `TOP_COMMENTS_PER_NOTE` top comments from the currently open note
 /// and insert them under `note["top_comments"]`. Best-effort: on failure the
 /// note is left without the field. Shared by `read_note` and `extract_note`.
 async fn attach_top_comments(xhs: &XhsPageRuntime<'_>, note: &mut Value) {
     let Ok(payload) = xhs
-        .extract_comments_with_wait(TOP_COMMENTS_PER_NOTE, 5.0)
+        .load_comments(TOP_COMMENTS_PER_NOTE, COMMENT_LOAD_TIMEOUT_S)
         .await
     else {
         return;
@@ -828,7 +880,7 @@ async fn scan_card_note(
         return skipped_note_entry(card, "already_processed", history);
     }
     if !card.note_id.is_empty()
-        && history.is_satisfied_by(&card.note_id, level, requested_media, download_media, ocr)
+        && history.is_satisfied_by(&card.note_id, level, requested_media, download_media, ocr, comment_count)
         // Only short-circuit when we actually have the cached entity to return;
         // a pre-upgrade entry without one is re-read so it backfills the cache
         // instead of degrading to a bare card.
@@ -895,12 +947,16 @@ async fn scan_card_note(
         }),
     };
 
-    // Pull comments separately after waiting for the slower comment list to
-    // hydrate. Body content often appears before comments. Scans always include
-    // comments — there is no longer a level gate.
+    // Pull comments separately after the body read: the list hydrates slower
+    // than the body, and reaching `comment_count` may require scrolling the
+    // comment area and expanding reply threads (replies count toward the total).
+    // Scans always include comments — there is no longer a level gate.
     if comment_count > 0 {
-        if let Ok(comments_payload) = xhs.extract_comments_with_wait(comment_count, 5.0).await {
-            let comments = comments_payload
+        if let Ok(payload) = xhs
+            .load_comments(comment_count, COMMENT_LOAD_TIMEOUT_S)
+            .await
+        {
+            let comments = payload
                 .get("comments")
                 .and_then(Value::as_array)
                 .cloned()
@@ -910,10 +966,11 @@ async fn scan_card_note(
                 map.insert(
                     "top_comments_wait".into(),
                     json!({
-                        "ready": comments_payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
-                        "reason": comments_payload.get("reason").and_then(Value::as_str).unwrap_or(""),
-                        "waited_ms": comments_payload.get("waited_ms").and_then(Value::as_i64).unwrap_or(0),
-                        "attempts": comments_payload.get("attempts").and_then(Value::as_i64).unwrap_or(0),
+                        "ready": payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
+                        "loaded_total": payload.get("loaded_total").and_then(Value::as_i64).unwrap_or(0),
+                        "returned_total": payload.get("returned_total").and_then(Value::as_i64).unwrap_or(0),
+                        "rounds": payload.get("rounds").and_then(Value::as_i64).unwrap_or(0),
+                        "stop_reason": payload.get("stop_reason").and_then(Value::as_str).unwrap_or(""),
                     }),
                 );
             }
@@ -1118,6 +1175,33 @@ const LEAN_NOTE_FIELDS: &[&str] = &[
     "ocr_text",
 ];
 
+/// Collapse one full comment object to its lean form: `null` when it has no text,
+/// a plain text string when it has no replies, or `{text, replies:[…]}` when it
+/// does. Reply objects are flattened to their text the same way (one level deep —
+/// XHS replies don't nest further).
+fn lean_comment(comment: &Value) -> Option<Value> {
+    let text = comment.get("text").and_then(Value::as_str).unwrap_or("");
+    if text.is_empty() {
+        return None;
+    }
+    let replies: Vec<Value> = comment
+        .get("sub_comments")
+        .and_then(Value::as_array)
+        .map(|subs| {
+            subs.iter()
+                .filter_map(|s| s.get("text").and_then(Value::as_str))
+                .filter(|s| !s.is_empty())
+                .map(|s| Value::String(s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    if replies.is_empty() {
+        Some(Value::String(text.to_string()))
+    } else {
+        Some(json!({ "text": text, "replies": replies }))
+    }
+}
+
 /// Trim one scanned-note entry to the lean shape: drop the per-entry provenance
 /// wrappers (`source_position`, `ok`, `skipped`, plus failure detail), collapse
 /// `top_comments` to a plain array of comment texts, and whitelist the entity to
@@ -1145,15 +1229,17 @@ fn lean_scan_note(note: &mut Value) {
     let Some(entity) = entity.as_object_mut() else {
         return;
     };
-    // Collapse comment objects to their text before the whitelist runs (the
-    // whitelist keeps `top_comments`, but we want the plain-string form).
+    // Collapse comment objects before the whitelist runs (which keeps
+    // `top_comments`): a comment with no replies becomes its plain text; one with
+    // replies becomes `{text, replies:[reply text, …]}` so the lean view keeps
+    // the thread structure. The full objects (usernames, likes, times) stay in
+    // the run artifact.
     if let Some(comments) = entity.get_mut("top_comments").and_then(Value::as_array_mut) {
-        let texts: Vec<Value> = comments
+        let lean: Vec<Value> = comments
             .iter()
-            .filter_map(|comment| comment.get("text").cloned())
-            .filter(|text| text.as_str().is_some_and(|s| !s.is_empty()))
+            .filter_map(lean_comment)
             .collect();
-        entity.insert("top_comments".into(), Value::Array(texts));
+        entity.insert("top_comments".into(), Value::Array(lean));
     }
     entity.retain(|key, _| LEAN_NOTE_FIELDS.contains(&key.as_str()));
 }
@@ -1335,7 +1421,7 @@ const ARTIFACT_EXTRA_NOTE_PROPERTIES: &[&str] = &[
     "author_url",
     "location",
     "content_source",
-    "top_comments (full objects: text, author, likes, time)",
+    "top_comments (full objects: text, author, likes, time, sub_comments[])",
 ];
 
 /// Per-card properties that live only in the `search --preview` artifact
@@ -1540,6 +1626,7 @@ impl Tool for ReadNoteTool {
                 options.include_media,
                 options.download_media,
                 options.ocr,
+                TOP_COMMENTS_PER_NOTE,
             ) {
                 let entry = self.history.get(id).unwrap_or_default();
                 return Ok(json_result(&json!({
@@ -1997,6 +2084,12 @@ impl Tool for SearchTool {
                     "default": DEFAULT_NUM_NOTES,
                     "minimum": 1
                 },
+                "num_comments": {
+                    "type": "integer",
+                    "description": "Comments to load per note. Scrolls the comment area and expands reply threads to reach this many; replies count toward the total. Higher values add latency per note. Ignored in preview mode.",
+                    "default": TOP_COMMENTS_PER_NOTE,
+                    "minimum": 0
+                },
                 "download_media": {
                     "type": "boolean",
                     "description": "Download note images/videos into the command run_dir, include local_path fields in returned notes, and write a stable media_manifest.json surfaced by media_manifest_path. Ignored in preview mode.",
@@ -2208,7 +2301,7 @@ impl Tool for SearchTool {
         // Every sampled note is read with the same extraction level (body +
         // top comments).
         let level = "deep";
-        let comment_count = TOP_COMMENTS_PER_NOTE;
+        let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
         let want = num_notes.max(1) as usize;
 
         // Read top-to-bottom: pull cards from the results state (which only
@@ -2352,7 +2445,7 @@ impl Tool for SearchTool {
             "sampling": {
                 "num_notes": num_notes,
                 "selected": selected.len(),
-                "comments_per_note": TOP_COMMENTS_PER_NOTE,
+                "comments_per_note": comment_count,
                 "include_media": include_media,
                 "download_media": download_media,
                 "ocr": ocr,
@@ -2463,6 +2556,12 @@ impl Tool for AuthorScanTool {
                     "description": "Collect at least this many note cards, scrolling the profile grid (lazy-loaded). Omit for the first screen only.",
                     "minimum": 1
                 },
+                "num_comments": {
+                    "type": "integer",
+                    "description": "Comments to load per note. Scrolls the comment area and expands reply threads to reach this many; replies count toward the total. Higher values add latency per note. Ignored in preview mode.",
+                    "default": TOP_COMMENTS_PER_NOTE,
+                    "minimum": 0
+                },
                 "preview": {
                     "type": "boolean",
                     "description": "Fast cards-only mode: return the note cards (titles/likes/covers) without opening notes or reading bodies/comments. Off by default (full scan: each note opened for its body + top comments).",
@@ -2512,6 +2611,7 @@ impl Tool for AuthorScanTool {
             .and_then(Value::as_i64)
             .filter(|n| *n > 0)
             .map(|n| n as usize);
+        let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
 
         // Media processor only needed when downloading note media (no vision,
         // so no LLM provider required).
@@ -2599,7 +2699,7 @@ impl Tool for AuthorScanTool {
                     ctx,
                     card,
                     "deep",
-                    TOP_COMMENTS_PER_NOTE,
+                    comment_count,
                     false,
                     download_media,
                     ocr,
@@ -2697,7 +2797,7 @@ impl Tool for AuthorScanTool {
                 "num_notes": num_notes,
                 "collected": cards.len(),
                 "preview": preview,
-                "comments_per_note": if preview { 0 } else { TOP_COMMENTS_PER_NOTE },
+                "comments_per_note": if preview { 0 } else { comment_count },
                 "download_media": download_media,
                 "ocr": ocr,
             },
@@ -2785,6 +2885,8 @@ fn sanitize_for_filename(value: &str) -> String {
         .collect()
 }
 
+// AGENTS.md: do NOT add new Rust tests unless the user explicitly asks. Update
+// the existing ones when an API they cover changes; don't grow this module.
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Adds `--num-comments N` (tool arg `num_comments`, default **8**) to the XHS `search` / `author_scan` scans, so a note read can return an arbitrary number of comments **including nested replies**.

Previously scans attached only the ~12 comments already sitting in the note DOM and never parsed replies at all.

## How

- **`page.rs` `load_comments`** — drives the open note like a human: scroll the comment area for more parent comments and click "展开 N 条回复" to expand reply threads, looping until one of: budget reached / thread exhausted (`- THE END -` + no reply buttons) / growth stalled (3 rounds) / a fixed per-note safety timeout (120s). Replies count toward the budget; the last parent's replies are truncated to fit exactly.
- **`page_scripts.js`** — fixes reply parsing (real node is `.comment-item-sub`), adds `commentAreaState` + `expandCommentReplies`. Only selectors verified in the live snapshot DOM are used (no guessed fallbacks).
- **History dedup** — gains `comments_loaded` / `comments_total` so a later scan asking for more comments than cached re-reads instead of reusing the smaller set; if the whole thread was already captured, a larger request still reuses it.
- **Lean output** — preserves reply structure as `{text, replies:[...]}` for parents with replies (plain string otherwise); full comment objects remain in the run artifact.
- **Docs** — knowledge.md, README (`--num-comments`), SKILL.md (new "only use snapshot-verified selectors" rule), AGENTS.md (stronger no-new-Rust-tests rule + inline reminders above test modules).

## Testing

Verified live against real notes: reply expansion (citywalk 6→19), scroll + budget trim (考研 170-comment note: 6 rounds → 72 loaded → trimmed to 60), author scan, default backward-compat, and dedup re-read. `cargo test -p socai-core` green (89 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)