### PR TITLE
feat(site): add Vercel Web Analytics + README star CTA/UTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # socai
 
-[![website](https://img.shields.io/badge/website-socai.io-blue?style=flat-square)](https://socai.io)
+[![website](https://img.shields.io/badge/website-socai.io-blue?style=flat-square)](https://socai.io/?utm_source=github&utm_medium=readme)
 [![release](https://img.shields.io/github/v/release/socai-io/socai?style=flat-square&color=blue&label=release)](https://github.com/socai-io/socai/releases/latest)
 
 专为小红书优化的 web use agent，执行小红书调研、内容抽取和自定义 agent 任务。
@@ -143,3 +143,5 @@ socai具有自我迭代能力，如果你是AI（Claude Code, Codex, Cursor等�
 ## 欢迎加群交流
 
 <img src="docs/assets/wechat-group-qr.jpg" alt="socai 小红书使用 微信群二维码" width="280">
+
+> 如果 socai 可能对你有帮助，欢迎点右上角的 ⭐ Star 支持一下，这对项目的持续更新很重要，感谢！

--- a/site/package.json
+++ b/site/package.json
@@ -11,5 +11,8 @@
   },
   "devDependencies": {
     "astro": "^5.13.5"
+  },
+  "dependencies": {
+    "@vercel/analytics": "^2.0.1"
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       astro:
         specifier: ^5.13.5
@@ -720,6 +724,35 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -2143,6 +2176,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vercel/analytics@2.0.1': {}
 
   acorn@8.16.0: {}
 

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -1,4 +1,5 @@
 ---
+import Analytics from "@vercel/analytics/astro";
 import { message } from "../lib/i18n";
 
 interface Props {
@@ -31,3 +32,4 @@ const t = (path: string) => message(messages, path, language);
         >
     </nav>
 </footer>
+<Analytics />


### PR DESCRIPTION
Wire `@vercel/analytics` into the shared `SiteFooter` so every page emits the insights script (the site has no shared layout, so the footer is the single universal injection point). Also add a README star ask and tag the website badge link with `utm_source=github&utm_medium=readme` so site traffic originating from the README is attributable in Vercel Analytics.

## Changes
- `site/package.json` + lockfile: add `@vercel/analytics@2.0.1`
- `site/src/components/SiteFooter.astro`: render `<Analytics />`
- `README.md`: star CTA + UTM-tagged website badge

## Follow-up
- Enable Web Analytics in the Vercel dashboard (Project → Analytics → Enable) after merge/deploy so collection starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)