### PR TITLE
feat: refresh model catalog (sonnet 5), weekly auto-sync workflow

### DIFF
--- a/.claude/skills/socai-model-sync/SKILL.md
+++ b/.claude/skills/socai-model-sync/SKILL.md
@@ -123,7 +123,7 @@ PY
 Expected UI behavior:
 
 - The desktop model menu groups rows by provider.
-- Each row shows a human name plus the concrete API model id.
+- Each row shows only the human display name.
 - API-key entry remains provider-level, not model-level.
 - Selecting a model persists `defaults.provider` and `defaults.{provider}_model`
   in `~/.socai/auth.json`.

--- a/.github/workflows/model-catalog-sync.yml
+++ b/.github/workflows/model-catalog-sync.yml
@@ -1,0 +1,122 @@
+name: model-catalog-sync
+
+on:
+  schedule:
+    # mondays 01:00 UTC (09:00 Beijing)
+    - cron: "0 1 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: model-catalog-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: refresh model catalog from latest pi-ai
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+          run_install: false
+
+      - name: set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: snapshot current catalog
+        run: cp core/src/agent/model_catalog.generated.json /tmp/catalog-before.json
+
+      - name: bump pi-ai to latest
+        working-directory: app
+        run: pnpm add -D -E @earendil-works/pi-ai@latest
+
+      - name: regenerate model catalog
+        run: node scripts/sync-model-catalog.mjs --no-official --write
+
+      - name: summarize catalog changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- core/src/agent/model_catalog.generated.json; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            echo "catalog unchanged; skipping PR"
+            exit 0
+          fi
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+
+          PI_AI_VERSION="$(node -p "require('./app/node_modules/@earendil-works/pi-ai/package.json').version")"
+          echo "pi_ai_version=${PI_AI_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          node - <<'EOF' > /tmp/pr-body.md
+          const fs = require("node:fs");
+          const before = JSON.parse(fs.readFileSync("/tmp/catalog-before.json", "utf8")).providers;
+          const after = JSON.parse(fs.readFileSync("core/src/agent/model_catalog.generated.json", "utf8")).providers;
+          const piVersion = require("./app/node_modules/@earendil-works/pi-ai/package.json").version;
+
+          const lines = [
+            "Weekly automated refresh of `core/src/agent/model_catalog.generated.json`",
+            `against pi-ai **${piVersion}** (\`sync-model-catalog.mjs --no-official --write\`).`,
+            "",
+            "## model changes",
+            "",
+          ];
+          const providers = [...new Set([...Object.keys(before), ...Object.keys(after)])].sort();
+          for (const provider of providers) {
+            const ids = (entries) => new Set((entries || []).map((m) => m.id));
+            const b = ids(before[provider]);
+            const a = ids(after[provider]);
+            const added = [...a].filter((id) => !b.has(id));
+            const removed = [...b].filter((id) => !a.has(id));
+            if (added.length === 0 && removed.length === 0) continue;
+            lines.push(`### ${provider}`);
+            for (const id of added) lines.push(`- added \`${id}\``);
+            for (const id of removed) lines.push(`- removed \`${id}\``);
+            lines.push("");
+          }
+          if (lines.length === 5) {
+            lines.push("_No model ids added or removed; ordering or metadata changed._", "");
+          }
+          lines.push(
+            "## review checklist",
+            "",
+            "- [ ] Qwen ids are valid DashScope model ids (pi routes Qwen through third-party providers; normalization is judgment-based)",
+            "- [ ] every provider still lists its compiled default from `core/src/agent/provider.rs`",
+            "- [ ] exactly one `recommended` entry per provider",
+            "",
+            "🤖 Generated with [Claude Code](https://claude.com/claude-code)",
+          );
+          console.log(lines.join("\n"));
+          EOF
+
+      - name: create pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/model-catalog-sync
+          delete-branch: true
+          commit-message: "chore: refresh model catalog from pi-ai ${{ steps.diff.outputs.pi_ai_version }}"
+          title: "chore: refresh model catalog from pi-ai ${{ steps.diff.outputs.pi_ai_version }}"
+          body-path: /tmp/pr-body.md
+          add-paths: |
+            core/src/agent/model_catalog.generated.json
+            app/package.json
+            app/pnpm-lock.yaml

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "marked": "^18.0.5"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.79.3",
+    "@earendil-works/pi-ai": "0.80.3",
     "@tauri-apps/cli": "^2.11.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         version: 18.0.5
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.79.3
-        version: 0.79.3(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.80.3
+        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
       '@tauri-apps/cli':
         specifier: ^2.11.1
         version: 2.11.1
@@ -153,8 +153,8 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@earendil-works/pi-ai@0.79.3':
-    resolution: {integrity: sha512-lMSput/haP5uZAGbXhS5rAYd3GB7GYdJkoAUxg3VFummBeqGqGqllaTWrbHFN12kVGyVfWHhdySNXkiqVh65Iw==}
+  '@earendil-works/pi-ai@0.80.3':
+    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -323,11 +323,24 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -967,7 +980,7 @@ snapshots:
       '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -1147,12 +1160,13 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@earendil-works/pi-ai@0.79.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.3(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -1256,16 +1270,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   '@nodable/entities@2.2.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -470,10 +470,9 @@ export namespace agentPanel {
   }
 
   function modelOptionLabel(info: ModelInfo): string {
-    const id = modelId(info);
     const name = modelNameLabel(info);
     const recommended = info.recommended ? ` (${t("agent.defaultModel")})` : "";
-    return name === id ? `${name}${recommended}` : `${name} — ${id}${recommended}`;
+    return `${name}${recommended}`;
   }
 
   function modelDisplayLabel(info: ModelInfo): string {

--- a/core/src/agent/model_catalog.generated.json
+++ b/core/src/agent/model_catalog.generated.json
@@ -3,6 +3,12 @@
   "providers": {
     "anthropic": [
       {
+        "id": "claude-sonnet-5",
+        "display_name": "Claude Sonnet 5",
+        "source": "pi-ai",
+        "recommended": true
+      },
+      {
         "id": "claude-fable-5",
         "display_name": "Claude Fable 5",
         "source": "pi-ai"
@@ -25,8 +31,7 @@
       {
         "id": "claude-sonnet-4-6",
         "display_name": "Claude Sonnet 4.6",
-        "source": "pi-ai",
-        "recommended": true
+        "source": "pi-ai"
       },
       {
         "id": "claude-opus-4-5-20251101",
@@ -99,18 +104,8 @@
         "source": "pi-ai"
       },
       {
-        "id": "claude-3-5-haiku-20241022",
-        "display_name": "Claude Haiku 3.5",
-        "source": "pi-ai"
-      },
-      {
         "id": "claude-3-5-sonnet-20240620",
         "display_name": "Claude Sonnet 3.5",
-        "source": "pi-ai"
-      },
-      {
-        "id": "claude-3-5-haiku-latest",
-        "display_name": "Claude Haiku 3.5 (latest)",
         "source": "pi-ai"
       },
       {
@@ -334,9 +329,14 @@
     ],
     "kimi": [
       {
+        "id": "kimi-k2.7-code-highspeed",
+        "display_name": "Kimi K2.7 Code HighSpeed",
+        "source": "pi-ai"
+      },
+      {
         "id": "kimi-k2.7-code",
         "display_name": "Kimi K2.7 Code",
-        "source": "fallback"
+        "source": "pi-ai"
       },
       {
         "id": "kimi-k2.6",
@@ -384,13 +384,13 @@
       {
         "id": "qwen3.7-plus",
         "display_name": "Qwen 3.7 Plus",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "recommended": true
       },
       {
         "id": "qwen3.6-plus-2026-04-02",
         "display_name": "Qwen 3.6 Plus (2026-04-02)",
-        "source": "fallback",
-        "recommended": true
+        "source": "fallback"
       },
       {
         "id": "qwen3.6-max-preview",

--- a/core/src/agent/provider.rs
+++ b/core/src/agent/provider.rs
@@ -139,7 +139,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         provider: Provider::Anthropic,
         display_name: "Anthropic",
-        default_model: "claude-sonnet-4-6",
+        default_model: "claude-sonnet-5",
         env_keys: &["ANTHROPIC_API_KEY"],
         base_url: None,
         model_prefixes: &["claude-"],
@@ -163,7 +163,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         provider: Provider::Qwen,
         display_name: "Qwen",
-        default_model: "qwen3.6-plus-2026-04-02",
+        default_model: "qwen3.7-plus",
         env_keys: &["QWEN_API_KEY", "DASHSCOPE_API_KEY"],
         base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
         model_prefixes: &["qwen", "qwq-", "qvq-"],
@@ -171,7 +171,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         provider: Provider::QwenIntl,
         display_name: "Qwen International",
-        default_model: "qwen3.6-plus-2026-04-02",
+        default_model: "qwen3.7-plus",
         env_keys: &["QWEN_INTL_API_KEY", "DASHSCOPE_INTL_API_KEY"],
         base_url: Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         // Model ids are identical to mainland Qwen, so prefix inference

--- a/scripts/sync-model-catalog.mjs
+++ b/scripts/sync-model-catalog.mjs
@@ -16,7 +16,8 @@ const noPi = args.has("--no-pi");
 
 const FALLBACK = {
   anthropic: [
-    entry("claude-sonnet-4-6", "Claude Sonnet 4.6", "fallback", true),
+    entry("claude-sonnet-5", "Claude Sonnet 5", "fallback", true),
+    entry("claude-sonnet-4-6", "Claude Sonnet 4.6"),
     entry("claude-opus-4-8", "Claude Opus 4.8"),
     entry("claude-opus-4-6", "Claude Opus 4.6"),
     entry("claude-haiku-4-5", "Claude Haiku 4.5"),
@@ -36,8 +37,8 @@ const FALLBACK = {
     entry("kimi-k2-thinking", "Kimi K2 Thinking"),
   ],
   qwen: [
-    entry("qwen3.6-plus-2026-04-02", "Qwen 3.6 Plus (2026-04-02)", "fallback", true),
-    entry("qwen3.7-plus", "Qwen 3.7 Plus"),
+    entry("qwen3.7-plus", "Qwen 3.7 Plus", "fallback", true),
+    entry("qwen3.6-plus-2026-04-02", "Qwen 3.6 Plus (2026-04-02)"),
     entry("qwen3.7-max", "Qwen 3.7 Max"),
     entry("qwen3.6-plus", "Qwen 3.6 Plus"),
     entry("qwen3.6-max-preview", "Qwen 3.6 Max Preview"),
@@ -156,15 +157,22 @@ async function loadPiAi() {
   const tried = [];
   const tryImport = async (specifier) => {
     try {
-      return await import(specifier);
+      const mod = await import(specifier);
+      // pi-ai < 0.80 exports getModels(provider) from the package root;
+      // 0.80+ keeps that legacy read on the "compat" entry point.
+      if (mod?.getModels) return mod;
+      tried.push(`${specifier}: no getModels export`);
+      return undefined;
     } catch (error) {
       tried.push(`${specifier}: ${error.message}`);
       return undefined;
     }
   };
 
-  const direct = await tryImport("@earendil-works/pi-ai");
-  if (direct?.getModels) return direct;
+  for (const specifier of ["@earendil-works/pi-ai", "@earendil-works/pi-ai/compat"]) {
+    const direct = await tryImport(specifier);
+    if (direct) return direct;
+  }
 
   let globalRoot;
   try {
@@ -173,17 +181,20 @@ async function loadPiAi() {
     globalRoot = "";
   }
 
-  const candidates = [
-    path.join(repoRoot, "app/node_modules/@earendil-works/pi-ai/dist/index.js"),
-    globalRoot && path.join(globalRoot, "@earendil-works/pi-ai/dist/index.js"),
-    globalRoot && path.join(globalRoot, "@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/index.js"),
-    "/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/index.js",
+  const packageRoots = [
+    path.join(repoRoot, "app/node_modules/@earendil-works/pi-ai"),
+    globalRoot && path.join(globalRoot, "@earendil-works/pi-ai"),
+    globalRoot && path.join(globalRoot, "@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai"),
+    "/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai",
   ].filter(Boolean);
 
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) continue;
-    const imported = await tryImport(pathToFileURL(candidate).href);
-    if (imported?.getModels) return imported;
+  for (const root of packageRoots) {
+    for (const file of ["dist/index.js", "dist/compat.js"]) {
+      const candidate = path.join(root, file);
+      if (!existsSync(candidate)) continue;
+      const imported = await tryImport(pathToFileURL(candidate).href);
+      if (imported) return imported;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- Bump `@earendil-works/pi-ai` 0.79.3 → 0.80.3; adapt `scripts/sync-model-catalog.mjs` to the 0.80+ API (legacy `getModels(provider)` now lives on the `compat` entry point; the loader tries package root then `compat`, for both bare specifiers and local file candidates).
- Regenerate `core/src/agent/model_catalog.generated.json`: **`claude-sonnet-5` lands** (anthropic 24 models, was stale since June with only fable 5), kimi picks up `kimi-k2.7-code-highspeed`.
- Defaults: anthropic → `claude-sonnet-5`, qwen + qwen-intl → `qwen3.7-plus` (both compiled defaults in `provider.rs` and `recommended` markers in the sync fallback table).
- Desktop model picker now shows display names only (drops the `— model-id` suffix).
- New `model-catalog-sync` workflow: weekly cron (Mon 01:00 UTC) installs **latest** pi-ai, regenerates the catalog, and auto-opens a PR with a per-provider add/remove summary when the catalog changed. Requires the org/repo "Allow GitHub Actions to create and approve pull requests" setting (already enabled).

## Validation

- `cargo test` all green (89 + 6 + 1 passed)
- `pnpm --dir app build` succeeds
- `sync --no-official --check` idempotent after regeneration
- Workflow YAML parses; PR-body diff script dry-run against this change produces the expected summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)