### PR TITLE
feat(core): per-note phase timing for scans — stats/scan.json

### DIFF
--- a/core/src/media/image.rs
+++ b/core/src/media/image.rs
@@ -295,9 +295,17 @@ impl MediaProcessor {
                     .to_string()
             })
             .collect();
-        let downloads = urls
-            .into_iter()
-            .map(|url| self.safe_download(url, referer.to_string()));
+        let downloads = urls.into_iter().map(|url| {
+            let referer = referer.to_string();
+            // Per-item wall time (from admission into the concurrency window to
+            // completion) so a single slow CDN fetch is visible inside the
+            // otherwise-concurrent batch.
+            async move {
+                let t_item = Instant::now();
+                let result = self.safe_download(url, referer).await;
+                (result, t_item.elapsed().as_millis() as u64)
+            }
+        });
         let download_results: Vec<_> = futures::stream::iter(downloads)
             .buffered(IMAGE_DOWNLOAD_CONCURRENCY)
             .collect()
@@ -308,13 +316,16 @@ impl MediaProcessor {
         images
             .iter()
             .zip(download_results)
-            .map(|(image, (payload, error))| {
+            .map(|(image, ((payload, error), download_ms))| {
                 let url = image
                     .get("url")
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .trim();
                 let mut item = image.clone();
+                if let Some(map) = item.as_object_mut() {
+                    map.insert("download_ms".into(), serde_json::json!(download_ms));
+                }
                 if url.is_empty() {
                     insert_string(&mut item, "download_error", "image URL is empty");
                     return item;

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -84,12 +84,19 @@ impl MediaProcessor {
             .unwrap_or("")
             .to_string();
         if !poster_url.is_empty() {
+            let t_poster = Instant::now();
             match self
                 .download_named_file(&poster_url, referer, label, "post.jpg")
                 .await
             {
                 Ok(path) => insert_string(&mut result, "poster_local_path", path.to_string_lossy()),
                 Err(err) => insert_string(&mut result, "poster_download_error", format!("{err:#}")),
+            }
+            if let Some(map) = result.as_object_mut() {
+                map.insert(
+                    "poster_download_ms".into(),
+                    serde_json::json!(t_poster.elapsed().as_millis() as u64),
+                );
             }
         }
         result
@@ -128,6 +135,7 @@ impl MediaProcessor {
             return result;
         }
 
+        let t_file = Instant::now();
         match self
             .download_file_with_timeout(
                 &source,
@@ -144,6 +152,12 @@ impl MediaProcessor {
         {
             Ok(path) => insert_string(&mut result, "local_path", path.to_string_lossy()),
             Err(err) => insert_string(&mut result, "download_error", format!("{err:#}")),
+        }
+        if let Some(map) = result.as_object_mut() {
+            map.insert(
+                "download_ms".into(),
+                serde_json::json!(t_file.elapsed().as_millis() as u64),
+            );
         }
         result
     }

--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -159,6 +159,7 @@ fn image_manifest_entry(
         "resolved_url_status": direct_resolution_status(&source_url),
         "download_status": status,
         "download_error": option_string_or_null(error.as_deref()),
+        "download_ms": option_i64_or_null(integer_field(image, "download_ms")),
     })
 }
 
@@ -190,6 +191,7 @@ fn video_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Value {
         "resolved_url_status": video_resolution_status(video, &source_url),
         "download_status": status,
         "download_error": option_string_or_null(error.as_deref()),
+        "download_ms": option_i64_or_null(integer_field(video, "download_ms")),
     })
 }
 
@@ -224,6 +226,7 @@ fn poster_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Option
         "resolved_url_status": direct_resolution_status(&source_url),
         "download_status": status,
         "download_error": option_string_or_null(error.as_deref()),
+        "download_ms": option_i64_or_null(integer_field(video, "poster_download_ms")),
     }))
 }
 

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -655,14 +655,31 @@ impl<'a> XhsPageRuntime<'a> {
         mut options: ReadNoteOptions,
     ) -> Result<Value> {
         let mut open = None;
+        // Per-phase wall times (open/extract/enrich/download/inline OCR),
+        // returned as `perf` on the payload so callers can record read timing
+        // without re-measuring. `open_strategy` tells whether the first card
+        // click opened the overlay or a retry click was needed.
+        let mut perf = Map::new();
         if options.note_id_fallback.trim().is_empty() && !note_id.trim().is_empty() {
             options.note_id_fallback = note_id.trim().to_string();
         }
         if !note_id.is_empty() || index.is_some() {
+            let t_open = Instant::now();
             let opened = self.open_note(note_id, index, wait_seconds).await?;
+            perf.insert(
+                "open_ms".into(),
+                json!(t_open.elapsed().as_millis() as u64),
+            );
+            if let Some(strategy) = opened
+                .get("strategy")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+            {
+                perf.insert("open_strategy".into(), json!(strategy));
+            }
             if !script_ok(&opened) {
                 return Ok(
-                    json!({ "ok": false, "open": opened, "error": opened.get("error").and_then(Value::as_str).unwrap_or("open_failed") }),
+                    json!({ "ok": false, "open": opened, "error": opened.get("error").and_then(Value::as_str).unwrap_or("open_failed"), "perf": perf }),
                 );
             }
             if options.poster_url_fallback.trim().is_empty() {
@@ -688,7 +705,7 @@ impl<'a> XhsPageRuntime<'a> {
             open = Some(opened);
         }
         let note = self
-            .extract_note_with_options(wait_seconds, options.clone())
+            .extract_note_with_perf(wait_seconds, options.clone(), &mut perf)
             .await?;
         if !note_id.is_empty() && !note.note_id.is_empty() && note.note_id != note_id {
             // Opened the wrong note. Do NOT fall back to a full-page navigate
@@ -702,9 +719,10 @@ impl<'a> XhsPageRuntime<'a> {
                 "entity": note,
                 "open": open,
                 "error": format!("stale_note: expected {note_id}, got {}", note.note_id),
+                "perf": perf,
             }));
         }
-        Ok(json!({ "ok": true, "entity": note, "open": open }))
+        Ok(json!({ "ok": true, "entity": note, "open": open, "perf": perf }))
     }
 
     pub async fn extract_comments(&self, max_comments: i64) -> Result<Vec<Value>> {
@@ -1250,6 +1268,22 @@ impl<'a> XhsPageRuntime<'a> {
         wait_seconds: f64,
         options: ReadNoteOptions,
     ) -> Result<XhsNote> {
+        let mut perf = Map::new();
+        self.extract_note_with_perf(wait_seconds, options, &mut perf)
+            .await
+    }
+
+    /// `extract_note_with_options`, with per-phase wall times recorded into
+    /// `perf`: `extract_ms` (JS extraction + parsing), `enrich_ms`,
+    /// `download_ms`, and `ocr_inline_ms` — each present only when that phase
+    /// actually ran.
+    async fn extract_note_with_perf(
+        &self,
+        wait_seconds: f64,
+        options: ReadNoteOptions,
+        perf: &mut Map<String, Value>,
+    ) -> Result<XhsNote> {
+        let t_extract = Instant::now();
         let timeout_ms = (wait_seconds.max(0.5) * 1000.0) as i64;
         let raw = self
             .run_script("noteWithWait", Some(&json!({ "timeout_ms": timeout_ms })))
@@ -1299,24 +1333,43 @@ impl<'a> XhsPageRuntime<'a> {
         if note.r#type == "video" && !options.poster_url_fallback.trim().is_empty() {
             apply_video_poster_fallback(&mut note.video, &options.poster_url_fallback);
         }
+        perf.insert(
+            "extract_ms".into(),
+            json!(t_extract.elapsed().as_millis() as u64),
+        );
 
         if options.include_media {
+            let t_enrich = Instant::now();
             self.enrich_note_media(&mut note, options.max_images, options.max_video_frames)
                 .await?;
+            perf.insert(
+                "enrich_ms".into(),
+                json!(t_enrich.elapsed().as_millis() as u64),
+            );
         }
         if options.download_media {
+            let t_download = Instant::now();
             self.download_note_media(&mut note, options.max_images, options.download_video_file)
                 .await?;
+            perf.insert(
+                "download_ms".into(),
+                json!(t_download.elapsed().as_millis() as u64),
+            );
             // OCR runs over the just-downloaded files: each carousel image for
             // an image note, the poster (cover) for a video note.
             if options.ocr {
                 if let Some(media) = &self.media {
+                    let t_ocr = Instant::now();
                     if note.r#type == "video" {
                         media.ocr_downloaded_video_poster(&mut note.video).await;
                     } else {
                         media.ocr_downloaded_images(&mut note.images).await;
                         note.image_count = note.images.len() as i64;
                     }
+                    perf.insert(
+                        "ocr_inline_ms".into(),
+                        json!(t_ocr.elapsed().as_millis() as u64),
+                    );
                 }
             }
         }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -928,6 +928,13 @@ async fn scan_card_note(
         return recorded_skip_entry(card, "already_analyzed", history, ctx, level);
     }
 
+    // Per-phase wall times for the scan perf record (stats/scan.json). Seeded
+    // from the read payload's `perf` (open/extract/download), then extended
+    // with the comment-loading time below. Attached to the entry under the
+    // transient `scan_perf` key; the browse loop strips it before the entry
+    // reaches the artifact or the LLM payload.
+    let mut scan_perf = serde_json::Map::new();
+    let t_read = std::time::Instant::now();
     let read_result = xhs
         .read_note_with_options(
             &card.note_id,
@@ -950,8 +957,17 @@ async fn scan_card_note(
             },
         )
         .await;
+    scan_perf.insert(
+        "read_ms".into(),
+        json!(t_read.elapsed().as_millis() as u64),
+    );
     let mut entry = match read_result {
         Ok(payload) => {
+            if let Some(perf) = payload.get("perf").and_then(Value::as_object) {
+                for (key, value) in perf {
+                    scan_perf.insert(key.clone(), value.clone());
+                }
+            }
             let ok = payload.get("ok").and_then(Value::as_bool).unwrap_or(false);
             let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
             ensure_entity_note_id(&mut entity, card);
@@ -991,10 +1007,13 @@ async fn scan_card_note(
     // comment area and expanding reply threads (replies count toward the total).
     // Scans always include comments — there is no longer a level gate.
     if comment_count > 0 {
-        if let Ok(payload) = xhs
-            .load_comments(comment_count, COMMENT_LOAD_TIMEOUT_S)
-            .await
-        {
+        let t_comments = std::time::Instant::now();
+        let comments_result = xhs.load_comments(comment_count, COMMENT_LOAD_TIMEOUT_S).await;
+        scan_perf.insert(
+            "comments_ms".into(),
+            json!(t_comments.elapsed().as_millis() as u64),
+        );
+        if let Ok(payload) = comments_result {
             let comments = payload
                 .get("comments")
                 .and_then(Value::as_array)
@@ -1034,6 +1053,10 @@ async fn scan_card_note(
         if let Some((note_id, record)) = build_note_record(&entry, ctx, level) {
             ctx.record_note(&note_id, record);
         }
+    }
+
+    if let Some(map) = entry.as_object_mut() {
+        map.insert("scan_perf".into(), Value::Object(scan_perf));
     }
 
     entry
@@ -1137,6 +1160,41 @@ struct NoteOcrTiming {
     started_ms: u64,
     finished_ms: u64,
     predict_ms: u64,
+}
+
+/// Pop the transient `scan_perf` off a scanned entry (so it never reaches the
+/// artifact or the LLM payload) and fold it into one per-note record for
+/// stats/scan.json: the read's phase times (open/extract/download/comments)
+/// plus the loop-level markers measured by the browse loop itself. Cache hits
+/// carry no `scan_perf` and are marked `cached` instead.
+fn harvest_note_perf(
+    entry: &mut Value,
+    idx: usize,
+    started_ms: u64,
+    close_ms: u64,
+    total_ms: u64,
+) -> Value {
+    let mut record = match entry.as_object_mut().and_then(|map| map.remove("scan_perf")) {
+        Some(Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+    let note_id = entry
+        .get("entity")
+        .and_then(|e| e.get("note_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    record.insert("idx".into(), json!(idx));
+    record.insert("note_id".into(), json!(note_id));
+    if entry.get("skipped").is_some() {
+        record.insert("cached".into(), json!(true));
+    }
+    if let Some(ok) = entry.get("ok").and_then(Value::as_bool) {
+        record.insert("ok".into(), json!(ok));
+    }
+    record.insert("started_ms".into(), json!(started_ms));
+    record.insert("close_ms".into(), json!(close_ms));
+    record.insert("total_ms".into(), json!(total_ms));
+    Value::Object(record)
 }
 
 /// Await the background OCR tasks and merge each result back into its note:
@@ -1608,13 +1666,36 @@ fn attach_note_ocr_summary(entity: &mut Value) {
     }
 }
 
-/// OCR performance/debug record, written to a separate file
-/// (`stats/ocr.json` in the tool-call dir) rather than the LLM-facing JSON
-/// artifact. OCR runs as one batched `predict` per note (fast, multi-core), so
-/// timing is per note/batch, not per image. The recognized `ocr_text` stays on
-/// the images for the LLM; only timing lives here.
+/// Per-note phase keys accumulated into `*_total_ms` summary fields by
+/// [`write_scan_perf`]. `total_ms` is summarized as `notes_total_ms`.
+const SCAN_PHASE_KEYS: &[&str] = &[
+    "open_ms",
+    "extract_ms",
+    "enrich_ms",
+    "download_ms",
+    "ocr_inline_ms",
+    "comments_ms",
+    "close_ms",
+];
+
+/// Scan performance/debug record, written to a separate file
+/// (`stats/scan.json` in the tool-call dir) rather than the LLM-facing JSON
+/// artifact.
+///
+/// Each note carries the phases of its serial browse-loop cost —
+/// `started_ms` (relative to scan start), `open_ms` + `open_strategy` (whether
+/// the first card click opened the overlay or a retry was needed),
+/// `extract_ms`, `download_ms`, `comments_ms`, `close_ms`, `read_ms`
+/// (open+extract+download combined, as measured around the whole read), and
+/// `total_ms` — plus, when OCR ran for it, `predict_ms` and
+/// `ocr_started_ms`/`ocr_finished_ms`/`ocr_wall_ms` on the same timeline.
+/// Cache hits are marked `cached` and carry only the loop-level markers.
 ///
 /// `summary` is the key to reading the pipeline. All `*_ms` are wall time:
+///   - per-phase `*_total_ms` — summed serial cost of that phase across notes;
+///     the biggest one is the scan's bottleneck.
+///   - `open_retries` — notes whose overlay needed a retry click (each burns
+///     the per-attempt open wait before the retry).
 ///   - `ocr_predict_total_ms` — summed per-note batch inference (total OCR CPU
 ///     cost).
 ///   - `ocr_wall_ms` — **measured** first-OCR-start → last-OCR-end. OCR tasks
@@ -1624,77 +1705,110 @@ fn attach_note_ocr_summary(entity: &mut Value) {
 ///   - `ocr_overhang_ms` — OCR still running after the browse loop ended (the
 ///     part the pipeline could NOT hide).
 ///   - `scan_total_ms` — whole scan wall.
-///
-/// Each note carries `predict_ms` (its batch inference), plus
-/// `ocr_started_ms`/`ocr_finished_ms`/`ocr_wall_ms` (relative to scan start) so
-/// you can see its OCR span on the same timeline as the browse loop.
-fn write_note_ocr_perf(
+fn write_scan_perf(
     ctx: &ToolContext,
     notes: &[Value],
     browse_loop_ms: u64,
-    timings: &[NoteOcrTiming],
+    ocr_timings: &[NoteOcrTiming],
+    note_perfs: &[Value],
 ) {
-    if timings.is_empty() {
+    if note_perfs.is_empty() && ocr_timings.is_empty() {
         return;
     }
+    let ocr_by_idx: std::collections::HashMap<usize, &NoteOcrTiming> =
+        ocr_timings.iter().map(|t| (t.idx, t)).collect();
+
     let mut note_reports: Vec<Value> = Vec::new();
     let mut total_images: u64 = 0;
     let mut predict_total_ms: u64 = 0;
-    for t in timings {
-        let Some(note) = notes.get(t.idx) else {
+    let mut cached_count: u64 = 0;
+    let mut open_retries: u64 = 0;
+    let mut notes_total_ms: u64 = 0;
+    let mut phase_totals: std::collections::BTreeMap<&str, u64> =
+        std::collections::BTreeMap::new();
+    for perf in note_perfs {
+        let Some(record) = perf.as_object() else {
             continue;
         };
-        let entity = note.get("entity");
-        let note_id = entity
-            .and_then(|e| e.get("note_id"))
+        let mut record = record.clone();
+        let idx = record.get("idx").and_then(Value::as_u64).unwrap_or(0) as usize;
+
+        if record.get("cached").and_then(Value::as_bool) == Some(true) {
+            cached_count += 1;
+        }
+        if record
+            .get("open_strategy")
             .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        let images = entity
+            .is_some_and(|s| s.starts_with("retry"))
+        {
+            open_retries += 1;
+        }
+        notes_total_ms += record.get("total_ms").and_then(Value::as_u64).unwrap_or(0);
+        for key in SCAN_PHASE_KEYS {
+            if let Some(ms) = record.get(*key).and_then(Value::as_u64) {
+                *phase_totals.entry(key).or_insert(0) += ms;
+            }
+        }
+
+        let images = notes
+            .get(idx)
+            .and_then(|note| note.get("entity"))
             .and_then(|e| e.get("images"))
             .and_then(Value::as_array)
             .map(|a| a.len())
             .unwrap_or(0) as u64;
         total_images += images;
-        predict_total_ms += t.predict_ms;
-        note_reports.push(json!({
-            "note_id": note_id,
-            "images": images,
-            "predict_ms": t.predict_ms,
-            "ocr_started_ms": t.started_ms,
-            "ocr_finished_ms": t.finished_ms,
-            "ocr_wall_ms": t.finished_ms.saturating_sub(t.started_ms),
-        }));
-    }
-    if note_reports.is_empty() {
-        return;
+        record.insert("images".into(), json!(images));
+        if let Some(t) = ocr_by_idx.get(&idx) {
+            predict_total_ms += t.predict_ms;
+            record.insert("predict_ms".into(), json!(t.predict_ms));
+            record.insert("ocr_started_ms".into(), json!(t.started_ms));
+            record.insert("ocr_finished_ms".into(), json!(t.finished_ms));
+            record.insert(
+                "ocr_wall_ms".into(),
+                json!(t.finished_ms.saturating_sub(t.started_ms)),
+            );
+        }
+        note_reports.push(Value::Object(record));
     }
 
     // Overall OCR wall = first start → last finish, measured across all notes.
     let ocr_wall_ms = match (
-        timings.iter().map(|t| t.started_ms).min(),
-        timings.iter().map(|t| t.finished_ms).max(),
+        ocr_timings.iter().map(|t| t.started_ms).min(),
+        ocr_timings.iter().map(|t| t.finished_ms).max(),
     ) {
         (Some(start), Some(end)) => end.saturating_sub(start),
         _ => 0,
     };
-    let last_finish = timings.iter().map(|t| t.finished_ms).max().unwrap_or(0);
+    let last_finish = ocr_timings.iter().map(|t| t.finished_ms).max().unwrap_or(0);
     let scan_total_ms = browse_loop_ms.max(last_finish);
     let ocr_overhang_ms = last_finish.saturating_sub(browse_loop_ms);
 
-    let perf = json!({
-        "ocr": ocr_diagnostics(),
-        "summary": {
-            "images": total_images,
-            "ocr_predict_total_ms": predict_total_ms,
-            "ocr_wall_ms": ocr_wall_ms,
-            "browse_loop_ms": browse_loop_ms,
-            "ocr_overhang_ms": ocr_overhang_ms,
-            "scan_total_ms": scan_total_ms,
-        },
-        "notes": note_reports,
-    });
-    write_run_perf_file(ctx, &perf);
+    let mut summary = serde_json::Map::new();
+    summary.insert("notes".into(), json!(note_perfs.len()));
+    summary.insert("notes_cached".into(), json!(cached_count));
+    summary.insert("open_retries".into(), json!(open_retries));
+    summary.insert("images".into(), json!(total_images));
+    summary.insert("notes_total_ms".into(), json!(notes_total_ms));
+    for (key, total) in &phase_totals {
+        let name = format!("{}_total_ms", key.trim_end_matches("_ms"));
+        summary.insert(name, json!(total));
+    }
+    summary.insert("browse_loop_ms".into(), json!(browse_loop_ms));
+    summary.insert("scan_total_ms".into(), json!(scan_total_ms));
+    if !ocr_timings.is_empty() {
+        summary.insert("ocr_predict_total_ms".into(), json!(predict_total_ms));
+        summary.insert("ocr_wall_ms".into(), json!(ocr_wall_ms));
+        summary.insert("ocr_overhang_ms".into(), json!(ocr_overhang_ms));
+    }
+
+    let mut perf = serde_json::Map::new();
+    if !ocr_timings.is_empty() {
+        perf.insert("ocr".into(), ocr_diagnostics());
+    }
+    perf.insert("summary".into(), Value::Object(summary));
+    perf.insert("notes".into(), Value::Array(note_reports));
+    write_run_perf_file(ctx, "scan.json", &Value::Object(perf));
 }
 
 /// OCR performance record for the preview path: all card covers are OCR'd in one
@@ -1716,17 +1830,17 @@ fn write_cover_ocr_perf(
             "ocr_wall_ms": wall.as_millis() as u64,
         },
     });
-    write_run_perf_file(ctx, &perf);
+    write_run_perf_file(ctx, "ocr.json", &perf);
 }
 
-/// Write the tool-specific OCR record under the current tool call's `stats/`.
-fn write_run_perf_file(ctx: &ToolContext, perf: &Value) {
+/// Write a tool-specific perf record under the current tool call's `stats/`.
+fn write_run_perf_file(ctx: &ToolContext, name: &str, perf: &Value) {
     let stats_dir = ctx.output_dir().join("stats");
     if std::fs::create_dir_all(&stats_dir).is_err() {
         return;
     }
     if let Ok(rendered) = serde_json::to_string_pretty(perf) {
-        let _ = std::fs::write(stats_dir.join("ocr.json"), rendered);
+        let _ = std::fs::write(stats_dir.join(name), rendered);
     }
 }
 
@@ -1992,13 +2106,27 @@ impl Tool for ReadNoteTool {
         if value.get("ok").and_then(Value::as_bool).unwrap_or(false) {
             // The note modal is still open here (the command's `after` hook
             // closes it), so always attach top comments before recording.
+            let mut comments_ms = None;
             if let Some(entity) = value.get_mut("entity") {
+                let t_comments = std::time::Instant::now();
                 attach_top_comments(&xhs, entity).await;
+                comments_ms = Some(t_comments.elapsed().as_millis() as u64);
+            }
+            if let (Some(ms), Some(perf)) = (
+                comments_ms,
+                value.get_mut("perf").and_then(Value::as_object_mut),
+            ) {
+                perf.insert("comments_ms".into(), json!(ms));
             }
             if let Some(entity) = value.get("entity") {
                 self.history
                     .record(entity, &options.level, options.include_media);
             }
+        }
+        // Phase timing is a debug record, not analysis input: move it out of
+        // the LLM-facing payload into stats/read.json.
+        if let Some(perf) = value.as_object_mut().and_then(|map| map.remove("perf")) {
+            write_run_perf_file(ctx, "read.json", &json!({ "read": perf }));
         }
         Ok(json_result(&value))
     }
@@ -2750,6 +2878,7 @@ impl Tool for SearchTool {
         // download; tasks are joined after the browse loop.
         let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
         let mut pending_ocr: Vec<(usize, tokio::task::JoinHandle<NoteOcrResult>)> = Vec::new();
+        let mut note_perfs: Vec<Value> = Vec::new();
         let scan_progress = ScanProgress::new(ctx, want);
         // Wall-clock markers so the perf file can show how much OCR overlapped
         // the browse loop (the pipeline benefit) vs. spilled past it.
@@ -2785,6 +2914,7 @@ impl Tool for SearchTool {
             let item_index = notes.len() + 1;
             let title = progress_title(&card);
             scan_progress.reading_started(item_index, title.clone());
+            let note_started_ms = browse_t0.elapsed().as_millis() as u64;
 
             let entry = scan_card_note(
                 &xhs,
@@ -2819,8 +2949,18 @@ impl Tool for SearchTool {
                     scan_progress.ocr_completed(item_index, title.clone());
                 }
             }
+            let t_close = std::time::Instant::now();
             let _ = xhs.close_note(0.6).await;
+            let close_ms = t_close.elapsed().as_millis() as u64;
             scan_progress.reading_completed(item_index, title);
+            let total_ms = (browse_t0.elapsed().as_millis() as u64).saturating_sub(note_started_ms);
+            note_perfs.push(harvest_note_perf(
+                &mut notes[idx],
+                idx,
+                note_started_ms,
+                close_ms,
+                total_ms,
+            ));
         }
 
         scan_progress.finish_reading(notes.len());
@@ -2829,10 +2969,10 @@ impl Tool for SearchTool {
         // browse_ms) and merge results back into the notes in place.
         let ocr_timings =
             join_note_ocr(&mut notes, pending_ocr, &self.history, level, include_media).await;
-        // Write OCR perf to a separate debug file and strip per-image ocr_ms from
-        // the notes so the JSON artifact stays LLM-facing (ocr_text only).
+        // Write the scan perf record (per-note phase timing + OCR pipeline) to a
+        // separate debug file; the JSON artifact stays LLM-facing.
+        write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
         if ocr {
-            write_note_ocr_perf(ctx, &notes, browse_ms, &ocr_timings);
             scan_progress.finish_ocr(notes.len());
         }
 
@@ -2893,8 +3033,9 @@ impl Tool for SearchTool {
                 map.insert("filters".into(), summary);
             }
         }
-        // OCR perf (model / EP / machine / per-image timing) is written to
-        // `stats/ocr.json` (see write_note_ocr_perf above), not the JSON artifact.
+        // Scan perf (per-note phases + OCR model / EP / machine timing) is
+        // written to `stats/scan.json` (see write_scan_perf above), not the
+        // JSON artifact.
         if let Some((media_manifest_count, media_manifest_path, media_manifest_error)) =
             media_manifest_metadata
         {
@@ -3127,6 +3268,7 @@ impl Tool for AuthorScanTool {
             // download; tasks are joined after the loop.
             let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
             let mut pending_ocr: Vec<(usize, tokio::task::JoinHandle<NoteOcrResult>)> = Vec::new();
+            let mut note_perfs: Vec<Value> = Vec::new();
             let scan_progress = ScanProgress::new(ctx, cards.len());
             let browse_t0 = std::time::Instant::now();
             for card in &cards {
@@ -3136,6 +3278,7 @@ impl Tool for AuthorScanTool {
                 let item_index = notes.len() + 1;
                 let title = progress_title(card);
                 scan_progress.reading_started(item_index, title.clone());
+                let note_started_ms = browse_t0.elapsed().as_millis() as u64;
                 let entry = scan_card_note(
                     &xhs,
                     &self.history,
@@ -3167,15 +3310,26 @@ impl Tool for AuthorScanTool {
                         scan_progress.ocr_completed(item_index, title.clone());
                     }
                 }
+                let t_close = std::time::Instant::now();
                 let _ = xhs.close_note(0.6).await;
+                let close_ms = t_close.elapsed().as_millis() as u64;
                 scan_progress.reading_completed(item_index, title);
+                let total_ms =
+                    (browse_t0.elapsed().as_millis() as u64).saturating_sub(note_started_ms);
+                note_perfs.push(harvest_note_perf(
+                    &mut notes[idx],
+                    idx,
+                    note_started_ms,
+                    close_ms,
+                    total_ms,
+                ));
             }
             scan_progress.finish_reading(notes.len());
             let browse_ms = browse_t0.elapsed().as_millis() as u64;
             let ocr_timings =
                 join_note_ocr(&mut notes, pending_ocr, &self.history, "deep", false).await;
+            write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
             if ocr {
-                write_note_ocr_perf(ctx, &notes, browse_ms, &ocr_timings);
                 scan_progress.finish_ocr(notes.len());
             }
         } else if ocr {
@@ -3248,7 +3402,7 @@ impl Tool for AuthorScanTool {
             "timing": { "media": media_timing },
         });
 
-        // OCR perf is written to `stats/ocr.json` (see above), not the artifact.
+        // Scan perf is written to `stats/scan.json` (see above), not the artifact.
 
         if let Some((count, path, error)) = media_manifest_metadata {
             if let Some(map) = payload.as_object_mut() {


### PR DESCRIPTION
## What

Scans previously wrote only OCR timing (`stats/ocr.json`); the browse loop — the actual bottleneck — was unmeasured. Now every scanned note records its full serial cost breakdown in **`stats/scan.json`**:

- `open_ms` + `open_strategy` (first click vs `retry_*_click`), `extract_ms`, `download_ms`, `comments_ms`, `close_ms`, `read_ms`, `started_ms`/`total_ms` on the browse-loop timeline; cache hits are marked `cached`.
- OCR pipeline fields (`predict_ms`, `ocr_started/finished/wall_ms`) merge into the same per-note record. `summary` gains per-phase `*_total_ms` plus `open_retries` — the biggest phase total is the scan's bottleneck at a glance.
- `read_note` writes the same phase record to `stats/read.json` (stripped from the LLM-facing payload).
- `media_manifest.json` items carry `download_ms` (per image inside the concurrent batch, video file, video poster).

`stats/scan.json` replaces the scan-path `ocr.json`; the cards-preview cover-OCR record keeps the `ocr.json` name.

## Example (real run, release build, VPN on, 10 notes per call)

| call | browse loop | open | extract | comments | download | close | OCR predict | OCR busy¹ | OCR overhang² |
|---|---|---|---|---|---|---|---|---|---|
| t1-01 | 37.8s | 3.1s | 14.7s | 10.9s | 3.9s | 4.9s | 8.8s | 11.6s | 4.1s |
| t1-02 | 42.1s | 3.3s | 12.0s | 17.0s | 4.6s | 4.9s | 5.4s | 7.5s | 2.7s |
| t1-03 | 58.2s | 22.7s | 13.4s | 10.5s | 3.7s | 6.9s | 5.9s | 8.4s | 0 |
| t1-04 | 62.9s | 31.4s | 9.8s | 10.5s | 3.4s | 7.6s | 3.4s | 4.5s | 0 |
| t2-01 | 199.2s | 46.4s | 35.7s | 64.7s | 27.8s | 24.6s | —³ | — | — |
| t2-02 | 86.1s | 27.1s | 39.4s | 10.9s | 2.8s | 5.9s | —³ | — | — |
| t2-03 | 32.8s | 11.9s | 4.7s | 5.7s | 1.2s | 9.3s | 0.3s | 4.2s | 0 |
| t2-04 | 49.6s | 14.7s | 4.8s | 22.9s | 2.9s | 4.2s | 2.0s | 36.1s⁴ | 0 |

¹ sum of per-note OCR walls, fully overlapped with browsing; ² the only OCR share that adds to total wall; ³ no OCR entries — nearly all fresh notes in those calls failed (`ok=false`, stale-note opens), and OCR only spawns for successful reads; ⁴ first-start→last-finish span, predict was 2.0s.

What the new data already surfaced on this one run:

- Downloads are cheap for images (40–1160ms/note) even over VPN, but a **video file download blocked one note for 25.2s** — visible per-item in the manifest now.
- The mid-scan slowdown is a constant **~5.3s `open_ms` with `cover_click`** (first click succeeds; no retries) — overlay hydration pinned near the 3s per-attempt wait plus ~2s card lookup, kicking in after a few dozen opens and never recovering: throttling-shaped, now measurable.
- `num_comments: 5` occasionally sends `load_comments` into long scroll loops (9.6–35.5s outliers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)