### PR TITLE
feat(app): live note cards in the timeline as each note downloads

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -478,6 +478,11 @@ async function main(): Promise<void> {
   // rows append in place to preserve scroll.
   await listen<AgentTaskEventPayload>("agent_task:event", (event) => {
     if (agentPanel.appendTaskEvent(event.payload)) render();
+    if (event.payload.kind === "tool_result") {
+      // Each finished step's notes are on disk — refresh so the result row's
+      // embed renders them now, not when the whole task ends.
+      void agentPanel.loadTaskNotes(event.payload.task_id, shell());
+    }
     if (isTaskFinishedEvent(event.payload)) {
       // A finished task is a good, quiet moment to check for an update, and the
       // point at which its full note archive (notes.json) is on disk to render.

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -174,8 +174,9 @@ export function renderAgentEvent(ev: AgentTaskEventPayload): string {
 
 // Note refs a tool_result surfaced: the design's `{type:"note", data:{ref}}`
 // entities, plus (for the current bulk `search`/`author_scan` tools) the note
-// ids nested in the xhs_search / card-grid / note entities.
-function noteRefsFromEvent(ev: AgentTaskEventPayload): string[] {
+// ids nested in the xhs_search / card-grid / note entities. Exported for the
+// live strip in tasks.ts, which shows only notes no result row has claimed yet.
+export function noteRefsFromEvent(ev: AgentTaskEventPayload): string[] {
   const refs: string[] = [];
   const push = (v: unknown): void => {
     if (typeof v === "string" && v && !refs.includes(v)) refs.push(v);

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -666,6 +666,13 @@ export namespace agentPanel {
     // Poll the note archive while the selected task runs (bind runs after
     // every render, so this tracks selection and status changes).
     syncNotesPolling(shell);
+    // A full render rebuilds the stream without the DOM-only live strip, and
+    // the poll skips ticks where no new note was recorded — so restore the
+    // strip here or it stays hidden until the next note lands.
+    const selected = selectedTask();
+    if (selected && (selected.status === "running" || selected.status === "queued")) {
+      updateLiveStrip(selected);
+    }
   }
 
   // Keep the event stream pinned to its newest row when the detail (re)renders,

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -13,8 +13,8 @@ import type {
 } from "../main";
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
-import { renderAgentEvent, renderSidebar as renderSidebarMarkup, renderTaskDetail } from "./task_history";
-import { bindNoteInteractions } from "./notes";
+import { noteRefsFromEvent, renderAgentEvent, renderSidebar as renderSidebarMarkup, renderTaskDetail } from "./task_history";
+import { bindNoteInteractions, renderTimelineEmbed, setNoteRegistry } from "./notes";
 import { renderComposePane } from "./task_new";
 
 // The workspace shows one of two views: the compose form (default / "new task")
@@ -123,6 +123,69 @@ export namespace agentPanel {
   export function loadSelectedTaskNotes(shell: ShellState): void {
     const selected = selectedTask();
     if (selected) void loadTaskNotes(selected.task_id, shell);
+  }
+
+  // ── live notes while a task runs ─────────────────────────────────────
+  // notes.json is written incrementally (one rewrite per note read), but no
+  // event fires mid-tool-call — a scan is silent for minutes. Poll the archive
+  // while the selected task runs so each note's card appears right after its
+  // media lands, in a "live strip" pinned to the bottom of the stream. Rows
+  // for finished steps render their own embeds from tool_result entities, so
+  // the strip only shows notes no result row has claimed yet.
+  let notesPollTimer: number | null = null;
+
+  function syncNotesPolling(shell: ShellState): void {
+    const selected = selectedTask();
+    const running = !!selected && (selected.status === "running" || selected.status === "queued");
+    if (running && notesPollTimer === null) {
+      notesPollTimer = window.setInterval(() => void pollLiveNotes(shell), 2000);
+    } else if (!running && notesPollTimer !== null) {
+      window.clearInterval(notesPollTimer);
+      notesPollTimer = null;
+    }
+  }
+
+  async function pollLiveNotes(shell: ShellState): Promise<void> {
+    const task = selectedTask();
+    if (!task || (task.status !== "running" && task.status !== "queued")) {
+      syncNotesPolling(shell);
+      return;
+    }
+    try {
+      const notes = await invoke<NoteData[]>("agent_task_notes", { taskId: task.task_id });
+      // Within a run records only accumulate; no growth means nothing to do.
+      if (notes.length <= (task.notes?.length ?? 0)) return;
+      task.notes = notes;
+      setNoteRegistry(notes, task.run_dir);
+      updateLiveStrip(task);
+    } catch (e) {
+      console.error("agent_task_notes poll failed:", e);
+    }
+  }
+
+  let liveStripKey = "";
+
+  function updateLiveStrip(task: AgentTaskView): void {
+    const stream = document.querySelector<HTMLDivElement>(`[data-agent-events="${task.task_id}"]`);
+    if (!stream) return;
+    const claimed = new Set<string>();
+    for (const ev of task.events) {
+      if (ev.kind !== "tool_result") continue;
+      for (const ref of noteRefsFromEvent(ev)) claimed.add(ref);
+    }
+    const refs = (task.notes ?? []).map((n) => n.note_id).filter((id) => !claimed.has(id));
+    const key = refs.join(",");
+    const existing = stream.querySelector("[data-live-strip]");
+    if (key === liveStripKey && existing) return;
+    liveStripKey = key;
+    existing?.remove();
+    if (refs.length === 0) return;
+    const html = renderTimelineEmbed(refs, "rich");
+    if (!html) return;
+    const pinned = stream.scrollTop + stream.clientHeight >= stream.scrollHeight - 8;
+    stream.insertAdjacentHTML("beforeend", html);
+    stream.lastElementChild?.setAttribute("data-live-strip", "1");
+    if (pinned) stream.scrollTop = stream.scrollHeight;
   }
 
   // Whether any task is running or queued — used to guard the app restart.
@@ -600,6 +663,9 @@ export namespace agentPanel {
 
     // Auto-follow the selected task's timeline to the latest row after a render.
     scrollSelectedEventsToBottom();
+    // Poll the note archive while the selected task runs (bind runs after
+    // every render, so this tracks selection and status changes).
+    syncNotesPolling(shell);
   }
 
   // Keep the event stream pinned to its newest row when the detail (re)renders,
@@ -787,7 +853,17 @@ export namespace agentPanel {
     const placeholder = stream.querySelector("[data-events-placeholder]");
     if (placeholder) placeholder.remove();
 
+    // A result row claims its notes (its own embed renders them), so refresh
+    // the live strip right away instead of waiting for the next poll tick.
+    if (payload.kind === "tool_result") {
+      stream.querySelector("[data-live-strip]")?.remove();
+      liveStripKey = "";
+    }
     stream.insertAdjacentHTML("beforeend", renderAgentEvent(payload));
     stream.scrollTop = stream.scrollHeight;
+    if (payload.kind === "tool_result") {
+      const task = tasks.find((item) => item.task_id === payload.task_id);
+      if (task) updateLiveStrip(task);
+    }
   }
 }

--- a/core/src/agent/note_store.rs
+++ b/core/src/agent/note_store.rs
@@ -29,7 +29,17 @@ pub(crate) fn write_notes(run_dir: &Path, notes: &BTreeMap<String, Value>) -> st
     let map: Map<String, Value> = notes.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     let rendered =
         serde_json::to_string_pretty(&Value::Object(map)).map_err(std::io::Error::other)?;
-    std::fs::write(notes_path(run_dir), rendered)
+    // The desktop app polls this file mid-run to show notes as they are
+    // recorded, so go through a temp file + rename: readers must never see a
+    // half-written JSON.
+    let path = notes_path(run_dir);
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, rendered)?;
+    // Windows can't rename over an existing file; a reader hitting the gap
+    // sees a missing file, which load_notes treats as "no notes yet".
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(&path);
+    std::fs::rename(&tmp, &path)
 }
 
 /// Load a run's recorded notes as an array of records (empty when the run


### PR DESCRIPTION
## What

Follow-up to #169. Note cards appeared in the timeline only when the whole task finished; now they appear **as each note's media lands**, with a per-round fallback:

- **Per note**: while the selected task runs, the app polls the run's note archive every 2s and renders newly-recorded notes in a *live strip* pinned to the bottom of the event stream. The strip shows only notes no `tool_result` row has claimed yet (claimed = the union of result rows' entity refs), so nothing renders twice — when the step finishes, its own embed takes over and the strip empties.
- **Per round**: every `tool_result` event triggers an archive reload + re-render, so the result row's embed is populated the moment the step completes (previously it rendered against an empty registry and stayed blank until task end).

## Why polling

`notes.json` is rewritten after every note read — the data is there mid-run — but the event channel is silent inside a tool call: a scan emits nothing between `ToolCall` and `ToolResult` for minutes (verified against a live run's broadcast log). A 2s poll of a small local file via the existing `agent_task_notes` command is the cheapest correct signal; plumbing per-note progress events through the agent loop can replace it later if a progress UI ever needs them.

## Core change

`write_notes` now goes through temp-file + rename, since the app reads the archive concurrently with the scan writing it. On Windows the destination is removed before the rename (no rename-over); the gap reads as "no notes yet".

## Validation

- Live concurrency test: during a real 4-note `search` (media downloads on), a reader polled `notes.json` every 300ms — records appeared **incrementally, one per note (~5s apart: 14.5s → 18.8s → 25.0s → 31.4s)** with **zero parse failures across ~800 reads**.
- Live `tool_result` events carry normalized entities (verified in `tool_result_event`), so the per-round embeds populate without replay.
- `cargo check` + `tsc --noEmit` clean.
- The strip's DOM behavior (appear/hand-off/scroll-pinning) needs an interactive run to observe — that's the one manual check: start a search and watch cards arrive one by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)