### PR TITLE
fix(xhs): pre-flight login gate + agent login recovery

### DIFF
--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -38,6 +38,13 @@ as a platform/session/rate-limit blocker: use whatever evidence was collected,
 try at most one narrower or slower query/profile path if it materially changes
 the route, and otherwise explain the blocker to the user.
 
+## Login Detection
+
+Both macros run a pre-flight login gate before interacting: if logged out they
+return `{ok:false, reason:"login_required"}` immediately. Login is read from the
+persistent sidebar (logged out shows a `登录` button, logged in shows the `我`
+entry), so a dismissed QR modal is never mistaken for a session.
+
 ## Tool Use
 
 ### `search` and `author_scan`

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -40,10 +40,16 @@ the route, and otherwise explain the blocker to the user.
 
 ## Login Detection
 
-Both macros run a pre-flight login gate before interacting: if logged out they
-return `{ok:false, reason:"login_required"}` immediately. Login is read from the
-persistent sidebar (logged out shows a `登录` button, logged in shows the `我`
-entry), so a dismissed QR modal is never mistaken for a session.
+Both macros run a pre-flight login gate: if logged out they return
+`{ok:false, reason:"login_required"}` immediately (login is read from the
+persistent sidebar, so a dismissed QR modal is never mistaken for a session).
+
+**On `reason:"login_required"`, do NOT retry the tool.** Retrying just hits the
+same wall. Instead: tell the user to scan the QR / sign in to Xiaohongshu in the
+browser, and call `wait_for_login` (which opens the login page and blocks until
+they're in). When it returns `logged_in:true`, re-run the original tool once and
+continue. If it returns `logged_in:false`, remind the user and call
+`wait_for_login` again.
 
 ## Tool Use
 

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -18,11 +18,22 @@ const PAGE_SCRIPTS_JS: &str = include_str!("page_scripts.js");
 /// generous ceiling only costs time on genuinely slow loads (e.g. over a VPN) —
 /// the fast path is unaffected.
 const SEARCH_TRANSITION_TIMEOUT_S: f64 = 12.0;
+/// Upper bound the login gate polls the sidebar for a definitive login read
+/// before falling back to "logged in" (only hit if no sidebar ever renders).
+const LOGIN_GATE_TIMEOUT_S: f64 = 6.0;
+
+/// Outcome of the pre-flight [`XhsPageRuntime::login_gate`] check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoginGate {
+    LoggedIn,
+    Required,
+}
 
 const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "note",
     "noteWithWait",
     "pageState",
+    "loginState",
     "searchCards",
     "searchInput",
     "setSearchInput",
@@ -177,6 +188,28 @@ impl<'a> XhsPageRuntime<'a> {
         );
     }
 
+    /// Pre-flight login check every browsing workflow runs before it interacts.
+    /// Ensures we're on XHS, then polls `loginState` until it reads `"out"`
+    /// (→ `Required`) or `"in"` (→ `LoggedIn`); `"unknown"` means the sidebar
+    /// hasn't rendered yet (it appears ~1-3s after a fresh navigation), so keep
+    /// polling. The timeout fallback is only reached if no sidebar ever renders.
+    pub async fn login_gate(&self, navigate_if_needed: bool) -> Result<LoginGate> {
+        self.ensure_xhs(navigate_if_needed).await?;
+        let deadline = Instant::now() + Duration::from_secs_f64(LOGIN_GATE_TIMEOUT_S);
+        loop {
+            let state = self.expect_object("loginState", None).await?;
+            match state.get("login").and_then(Value::as_str) {
+                Some("out") => return Ok(LoginGate::Required),
+                Some("in") => return Ok(LoginGate::LoggedIn),
+                _ => {}
+            }
+            if Instant::now() >= deadline {
+                return Ok(LoginGate::LoggedIn);
+            }
+            sleep_ms(200).await;
+        }
+    }
+
     pub async fn detect_state(&self) -> Result<Value> {
         self.ensure_xhs(false).await?;
         self.expect_object("pageState", None).await
@@ -194,7 +227,20 @@ impl<'a> XhsPageRuntime<'a> {
             anyhow::bail!("query is required");
         }
 
-        self.ensure_xhs(true).await?;
+        // Pre-flight login gate: if logged out, bail immediately with
+        // `login_required` instead of paying the full input→Enter→click→wait
+        // retry cycle (which would grind for ~30s behind the wall). Same
+        // failure shape (`ok:false` + `reason`) the transition-failure path
+        // below returns, so callers handle both identically.
+        if self.login_gate(true).await? == LoginGate::Required {
+            return Ok(json!({
+                "ok": false,
+                "query": keyword,
+                "count": 0,
+                "cards": [],
+                "reason": "login_required",
+            }));
+        }
         let submit = self.submit_search(keyword, wait_seconds).await?;
         let ok = script_ok(&submit);
         // Apply any search-result filters before reading cards, so the returned
@@ -1073,6 +1119,16 @@ impl<'a> XhsPageRuntime<'a> {
         if id.is_empty() {
             anyhow::bail!("author id is required");
         }
+        // Pre-flight login gate before navigating to the profile: bail fast with
+        // `login_required` rather than loading the profile only to hit the wall.
+        // (The wait loop below still catches a session that expires mid-scan.)
+        if self.login_gate(true).await? == LoginGate::Required {
+            return Ok(json!({
+                "ok": false,
+                "url": self.current_url().await?,
+                "reason": "login_required",
+            }));
+        }
         let url = format!("https://www.xiaohongshu.com/user/profile/{id}");
         self.page.navigate_with_timeout(&url, 60.0).await?;
 
@@ -1098,10 +1154,7 @@ impl<'a> XhsPageRuntime<'a> {
             .unwrap_or(false);
         Ok(json!({
             "ok": kind == "profile_page",
-            "author_id": id,
             "url": self.current_url().await?,
-            "login_required": login,
-            "state": state,
             "reason": if kind == "profile_page" {
                 ""
             } else if login {

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -210,6 +210,14 @@ impl<'a> XhsPageRuntime<'a> {
         }
     }
 
+    /// One-shot login read (no navigation, no polling): `true` only when the
+    /// sidebar shows the logged-in "我" entry. Used by the `wait_for_login` tool
+    /// to poll for the user completing a QR scan.
+    pub async fn is_logged_in(&self) -> Result<bool> {
+        let state = self.expect_object("loginState", None).await?;
+        Ok(state.get("login").and_then(Value::as_str) == Some("in"))
+    }
+
     pub async fn detect_state(&self) -> Result<Value> {
         self.ensure_xhs(false).await?;
         self.expect_object("pageState", None).await

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -191,17 +191,38 @@ const SocaiXhsPageScripts = (() => {
       card_count: cards.length,
       loading,
       has_no_results: hasNoResults,
-      login_required: hasLoginModal(),
+      login_required: loginWallVisible(),
     };
   }
 
-  function hasLoginModal() {
-    const bodyText = text(document.body);
-    const modal = $$('.login-container, .login-modal, .login-box, [class*="login"]').some((el) => {
-      if (!isVisible(el)) return false;
-      return /手机号登录|扫码|登录后|获取验证码/.test(text(el));
-    });
-    return modal || /手机号登录[\s\S]{0,80}获取验证码|登录后查看搜索结果|登录后推荐更懂你的笔记/.test(bodyText);
+  // ── login state ──────────────────────────────────────────────
+  // The logged-out wall: XHS's .reds-modal.login-modal / .login-container (QR +
+  // phone-login form). Structural classes verified against snapshot DOM (not
+  // hashed build classes); text fallback catches an unanticipated variant. This
+  // is the single wall primitive — loginState() and the pageState/searchState
+  // login_required flags all read it.
+  function loginWallVisible() {
+    if ($$('.login-container, .reds-modal.login-modal, .login-modal').some(isVisible)) {
+      return true;
+    }
+    return $$('[class*="login"]').some(
+      (el) => isVisible(el) && /手机号登录|扫码登录|获取验证码/.test(text(el)),
+    );
+  }
+
+  // Tri-state login read for the pre-flight gate, keyed off the persistent left
+  // sidebar so a dismissed QR modal isn't misread: the "登录" button
+  // (.side-bar-component.login-btn) shows only logged out and survives closing
+  // the modal; the "我" entry (.user.side-bar-component) replaces it once logged
+  // in. 'unknown' = sidebar not rendered yet, so the gate keeps polling.
+  function loginState() {
+    if (loginWallVisible() || $$('.side-bar-component.login-btn').some(isVisible)) {
+      return { ok: true, login: 'out' };
+    }
+    if ($$('.user.side-bar-component').some(isVisible)) {
+      return { ok: true, login: 'in' };
+    }
+    return { ok: true, login: 'unknown' };
   }
 
   function pageState() {
@@ -218,7 +239,7 @@ const SocaiXhsPageScripts = (() => {
       title: document.title,
       note_open: noteOpen(),
       search: searchState(),
-      login_required: hasLoginModal(),
+      login_required: loginWallVisible(),
     };
   }
 
@@ -431,7 +452,7 @@ const SocaiXhsPageScripts = (() => {
       url,
       on_detail_route: /\/(?:explore|discovery|search_result)\/[^/?#]+/.test(url),
       has_modal: !!getNoteOverlay(),
-      login_required: hasLoginModal(),
+      login_required: loginWallVisible(),
     };
   }
 
@@ -1281,6 +1302,7 @@ const SocaiXhsPageScripts = (() => {
     note,
     noteWithWait,
     pageState,
+    loginState,
     searchCards,
     searchInput,
     setSearchInput,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -2633,8 +2633,6 @@ impl Tool for AuthorScanTool {
             return Ok(json_result(&json!({
                 "ok": false,
                 "author_id": author_id,
-                "open": open,
-                "profile": Value::Null,
                 "notes": [],
                 "reason": reason,
             })));

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -96,6 +96,7 @@ pub fn xhs_tools_with_llm_provider(
             always_download_media: false,
             always_ocr: false,
         }),
+        Arc::new(WaitForLoginTool { page: page.clone() }),
         Arc::new(PageStateTool { page }),
     ]
 }
@@ -117,11 +118,12 @@ pub fn xhs_macro_tools_with_llm_provider(
             always_ocr: true,
         }) as Arc<dyn Tool>,
         Arc::new(AuthorScanTool {
-            page,
+            page: page.clone(),
             history,
             always_download_media: true,
             always_ocr: true,
         }),
+        Arc::new(WaitForLoginTool { page }),
     ]
 }
 
@@ -1789,6 +1791,83 @@ impl Tool for PageStateTool {
         // report whatever the current page is.
         let value = xhs.detect_state().await?;
         Ok(json_result(&value))
+    }
+}
+
+/// wait_for_login — the login-recovery tool. When a macro returns
+/// `reason: login_required`, the agent surfaces the login prompt to the user and
+/// calls this instead of retrying; it brings up the XHS login page and blocks
+/// (polling) until the user finishes scanning, then returns so the agent can
+/// resume the original task.
+pub struct WaitForLoginTool {
+    page: Arc<PageSession>,
+}
+
+/// How long `wait_for_login` polls before giving up so the agent can re-prompt.
+const WAIT_FOR_LOGIN_DEFAULT_SECS: i64 = 180;
+const WAIT_FOR_LOGIN_MAX_SECS: i64 = 600;
+
+#[async_trait]
+impl Tool for WaitForLoginTool {
+    fn name(&self) -> &str {
+        "wait_for_login"
+    }
+
+    fn description(&self) -> &str {
+        "Recover from a login wall: after a tool returns `reason:login_required`, \
+         call this (don't retry) to open the login page and block until the user \
+         signs in. Returns `logged_in:true` when done, else `logged_in:false` on \
+         timeout. See the login protocol in the instructions."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": "Seconds to wait before returning (default 180, max 600)."
+                }
+            }
+        })
+    }
+
+    async fn call(&self, input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let xhs = XhsPageRuntime::new(&self.page);
+        // Already logged in? Return right away — nothing to wait for.
+        if xhs.is_logged_in().await.unwrap_or(false) {
+            return Ok(json_result(&json!({
+                "logged_in": true,
+                "message": "Already logged in. Re-run the original tool.",
+            })));
+        }
+        // Bring the XHS login wall on screen so the user has a QR to scan.
+        xhs.ensure_xhs(true).await?;
+
+        let timeout = get_i64(&input, "timeout_seconds", WAIT_FOR_LOGIN_DEFAULT_SECS)
+            .clamp(10, WAIT_FOR_LOGIN_MAX_SECS);
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(timeout as u64);
+        loop {
+            if xhs.is_logged_in().await.unwrap_or(false) {
+                return Ok(json_result(&json!({
+                    "logged_in": true,
+                    "message": "Login detected. Re-run the original tool to continue.",
+                })));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(json_result(&json!({
+                    "logged_in": false,
+                    "timed_out": true,
+                    "message": format!(
+                        "Still not logged in after {timeout}s. Ask the user to scan \
+                         the QR / sign in on xiaohongshu.com in the browser, then \
+                         call wait_for_login again."
+                    ),
+                })));
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
     }
 }
 


### PR DESCRIPTION
## What

Two related fixes to Xiaohongshu login handling.

### 1. Pre-flight login gate — fail fast on the login wall
`search`/`author_scan` used to grind through the full input→Enter→click→wait retry cycle (~30s) when a login wall was up. They now run a pre-flight gate first and return `login_required` immediately (~3s).

Detection is structural (snapshot-verified), keyed off the persistent left sidebar so a **dismissed QR modal** isn't misread:
- logged out → `.side-bar-component.login-btn` (survives closing the modal) or the `.reds-modal.login-modal` wall
- logged in → `.user.side-bar-component` (`我` entry)

`loginState` returns a single tri-state (`out`/`in`/`unknown`); removed the redundant `hasLoginModal` wrapper (`loginWallVisible` is the one primitive) and slimmed the author failure payload / `open_profile` return to the fields callers actually read.

### 2. Agent login recovery — `wait_for_login`
The desktop/TUI agent used to keep retrying the tool on a login wall. New `wait_for_login` tool (in both agent tool sets) opens the login page and polls until the user signs in; `knowledge.md` tells the agent to call it instead of retrying and to re-run the original tool once logged in.

## Testing
- Logged-out search: ~30s → **3.3s** `login_required`.
- Logged-in search/author: return real data; detection confirmed against real DOM (logged-out author snapshot showed the wall; the gate correctly returned `login_required`).
- `wait_for_login` is agent-only (no CLI entry); its detection primitive (`loginState`/`is_logged_in`) is validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)