### PR TITLE
fix(app): align answer citation pills with surrounding text

### DIFF
--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1217,7 +1217,7 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
 
 /* ── answer citations (inline pill + hover preview) ────────────────── */
 .note-cite {
-  display: inline-flex; align-items: center; gap: 5px; vertical-align: baseline;
+  display: inline-flex; align-items: center; gap: 5px; vertical-align: middle;
   padding: 1px 8px 1px 4px; margin: 0 1px; border: var(--hairline); border-radius: var(--r-pill);
   background: var(--surface); color: var(--fg-muted); font-size: 0.85em; line-height: 1.35; cursor: pointer;
   transition: border-color var(--t-fast) var(--ease), color var(--t-fast) var(--ease);


### PR DESCRIPTION
## Summary
- Answer citation pills (`.note-cite`) rendered ~4px higher than the surrounding answer text (see screenshot report from the embedded-notes feature).
- Root cause: an `inline-flex` box derives its baseline from its **first flex item** — here the 15px cover thumbnail, which contains no text, so its baseline is synthesized from its bottom edge. `vertical-align: baseline` therefore pinned the thumbnail's bottom to the sentence baseline, lifting the entire pill.
- Fix: `vertical-align: middle`, which centers the pill on the line. Since the label is already vertically centered inside the pill, its text lands within a fraction of a pixel of the surrounding baseline at current sizes (13px body / 11px label / 15px dot). This also matches `.note-chip`, the timeline variant, which already used `middle`.

## Test plan
- [ ] Run `pnpm exec tauri dev`, open a run whose answer cites notes, and confirm the pills sit on the text line instead of floating above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)