### PR TITLE
feat(app): embedded rich note cards in the run timeline and answer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,6 +5365,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.5.6", features = [] }
 
 [dependencies]
-tauri = { version = "2.11.1", features = [] }
+tauri = { version = "2.11.1", features = ["protocol-asset"] }
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
 serde.workspace = true

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -436,6 +436,27 @@ pub async fn agent_task_events(
         .ok_or_else(|| format!("unknown task: {task_id}"))
 }
 
+/// Notes the agent saw during a run — full content + resolved local media,
+/// read from `<run_dir>/notes.json`. Empty when the run recorded none (or has
+/// not scanned yet). Powers the desktop app's embedded rich-note cards; works
+/// live (run_dir is set at task creation) and on history reload.
+#[tauri::command]
+pub async fn agent_task_notes(
+    tasks: State<'_, AgentTaskRegistry>,
+    task_id: String,
+) -> Result<Vec<Value>, String> {
+    let snapshot = tasks
+        .get(&task_id)
+        .await
+        .ok_or_else(|| format!("unknown task: {task_id}"))?;
+    let Some(run_dir) = snapshot.run_dir else {
+        return Ok(Vec::new());
+    };
+    Ok(socai_core::agent::note_store::load_notes(
+        std::path::Path::new(&run_dir),
+    ))
+}
+
 #[tauri::command]
 pub async fn agent_task_cancel(
     app: AppHandle,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -75,6 +75,19 @@ pub fn run() {
         .manage(AgentTaskRegistry::default())
         .manage(telemetry)
         .setup(|app| {
+            // Let the webview load locally-downloaded note media (images/video)
+            // from the run-artifact root via the asset protocol (convertFileSrc).
+            // The static scope in tauri.conf.json covers the default ~/.socai/runs;
+            // extend it to the resolved root so a custom SOCAI_RUNS_DIR / `runs.dir`
+            // also resolves. allow_directory tolerates a not-yet-created dir.
+            let runs_root = socai_core::agent::run_logging::default_runs_root();
+            if let Err(err) = app.asset_protocol_scope().allow_directory(&runs_root, true) {
+                eprintln!(
+                    "failed to allow runs dir {} in asset scope: {err:#}",
+                    runs_root.display()
+                );
+            }
+
             let runtime = app.state::<SocaiRuntime>().inner().clone();
             let tasks = app.state::<AgentTaskRegistry>().inner().clone();
             let telemetry = app.state::<DesktopTelemetry>().inner().clone();
@@ -188,6 +201,7 @@ pub fn run() {
             commands::agent_task_list,
             commands::agent_task_get,
             commands::agent_task_events,
+            commands::agent_task_notes,
             commands::agent_task_cancel,
             commands::config_get,
             commands::config_set,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -77,9 +77,11 @@ pub fn run() {
         .setup(|app| {
             // Let the webview load locally-downloaded note media (images/video)
             // from the run-artifact root via the asset protocol (convertFileSrc).
-            // The static scope in tauri.conf.json covers the default ~/.socai/runs;
-            // extend it to the resolved root so a custom SOCAI_RUNS_DIR / `runs.dir`
-            // also resolves. allow_directory tolerates a not-yet-created dir.
+            // The static scope in tauri.conf.json can only name the default
+            // ~/.socai/runs — build-time config can't know the user's setting —
+            // so the runs dir stays fully relocatable: whatever root
+            // SOCAI_RUNS_DIR / `runs.dir` resolves to is granted here at
+            // startup. allow_directory tolerates a not-yet-created dir.
             let runs_root = socai_core::agent::run_logging::default_runs_root();
             if let Err(err) = app.asset_protocol_scope().allow_directory(&runs_root, true) {
                 eprintln!(

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -269,13 +269,39 @@ pub(crate) fn live_timeline_event(
 
 pub(crate) fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
     let mut events = replay_task_events(snapshot);
-    if !events.is_empty() {
+    if events.is_empty() {
+        // Runs recorded before the run.json/llm/tools layout kept the full
+        // sequenced stream in timeline.jsonl — replay that directly so old runs
+        // still show their timeline.
+        events = read_legacy_timeline(snapshot);
+    } else {
         ensure_started_event(snapshot, &mut events);
         reindex_replay_events(snapshot, &mut events);
     }
     append_terminal_snapshot_events(snapshot, &mut events);
     events.sort_by(compare_events);
     events
+}
+
+// Fallback event source for runs predating the run.json/llm/tools layout: the
+// per-event timeline.jsonl the app wrote at run time (one AgentTaskEventPayload
+// per line, already sequenced with entities). append_terminal_snapshot_events is
+// idempotent, so any done/completed already present is not duplicated.
+fn read_legacy_timeline(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
+    let Some(run_dir) = snapshot
+        .run_dir
+        .as_ref()
+        .filter(|dir| !dir.trim().is_empty())
+    else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(PathBuf::from(run_dir).join("timeline.jsonl")) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<AgentTaskEventPayload>(line).ok())
+        .collect()
 }
 
 pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind {

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -283,10 +283,13 @@ pub(crate) fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEve
     events
 }
 
-// Fallback event source for runs predating the run.json/llm/tools layout: the
-// per-event timeline.jsonl the app wrote at run time (one AgentTaskEventPayload
-// per line, already sequenced with entities). append_terminal_snapshot_events is
-// idempotent, so any done/completed already present is not duplicated.
+// Read-only compat for runs recorded before the run.json/llm/tools layout
+// (#160): those run dirs carry only the per-event timeline.jsonl the app used
+// to write (one AgentTaskEventPayload per line, already sequenced with
+// entities). Nothing writes timeline.jsonl anymore, so new runs never take
+// this path — delete it once pre-#160 local history stops mattering.
+// append_terminal_snapshot_events is idempotent, so any done/completed already
+// present is not duplicated.
 fn read_legacy_timeline(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
     let Some(run_dir) = snapshot
         .run_dir

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -268,43 +268,17 @@ pub(crate) fn live_timeline_event(
 }
 
 pub(crate) fn load_task_events(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
+    // Replays the run.json/llm/tools layout only. Runs recorded before that
+    // layout (#160, pre-2026-07) replay as just their terminal state —
+    // legacy timeline.jsonl support was deliberately dropped.
     let mut events = replay_task_events(snapshot);
-    if events.is_empty() {
-        // Runs recorded before the run.json/llm/tools layout kept the full
-        // sequenced stream in timeline.jsonl — replay that directly so old runs
-        // still show their timeline.
-        events = read_legacy_timeline(snapshot);
-    } else {
+    if !events.is_empty() {
         ensure_started_event(snapshot, &mut events);
         reindex_replay_events(snapshot, &mut events);
     }
     append_terminal_snapshot_events(snapshot, &mut events);
     events.sort_by(compare_events);
     events
-}
-
-// Read-only compat for runs recorded before the run.json/llm/tools layout
-// (#160): those run dirs carry only the per-event timeline.jsonl the app used
-// to write (one AgentTaskEventPayload per line, already sequenced with
-// entities). Nothing writes timeline.jsonl anymore, so new runs never take
-// this path — delete it once pre-#160 local history stops mattering.
-// append_terminal_snapshot_events is idempotent, so any done/completed already
-// present is not duplicated.
-fn read_legacy_timeline(snapshot: &AgentTaskSnapshot) -> Vec<AgentTaskEventPayload> {
-    let Some(run_dir) = snapshot
-        .run_dir
-        .as_ref()
-        .filter(|dir| !dir.trim().is_empty())
-    else {
-        return Vec::new();
-    };
-    let Ok(text) = std::fs::read_to_string(PathBuf::from(run_dir).join("timeline.jsonl")) else {
-        return Vec::new();
-    };
-    text.lines()
-        .filter(|line| !line.trim().is_empty())
-        .filter_map(|line| serde_json::from_str::<AgentTaskEventPayload>(line).ok())
-        .collect()
 }
 
 pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind {

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -25,7 +25,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$HOME/.socai/runs/**/*"]
+      }
     }
   },
   "bundle": {

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -139,6 +139,14 @@ const messages = {
   },
   "task.today": { en: "today", zh: "今天" },
   "task.yesterday": { en: "yesterday", zh: "昨天" },
+
+  "note.seen": { en: "notes the agent saw", zh: "智能体看过的笔记" },
+  "note.openOriginal": { en: "open original ↗", zh: "查看原文 ↗" },
+  "note.videoUnavailable": { en: "video unavailable", zh: "视频不可用" },
+  "note.noMedia": { en: "no media", zh: "无媒体" },
+  "note.likes": { en: "likes", zh: "赞" },
+  "note.saves": { en: "saves", zh: "收藏" },
+  "note.comments": { en: "comments", zh: "评论" },
 } as const satisfies Record<string, Record<Language, string>>;
 
 const taskStatusLabels = {

--- a/app/src/lib/markdown.ts
+++ b/app/src/lib/markdown.ts
@@ -7,10 +7,19 @@ import DOMPurify from "dompurify";
 
 marked.setOptions({ gfm: true, breaks: true });
 
+// Preserve `note:<id>` citation links (a custom scheme the answer upgrades into
+// embedded note pills). DOMPurify's default URI allowlist would strip them.
+DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+  if (data.attrName === "href" && data.attrValue.startsWith("note:")) {
+    data.forceKeepAttr = true;
+  }
+});
+
 // Open links in a new tab/window and harden against reverse-tabnabbing. Runs
 // after sanitization so the attributes we add are not themselves stripped.
+// `note:` links are left as-is — the answer renderer upgrades them.
 DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.tagName === "A") {
+  if (node.tagName === "A" && !(node.getAttribute("href") || "").startsWith("note:")) {
     node.setAttribute("target", "_blank");
     node.setAttribute("rel", "noopener noreferrer");
   }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -65,38 +65,30 @@ export interface TimelineEntity {
   data: unknown;
 }
 
-/** One downloaded (or failed) media asset of a note, from `<run_dir>/notes.json`. */
-export interface NoteMediaAsset {
-  type: string; // "image" | "video"
-  role: string; // "image" | "video" | "video_poster"
-  index: number | null;
-  local_path: string | null; // absolute path on disk; null when not downloaded
-  width: number | null;
-  height: number | null;
-  duration_s: number | null;
-  download_status: string; // "downloaded" | "failed"
-  source_url: string | null;
+/** One media item of a note (SocaiV2 design contract). media[0] === cover. */
+export interface NoteMedia {
+  kind: "image" | "video";
+  ratio?: string; // "3:4" | "1:1" | "9:16" | "16:9"
+  src?: string; // downloaded file — absolute path, or media_dir-relative
+  poster?: string; // video only — first-frame still (path)
+  dur?: string; // video only — "0:48"
+  w?: number;
+  h?: number;
 }
 
-/** A note the agent saw, archived locally so it can be rendered without re-fetching. */
-export interface NoteRecord {
+/** A note the agent saw/cited — one canonical object per note (the registry unit). */
+export interface NoteData {
   note_id: string;
   url?: string;
   title?: string;
-  author?: string;
-  author_url?: string;
-  content?: string;
-  hashtags?: string[];
-  date?: string;
-  location?: string;
-  likes?: string;
-  favorites?: string;
-  comments_count?: string;
-  image_count?: number;
-  type?: string; // "image" | "video"
-  media?: NoteMediaAsset[];
-  first_seen_turn?: number;
-  // Tolerate extra fields the record carries (images, video, top_comments, …).
+  excerpt?: string;
+  author?: { name?: string; handle?: string; avatar?: string };
+  posted_at?: number; // epoch ms
+  stats?: { likes?: number; collects?: number; comments?: number; shares?: number };
+  media?: NoteMedia[]; // media[0] === cover
+  media_dir?: string; // run-relative folder, when src paths are relative
+  saved?: boolean;
+  // Tolerate extra fields the archive may carry.
   [key: string]: unknown;
 }
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -65,6 +65,41 @@ export interface TimelineEntity {
   data: unknown;
 }
 
+/** One downloaded (or failed) media asset of a note, from `<run_dir>/notes.json`. */
+export interface NoteMediaAsset {
+  type: string; // "image" | "video"
+  role: string; // "image" | "video" | "video_poster"
+  index: number | null;
+  local_path: string | null; // absolute path on disk; null when not downloaded
+  width: number | null;
+  height: number | null;
+  duration_s: number | null;
+  download_status: string; // "downloaded" | "failed"
+  source_url: string | null;
+}
+
+/** A note the agent saw, archived locally so it can be rendered without re-fetching. */
+export interface NoteRecord {
+  note_id: string;
+  url?: string;
+  title?: string;
+  author?: string;
+  author_url?: string;
+  content?: string;
+  hashtags?: string[];
+  date?: string;
+  location?: string;
+  likes?: string;
+  favorites?: string;
+  comments_count?: string;
+  image_count?: number;
+  type?: string; // "image" | "video"
+  media?: NoteMediaAsset[];
+  first_seen_turn?: number;
+  // Tolerate extra fields the record carries (images, video, top_comments, …).
+  [key: string]: unknown;
+}
+
 export interface AgentTaskEventPayload {
   task_id: string;
   kind:
@@ -451,8 +486,12 @@ async function main(): Promise<void> {
   // rows append in place to preserve scroll.
   await listen<AgentTaskEventPayload>("agent_task:event", (event) => {
     if (agentPanel.appendTaskEvent(event.payload)) render();
-    // A finished task is a good, quiet moment to check for an update.
-    if (isTaskFinishedEvent(event.payload)) void maybeCheckForUpdate();
+    if (isTaskFinishedEvent(event.payload)) {
+      // A finished task is a good, quiet moment to check for an update, and the
+      // point at which its full note archive (notes.json) is on disk to render.
+      void maybeCheckForUpdate();
+      void agentPanel.loadTaskNotes(event.payload.task_id, shell());
+    }
   });
 
   let initialTasks: AgentTaskSnapshot[] = [];
@@ -483,6 +522,7 @@ async function main(): Promise<void> {
   bindGlobalDismiss();
   installUpdatePreviewHook();
   void hydrateTaskEvents(initialTasks);
+  void agentPanel.loadSelectedTaskNotes(shell());
   void maybeCheckForUpdate();
 
   const refresh = (): void => {

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -1,0 +1,421 @@
+//! Embedded rich-note UI (SocaiV2 design, ported from the Claude Design handoff).
+//!
+//! A note is a Xiaohongshu post the agent saw/cited. Notes live in a per-run
+//! registry (note_id -> NoteData); the timeline embeds a rich card per note it
+//! surfaced, the answer cites notes with `note:<id>` links upgraded into pills,
+//! and any reference opens one lightbox viewer. Media is served from disk via
+//! the Tauri asset protocol (convertFileSrc) — images/video play locally.
+
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { esc } from "../lib/html";
+import { renderMarkdown } from "../lib/markdown";
+import type { NoteData, NoteMedia } from "../main";
+
+// ── per-run registry (the selected task's notes) ────────────────────
+let REGISTRY: Record<string, NoteData> = {};
+let RUN_DIR = "";
+
+/** Point the note UI at the selected task's archive. Call before rendering. */
+export function setNoteRegistry(notes: NoteData[] | undefined, runDir: string | null | undefined): void {
+  REGISTRY = {};
+  for (const note of notes ?? []) {
+    if (note && typeof note.note_id === "string" && note.note_id) REGISTRY[note.note_id] = note;
+  }
+  RUN_DIR = runDir ?? "";
+}
+function resolveNote(ref: string): NoteData | null {
+  return REGISTRY[ref] ?? null;
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+function coverOf(note: NoteData): NoteMedia {
+  return (note.media && note.media[0]) || { kind: "image", ratio: "3:4" };
+}
+function fmtStat(n: number | undefined | null): string {
+  if (n == null) return "—";
+  if (n >= 1000) {
+    const k = n / 1000;
+    return (k >= 100 ? Math.round(k) : Math.round(k * 10) / 10) + "k";
+  }
+  return String(n);
+}
+function fmtDate(ms: number | undefined): string {
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}
+function authorInitial(note: NoteData): string {
+  const n = note.author && note.author.name;
+  return n ? Array.from(n)[0] : "·";
+}
+// Resolve a note media path (absolute, or media_dir-relative to run_dir) to a
+// webview-loadable asset URL. Empty when the file isn't available.
+function assetUrl(note: NoteData, path: string | undefined): string {
+  if (!path) return "";
+  if (/^(asset|https?):/.test(path)) return path;
+  if (path.startsWith("/")) return convertFileSrc(path);
+  const base = `${RUN_DIR.replace(/\/$/, "")}/${(note.media_dir || "").replace(/\/$/, "")}`;
+  return convertFileSrc(`${base.replace(/\/$/, "")}/${path}`);
+}
+
+// ── tiny line icons (currentColor, 24-box) ──────────────────────────
+const svg = (inner: string, sw = 1.7, filled = false): string =>
+  `<svg viewBox="0 0 24 24" fill="${filled ? "currentColor" : "none"}" stroke="${filled ? "none" : "currentColor"}" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${inner}</svg>`;
+const IC = {
+  heart: () => svg(`<path d="M12 20s-6.5-4.1-6.5-9A3.5 3.5 0 0 1 12 7a3.5 3.5 0 0 1 6.5 4c0 4.9-6.5 9-6.5 9z" />`),
+  bookmark: () => svg(`<path d="M6.5 4.5h11v15l-5.5-3.6-5.5 3.6z" />`),
+  comment: () => svg(`<path d="M5 5.5h14v9H9.5L5 18z" />`),
+  share: () => svg(`<path d="M12 3.5v11" /><path d="M8 7l4-3.5L16 7" /><path d="M5 12.5V20h14v-7.5" />`),
+  play: () => svg(`<path d="M8 5.2v13.6L19 12z" />`, 1.7, true),
+  stack: () => svg(`<rect x="8" y="3.5" width="12.5" height="12.5" rx="1.6" /><path d="M15.5 19.5H4.5a1 1 0 0 1-1-1V7.5" />`, 1.8),
+  external: () => svg(`<path d="M14 4.5h5.5V10" /><path d="M19.5 4.5 11 13" /><path d="M18 14.5v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1h4" />`),
+  chevL: () => svg(`<path d="M14.5 6 9 12l5.5 6" />`, 1.9),
+  chevR: () => svg(`<path d="M9.5 6 15 12l-5.5 6" />`, 1.9),
+  close: () => svg(`<path d="M6 6l12 12M18 6 6 18" />`, 1.8),
+};
+function kindIcon(note: NoteData): string {
+  const cover = coverOf(note);
+  if (cover.kind === "video") return IC.play();
+  if ((note.media || []).length > 1) return IC.stack();
+  return "";
+}
+
+// ── media frame ─────────────────────────────────────────────────────
+// Universal 3:4 frame. Images fill (cover). A 9:16 video is pillarboxed inside.
+// `gallery` renders a real <video controls>; elsewhere video shows poster+play.
+type MediaVariant = "cover" | "thumb" | "dot" | "gallery";
+function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count = 0): string {
+  const decorative = variant === "thumb" || variant === "dot";
+  if (m.kind === "video") {
+    const posterUrl = assetUrl(note, m.poster);
+    const posterImg = posterUrl ? `<img class="note-media__img" src="${esc(posterUrl)}" alt="" loading="lazy" />` : "";
+    if (variant === "gallery") {
+      const videoUrl = assetUrl(note, m.src);
+      const inner = videoUrl
+        ? `<video class="note-media__img" controls preload="metadata"${posterUrl ? ` poster="${esc(posterUrl)}"` : ""} src="${esc(videoUrl)}"></video>`
+        : `${posterImg}<span class="note-media__play">${IC.play()}</span>`;
+      return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${inner}</span></span>`;
+    }
+    return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${
+      decorative ? "" : `<span class="note-media__play">${IC.play()}</span>`
+    }${m.dur && !decorative ? `<span class="note-media__dur t-mono">${esc(m.dur)}</span>` : ""}</span></span>`;
+  }
+  const url = assetUrl(note, m.src);
+  const img = url
+    ? `<img class="note-media__img" src="${esc(url)}" alt="" loading="lazy" />`
+    : `<span class="note-media--placeholder" style="position:absolute;inset:0"></span>`;
+  const badge = count > 1 && !decorative ? `<span class="note-media__count t-mono">${IC.stack()}${count}</span>` : "";
+  return `<span class="note-media" data-kind="image">${img}${badge}</span>`;
+}
+
+function statsRow(note: NoteData): string {
+  const s = note.stats || {};
+  const items: Array<[string, string, number | undefined]> = [
+    ["likes", IC.heart(), s.likes],
+    ["collects", IC.bookmark(), s.collects],
+    ["comments", IC.comment(), s.comments],
+    ["shares", IC.share(), s.shares],
+  ];
+  return `<span class="note-stats">${items
+    .map(([k, icon, v]) => `<span class="note-stat" title="${k}">${icon}${fmtStat(v)}</span>`)
+    .join("")}</span>`;
+}
+function avatar(note: NoteData, cls = ""): string {
+  return `<span class="note-author__avatar ${cls}" aria-hidden="true">${esc(authorInitial(note))}</span>`;
+}
+
+// ── rich card (the timeline embed unit + answer sources) ────────────
+function coverInner(note: NoteData, idx: number): string {
+  const media = note.media && note.media.length ? note.media : [coverOf(note)];
+  const i = Math.max(0, Math.min(idx, media.length - 1));
+  const multi = media.length > 1;
+  const nav = multi
+    ? `<button type="button" class="note-card__nav note-card__nav--prev" data-note-nav="-1" aria-label="previous image">${IC.chevL()}</button>` +
+      `<button type="button" class="note-card__nav note-card__nav--next" data-note-nav="1" aria-label="next image">${IC.chevR()}</button>` +
+      `<span class="note-card__idx t-mono">${i + 1}/${media.length}</span>`
+    : "";
+  return mediaFrame(note, media[i], "cover", media.length) + nav;
+}
+function renderCard(note: NoteData, density: "rich" | "compact" = "rich"): string {
+  const title = esc(note.title || "");
+  const name = esc((note.author && note.author.name) || "");
+  return `
+    <div class="note-card" data-density="${density}" data-note-open="${esc(note.note_id)}" role="button" tabindex="0" title="${title}">
+      <div class="note-card__cover" data-note-cover="${esc(note.note_id)}" data-idx="0">${coverInner(note, 0)}</div>
+      <div class="note-card__body">
+        <div class="note-card__title">${title}</div>
+        ${statsRow(note)}
+        <div class="note-card__meta">
+          <span class="note-author">${avatar(note)}<span class="note-author__name">${name}</span></span>
+          <span class="note-card__date">${esc(fmtDate(note.posted_at))}</span>
+          ${
+            note.url
+              ? `<span class="note-card__link" data-note-external="${esc(note.url)}" title="open on xiaohongshu" role="button" tabindex="0" aria-label="open on xiaohongshu">${IC.external()}</span>`
+              : ""
+          }
+        </div>
+      </div>
+    </div>`;
+}
+
+/** The notes a tool_result surfaced, as rich cards beneath its row. */
+export function renderTimelineEmbed(refs: string[], density: "rich" | "compact" = "rich"): string {
+  const notes = refs.map(resolveNote).filter((n): n is NoteData => !!n);
+  if (notes.length === 0) return "";
+  return `<div class="event-embed">${notes.map((n) => renderCard(n, density)).join("")}</div>`;
+}
+
+// ── answer citations (pills + hover preview) ────────────────────────
+function pillHTML(id: string, label: string, note: NoteData): string {
+  const cover = coverOf(note);
+  return (
+    `<span class="note-cite-wrap" data-note-cite="${esc(id)}">` +
+    `<span class="note-cite" data-note-open="${esc(id)}" role="button" tabindex="0">` +
+    `<span class="note-cite__dot">${mediaFrame(note, cover, "dot")}</span>${esc(label)}` +
+    `<span class="note-cite__kind">${kindIcon(note)}</span></span></span>`
+  );
+}
+function citePreviewHTML(note: NoteData): string {
+  const cover = coverOf(note);
+  const name = esc((note.author && note.author.name) || "");
+  return (
+    `<span class="note-cite-pop__inner">` +
+    `<span class="note-cite-pop__media">${mediaFrame(note, cover, "dot")}</span>` +
+    `<span class="note-cite-pop__body">` +
+    `<span class="note-cite-pop__title">${esc(note.title || "")}</span>` +
+    `<span class="note-cite-pop__author">${avatar(note)}${name}</span>${statsRow(note)}</span></span>`
+  );
+}
+
+/** Render the markdown answer, upgrading `note:<id>` links into citation pills.
+ *  The `note:` scheme is rewritten to a `#note:` fragment before markdown so it
+ *  survives DOMPurify untouched (a raw custom scheme gets sanitized away). */
+export function renderNoteAnswer(src: string): string {
+  const rewritten = String(src || "")
+    .trim()
+    .replace(/\]\(note:([^)\s]+)\)/g, "](#note:$1)");
+  const html = renderMarkdown(rewritten);
+  const doc = new DOMParser().parseFromString(`<div id="r">${html}</div>`, "text/html");
+  const root = doc.getElementById("r");
+  if (!root) return html;
+  root.querySelectorAll('a[href^="#note:"], a[href^="note:"]').forEach((a) => {
+    const id = (a.getAttribute("href") || "").replace(/^#?note:/, "");
+    const label = a.textContent || id;
+    const note = resolveNote(id);
+    const holder = doc.createElement("span");
+    holder.innerHTML = note ? pillHTML(id, label, note) : esc(label);
+    a.replaceWith(...Array.from(holder.childNodes));
+  });
+  return root.innerHTML;
+}
+
+// ── viewer (lightbox) ───────────────────────────────────────────────
+function galleryStage(note: NoteData, idx: number): string {
+  const media = note.media && note.media.length ? note.media : [coverOf(note)];
+  const i = Math.max(0, Math.min(idx, media.length - 1));
+  const multi = media.length > 1;
+  const nav = multi
+    ? `<button type="button" class="note-gallery__nav note-gallery__nav--prev" data-gallery-nav="-1"${i === 0 ? " disabled" : ""} aria-label="previous">${IC.chevL()}</button>` +
+      `<button type="button" class="note-gallery__nav note-gallery__nav--next" data-gallery-nav="1"${i === media.length - 1 ? " disabled" : ""} aria-label="next">${IC.chevR()}</button>`
+    : "";
+  return `<div class="note-gallery__frame">${mediaFrame(note, media[i], "gallery")}</div>${nav}`;
+}
+function galleryThumbs(note: NoteData, idx: number): string {
+  const media = note.media || [];
+  if (media.length <= 1) return "";
+  return `<div class="note-gallery__thumbs">${media
+    .map(
+      (m, i) =>
+        `<button type="button" class="note-gallery__thumb${i === idx ? " is-active" : ""}" data-gallery-thumb="${i}" aria-label="media ${i + 1}">${mediaFrame(note, m, "thumb")}</button>`,
+    )
+    .join("")}</div>`;
+}
+function metaPanel(note: NoteData): string {
+  const s = note.stats || {};
+  const stats: Array<[string, string, number | undefined]> = [
+    ["likes", IC.heart(), s.likes],
+    ["collects", IC.bookmark(), s.collects],
+    ["comments", IC.comment(), s.comments],
+    ["shares", IC.share(), s.shares],
+  ];
+  const statGrid = stats
+    .map(
+      ([k, icon, v]) =>
+        `<div class="note-meta__stat"><span class="note-meta__stat-k">${icon}${k}</span><span class="note-meta__stat-v">${fmtStat(v)}</span></div>`,
+    )
+    .join("");
+  return `
+    <div class="note-meta">
+      <h3 class="note-meta__title">${esc(note.title || "")}</h3>
+      ${note.excerpt ? `<p class="note-meta__excerpt">${esc(note.excerpt)}</p>` : ""}
+      <div class="note-meta__statgrid">${statGrid}</div>
+      <div class="note-meta__rows">
+        <div class="note-meta__row"><span class="note-meta__row-k">posted</span><span class="note-meta__row-v">${esc(fmtDate(note.posted_at))}</span></div>
+        <div class="note-meta__row"><span class="note-meta__row-k">note_id</span><span class="note-meta__row-v" title="${esc(note.note_id)}">${esc(note.note_id)}</span></div>
+      </div>
+      ${
+        note.url
+          ? `<span class="btn-ghost btn-compact note-meta__link" data-note-external="${esc(note.url)}" role="button" tabindex="0">${IC.external()}open on xiaohongshu</span>`
+          : ""
+      }
+      <span class="note-meta__saved"><i></i>${(note.media || []).length} media · saved locally</span>
+    </div>`;
+}
+function viewerHTML(note: NoteData): string {
+  const name = esc((note.author && note.author.name) || "");
+  const handle = esc((note.author && note.author.handle) || note.note_id);
+  return `
+    <div class="note-viewer-backdrop" data-note-close>
+      <div class="note-viewer-panel" role="dialog" aria-label="${esc(note.title || "note")}" data-note-stop>
+        <div class="note-viewer-head">
+          <span class="note-viewer-head__author">
+            ${avatar(note, "note-viewer-head__avatar")}
+            <span class="note-viewer-head__meta">
+              <span class="note-viewer-head__name">${name}</span>
+              <span class="note-viewer-head__handle">${handle}</span>
+            </span>
+          </span>
+          <button type="button" class="note-viewer-close" data-note-close aria-label="close">${IC.close()}</button>
+        </div>
+        <div class="note-viewer-body">
+          <div class="note-gallery" data-gallery data-idx="0" data-note="${esc(note.note_id)}">
+            <div class="note-gallery__stage">${galleryStage(note, 0)}</div>
+            ${galleryThumbs(note, 0)}
+          </div>
+          ${metaPanel(note)}
+        </div>
+      </div>
+    </div>`;
+}
+function galleryGo(gallery: HTMLElement, idx: number): void {
+  const note = resolveNote(gallery.getAttribute("data-note") || "");
+  if (!note) return;
+  const n = (note.media || []).length || 1;
+  const next = Math.max(0, Math.min(n - 1, idx));
+  gallery.setAttribute("data-idx", String(next));
+  const stage = gallery.querySelector(".note-gallery__stage");
+  if (stage) stage.innerHTML = galleryStage(note, next);
+  gallery.querySelectorAll(".note-gallery__thumb").forEach((th, i) =>
+    th.classList.toggle("is-active", i === next),
+  );
+}
+function closeViewer(): void {
+  document.querySelector(".note-viewer-backdrop")?.parentElement?.remove();
+}
+function openViewer(id: string): void {
+  const note = resolveNote(id);
+  if (!note) return;
+  closeViewer();
+  const host = document.createElement("div");
+  host.className = "note-viewer note-viewer--lightbox";
+  host.innerHTML = viewerHTML(note);
+  document.body.appendChild(host);
+}
+
+// ── interactions (one delegated listener set, attached once) ────────
+let bound = false;
+/** Wire note interactions globally (idempotent): open viewer, card carousel,
+ *  gallery nav/thumbs, citation hover preview, external links. */
+export function bindNoteInteractions(): void {
+  if (bound) return;
+  bound = true;
+
+  document.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+
+    // external link (Tauri webview won't honour target=_blank)
+    const ext = target.closest<HTMLElement>("[data-note-external]");
+    if (ext) {
+      e.preventDefault();
+      e.stopPropagation();
+      const url = ext.getAttribute("data-note-external");
+      if (url) invoke("open_external", { url }).catch((err) => console.error("open_external failed:", err));
+      return;
+    }
+    // card carousel nav — must not open the viewer
+    const nav = target.closest<HTMLElement>("[data-note-nav]");
+    if (nav) {
+      e.preventDefault();
+      e.stopPropagation();
+      const cover = nav.closest<HTMLElement>("[data-note-cover]");
+      const note = cover && resolveNote(cover.getAttribute("data-note-cover") || "");
+      if (cover && note) {
+        const n = (note.media || []).length || 1;
+        const cur = parseInt(cover.getAttribute("data-idx") || "0", 10) || 0;
+        const nextIdx = (cur + parseInt(nav.getAttribute("data-note-nav") || "0", 10) + n) % n;
+        cover.setAttribute("data-idx", String(nextIdx));
+        cover.innerHTML = coverInner(note, nextIdx);
+      }
+      return;
+    }
+    // viewer gallery nav
+    const gnav = target.closest<HTMLElement>("[data-gallery-nav]");
+    if (gnav) {
+      const gallery = gnav.closest<HTMLElement>("[data-gallery]");
+      if (gallery) galleryGo(gallery, (parseInt(gallery.getAttribute("data-idx") || "0", 10) || 0) + parseInt(gnav.getAttribute("data-gallery-nav") || "0", 10));
+      return;
+    }
+    const thumb = target.closest<HTMLElement>("[data-gallery-thumb]");
+    if (thumb) {
+      const gallery = thumb.closest<HTMLElement>("[data-gallery]");
+      if (gallery) galleryGo(gallery, parseInt(thumb.getAttribute("data-gallery-thumb") || "0", 10));
+      return;
+    }
+    // close: the X button, or a click on the backdrop itself (outside the panel)
+    if (target.closest(".note-viewer-close")) {
+      closeViewer();
+      return;
+    }
+    if (target.closest("[data-note-close]") && !target.closest("[data-note-stop]")) {
+      closeViewer();
+      return;
+    }
+    // open the viewer from any reference
+    const open = target.closest<HTMLElement>("[data-note-open]");
+    if (open) {
+      e.preventDefault();
+      openViewer(open.getAttribute("data-note-open") || "");
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeViewer();
+  });
+
+  // citation hover preview (position:fixed popover so it escapes overflow)
+  document.addEventListener(
+    "mouseover",
+    (e) => {
+      const wrap = (e.target as HTMLElement).closest<HTMLElement>(".note-cite-wrap[data-note-cite]");
+      if (!wrap || wrap.querySelector(".note-cite-pop")) return;
+      const note = resolveNote(wrap.getAttribute("data-note-cite") || "");
+      if (!note) return;
+      const r = wrap.getBoundingClientRect();
+      const W = 250,
+        H = 128,
+        gap = 8;
+      const above = r.top > H + gap;
+      const left = Math.max(W / 2 + 8, Math.min(window.innerWidth - W / 2 - 8, r.left + r.width / 2));
+      const top = above ? r.top - gap : r.bottom + gap;
+      const pop = document.createElement("span");
+      pop.className = "note-cite-pop";
+      pop.style.left = `${left}px`;
+      pop.style.top = `${top}px`;
+      pop.style.transform = above ? "translate(-50%, -100%)" : "translate(-50%, 0)";
+      pop.innerHTML = citePreviewHTML(note);
+      wrap.appendChild(pop);
+    },
+    true,
+  );
+  document.addEventListener(
+    "mouseout",
+    (e) => {
+      const wrap = (e.target as HTMLElement).closest<HTMLElement>(".note-cite-wrap");
+      if (wrap) wrap.querySelector(".note-cite-pop")?.remove();
+    },
+    true,
+  );
+}

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -382,7 +382,21 @@ export function bindNoteInteractions(): void {
   });
 
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeViewer();
+    if (e.key === "Escape") {
+      closeViewer();
+      return;
+    }
+    // Activate role="button" note controls from the keyboard: Enter/Space
+    // synthesize a click so the delegated click handler above does the rest.
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const target = e.target as HTMLElement;
+    if (target.closest("input, textarea, select, [contenteditable]")) return;
+    const actionable = target.closest<HTMLElement>(
+      "[data-note-open], [data-note-external], [data-note-nav], [data-gallery-nav], [data-gallery-thumb], [data-note-close], .note-viewer-close",
+    );
+    if (!actionable) return;
+    e.preventDefault();
+    actionable.click();
   });
 
   // citation hover preview (position:fixed popover so it escapes overflow)
@@ -414,7 +428,12 @@ export function bindNoteInteractions(): void {
     "mouseout",
     (e) => {
       const wrap = (e.target as HTMLElement).closest<HTMLElement>(".note-cite-wrap");
-      if (wrap) wrap.querySelector(".note-cite-pop")?.remove();
+      if (!wrap) return;
+      // mouseout bubbles for moves between the pill's children (including onto
+      // the popover itself) — only remove once the pointer truly leaves the wrap.
+      const to = e.relatedTarget as Node | null;
+      if (to && wrap.contains(to)) return;
+      wrap.querySelector(".note-cite-pop")?.remove();
     },
     true,
   );

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -7,10 +7,9 @@
 //!
 //! Below the body, a full-width filmstrip shows the notes the agent saw.
 
-import { convertFileSrc } from "@tauri-apps/api/core";
-import type { AgentTaskEventPayload, NoteMediaAsset, NoteRecord } from "../main";
+import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
-import { renderMarkdown } from "../lib/markdown";
+import { renderNoteAnswer, renderTimelineEmbed, setNoteRegistry } from "./notes";
 import { formatTaskCount, formatTaskTimestamp, formatTokenUsage, formatTurns, taskStatusLabel, t } from "../lib/i18n";
 import type { AgentTaskView } from "./tasks";
 
@@ -64,6 +63,10 @@ function renderTaskRows(props: SidebarProps): string {
 export function renderTaskDetail(task: AgentTaskView | undefined): string {
   if (!task) return renderEmptyDetail();
 
+  // Point the note UI at this task's archive; the timeline embeds and answer
+  // citations below resolve refs against it, and so does the viewer on click.
+  setNoteRegistry(task.notes, task.run_dir);
+
   const running = task.status === "running" || task.status === "queued";
   const hasTimeline = task.events.length > 0 || running;
   const hasResult = !!task.final_text || !!task.error;
@@ -87,7 +90,7 @@ export function renderTaskDetail(task: AgentTaskView | undefined): string {
     `;
   }
 
-  return `${renderDetailHead(task, running)}${body}${renderNotesSection(task)}`;
+  return `${renderDetailHead(task, running)}${body}`;
 }
 
 function renderDetailHead(task: AgentTaskView, running: boolean): string {
@@ -137,7 +140,7 @@ function renderResultPanel(task: AgentTaskView): string {
     return `
       <div class="agent-outcome detail-panel">
         <p class="t-eyebrow result-label detail-panel-label">${esc(t("task.finalAnswer"))}</p>
-        <div class="result-pre result-md">${renderMarkdown(task.final_text.trim())}</div>
+        <div class="result-pre result-md note-answer">${renderNoteAnswer(task.final_text)}</div>
       </div>
     `;
   }
@@ -158,114 +161,41 @@ function renderEmptyDetail(): string {
   `;
 }
 
-// ── Embedded note cards ───────────────────────────────────────────────────
-// The notes the agent saw this run, rendered from the local archive
-// (`agent_task_notes`). Media is served from disk via the Tauri asset protocol
-// (convertFileSrc), so images and video play locally without re-fetching.
-
-function renderNotesSection(task: AgentTaskView): string {
-  const notes = task.notes ?? [];
-  if (notes.length === 0) return "";
-  return `
-    <section class="note-rail-wrap" aria-label="${esc(t("note.seen"))}">
-      <p class="t-eyebrow result-label">${esc(t("note.seen"))} · ${notes.length}</p>
-      <div class="note-rail">
-        ${notes.map(renderNoteCard).join("")}
-      </div>
-    </section>
-  `;
-}
-
-function renderNoteCard(note: NoteRecord): string {
-  const title = (note.title ?? "").trim();
-  const author = (note.author ?? "").trim();
-  const content = (note.content ?? "").trim();
-  const stats = noteStatsLine(note);
-  const url = (note.url ?? "").trim();
-  const tags = (note.hashtags ?? []).filter((tag) => tag.trim()).slice(0, 4);
-  return `
-    <article class="note-card">
-      ${renderNoteMedia(note)}
-      <div class="note-card-body">
-        ${title ? `<p class="note-card-title">${esc(title)}</p>` : ""}
-        ${author ? `<p class="note-card-author t-small subtle">${esc(author)}</p>` : ""}
-        ${stats ? `<p class="note-card-stats t-small subtle">${esc(stats)}</p>` : ""}
-        ${content ? `<p class="note-card-content t-small">${esc(content)}</p>` : ""}
-        ${tags.length ? `<div class="note-card-tags">${tags.map((tag) => `<span class="note-card-tag">${esc(formatTag(tag))}</span>`).join("")}</div>` : ""}
-        ${url ? `<button type="button" class="note-card-open" data-open-note-url="${esc(url)}">${esc(t("note.openOriginal"))}</button>` : ""}
-      </div>
-    </article>
-  `;
-}
-
-function renderNoteMedia(note: NoteRecord): string {
-  const media = note.media ?? [];
-  if (note.type === "video") {
-    const video = pickDownloadedAsset(media, "video");
-    const poster = pickDownloadedAsset(media, "video_poster");
-    const posterSrc = poster?.local_path ? convertFileSrc(poster.local_path) : "";
-    if (video?.local_path) {
-      return `
-        <div class="note-card-media note-card-media-video">
-          <video class="note-card-asset" controls preload="metadata"${posterSrc ? ` poster="${esc(posterSrc)}"` : ""} src="${esc(convertFileSrc(video.local_path))}"></video>
-        </div>`;
-    }
-    // Video not downloadable (e.g. a blob: URL): show the poster if we have it,
-    // flagged, rather than a broken player.
-    if (posterSrc) {
-      return `
-        <div class="note-card-media note-card-media-video">
-          <img class="note-card-asset" src="${esc(posterSrc)}" alt="" loading="lazy" />
-          <span class="note-card-media-flag t-small">${esc(t("note.videoUnavailable"))}</span>
-        </div>`;
-    }
-    return renderNoteMediaEmpty();
-  }
-  // Image note: first downloaded image as the cover; badge the carousel length.
-  const images = media.filter(
-    (asset) => asset.role === "image" && asset.download_status === "downloaded" && asset.local_path,
-  );
-  const cover = images[0];
-  if (cover?.local_path) {
-    const count = images.length > 1 ? `<span class="note-card-media-count t-small">1/${images.length}</span>` : "";
-    return `
-      <div class="note-card-media">
-        <img class="note-card-asset" src="${esc(convertFileSrc(cover.local_path))}" alt="" loading="lazy" />
-        ${count}
-      </div>`;
-  }
-  return renderNoteMediaEmpty();
-}
-
-function renderNoteMediaEmpty(): string {
-  return `<div class="note-card-media note-card-media-empty"><span class="t-small placeholder">${esc(t("note.noMedia"))}</span></div>`;
-}
-
-function pickDownloadedAsset(media: NoteMediaAsset[], role: string): NoteMediaAsset | undefined {
-  return media.find(
-    (asset) => asset.role === role && asset.download_status === "downloaded" && !!asset.local_path,
-  );
-}
-
-function noteStatsLine(note: NoteRecord): string {
-  const parts: string[] = [];
-  const likes = (note.likes ?? "").trim();
-  const favorites = (note.favorites ?? "").trim();
-  const comments = (note.comments_count ?? "").trim();
-  if (likes) parts.push(`${likes} ${t("note.likes")}`);
-  if (favorites) parts.push(`${favorites} ${t("note.saves")}`);
-  if (comments) parts.push(`${comments} ${t("note.comments")}`);
-  return parts.join(" · ");
-}
-
-function formatTag(tag: string): string {
-  const trimmed = tag.trim();
-  return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
-}
-
 export function renderAgentEvent(ev: AgentTaskEventPayload): string {
   const glyph = eventGlyph(ev.kind);
-  return `<div class="event event-${ev.kind}"><span class="event-glyph">${glyph}</span><span class="event-text">${esc(ev.text)}</span></div>`;
+  const row = `<div class="event event-${ev.kind}"><span class="event-glyph">${glyph}</span><span class="event-text">${esc(ev.text)}</span></div>`;
+  // Embed the notes this step surfaced as rich cards beneath the row.
+  if (ev.kind === "tool_result") {
+    const embed = renderTimelineEmbed(noteRefsFromEvent(ev), "rich");
+    if (embed) return `${row}${embed}`;
+  }
+  return row;
+}
+
+// Note refs a tool_result surfaced: the design's `{type:"note", data:{ref}}`
+// entities, plus (for the current bulk `search`/`author_scan` tools) the note
+// ids nested in the xhs_search / card-grid / note entities.
+function noteRefsFromEvent(ev: AgentTaskEventPayload): string[] {
+  const refs: string[] = [];
+  const push = (v: unknown): void => {
+    if (typeof v === "string" && v && !refs.includes(v)) refs.push(v);
+  };
+  const asArray = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+  for (const entity of ev.entities ?? []) {
+    const data = (entity?.data ?? {}) as Record<string, unknown>;
+    if (entity?.type === "note") {
+      push(typeof data.ref === "string" ? data.ref : (data as { note_id?: unknown }).note_id);
+      continue;
+    }
+    push(data.note_id);
+    for (const n of asArray(data.notes)) {
+      const obj = n as { entity?: { note_id?: unknown }; note_id?: unknown };
+      push(obj?.entity?.note_id ?? obj?.note_id);
+    }
+    for (const c of asArray(data.cards)) push((c as { note_id?: unknown })?.note_id);
+    for (const c of asArray(data.note_cards)) push((c as { note_id?: unknown })?.note_id);
+  }
+  return refs;
 }
 
 // Elapsed run time: started→finished, or started→now while still running.

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -4,8 +4,11 @@
 //! filling the pane. When only one panel has content — a running task with no
 //! answer yet, or a failed task that produced only an error — it falls back to a
 //! single stacked panel. (Narrow windows fold split into a stack via CSS.)
+//!
+//! Below the body, a full-width filmstrip shows the notes the agent saw.
 
-import type { AgentTaskEventPayload } from "../main";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import type { AgentTaskEventPayload, NoteMediaAsset, NoteRecord } from "../main";
 import { esc } from "../lib/html";
 import { renderMarkdown } from "../lib/markdown";
 import { formatTaskCount, formatTaskTimestamp, formatTokenUsage, formatTurns, taskStatusLabel, t } from "../lib/i18n";
@@ -84,7 +87,7 @@ export function renderTaskDetail(task: AgentTaskView | undefined): string {
     `;
   }
 
-  return `${renderDetailHead(task, running)}${body}`;
+  return `${renderDetailHead(task, running)}${body}${renderNotesSection(task)}`;
 }
 
 function renderDetailHead(task: AgentTaskView, running: boolean): string {
@@ -153,6 +156,111 @@ function renderEmptyDetail(): string {
       <p class="t-small placeholder">${esc(t("task.emptyDetail"))}</p>
     </div>
   `;
+}
+
+// ── Embedded note cards ───────────────────────────────────────────────────
+// The notes the agent saw this run, rendered from the local archive
+// (`agent_task_notes`). Media is served from disk via the Tauri asset protocol
+// (convertFileSrc), so images and video play locally without re-fetching.
+
+function renderNotesSection(task: AgentTaskView): string {
+  const notes = task.notes ?? [];
+  if (notes.length === 0) return "";
+  return `
+    <section class="note-rail-wrap" aria-label="${esc(t("note.seen"))}">
+      <p class="t-eyebrow result-label">${esc(t("note.seen"))} · ${notes.length}</p>
+      <div class="note-rail">
+        ${notes.map(renderNoteCard).join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderNoteCard(note: NoteRecord): string {
+  const title = (note.title ?? "").trim();
+  const author = (note.author ?? "").trim();
+  const content = (note.content ?? "").trim();
+  const stats = noteStatsLine(note);
+  const url = (note.url ?? "").trim();
+  const tags = (note.hashtags ?? []).filter((tag) => tag.trim()).slice(0, 4);
+  return `
+    <article class="note-card">
+      ${renderNoteMedia(note)}
+      <div class="note-card-body">
+        ${title ? `<p class="note-card-title">${esc(title)}</p>` : ""}
+        ${author ? `<p class="note-card-author t-small subtle">${esc(author)}</p>` : ""}
+        ${stats ? `<p class="note-card-stats t-small subtle">${esc(stats)}</p>` : ""}
+        ${content ? `<p class="note-card-content t-small">${esc(content)}</p>` : ""}
+        ${tags.length ? `<div class="note-card-tags">${tags.map((tag) => `<span class="note-card-tag">${esc(formatTag(tag))}</span>`).join("")}</div>` : ""}
+        ${url ? `<button type="button" class="note-card-open" data-open-note-url="${esc(url)}">${esc(t("note.openOriginal"))}</button>` : ""}
+      </div>
+    </article>
+  `;
+}
+
+function renderNoteMedia(note: NoteRecord): string {
+  const media = note.media ?? [];
+  if (note.type === "video") {
+    const video = pickDownloadedAsset(media, "video");
+    const poster = pickDownloadedAsset(media, "video_poster");
+    const posterSrc = poster?.local_path ? convertFileSrc(poster.local_path) : "";
+    if (video?.local_path) {
+      return `
+        <div class="note-card-media note-card-media-video">
+          <video class="note-card-asset" controls preload="metadata"${posterSrc ? ` poster="${esc(posterSrc)}"` : ""} src="${esc(convertFileSrc(video.local_path))}"></video>
+        </div>`;
+    }
+    // Video not downloadable (e.g. a blob: URL): show the poster if we have it,
+    // flagged, rather than a broken player.
+    if (posterSrc) {
+      return `
+        <div class="note-card-media note-card-media-video">
+          <img class="note-card-asset" src="${esc(posterSrc)}" alt="" loading="lazy" />
+          <span class="note-card-media-flag t-small">${esc(t("note.videoUnavailable"))}</span>
+        </div>`;
+    }
+    return renderNoteMediaEmpty();
+  }
+  // Image note: first downloaded image as the cover; badge the carousel length.
+  const images = media.filter(
+    (asset) => asset.role === "image" && asset.download_status === "downloaded" && asset.local_path,
+  );
+  const cover = images[0];
+  if (cover?.local_path) {
+    const count = images.length > 1 ? `<span class="note-card-media-count t-small">1/${images.length}</span>` : "";
+    return `
+      <div class="note-card-media">
+        <img class="note-card-asset" src="${esc(convertFileSrc(cover.local_path))}" alt="" loading="lazy" />
+        ${count}
+      </div>`;
+  }
+  return renderNoteMediaEmpty();
+}
+
+function renderNoteMediaEmpty(): string {
+  return `<div class="note-card-media note-card-media-empty"><span class="t-small placeholder">${esc(t("note.noMedia"))}</span></div>`;
+}
+
+function pickDownloadedAsset(media: NoteMediaAsset[], role: string): NoteMediaAsset | undefined {
+  return media.find(
+    (asset) => asset.role === role && asset.download_status === "downloaded" && !!asset.local_path,
+  );
+}
+
+function noteStatsLine(note: NoteRecord): string {
+  const parts: string[] = [];
+  const likes = (note.likes ?? "").trim();
+  const favorites = (note.favorites ?? "").trim();
+  const comments = (note.comments_count ?? "").trim();
+  if (likes) parts.push(`${likes} ${t("note.likes")}`);
+  if (favorites) parts.push(`${favorites} ${t("note.saves")}`);
+  if (comments) parts.push(`${comments} ${t("note.comments")}`);
+  return parts.join(" · ");
+}
+
+function formatTag(tag: string): string {
+  const trimmed = tag.trim();
+  return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
 }
 
 export function renderAgentEvent(ev: AgentTaskEventPayload): string {

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -8,6 +8,7 @@ import type {
   AgentTaskSnapshot,
   AgentTaskStatus,
   ModelInfo,
+  NoteRecord,
   ShellState,
 } from "../main";
 import { esc } from "../lib/html";
@@ -18,7 +19,10 @@ import { renderComposePane } from "./task_new";
 // The workspace shows one of two views: the compose form (default / "new task")
 // or the selected task's detail. The sidebar history list is always present.
 type WorkspaceView = "compose" | "detail";
-export type AgentTaskView = AgentTaskSnapshot & { events: AgentTaskEventPayload[] };
+export type AgentTaskView = AgentTaskSnapshot & {
+  events: AgentTaskEventPayload[];
+  notes?: NoteRecord[];
+};
 type CodexLoginStart = { message: string };
 
 // ── Agent task workspace ──────────────────────────────────────────────────
@@ -93,6 +97,29 @@ export namespace agentPanel {
     const before = task.events.length;
     task.events = mergeEvents(task.events, events);
     return task.events.length !== before && taskId === selectedTaskId;
+  }
+
+  export function setTaskNotes(taskId: string, notes: NoteRecord[]): boolean {
+    const task = tasks.find((item) => item.task_id === taskId);
+    if (!task) return false;
+    task.notes = notes;
+    return taskId === selectedTaskId;
+  }
+
+  // Fetch a task's note archive (notes.json) and re-render when it changed the
+  // currently-selected task. Best-effort: a run simply may have no notes.
+  export async function loadTaskNotes(taskId: string, shell: ShellState): Promise<void> {
+    try {
+      const notes = await invoke<NoteRecord[]>("agent_task_notes", { taskId });
+      if (setTaskNotes(taskId, notes)) shell.rerender();
+    } catch (e) {
+      console.error("agent_task_notes failed:", e);
+    }
+  }
+
+  export function loadSelectedTaskNotes(shell: ShellState): void {
+    const selected = selectedTask();
+    if (selected) void loadTaskNotes(selected.task_id, shell);
   }
 
   // Whether any task is running or queued — used to guard the app restart.
@@ -485,6 +512,14 @@ export namespace agentPanel {
         selectedTaskId = btn.dataset.taskId ?? null;
         view = "detail";
         shell.rerender();
+        if (selectedTaskId) void loadTaskNotes(selectedTaskId, shell);
+      });
+    });
+    document.querySelectorAll<HTMLButtonElement>("[data-open-note-url]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const url = btn.dataset.openNoteUrl;
+        if (!url) return;
+        invoke("open_external", { url }).catch((e) => console.error("open_external failed:", e));
       });
     });
     document.querySelectorAll<HTMLButtonElement>("[data-cancel-task]").forEach((btn) => {

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -8,12 +8,13 @@ import type {
   AgentTaskSnapshot,
   AgentTaskStatus,
   ModelInfo,
-  NoteRecord,
+  NoteData,
   ShellState,
 } from "../main";
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
 import { renderAgentEvent, renderSidebar as renderSidebarMarkup, renderTaskDetail } from "./task_history";
+import { bindNoteInteractions } from "./notes";
 import { renderComposePane } from "./task_new";
 
 // The workspace shows one of two views: the compose form (default / "new task")
@@ -21,7 +22,7 @@ import { renderComposePane } from "./task_new";
 type WorkspaceView = "compose" | "detail";
 export type AgentTaskView = AgentTaskSnapshot & {
   events: AgentTaskEventPayload[];
-  notes?: NoteRecord[];
+  notes?: NoteData[];
 };
 type CodexLoginStart = { message: string };
 
@@ -99,7 +100,7 @@ export namespace agentPanel {
     return task.events.length !== before && taskId === selectedTaskId;
   }
 
-  export function setTaskNotes(taskId: string, notes: NoteRecord[]): boolean {
+  export function setTaskNotes(taskId: string, notes: NoteData[]): boolean {
     const task = tasks.find((item) => item.task_id === taskId);
     if (!task) return false;
     task.notes = notes;
@@ -110,7 +111,7 @@ export namespace agentPanel {
   // currently-selected task. Best-effort: a run simply may have no notes.
   export async function loadTaskNotes(taskId: string, shell: ShellState): Promise<void> {
     try {
-      const notes = await invoke<NoteRecord[]>("agent_task_notes", { taskId });
+      const notes = await invoke<NoteData[]>("agent_task_notes", { taskId });
       if (setTaskNotes(taskId, notes)) shell.rerender();
     } catch (e) {
       console.error("agent_task_notes failed:", e);
@@ -515,13 +516,9 @@ export namespace agentPanel {
         if (selectedTaskId) void loadTaskNotes(selectedTaskId, shell);
       });
     });
-    document.querySelectorAll<HTMLButtonElement>("[data-open-note-url]").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const url = btn.dataset.openNoteUrl;
-        if (!url) return;
-        invoke("open_external", { url }).catch((e) => console.error("open_external failed:", e));
-      });
-    });
+    // Note interactions (viewer, card carousel, citation hover, external links)
+    // are wired once via delegation on document.
+    bindNoteInteractions();
     document.querySelectorAll<HTMLButtonElement>("[data-cancel-task]").forEach((btn) => {
       btn.addEventListener("click", async () => {
         const taskId = btn.dataset.cancelTask;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1147,9 +1147,10 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
 .note-card {
   display: flex; border: var(--hairline); border-radius: var(--r-4); background: var(--surface);
   overflow: hidden; cursor: pointer; text-align: left; color: var(--fg);
-  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+  transition: border-color var(--t-fast) var(--ease);
 }
-.note-card:hover { border-color: var(--line-strong); box-shadow: var(--shadow-pop); }
+/* hover = hairline strengthens; --shadow-pop stays reserved for popovers */
+.note-card:hover { border-color: var(--line-strong); }
 .note-card__cover { position: relative; flex: 0 0 auto; }
 .note-card__body { min-width: 0; display: flex; flex-direction: column; gap: 7px; padding: 10px 12px 11px; }
 .note-card__title {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1049,131 +1049,269 @@ body.has-paper > * { position: relative; z-index: 1; }
   max-height: none;
 }
 
-/* ── Embedded note cards ──────────────────────────────────────────
-   A horizontal filmstrip of the notes the agent saw. Fixed-basis so it
-   never fights the timeline (flex:1) / answer (flex:2) for vertical space;
-   scrolls sideways. Media is served locally via the asset protocol. */
-.note-rail-wrap {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
-}
-.note-rail-wrap .result-label { margin: 0; }
-.note-rail {
-  display: flex;
-  gap: var(--sp-3);
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding-bottom: var(--sp-1);
-}
-.note-card {
-  flex: 0 0 220px;
-  width: 220px;
-  max-height: 320px;
-  display: flex;
-  flex-direction: column;
-  border: var(--hairline);
-  border-radius: var(--r-4);
-  background: var(--surface);
-  overflow: hidden;
-}
-.note-card-media {
+/* ── Embedded rich notes (SocaiV2 design) ─────────────────────────────
+   Xiaohongshu notes the agent saw/cited, rendered in the timeline and answer.
+   Monochrome — reuses the ink scale + tokens above. Real media is a local
+   download served via the asset protocol (convertFileSrc). Ported from the
+   Claude Design handoff (notes.css). */
+
+/* ── media frame (universal 3:4; video pillarboxed to 9:16 inside) ── */
+.note-media {
   position: relative;
-  height: 150px;
-  flex: 0 0 auto;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--ink-7);
-  border-bottom: var(--hairline);
+  background-color: var(--ink-8);
+  color: var(--fg-faint);
   overflow: hidden;
 }
-.note-card-asset {
-  width: 100%;
+.note-media__img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.note-media--placeholder {
+  background-image: repeating-linear-gradient(135deg, var(--ink-7) 0 7px, transparent 7px 15px);
+}
+.note-media[data-kind="video"] { background-color: var(--ink-7); }
+.note-media--pillarbox[data-kind="video"] { background-color: var(--ink-5); background-image: none; }
+.note-media__inner {
+  position: relative;
   height: 100%;
-  object-fit: cover;
-  display: block;
-}
-.note-card-media-video .note-card-asset {
-  object-fit: contain;
-  background: var(--ink-0);
-}
-.note-card-media-empty { background: var(--canvas); }
-.note-card-media-count,
-.note-card-media-flag {
-  position: absolute;
-  bottom: var(--sp-1);
-  right: var(--sp-1);
-  padding: 1px var(--sp-1);
-  border-radius: var(--r-2);
-  background: rgba(0, 0, 0, 0.62);
-  color: var(--ink-9);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  line-height: 1.5;
-}
-.note-card-media-flag { left: var(--sp-1); right: auto; }
-.note-card-body {
-  flex: 1;
-  min-height: 0;
+  aspect-ratio: 9 / 16;
+  max-width: 100%;
   display: flex;
-  flex-direction: column;
-  gap: var(--sp-1);
-  padding: var(--sp-2) var(--sp-3);
-}
-.note-card-title {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.35;
-  color: var(--fg);
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
+  background-color: var(--ink-7);
 }
-.note-card-author,
-.note-card-stats { margin: 0; }
-.note-card-stats { font-family: var(--font-mono); font-size: 11px; }
-.note-card-content {
-  margin: 0;
-  min-height: 0;
-  max-height: 5.4em;
-  overflow-y: auto;
-  color: var(--fg-muted);
-  font-size: 12px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+.note-media__inner .note-media__img,
+.note-media__inner video { width: 100%; height: 100%; object-fit: cover; display: block; }
+.note-media__label {
+  font-size: 10px; letter-spacing: 0.04em; color: var(--fg-soft);
+  background: rgba(250, 250, 249, 0.82); padding: 2px 7px; border-radius: var(--r-pill);
+  white-space: nowrap; pointer-events: none;
 }
-.note-card-tags {
+.note-media__count {
+  position: absolute; top: 6px; right: 6px;
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10px; color: var(--ink-9); background: rgba(10, 10, 10, 0.55);
+  padding: 2px 6px; border-radius: var(--r-pill); pointer-events: none;
+}
+.note-media__count svg { width: 11px; height: 11px; }
+.note-media__dur {
+  position: absolute; bottom: 6px; right: 6px;
+  font-size: 10px; color: var(--ink-9); background: rgba(10, 10, 10, 0.62);
+  padding: 1px 6px; border-radius: var(--r-2); pointer-events: none;
+}
+.note-media__play {
+  position: absolute; width: 38px; height: 38px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0; border-radius: var(--r-pill); background: rgba(10, 10, 10, 0.55);
+  color: var(--ink-9); cursor: pointer;
+  transition: background var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
+}
+.note-media__play svg { width: 16px; height: 16px; margin-left: 2px; }
+button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: scale(1.05); }
+
+/* ── author + stats primitives ─────────────────────────────────────── */
+.note-author { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }
+.note-author__avatar {
+  flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-pill); background: var(--ink-6); color: var(--fg-muted);
+  font-family: var(--font-mono); font-weight: 500; text-transform: uppercase; overflow: hidden;
+}
+.note-author__name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg-muted); }
+.note-stats {
+  display: inline-flex; align-items: center; flex-wrap: wrap; gap: 12px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-soft);
+}
+.note-stat { display: inline-flex; align-items: center; gap: 4px; white-space: nowrap; }
+.note-stat svg { width: 13px; height: 13px; flex: 0 0 auto; color: var(--fg-faint); }
+
+/* ── chip (compact inline reference) ───────────────────────────────── */
+.note-chip {
+  display: inline-flex; align-items: center; gap: 8px; max-width: 320px;
+  padding: 4px 11px 4px 4px; border: var(--hairline); border-radius: var(--r-pill);
+  background: var(--surface); color: var(--fg); cursor: pointer; text-align: left; vertical-align: middle;
+  transition: border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+.note-chip:hover { border-color: var(--line-strong); background: var(--ink-7); }
+.note-chip__thumb { flex: 0 0 auto; width: 30px; height: 30px; border-radius: var(--r-pill); overflow: hidden; position: relative; }
+.note-chip__copy { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.note-chip__title { font-size: 12px; line-height: 1.3; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.note-chip__author { font-family: var(--font-mono); font-size: 10px; color: var(--fg-soft); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.note-chip__kind { flex: 0 0 auto; color: var(--fg-faint); display: inline-flex; }
+.note-chip__kind svg { width: 13px; height: 13px; }
+
+/* ── card (rich = vertical tile; compact = horizontal) ─────────────── */
+.note-card {
+  display: flex; border: var(--hairline); border-radius: var(--r-4); background: var(--surface);
+  overflow: hidden; cursor: pointer; text-align: left; color: var(--fg);
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+.note-card:hover { border-color: var(--line-strong); box-shadow: var(--shadow-pop); }
+.note-card__cover { position: relative; flex: 0 0 auto; }
+.note-card__body { min-width: 0; display: flex; flex-direction: column; gap: 7px; padding: 10px 12px 11px; }
+.note-card__title {
+  font-family: var(--font-sans); font-size: 13px; font-weight: 500; line-height: 1.34;
+  letter-spacing: -0.005em; color: var(--ink-1);
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.note-card__meta { display: flex; align-items: center; gap: 7px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); }
+.note-card__meta .note-author { flex: 1 1 auto; min-width: 0; gap: 6px; }
+.note-card__date { flex: 0 0 auto; white-space: nowrap; }
+.note-card__link { flex: 0 0 auto; display: inline-flex; align-items: center; color: var(--fg-soft); text-decoration: none; }
+.note-card__link:hover { color: var(--ink-0); }
+.note-card__link svg { width: 13px; height: 13px; }
+.note-card__nav {
+  position: absolute; top: 50%; transform: translateY(-50%); width: 26px; height: 26px;
+  display: inline-flex; align-items: center; justify-content: center; border: 0; border-radius: var(--r-pill);
+  background: rgba(10, 10, 10, 0.5); color: var(--ink-9); cursor: pointer; opacity: 0;
+  transition: opacity var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+.note-card__cover:hover .note-card__nav { opacity: 1; }
+.note-card__nav:hover { background: rgba(10, 10, 10, 0.74); }
+.note-card__nav svg { width: 14px; height: 14px; }
+.note-card__nav--prev { left: 7px; }
+.note-card__nav--next { right: 7px; }
+.note-card__idx {
+  position: absolute; top: 7px; right: 7px; font-size: 10px; color: var(--ink-9);
+  background: rgba(10, 10, 10, 0.55); padding: 2px 7px; border-radius: var(--r-pill); pointer-events: none;
+}
+.note-card[data-density="rich"] { flex-direction: column; width: 208px; }
+.note-card[data-density="rich"] .note-card__cover { width: 100%; aspect-ratio: 3 / 4; }
+.note-card[data-density="rich"] .note-card__body { gap: 8px; padding: 10px 11px 11px; }
+.note-card[data-density="rich"] .note-stats { flex-wrap: nowrap; gap: 8px; font-size: 10px; }
+.note-card[data-density="rich"] .note-stat { gap: 3px; }
+.note-card[data-density="rich"] .note-stat svg { width: 12px; height: 12px; }
+.note-card[data-density="rich"] .note-author__avatar { width: 18px; height: 18px; font-size: 8px; }
+.note-card[data-density="rich"] .note-author__name { font-size: 11px; }
+.note-card[data-density="compact"] { flex-direction: row; width: 320px; align-items: stretch; }
+.note-card[data-density="compact"] .note-card__cover { width: 92px; aspect-ratio: 3 / 4; }
+.note-card[data-density="compact"] .note-card__body { padding: 9px 11px; gap: 5px; }
+.note-card[data-density="compact"] .note-card__title { font-size: 12.5px; }
+.note-card[data-density="compact"] .note-stats { flex-wrap: nowrap; gap: 9px; font-size: 10px; }
+.note-card[data-density="compact"] .note-author__avatar { width: 17px; height: 17px; font-size: 8px; }
+.note-card[data-density="compact"] .note-author__name { font-size: 11px; }
+
+/* ── timeline embed (under a tool_result row) ──────────────────────── */
+/* One row, scrolling inside its own box: the 28px gutter is margin (not
+   padding) so cards clip at the strip's edge instead of sliding through the
+   glyph column, and overscroll stays contained so trackpad momentum never
+   bleeds into the timeline panel. `flex: none` is load-bearing — overflow-x
+   makes this a scroll container whose auto min-height is zero, so as a flex
+   child of the overflowing .event-stream it would otherwise be squashed flat. */
+.event-embed {
+  flex: none;
+  margin: 3px 0 9px 28px;
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--sp-1);
+  flex-wrap: nowrap;
+  gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
 }
-.note-card-tag {
-  padding: 1px var(--sp-2);
-  border-radius: var(--r-pill);
-  background: var(--surface-2);
-  color: var(--fg-soft);
-  font-family: var(--font-mono);
-  font-size: 10px;
+.event-embed .note-card { flex: 0 0 auto; }
+
+/* ── answer citations (inline pill + hover preview) ────────────────── */
+.note-cite {
+  display: inline-flex; align-items: center; gap: 5px; vertical-align: baseline;
+  padding: 1px 8px 1px 4px; margin: 0 1px; border: var(--hairline); border-radius: var(--r-pill);
+  background: var(--surface); color: var(--fg-muted); font-size: 0.85em; line-height: 1.35; cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
 }
-.note-card-open {
-  align-self: flex-start;
-  margin-top: auto;
-  appearance: none;
-  border: 0;
-  background: transparent;
-  padding: var(--sp-1) 0;
-  color: var(--fg-muted);
-  font-family: var(--font-sans);
-  font-size: 12px;
-  cursor: pointer;
-  transition: color var(--t-fast) var(--ease);
+.note-cite:hover { border-color: var(--line-strong); color: var(--ink-0); }
+.note-cite__dot { flex: 0 0 auto; width: 15px; height: 15px; border-radius: var(--r-pill); overflow: hidden; position: relative; }
+.note-cite__kind { display: inline-flex; color: var(--fg-faint); }
+.note-cite__kind svg { width: 11px; height: 11px; }
+.note-cite-pop {
+  position: fixed; z-index: 80; width: 250px; background: var(--surface); border: var(--hairline);
+  border-radius: var(--r-4); box-shadow: var(--shadow-pop); overflow: hidden; pointer-events: none;
+  animation: noteFade var(--t-fast) var(--ease);
 }
-.note-card-open:hover { color: var(--ink-0); }
+.note-cite-pop__inner { display: flex; gap: 10px; padding: 9px; }
+.note-cite-pop__media { position: relative; flex: 0 0 auto; width: 54px; aspect-ratio: 3 / 4; border-radius: var(--r-2); overflow: hidden; }
+.note-cite-pop__body { min-width: 0; display: flex; flex-direction: column; gap: 5px; }
+.note-cite-pop__title { font-size: 12px; font-weight: 500; color: var(--ink-1); line-height: 1.32; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.note-cite-pop__author { display: inline-flex; align-items: center; gap: 6px; min-width: 0; font-size: 11px; color: var(--fg-muted); }
+.note-cite-pop__author .note-author__avatar { width: 16px; height: 16px; font-size: 8px; }
+.note-cite-pop .note-stats { font-size: 10px; gap: 8px; }
+
+/* ── viewer (lightbox) ─────────────────────────────────────────────── */
+.note-viewer-backdrop {
+  position: fixed; inset: 0; z-index: 100; display: flex; align-items: center; justify-content: center;
+  padding: var(--sp-6); background: rgba(10, 10, 10, 0.42); animation: noteFade var(--t-base) var(--ease);
+}
+@keyframes noteFade { from { opacity: 0; } to { opacity: 1; } }
+.note-viewer-panel {
+  display: flex; flex-direction: column; background: var(--surface); border: var(--hairline);
+  overflow: hidden; min-height: 0; width: min(900px, 96vw); max-height: min(620px, 90vh);
+  border-radius: var(--r-5); box-shadow: var(--shadow-pop);
+}
+.note-viewer-head {
+  flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 11px 12px 11px 14px; border-bottom: var(--hairline); background: var(--surface);
+}
+.note-viewer-head__author { display: inline-flex; align-items: center; gap: 9px; min-width: 0; }
+.note-viewer-head__avatar { width: 26px; height: 26px; font-size: 11px; }
+.note-viewer-head__meta { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.note-viewer-head__name { font-size: 13px; font-weight: 500; color: var(--ink-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.note-viewer-head__handle { font-family: var(--font-mono); font-size: 10px; color: var(--fg-soft); }
+.note-viewer-close {
+  flex: 0 0 auto; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;
+  border: 0; border-radius: var(--r-pill); background: transparent; color: var(--fg-soft); cursor: pointer;
+  transition: background var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+.note-viewer-close:hover { background: var(--ink-7); color: var(--ink-0); }
+.note-viewer-close svg { width: 16px; height: 16px; }
+.note-viewer-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 1.32fr 1fr; }
+
+.note-gallery { position: relative; display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--ink-8); }
+.note-gallery__stage { position: relative; flex: 1; display: flex; align-items: center; justify-content: center; padding: 18px; min-height: 0; }
+.note-gallery__frame { position: relative; max-width: 100%; max-height: 100%; aspect-ratio: 3 / 4; height: 100%; border-radius: var(--r-3); overflow: hidden; border: var(--hairline); }
+.note-gallery__frame .note-media__img { object-fit: contain; background: var(--ink-8); }
+.note-gallery__nav {
+  position: absolute; top: 50%; transform: translateY(-50%); width: 32px; height: 32px;
+  display: inline-flex; align-items: center; justify-content: center; border: var(--hairline);
+  border-radius: var(--r-pill); background: var(--surface); color: var(--fg-muted); cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+.note-gallery__nav:hover { border-color: var(--ink-0); color: var(--ink-0); }
+.note-gallery__nav:disabled { opacity: 0.35; cursor: default; }
+.note-gallery__nav svg { width: 16px; height: 16px; }
+.note-gallery__nav--prev { left: 12px; }
+.note-gallery__nav--next { right: 12px; }
+.note-gallery__thumbs { display: flex; gap: 6px; padding: 8px 10px 11px; overflow-x: auto; scrollbar-width: thin; }
+.note-gallery__thumb {
+  flex: 0 0 auto; width: 40px; height: 52px; border-radius: var(--r-2); overflow: hidden; position: relative;
+  border: 1px solid transparent; cursor: pointer; opacity: 0.6;
+  transition: opacity var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+}
+.note-gallery__thumb:hover { opacity: 1; }
+.note-gallery__thumb.is-active { opacity: 1; border-color: var(--ink-0); }
+
+.note-meta { display: flex; flex-direction: column; gap: 14px; padding: 16px; overflow: auto; min-height: 0; border-left: var(--hairline); }
+.note-meta__title { margin: 0; font-family: var(--font-sans); font-weight: 500; font-size: 16px; line-height: 1.32; letter-spacing: -0.01em; color: var(--ink-0); }
+.note-meta__excerpt { margin: 0; font-size: 13px; line-height: 1.6; color: var(--fg-muted); }
+.note-meta__statgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; border: var(--hairline); border-radius: var(--r-3); overflow: hidden; background: var(--line); }
+.note-meta__stat { display: flex; flex-direction: column; gap: 3px; padding: 10px 12px; background: var(--canvas); }
+.note-meta__stat-k { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--fg-soft); }
+.note-meta__stat-k svg { width: 12px; height: 12px; }
+.note-meta__stat-v { font-family: var(--font-mono); font-size: 15px; color: var(--ink-0); }
+.note-meta__rows { display: flex; flex-direction: column; gap: 0; border-top: var(--hairline); }
+.note-meta__row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 0; border-bottom: var(--hairline); }
+.note-meta__row-k { font-family: var(--font-mono); font-size: 11px; color: var(--fg-soft); }
+.note-meta__row-v { font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted); text-align: right; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.note-meta__link { align-self: flex-start; display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.note-meta__link svg { width: 13px; height: 13px; }
+.note-meta__saved { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; font-family: var(--font-mono); font-size: 10px; color: var(--fg-soft); }
+.note-meta__saved i { width: 6px; height: 6px; border-radius: var(--r-pill); background: var(--ink-0); }
+
+@media (max-width: 720px) {
+  .note-viewer-body { grid-template-columns: 1fr; }
+  .note-meta { border-left: 0; border-top: var(--hairline); }
+}
 
 code {
   font-family: var(--font-mono);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1049,6 +1049,132 @@ body.has-paper > * { position: relative; z-index: 1; }
   max-height: none;
 }
 
+/* ── Embedded note cards ──────────────────────────────────────────
+   A horizontal filmstrip of the notes the agent saw. Fixed-basis so it
+   never fights the timeline (flex:1) / answer (flex:2) for vertical space;
+   scrolls sideways. Media is served locally via the asset protocol. */
+.note-rail-wrap {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.note-rail-wrap .result-label { margin: 0; }
+.note-rail {
+  display: flex;
+  gap: var(--sp-3);
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: var(--sp-1);
+}
+.note-card {
+  flex: 0 0 220px;
+  width: 220px;
+  max-height: 320px;
+  display: flex;
+  flex-direction: column;
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  background: var(--surface);
+  overflow: hidden;
+}
+.note-card-media {
+  position: relative;
+  height: 150px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ink-7);
+  border-bottom: var(--hairline);
+  overflow: hidden;
+}
+.note-card-asset {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.note-card-media-video .note-card-asset {
+  object-fit: contain;
+  background: var(--ink-0);
+}
+.note-card-media-empty { background: var(--canvas); }
+.note-card-media-count,
+.note-card-media-flag {
+  position: absolute;
+  bottom: var(--sp-1);
+  right: var(--sp-1);
+  padding: 1px var(--sp-1);
+  border-radius: var(--r-2);
+  background: rgba(0, 0, 0, 0.62);
+  color: var(--ink-9);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.5;
+}
+.note-card-media-flag { left: var(--sp-1); right: auto; }
+.note-card-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3);
+}
+.note-card-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--fg);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+.note-card-author,
+.note-card-stats { margin: 0; }
+.note-card-stats { font-family: var(--font-mono); font-size: 11px; }
+.note-card-content {
+  margin: 0;
+  min-height: 0;
+  max-height: 5.4em;
+  overflow-y: auto;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.note-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+}
+.note-card-tag {
+  padding: 1px var(--sp-2);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.note-card-open {
+  align-self: flex-start;
+  margin-top: auto;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: var(--sp-1) 0;
+  color: var(--fg-muted);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease);
+}
+.note-card-open:hover { color: var(--ink-0); }
+
 code {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -10,6 +10,7 @@ pub mod file_bash_tools;
 pub mod llm;
 pub mod r#loop;
 pub mod memory;
+pub mod note_store;
 pub mod provider;
 pub mod report;
 pub mod run_logging;

--- a/core/src/agent/note_store.rs
+++ b/core/src/agent/note_store.rs
@@ -33,9 +33,10 @@ pub(crate) fn write_notes(run_dir: &Path, notes: &BTreeMap<String, Value>) -> st
 }
 
 /// Load a run's recorded notes as an array of records (empty when the run
-/// recorded none or hasn't scanned yet). Missing/unreadable/malformed files
-/// degrade to an empty list rather than an error — a run simply may have no
-/// notes. The array form is tolerated alongside the canonical object map.
+/// recorded none or hasn't scanned yet). A missing file is normal and silent;
+/// a file that exists but fails to parse degrades to an empty list with a
+/// warning — never an error. The array form is tolerated alongside the
+/// canonical object map.
 pub fn load_notes(run_dir: &Path) -> Vec<Value> {
     let Ok(text) = std::fs::read_to_string(notes_path(run_dir)) else {
         return Vec::new();
@@ -43,6 +44,20 @@ pub fn load_notes(run_dir: &Path) -> Vec<Value> {
     match serde_json::from_str::<Value>(&text) {
         Ok(Value::Object(map)) => map.into_iter().map(|(_, v)| v).collect(),
         Ok(Value::Array(items)) => items,
-        _ => Vec::new(),
+        Ok(_) => {
+            tracing::warn!(
+                path = %notes_path(run_dir).display(),
+                "notes.json is not an object map or array; ignoring"
+            );
+            Vec::new()
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                path = %notes_path(run_dir).display(),
+                "failed to parse notes.json; ignoring"
+            );
+            Vec::new()
+        }
     }
 }

--- a/core/src/agent/note_store.rs
+++ b/core/src/agent/note_store.rs
@@ -1,0 +1,48 @@
+//! Per-run archive of the notes the agent actually saw.
+//!
+//! As site tools fully read a note, they record it (full content + resolved
+//! local media) into `<run_dir>/notes.json` — a `{ "<note_id>": <record> }`
+//! map. This is the local, re-fetch-free source the desktop app renders as
+//! rich embedded note cards in the run timeline and the final answer.
+//!
+//! The record *shape* is site-specific and built by the site's tools (see
+//! `sites/xhs/tools.rs`); this module only owns the file path, persistence,
+//! and load. Records are keyed by note id, so re-reading a note overwrites the
+//! prior entry (latest read wins) and the archive stays deduped.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+/// Path to a run's note archive: `<run_dir>/notes.json`.
+pub fn notes_path(run_dir: &Path) -> PathBuf {
+    run_dir.join("notes.json")
+}
+
+/// Persist the full `note_id -> record` map to `<run_dir>/notes.json`.
+///
+/// Rewrites the whole file each call; the archive is small (tens of notes per
+/// run) and recording is sequential within a run, so this stays cheap.
+pub(crate) fn write_notes(run_dir: &Path, notes: &BTreeMap<String, Value>) -> std::io::Result<()> {
+    std::fs::create_dir_all(run_dir)?;
+    let map: Map<String, Value> = notes.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    let rendered =
+        serde_json::to_string_pretty(&Value::Object(map)).map_err(std::io::Error::other)?;
+    std::fs::write(notes_path(run_dir), rendered)
+}
+
+/// Load a run's recorded notes as an array of records (empty when the run
+/// recorded none or hasn't scanned yet). Missing/unreadable/malformed files
+/// degrade to an empty list rather than an error — a run simply may have no
+/// notes. The array form is tolerated alongside the canonical object map.
+pub fn load_notes(run_dir: &Path) -> Vec<Value> {
+    let Ok(text) = std::fs::read_to_string(notes_path(run_dir)) else {
+        return Vec::new();
+    };
+    match serde_json::from_str::<Value>(&text) {
+        Ok(Value::Object(map)) => map.into_iter().map(|(_, v)| v).collect(),
+        Ok(Value::Array(items)) => items,
+        _ => Vec::new(),
+    }
+}

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -310,6 +310,11 @@ impl ToolContext {
             return;
         };
         guard.insert(note_id.to_string(), record);
+        // Deliberately write while holding the lock: it keeps on-disk snapshots
+        // in insertion order (clone-then-write lets an older snapshot land after
+        // a newer one, dropping notes from disk until the next write). Tool
+        // calls run sequentially within a run and nothing else locks this map,
+        // so there is no contention to relieve.
         if let Err(err) = crate::agent::note_store::write_notes(&self.run_dir, &guard) {
             // Non-fatal: the in-memory copy still serves this process; only the
             // on-disk archive the desktop app reads is affected.

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -157,6 +157,11 @@ pub struct ToolContext {
     /// Note ids the agent has sampled via `search` in this run — useful
     /// for "show me what I've already covered" tools.
     search_note_ids: Arc<Mutex<Vec<String>>>,
+    /// Notes the agent fully read this run, keyed by note id. Archived to
+    /// `<run_dir>/notes.json` so the desktop app can render them as rich,
+    /// locally-served cards without re-fetching. The record shape is built by
+    /// the site tools; see [`crate::agent::note_store`].
+    notes_seen: Arc<Mutex<BTreeMap<String, Value>>>,
 }
 
 #[derive(Default)]
@@ -197,6 +202,7 @@ impl ToolContext {
             counters: Arc::new(Mutex::new(Counters::default())),
             processed_notes: Arc::new(Mutex::new(BTreeMap::new())),
             search_note_ids: Arc::new(Mutex::new(Vec::new())),
+            notes_seen: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -290,6 +296,25 @@ impl ToolContext {
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default()
+    }
+
+    /// Record a fully-read note (full content + resolved local media) into the
+    /// run's note archive (`<run_dir>/notes.json`). Re-recording the same
+    /// `note_id` overwrites the prior entry (latest read wins). No-op on empty
+    /// id. The record shape is built by the caller (site tools).
+    pub fn record_note(&self, note_id: &str, record: Value) {
+        if note_id.is_empty() {
+            return;
+        }
+        let Ok(mut guard) = self.notes_seen.lock() else {
+            return;
+        };
+        guard.insert(note_id.to_string(), record);
+        if let Err(err) = crate::agent::note_store::write_notes(&self.run_dir, &guard) {
+            // Non-fatal: the in-memory copy still serves this process; only the
+            // on-disk archive the desktop app reads is affected.
+            tracing::warn!(error = %err, note_id, "failed to persist note archive");
+        }
     }
 
     pub fn with_run_state(mut self, run_state: Arc<RunState>) -> Self {

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1065,11 +1065,12 @@ async fn join_note_ocr(
 }
 
 /// Build the archived note record from a freshly-read scan entry
-/// (`{ ok, entity }`): the full note entity, plus a normalized, on-disk-validated
-/// `media` array (reusing the media-manifest asset builder, which resolves each
-/// image/video/poster `local_path`, confirms the file exists, and reads dims),
-/// plus run provenance (`site`, `first_seen_turn`, `level`). Returns
-/// `(note_id, record)`, or `None` when the entity carries no usable note id.
+/// (`{ ok, entity }`): the full note entity, an on-disk-validated
+/// `media_manifest` (manifest asset shape — `local_path`, `download_status`,
+/// dims — NOT the app's `NoteMedia` contract; the `media` key is left free for
+/// the normalized `NoteData` array a follow-up emits), plus run provenance
+/// (`site`, `first_seen_turn`, `level`). Returns `(note_id, record)`, or
+/// `None` when the entity carries no usable note id.
 fn build_note_record(entry: &Value, ctx: &ToolContext, level: &str) -> Option<(String, Value)> {
     let entity = entry.get("entity").filter(|v| v.is_object())?;
     let note_id = entity
@@ -1081,11 +1082,11 @@ fn build_note_record(entry: &Value, ctx: &ToolContext, level: &str) -> Option<(S
     if note_id.is_empty() {
         return None;
     }
-    let media = search_media_manifest(std::slice::from_ref(entry), ctx.output_dir());
+    let manifest = search_media_manifest(std::slice::from_ref(entry), ctx.output_dir());
     let mut record = entity.clone();
     if let Some(map) = record.as_object_mut() {
         map.insert("site".into(), Value::String("xhs".into()));
-        map.insert("media".into(), media);
+        map.insert("media_manifest".into(), manifest);
         map.insert("first_seen_turn".into(), Value::from(ctx.turn));
         map.insert("level".into(), Value::String(level.to_string()));
     }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -931,6 +931,13 @@ async fn scan_card_note(
         if let Some(entity) = entry.get("entity") {
             history.record(entity, level, requested_media);
         }
+        // Archive the fully-read note (full content + resolved local media) so
+        // the desktop app can render it as a rich, locally-served card without
+        // re-fetching. Recorded here — before the lean trim strips images/video
+        // from the agent-facing payload — so the archive keeps the full note.
+        if let Some((note_id, record)) = build_note_record(&entry, ctx, level) {
+            ctx.record_note(&note_id, record);
+        }
     }
 
     entry
@@ -1055,6 +1062,34 @@ async fn join_note_ocr(
         }
     }
     timings
+}
+
+/// Build the archived note record from a freshly-read scan entry
+/// (`{ ok, entity }`): the full note entity, plus a normalized, on-disk-validated
+/// `media` array (reusing the media-manifest asset builder, which resolves each
+/// image/video/poster `local_path`, confirms the file exists, and reads dims),
+/// plus run provenance (`site`, `first_seen_turn`, `level`). Returns
+/// `(note_id, record)`, or `None` when the entity carries no usable note id.
+fn build_note_record(entry: &Value, ctx: &ToolContext, level: &str) -> Option<(String, Value)> {
+    let entity = entry.get("entity").filter(|v| v.is_object())?;
+    let note_id = entity
+        .get("note_id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if note_id.is_empty() {
+        return None;
+    }
+    let media = search_media_manifest(std::slice::from_ref(entry), ctx.output_dir());
+    let mut record = entity.clone();
+    if let Some(map) = record.as_object_mut() {
+        map.insert("site".into(), Value::String("xhs".into()));
+        map.insert("media".into(), media);
+        map.insert("first_seen_turn".into(), Value::from(ctx.turn));
+        map.insert("level".into(), Value::String(level.to_string()));
+    }
+    Some((note_id, record))
 }
 
 /// Trim a search / author_scan bundle to the shape we hand back to the


### PR DESCRIPTION
## What

Users can now see which XHS notes the agent actually saw, embedded where the agent used them — with locally saved images viewable and video playable, no re-fetching:

- **Timeline**: each `tool_result` step embeds the notes it surfaced as a single row of rich cards (3:4 cover with inline carousel, stats, author) that scrolls horizontally inside its own strip — never the panel.
- **Answer**: `[label](note:id)` markdown citations render as pills with a hover preview popover.
- **Viewer**: clicking a card or pill opens a lightbox — image gallery / video player beside a stats + metadata panel, with an "open on xiaohongshu" escape hatch.

<img width="3984" height="2696" alt="CleanShot 2026-07-02 at 05 21 54@2x" src="https://github.com/user-attachments/assets/0cfe88d0-8a33-4b88-9009-cec44b46d3a9" />


This is the SocaiV2 design handoff, ported to the app's no-framework vanilla-TS architecture at the design defaults (rich cards / pills / lightbox), notes-only on the existing shell.

## How it works

- Site tools record each note (content + resolved local media paths) into `<run_dir>/notes.json` at scan time, before the lean trim strips media from the agent-facing payload (foundation commits: note archive + `agent_task_notes` command + Tauri asset-protocol scope for `~/.socai/runs`).
- The frontend loads the archive on task selection / task finish into a note registry; timeline embeds and answer pills resolve refs against it; media renders via `convertFileSrc`.
- A DOMPurify hook keeps the custom `note:` href scheme through sanitization.

## Data contract going forward

The registry unit the frontend renders is `NoteData` (types in `app/src/main.ts`). This is the shape `build_note_record` in `core/src/sites/xhs/tools.rs` must emit into `<run_dir>/notes.json` in the follow-up PR:

```ts
interface NoteData {
  note_id: string;          // registry key — timeline refs and answer citations resolve against it
  url: string;              // canonical xiaohongshu link ("open on xiaohongshu")
  title: string;
  excerpt?: string;         // ~90 chars of body text
  author?: { name: string; handle?: string; avatar?: string };
  posted_at?: number;       // epoch ms
  stats?: { likes?: number; collects?: number; comments?: number; shares?: number };
  media: NoteMedia[];       // cover first
  media_dir?: string;       // run_dir-relative base for relative media paths
  saved?: boolean;          // all media present on disk
}
interface NoteMedia {
  kind: "image" | "video";
  ratio?: string;           // "3:4", "9:16", …
  src?: string;             // local path — absolute, or relative to media_dir
  poster?: string;          // video poster frame
  dur?: string;             // display duration, "MM:SS"
}
```

Two emission points reference it:

- **Timeline**: tool events carry `entities: [{ type: "note", data: { ref: "<note_id>" } }]` per note surfaced. (As a bridge, the frontend also extracts ids from today's `xhs_search` entity shapes, which is how strips light up for existing runs.)
- **Answer**: the agent cites `[label](note:<note_id>)` in `report.md` (system-prompt change, follow-up).

**Until then, real runs degrade gracefully, not break**: they already write `notes.json` in the legacy shape — the raw entity spread plus manifest-shaped assets under `media_manifest` (`local_path`/`download_status`/dims); the `media` key is reserved for the `NoteMedia` array above. The registry still resolves by `note_id`, so strips appear — as skeletal cards: real title, hairline placeholder cover, "—" stats, and the viewer's external link works. Answers have no pills until the prompt change lands. Every `NoteData` field access in the UI is defensive, so mixed/old archives render without errors.

## Also in here

- Timeline replay covers the `run.json`/`llm`/`tools` layout (#160) only. Runs recorded before it replay as just their terminal state — a legacy `timeline.jsonl` fallback was tried during review and deliberately dropped; nothing writes that file anymore and we'd rather carry one replay format.
- `note_store::load_notes` warns instead of silently returning empty when `notes.json` exists but fails to parse (a malformed archive previously rendered as "no notes" with zero signal).

## What reviewers should know

- **Real runs don't produce the new record shape yet** — see "Data contract going forward" above for the target shape and the interim (degraded, non-breaking) behavior. Validated against a retrofitted fixture run (79 notes, 15 citations); wiring core + the system prompt to `NoteData` is the follow-up PR.
- `flex: none` on `.event-embed` is load-bearing: `overflow-x` makes the strip a scroll container whose automatic min-height is zero, and the overflowing event stream would otherwise squash it flat (verified with a headless-Chrome before/after repro: 0px vs 367px).
- XHS extraction has no share count or author avatar — cards show "—" and a letter avatar.
- The video path (pillarboxed 9:16, poster + play affordance, `<video controls>` in the gallery) is implemented but the fixture run is all-image, so it's unexercised end to end.

## Testing

- `cargo check --workspace` and `tsc --noEmit` clean.
- Rust probe replicating `agent_task_notes` against the fixture run: 79 records parse and load.
- Headless-Chrome repro of the strip layout using the real stylesheet: strip scrolls (`scrollWidth > clientWidth`), timeline panel does not.
- Verified in the running app against the fixture task: card strips per search step, pills + popover + viewer in the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
