### PR TITLE
feat(core,app): real runs emit NoteData — embedded notes light up end to end

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -22,7 +22,17 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
-const TAURI_AGENT_PREAMBLE: &str = "You are running inside the socai desktop app.";
+// The note-citation rule lives in this desktop preamble, not the shared site
+// knowledge: only the app renders `note:` links (as rich note pills); in the
+// TUI's plain-markdown answer they would be dead links.
+const TAURI_AGENT_PREAMBLE: &str = "You are running inside the socai desktop app.\n\
+    When your final answer references a specific note you read (including cached \
+    notes returned by scans), cite it inline as a markdown link: \
+    [<note title>](note:<note_id>), with the exact note_id from tool results and \
+    the note's title as the link text (drop any square brackets inside the \
+    title). For notes only seen as preview cards and never read, link their url \
+    instead. Cite each note where it is discussed rather than in a separate \
+    list.";
 
 /// Site the desktop agent runner drives. Becomes a runtime choice once the
 /// app grows a site switcher.

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -22,17 +22,22 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
-// The note-citation rule lives in this desktop preamble, not the shared site
-// knowledge: only the app renders `note:` links (as rich note pills); in the
-// TUI's plain-markdown answer they would be dead links.
-const TAURI_AGENT_PREAMBLE: &str = "You are running inside the socai desktop app.\n\
-    When your final answer references a specific note you read (including cached \
-    notes returned by scans), cite it inline as a markdown link: \
-    [<note title>](note:<note_id>), with the exact note_id from tool results and \
-    the note's title as the link text (drop any square brackets inside the \
-    title). For notes only seen as preview cards and never read, link their url \
-    instead. Cite each note where it is discussed rather than in a separate \
-    list.";
+const TAURI_AGENT_PREAMBLE: &str = "You are running inside the socai desktop app.";
+
+// Appended AFTER the site playbook so it sits at the tail of the system
+// prompt — the position models weight most (prepended into the preamble,
+// qwen3.7-max ignored it). Desktop-only, not shared site knowledge: only the
+// app renders `note:` links (as rich note pills); in the TUI's plain-markdown
+// answer they would be dead links.
+const TAURI_CITATION_RULES: &str = "\n\n## Citing notes in the final answer (required)\n\
+    The app renders note citations as rich note cards. In your final answer, \
+    every time you mention a specific note you read (including cached notes \
+    returned by scans), cite it inline as a markdown link — \
+    [<note title>](note:<note_id>) — using the exact note_id from tool results.\n\
+    Example: 推荐 [湾区遛娃|坐小火车喂羊驼](note:65f0a1b2000000000c030d1e) 的路线。\n\
+    - Link text is the note's title; drop any square brackets inside it.\n\
+    - For notes only seen as preview cards and never read, link their url instead.\n\
+    - Cite each note where it is discussed, not in a separate list at the end.";
 
 /// Site the desktop agent runner drives. Becomes a runtime choice once the
 /// app grows a site switcher.
@@ -765,7 +770,11 @@ async fn run_agent_task_on_fresh_page(
             .default_agent_instructions
             .unwrap_or(site.agent_instructions);
         let config = AgentRunConfig {
-            extra_instructions: agent_instructions(TAURI_AGENT_PREAMBLE),
+            extra_instructions: format!(
+                "{}{}",
+                agent_instructions(TAURI_AGENT_PREAMBLE),
+                TAURI_CITATION_RULES
+            ),
             enabled_sites: vec![site.id.to_string()],
             run_dir,
             session_id,

--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -1,3 +1,4 @@
+use chrono::{Datelike, FixedOffset, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
@@ -127,6 +128,60 @@ pub fn parse_count_text(raw: &str) -> i64 {
         _ => 1.0,
     };
     (number * multiplier).round() as i64
+}
+
+/// Parse a count display string into a stat value, distinguishing "no count
+/// shown" from zero: strings without any digit — empty, or the bare button
+/// labels ("收藏", "评论") XHS renders when a count is hidden — yield `None`
+/// rather than 0.
+pub fn parse_stat_count(raw: &str) -> Option<i64> {
+    let trimmed = raw.trim();
+    if !trimmed.chars().any(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(parse_count_text(trimmed))
+}
+
+/// Parse a note's normalized `date` string — "YYYY-M-D", or "M-D" with the
+/// current year implied (the page scripts resolve relative forms like 昨天 to
+/// this) — into epoch milliseconds. Returns `None` for empty strings,
+/// non-date text, and score-like junk that occasionally leaks into the field
+/// ("6-0"): real calendar validation via `NaiveDate` rejects impossible
+/// month/day pairs.
+///
+/// The instant is pinned at 20:00 Beijing = 12:00 UTC — noon-UTC anchoring
+/// makes viewer-local date formatting reproduce the Beijing calendar date for
+/// every timezone in UTC-12…UTC+11 (an 08:00 anchor would be midnight UTC and
+/// render one day early across the Americas).
+pub fn parse_posted_at_ms(raw: &str) -> Option<i64> {
+    let beijing = FixedOffset::east_opt(8 * 3600)?;
+    let stamp = |year: i32, month: u32, day: u32| -> Option<i64> {
+        if !(2000..=2100).contains(&year) {
+            return None;
+        }
+        NaiveDate::from_ymd_opt(year, month, day)?
+            .and_hms_opt(20, 0, 0)?
+            .and_local_timezone(beijing)
+            .single()
+            .map(|dt| dt.timestamp_millis())
+    };
+    let parts: Vec<&str> = raw.trim().split('-').collect();
+    match parts.as_slice() {
+        [y, m, d] => stamp(y.parse().ok()?, m.parse().ok()?, d.parse().ok()?),
+        [m, d] => {
+            let (month, day) = (m.parse().ok()?, d.parse().ok()?);
+            let now = Utc::now().with_timezone(&beijing);
+            let ms = stamp(now.year(), month, day)?;
+            // A yearless label can never be in the future: "12-31" read in
+            // early January belongs to the year that just ended.
+            if ms > now.timestamp_millis() + 24 * 3600 * 1000 {
+                stamp(now.year() - 1, month, day)
+            } else {
+                Some(ms)
+            }
+        }
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -5,6 +5,7 @@
 //! visible, note modal open, etc.). The caller is responsible for creating
 //! the page and closing it after `run_agent` returns.
 
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -29,6 +30,7 @@ use crate::sites::xhs::media_manifest::{
     ensure_entity_note_id, search_media_manifest, write_media_manifest_file,
 };
 use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
+use crate::sites::xhs::entities::{parse_posted_at_ms, parse_stat_count};
 use crate::sites::xhs::{
     ReadNoteOptions, XhsAuthorProfile, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
 };
@@ -737,6 +739,32 @@ fn skipped_note_entry(card: &XhsNoteCard, reason: &str, history: &XhsHistoryStor
     })
 }
 
+/// A cache hit still lands in the run's note archive: the cached entity is
+/// evidence the agent may cite, so the app needs a record to resolve the
+/// citation against. Cached media paths point (absolute) into the run that
+/// downloaded them; the app resolves absolute paths as-is, and the asset
+/// scope covers the whole runs root.
+fn recorded_skip_entry(
+    card: &XhsNoteCard,
+    reason: &str,
+    history: &XhsHistoryStore,
+    ctx: &ToolContext,
+    level: &str,
+) -> Value {
+    let entry = skipped_note_entry(card, reason, history);
+    if let Some(entity) = entry.get("entity").filter(|v| v.is_object()) {
+        // note_data_record expects an ok-shaped entry (the media-manifest
+        // builder ignores anything that isn't `ok: true`).
+        let readable = json!({ "ok": true, "entity": entity });
+        if let Some((note_id, record)) =
+            note_data_record(&readable, ctx.output_dir(), &ctx.run_dir, ctx.turn, level)
+        {
+            ctx.record_note(&note_id, record);
+        }
+    }
+    entry
+}
+
 fn progress_title(card: &XhsNoteCard) -> Option<String> {
     let title = card.title.trim();
     (!title.is_empty()).then(|| title.to_string())
@@ -887,7 +915,7 @@ async fn scan_card_note(
     // re-downloading, and re-OCR'ing it. The cached entity carries its prior
     // ocr_text / local_path, so the reuse is complete.
     if !card.note_id.is_empty() && ctx.has_processed_note(&card.note_id, level, requested_media) {
-        return skipped_note_entry(card, "already_processed", history);
+        return recorded_skip_entry(card, "already_processed", history, ctx, level);
     }
     if !card.note_id.is_empty()
         && history.is_satisfied_by(&card.note_id, level, requested_media, download_media_requested, ocr, comment_count)
@@ -897,7 +925,7 @@ async fn scan_card_note(
         && history.has_cached_entity(&card.note_id)
     {
         ctx.mark_processed_note(&card.note_id, level, requested_media);
-        return skipped_note_entry(card, "already_analyzed", history);
+        return recorded_skip_entry(card, "already_analyzed", history, ctx, level);
     }
 
     let read_result = xhs
@@ -1157,32 +1185,212 @@ async fn join_note_ocr(
 }
 
 /// Build the archived note record from a freshly-read scan entry
-/// (`{ ok, entity }`): the full note entity, an on-disk-validated
-/// `media_manifest` (manifest asset shape — `local_path`, `download_status`,
-/// dims — NOT the app's `NoteMedia` contract; the `media` key is left free for
-/// the normalized `NoteData` array a follow-up emits), plus run provenance
-/// (`site`, `first_seen_turn`, `level`). Returns `(note_id, record)`, or
-/// `None` when the entity carries no usable note id.
-fn build_note_record(entry: &Value, ctx: &ToolContext, level: &str) -> Option<(String, Value)> {
+/// (`{ ok, entity }`) in the desktop app's `NoteData` shape (see
+/// app/src/main.ts): identity + title/excerpt, author, `posted_at` (epoch
+/// ms), numeric `stats` (a key is omitted when XHS hid the count; `shares`
+/// has no source at all), and a `media` array of locally-downloaded assets —
+/// cover first, a video before its carousel — with run-relative paths, plus
+/// run provenance (`site`, `first_seen_turn`, `level`). Media entries come
+/// from the on-disk-validated media manifest, so only files that actually
+/// downloaded are listed. Returns `(note_id, record)`, or `None` when the
+/// entity carries no usable note id.
+pub fn note_data_record(
+    entry: &Value,
+    media_base: &Path,
+    run_dir: &Path,
+    turn: u32,
+    level: &str,
+) -> Option<(String, Value)> {
     let entity = entry.get("entity").filter(|v| v.is_object())?;
-    let note_id = entity
-        .get("note_id")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let text = |key: &str| -> String {
+        entity
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+    let note_id = text("note_id");
     if note_id.is_empty() {
         return None;
     }
-    let manifest = search_media_manifest(std::slice::from_ref(entry), ctx.output_dir());
-    let mut record = entity.clone();
-    if let Some(map) = record.as_object_mut() {
-        map.insert("site".into(), Value::String("xhs".into()));
-        map.insert("media_manifest".into(), manifest);
-        map.insert("first_seen_turn".into(), Value::from(ctx.turn));
-        map.insert("level".into(), Value::String(level.to_string()));
+
+    let manifest = search_media_manifest(std::slice::from_ref(entry), media_base);
+    let media = note_media_from_manifest(&manifest, run_dir);
+
+    let mut record = Map::new();
+    record.insert("note_id".into(), Value::String(note_id.clone()));
+    let url = text("url");
+    if !url.is_empty() {
+        record.insert("url".into(), Value::String(url));
     }
-    Some((note_id, record))
+    record.insert("title".into(), Value::String(text("title")));
+    if let Some(excerpt) = note_excerpt(&text("content")) {
+        record.insert("excerpt".into(), Value::String(excerpt));
+    }
+    let author_name = text("author");
+    if !author_name.is_empty() {
+        // Just the display name: XHS note pages expose no avatar, and the
+        // internal author_id is not the user-facing handle (小红书号) — a
+        // fabricated "@<id-prefix>" would masquerade as one. `handle` stays
+        // absent until the extractor captures the real thing.
+        let mut author = Map::new();
+        author.insert("name".into(), Value::String(author_name));
+        record.insert("author".into(), Value::Object(author));
+    }
+    if let Some(posted_at) = parse_posted_at_ms(&text("date")) {
+        record.insert("posted_at".into(), Value::from(posted_at));
+    }
+    let mut stats = Map::new();
+    for (stat, field) in [
+        ("likes", "likes"),
+        ("collects", "favorites"),
+        ("comments", "comments_count"),
+    ] {
+        if let Some(count) = parse_stat_count(&text(field)) {
+            stats.insert(stat.into(), Value::from(count));
+        }
+    }
+    record.insert("stats".into(), Value::Object(stats));
+    record.insert("media".into(), Value::Array(media.clone()));
+    record.insert("media_dir".into(), Value::String(String::new()));
+    record.insert("saved".into(), Value::Bool(!media.is_empty()));
+    record.insert("site".into(), Value::String("xhs".into()));
+    record.insert("first_seen_turn".into(), Value::from(turn));
+    record.insert("level".into(), Value::String(level.to_string()));
+    Some((note_id, Value::Object(record)))
+}
+
+fn build_note_record(entry: &Value, ctx: &ToolContext, level: &str) -> Option<(String, Value)> {
+    note_data_record(entry, ctx.output_dir(), &ctx.run_dir, ctx.turn, level)
+}
+
+/// Map validated manifest rows to the app's `NoteMedia` entries: only assets
+/// that downloaded, the video first as the cover (it renders even when only
+/// its poster came down — blob-URL videos can't be fetched, and the app falls
+/// back to poster + play glyph), then carousel images in index order.
+fn note_media_from_manifest(manifest: &Value, run_dir: &Path) -> Vec<Value> {
+    let rows: Vec<&Map<String, Value>> = manifest
+        .as_array()
+        .map(|items| items.iter().filter_map(Value::as_object).collect())
+        .unwrap_or_default();
+    fn role(row: &Map<String, Value>) -> &str {
+        row.get("role").and_then(Value::as_str).unwrap_or("")
+    }
+    let downloaded_path = |row: &Map<String, Value>| -> Option<String> {
+        if row.get("download_status").and_then(Value::as_str) != Some("downloaded") {
+            return None;
+        }
+        row.get("local_path")
+            .and_then(Value::as_str)
+            .filter(|path| !path.is_empty())
+            .map(|path| run_relative_path(path, run_dir))
+    };
+
+    let mut media = Vec::new();
+    let video_row = rows.iter().find(|row| role(row) == "video");
+    let video_src = video_row.and_then(|row| downloaded_path(row));
+    let poster = rows
+        .iter()
+        .find(|row| role(row) == "video_poster")
+        .and_then(|row| downloaded_path(row));
+    if video_src.is_some() || poster.is_some() {
+        let mut item = Map::new();
+        item.insert("kind".into(), Value::String("video".into()));
+        item.insert("ratio".into(), Value::String("9:16".into()));
+        if let Some(src) = video_src {
+            item.insert("src".into(), Value::String(src));
+        }
+        if let Some(poster) = poster {
+            item.insert("poster".into(), Value::String(poster));
+        }
+        if let Some(duration_s) = video_row.and_then(|row| {
+            row.get("duration_s")
+                .and_then(Value::as_f64)
+                .filter(|s| *s > 0.0)
+        }) {
+            item.insert(
+                "dur".into(),
+                Value::String(format_media_duration(duration_s)),
+            );
+        }
+        media.push(Value::Object(item));
+    }
+
+    let mut images: Vec<(i64, String)> = rows
+        .iter()
+        .filter(|row| role(row) == "image")
+        .filter_map(|row| {
+            downloaded_path(row).map(|path| {
+                let index = row.get("index").and_then(Value::as_i64).unwrap_or(i64::MAX);
+                (index, path)
+            })
+        })
+        .collect();
+    images.sort_by_key(|(index, _)| *index);
+    for (_, src) in images {
+        media.push(json!({ "kind": "image", "ratio": "3:4", "src": src }));
+    }
+    media
+}
+
+/// First ~90 code points of the note body, whitespace collapsed. Truncation
+/// counts chars, not bytes — a byte slice could split a multi-byte char and
+/// panic (the JS fixture generator had the UTF-16 twin of this bug) — and the
+/// tail is trimmed so the cut can't end mid grapheme cluster (a ZWJ-joined
+/// emoji family, a skin-tone modifier, or half a regional-indicator flag).
+fn note_excerpt(content: &str) -> Option<String> {
+    let collapsed = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let mut chars: Vec<char> = collapsed.chars().collect();
+    if chars.len() <= 90 {
+        return Some(collapsed);
+    }
+    chars.truncate(88);
+    let fragile = |c: char| {
+        c == '\u{200D}' // zero-width joiner
+            || ('\u{FE00}'..='\u{FE0F}').contains(&c) // variation selectors
+            || ('\u{1F3FB}'..='\u{1F3FF}').contains(&c) // skin-tone modifiers
+    };
+    loop {
+        match chars.last() {
+            Some(&c) if fragile(c) => {
+                chars.pop();
+            }
+            // A char right after a ZWJ is a fragment of a joined sequence —
+            // drop it together with its joiner and re-check the new tail.
+            Some(_) if chars.len() >= 2 && chars[chars.len() - 2] == '\u{200D}' => {
+                chars.pop();
+                chars.pop();
+            }
+            _ => break,
+        }
+    }
+    let regional = |c: &&char| ('\u{1F1E6}'..='\u{1F1FF}').contains(*c);
+    if chars.iter().rev().take_while(regional).count() % 2 == 1 {
+        chars.pop();
+    }
+    let mut excerpt: String = chars.into_iter().collect();
+    excerpt.push('…');
+    Some(excerpt)
+}
+
+/// Media paths are emitted relative to the run dir so the archive survives the
+/// run being moved or synced to another machine; paths outside the run dir
+/// (custom output roots) stay absolute, which the app also resolves.
+fn run_relative_path(path: &str, run_dir: &Path) -> String {
+    Path::new(path)
+        .strip_prefix(run_dir)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| path.to_string())
+}
+
+/// Seconds → the app's display duration, "M:SS".
+fn format_media_duration(seconds: f64) -> String {
+    let total = seconds.round().max(0.0) as i64;
+    format!("{}:{:02}", total / 60, total % 60)
 }
 
 /// Trim a search / author_scan bundle to the shape we hand back to the


### PR DESCRIPTION
## What

The follow-up to #166: real agent runs now produce the data the embedded-notes UI renders, with no fixture scripts.

- **Core**: `build_note_record` emits the `NoteData` contract (documented in #166) into `<run_dir>/notes.json` — title, code-point-safe `excerpt`, author name, `posted_at` (epoch ms), numeric `stats`, and a `media[]` of locally-downloaded assets (video-first cover with poster + `M:SS` duration, carousel images in order, run-relative paths).
- **Cache hits are recorded too**: `already_processed`/`already_analyzed` notes land in the archive with their cached entity — they're evidence the agent may cite, and previously they'd have produced dead citations.
- **App**: the desktop agent instructions require inline citations — `[<note title>](note:<note_id>)` for notes the agent read, plain `url` links for preview-only cards. The rule is a dedicated section appended **after** the site playbook (tail of the system prompt — see validation below), and deliberately desktop-only rather than shared `knowledge.md`: only the app renders `note:` links as pills; in the TUI's plain-markdown answer they'd be dead links.

## Parsing decisions grounded in the real corpus (1,508 entities surveyed)

- **Counts**: `万`/`w`/`k` display strings via the existing `parse_count_text`; a hidden count (XHS renders the bare button label `收藏`/`评论`) is **omitted**, not recorded as 0 — the app shows "—". `shares` has no XHS source.
- **Dates**: real calendar validation rejects the score-like junk that leaks into the field (`"6-0"`, `"15-6"`); yearless `M-D` labels assume the current Beijing year with a one-year backoff when the result would be in the future (New-Year reads of `12-31`); the instant is pinned at **20:00 Beijing = noon UTC**, so viewer-local date formatting reproduces the Beijing calendar date for every timezone UTC-12…UTC+11 (an earlier 08:00 anchor was midnight UTC — every date rendered one day early across the Americas).
- **No fabricated handle**: the internal `author_id` is not the user-facing 小红书号, so `author.handle` stays absent until the extractor captures the real one.
- **Excerpt**: ≤90 code points with the tail trimmed so the cut can't strand half a ZWJ emoji family, a skin-tone modifier, or half a flag pair.
- **Paths**: run-relative when under the run dir (survives moving/syncing the run), absolute pass-through otherwise (cache-hit media points into the run that downloaded it; the asset scope covers the whole runs root).

## How it was validated

- A probe drove the **real** `note_data_record` over **1,497 entries from every run on disk** (including 216 real cache-hit entities through the same wrapper the scan path uses): **zero contract violations, zero unresolvable media paths**, 556 video covers with correct poster/duration pairing.
- An adversarial review pass (3 lenses, per-finding refutation) confirmed 7 distinct issues — all fixed in this diff (the timezone anchor, New-Year backoff, fabricated handle, grapheme-cluster tail, cache-hit recording, preview-card citation scoping, TUI dead-link gating); 3 further claims were refuted on verification.
- **Live end-to-end verified** via a headless replica of the app's agent runner (same runtime, provider resolution, tools, and instructions) against live XHS with the configured model (qwen3.7-max):
  - A real CLI `search` run and two real agent runs each wrote clean `NoteData` records to `notes.json` — numeric stats, epoch-ms dates, run-relative media paths, every file on disk.
  - Rerunning the same query exercised the cache-hit path live: the cached note recorded with absolute media paths into the run that downloaded them, all resolving.
  - **Citations required one fix** (last commit): with the rule at the top of `extra_instructions`, the model ignored it and answered in plain prose. Moved to an imperative tail section with a concrete example, the same model cited **all 3 notes** inline as `[title](note:<note_id>)` with exact ids.
- The 20260628 fixture run's `notes.json` was regenerated with genuine builder output and renders in the app.
- `cargo check --workspace` clean.

## What reviewers should know

- `note_data_record` is `pub` so the archive shape can be exercised offline against real artifacts (same precedent as `parse_count_text`).
- Video notes almost never expose a date on XHS (7/710 in the corpus), so `posted_at` is mostly an image-note field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
