### PR TITLE
fix(app): give note-viewer videos their full width and a taller panel

### DIFF
--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -285,13 +285,9 @@ function metaPanel(note: NoteData): string {
 function viewerHTML(note: NoteData): string {
   const name = esc((note.author && note.author.name) || "");
   const handle = esc((note.author && note.author.handle) || note.note_id);
-  // Video notes get the taller panel: a portrait 9:16 stage needs the vertical
-  // room, and the extra height widens the height-driven video column enough
-  // for the native controls to show their full timeline.
-  const video = coverOf(note).kind === "video" ? " note-viewer-panel--video" : "";
   return `
     <div class="note-viewer-backdrop" data-note-close>
-      <div class="note-viewer-panel${video}" role="dialog" aria-label="${esc(note.title || "note")}" data-note-stop>
+      <div class="note-viewer-panel" role="dialog" aria-label="${esc(note.title || "note")}" data-note-stop>
         <div class="note-viewer-head">
           <span class="note-viewer-head__author">
             ${avatar(note, "note-viewer-head__avatar")}

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -103,7 +103,7 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
     }
     return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${
       decorative ? "" : `<span class="note-media__play">${IC.play()}</span>`
-    }${m.dur && !decorative ? `<span class="note-media__dur t-mono">${esc(m.dur)}</span>` : ""}</span></span>`;
+    }${m.dur && !decorative ? `<span class="note-media__dur">${esc(m.dur)}</span>` : ""}</span></span>`;
   }
   const url = assetUrl(note, m.src);
   // gallery slides are pre-rendered hidden — lazy would defer them to first
@@ -111,7 +111,7 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
   const img = url
     ? `<img class="note-media__img" src="${esc(url)}" alt=""${variant === "gallery" ? "" : ` loading="lazy"`} />`
     : `<span class="note-media--placeholder" style="position:absolute;inset:0"></span>`;
-  const badge = count > 1 && !decorative ? `<span class="note-media__count t-mono">${IC.stack()}${count}</span>` : "";
+  const badge = count > 1 && !decorative ? `<span class="note-media__count">${IC.stack()}${count}</span>` : "";
   return `<span class="note-media" data-kind="image">${img}${badge}</span>`;
 }
 
@@ -142,7 +142,7 @@ function coverInner(note: NoteData, idx: number): string {
   const nav = multi
     ? `<button type="button" class="note-card__nav note-card__nav--prev" data-note-nav="-1" aria-label="previous image">${IC.chevL()}</button>` +
       `<button type="button" class="note-card__nav note-card__nav--next" data-note-nav="1" aria-label="next image">${IC.chevR()}</button>` +
-      `<span class="note-card__idx t-mono">${i + 1}/${media.length}</span>`
+      `<span class="note-card__idx">${i + 1}/${media.length}</span>`
     : "";
   return mediaFrame(note, media[i], "cover") + nav;
 }

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -132,6 +132,9 @@ function avatar(note: NoteData, cls = ""): string {
 }
 
 // ── rich card (the timeline embed unit + answer sources) ────────────
+// The carousel corner belongs to the `1/2` idx chip alone — the ▣-count badge
+// (same corner, same pill) is for static covers only; stacking both reads as
+// a broken chip. Rich covers carousel, compact covers stay static (design).
 function coverInner(note: NoteData, idx: number): string {
   const media = note.media && note.media.length ? note.media : [coverOf(note)];
   const i = Math.max(0, Math.min(idx, media.length - 1));
@@ -141,14 +144,18 @@ function coverInner(note: NoteData, idx: number): string {
       `<button type="button" class="note-card__nav note-card__nav--next" data-note-nav="1" aria-label="next image">${IC.chevR()}</button>` +
       `<span class="note-card__idx t-mono">${i + 1}/${media.length}</span>`
     : "";
-  return mediaFrame(note, media[i], "cover", media.length) + nav;
+  return mediaFrame(note, media[i], "cover") + nav;
 }
 function renderCard(note: NoteData, density: "rich" | "compact" = "rich"): string {
   const title = esc(note.title || "");
   const name = esc((note.author && note.author.name) || "");
+  const cover =
+    density === "rich"
+      ? `<div class="note-card__cover" data-note-cover="${esc(note.note_id)}" data-idx="0">${coverInner(note, 0)}</div>`
+      : `<div class="note-card__cover">${mediaFrame(note, coverOf(note), "cover", (note.media || []).length)}</div>`;
   return `
     <div class="note-card" data-density="${density}" data-note-open="${esc(note.note_id)}" role="button" tabindex="0" title="${title}">
-      <div class="note-card__cover" data-note-cover="${esc(note.note_id)}" data-idx="0">${coverInner(note, 0)}</div>
+      ${cover}
       <div class="note-card__body">
         <div class="note-card__title">${title}</div>
         ${statsRow(note)}

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -84,8 +84,10 @@ function kindIcon(note: NoteData): string {
 }
 
 // ── media frame ─────────────────────────────────────────────────────
-// Universal 3:4 frame. Images fill (cover). A 9:16 video is pillarboxed inside.
-// `gallery` renders a real <video controls>; elsewhere video shows poster+play.
+// Cards/thumbs/dots: universal 3:4 frame — images fill (cover), a 9:16 video
+// is pillarboxed inside. `gallery` is full-bleed: the gallery frame adopts the
+// media's own ratio (see frameRatio), so a real <video controls> spans the
+// frame's full width and the native timeline scrubber has room to render.
 type MediaVariant = "cover" | "thumb" | "dot" | "gallery";
 function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count = 0): string {
   const decorative = variant === "thumb" || variant === "dot";
@@ -97,7 +99,7 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
       const inner = videoUrl
         ? `<video class="note-media__img" controls preload="metadata"${posterUrl ? ` poster="${esc(posterUrl)}"` : ""} src="${esc(videoUrl)}"></video>`
         : `${posterImg}<span class="note-media__play">${IC.play()}</span>`;
-      return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${inner}</span></span>`;
+      return `<span class="note-media" data-kind="video">${inner}</span>`;
     }
     return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${
       decorative ? "" : `<span class="note-media__play">${IC.play()}</span>`
@@ -213,6 +215,14 @@ export function renderNoteAnswer(src: string): string {
 }
 
 // ── viewer (lightbox) ───────────────────────────────────────────────
+// The gallery frame hugs the current media's own ratio (core stamps "9:16" on
+// videos, "3:4" on images) rather than the cards' universal 3:4 — no gray
+// pillarbox bars, and the video's native controls get the full frame width.
+function frameRatio(m: NoteMedia): string {
+  const parsed = /^(\d+)\s*:\s*(\d+)$/.exec(m.ratio || "");
+  if (parsed) return `${parsed[1]} / ${parsed[2]}`;
+  return m.kind === "video" ? "9 / 16" : "3 / 4";
+}
 function galleryStage(note: NoteData, idx: number): string {
   const media = note.media && note.media.length ? note.media : [coverOf(note)];
   const i = Math.max(0, Math.min(idx, media.length - 1));
@@ -221,7 +231,7 @@ function galleryStage(note: NoteData, idx: number): string {
     ? `<button type="button" class="note-gallery__nav note-gallery__nav--prev" data-gallery-nav="-1"${i === 0 ? " disabled" : ""} aria-label="previous">${IC.chevL()}</button>` +
       `<button type="button" class="note-gallery__nav note-gallery__nav--next" data-gallery-nav="1"${i === media.length - 1 ? " disabled" : ""} aria-label="next">${IC.chevR()}</button>`
     : "";
-  return `<div class="note-gallery__frame">${mediaFrame(note, media[i], "gallery")}</div>${nav}`;
+  return `<div class="note-gallery__frame" style="aspect-ratio: ${frameRatio(media[i])}">${mediaFrame(note, media[i], "gallery")}</div>${nav}`;
 }
 function galleryThumbs(note: NoteData, idx: number): string {
   const media = note.media || [];
@@ -267,9 +277,13 @@ function metaPanel(note: NoteData): string {
 function viewerHTML(note: NoteData): string {
   const name = esc((note.author && note.author.name) || "");
   const handle = esc((note.author && note.author.handle) || note.note_id);
+  // Video notes get the taller panel: a portrait 9:16 stage needs the vertical
+  // room, and the extra height widens the height-driven video column enough
+  // for the native controls to show their full timeline.
+  const video = coverOf(note).kind === "video" ? " note-viewer-panel--video" : "";
   return `
     <div class="note-viewer-backdrop" data-note-close>
-      <div class="note-viewer-panel" role="dialog" aria-label="${esc(note.title || "note")}" data-note-stop>
+      <div class="note-viewer-panel${video}" role="dialog" aria-label="${esc(note.title || "note")}" data-note-stop>
         <div class="note-viewer-head">
           <span class="note-viewer-head__author">
             ${avatar(note, "note-viewer-head__avatar")}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1055,7 +1055,8 @@ body.has-paper > * { position: relative; z-index: 1; }
    download served via the asset protocol (convertFileSrc). Ported from the
    Claude Design handoff (notes.css). */
 
-/* ── media frame (universal 3:4; video pillarboxed to 9:16 inside) ── */
+/* ── media frame (cards: universal 3:4, video pillarboxed to 9:16 inside;
+      the viewer gallery instead adopts the media's own ratio — full-bleed) ── */
 .note-media {
   position: relative;
   width: 100%;
@@ -1250,6 +1251,11 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
   overflow: hidden; min-height: 0; width: min(900px, 96vw); max-height: min(620px, 90vh);
   border-radius: var(--r-5); box-shadow: var(--shadow-pop);
 }
+/* Video notes are mostly 9:16 portrait — a taller panel gives the stage the
+   vertical room, which in turn widens the height-driven video column so the
+   native controls render their full timeline (narrow videos collapse to a
+   scrubber-less pill). */
+.note-viewer-panel--video { max-height: min(800px, 90vh); }
 .note-viewer-head {
   flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 12px;
   padding: 11px 12px 11px 14px; border-bottom: var(--hairline); background: var(--surface);
@@ -1270,6 +1276,8 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
 
 .note-gallery { position: relative; display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--ink-8); }
 .note-gallery__stage { position: relative; flex: 1; display: flex; align-items: center; justify-content: center; padding: 18px; min-height: 0; }
+/* aspect-ratio here is only the fallback — galleryStage sets the current
+   media's own ratio inline (9:16 videos render full-bleed, no pillarbox). */
 .note-gallery__frame { position: relative; max-width: 100%; max-height: 100%; aspect-ratio: 3 / 4; height: 100%; border-radius: var(--r-3); overflow: hidden; border: var(--hairline); }
 .note-gallery__frame .note-media__img { object-fit: contain; background: var(--ink-8); }
 .note-gallery__nav {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1246,16 +1246,14 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
   padding: var(--sp-6); background: rgba(10, 10, 10, 0.42); animation: noteFade var(--t-base) var(--ease);
 }
 @keyframes noteFade { from { opacity: 0; } to { opacity: 1; } }
+/* The tall panel is deliberate: media viewing wants the vertical room. For
+   9:16 video the height also drives the width — wide enough that the native
+   controls render their full timeline instead of the scrubber-less pill. */
 .note-viewer-panel {
   display: flex; flex-direction: column; background: var(--surface); border: var(--hairline);
-  overflow: hidden; min-height: 0; width: min(900px, 96vw); max-height: min(620px, 90vh);
+  overflow: hidden; min-height: 0; width: min(900px, 96vw); max-height: min(800px, 90vh);
   border-radius: var(--r-5); box-shadow: var(--shadow-pop);
 }
-/* Video notes are mostly 9:16 portrait — a taller panel gives the stage the
-   vertical room, which in turn widens the height-driven video column so the
-   native controls render their full timeline (narrow videos collapse to a
-   scrubber-less pill). */
-.note-viewer-panel--video { max-height: min(800px, 90vh); }
 .note-viewer-head {
   flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 12px;
   padding: 11px 12px 11px 14px; border-bottom: var(--hairline); background: var(--surface);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1092,15 +1092,20 @@ body.has-paper > * { position: relative; z-index: 1; }
   background: rgba(250, 250, 249, 0.82); padding: 2px 7px; border-radius: var(--r-pill);
   white-space: nowrap; pointer-events: none;
 }
+/* Overlay badges set the mono face themselves rather than via .t-mono — the
+   utility class is defined later in this sheet, so at equal specificity its
+   13px/fg-muted would override the badges' 10px/ink-9 on-image styling. */
 .note-media__count {
   position: absolute; top: 6px; right: 6px;
   display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-mono); letter-spacing: var(--ls-mono);
   font-size: 10px; color: var(--ink-9); background: rgba(10, 10, 10, 0.55);
   padding: 2px 6px; border-radius: var(--r-pill); pointer-events: none;
 }
 .note-media__count svg { width: 11px; height: 11px; }
 .note-media__dur {
   position: absolute; bottom: 6px; right: 6px;
+  font-family: var(--font-mono); letter-spacing: var(--ls-mono);
   font-size: 10px; color: var(--ink-9); background: rgba(10, 10, 10, 0.62);
   padding: 1px 6px; border-radius: var(--r-2); pointer-events: none;
 }
@@ -1178,6 +1183,7 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
 .note-card__nav--next { right: 7px; }
 .note-card__idx {
   position: absolute; top: 7px; right: 7px; font-size: 10px; color: var(--ink-9);
+  font-family: var(--font-mono); letter-spacing: var(--ls-mono);
   background: rgba(10, 10, 10, 0.55); padding: 2px 7px; border-radius: var(--r-pill); pointer-events: none;
 }
 .note-card[data-density="rich"] { flex-direction: column; width: 208px; }


### PR DESCRIPTION
## What changed

Feedback on the rich note components (viewer + timeline cards), checked against the SocaiV2 design handoff.

### 1. Note viewer: video timeline scrubber broken / portrait video cramped

**Root cause:** 9:16 videos were pillarboxed inside the viewer's universal 3:4 gallery frame. At the panel's 620px max-height that video column is only ~300px wide — below the width where WebKit's native `<video controls>` collapse to the compact play/time pill with **no scrubber**.

- **Full-bleed gallery media** (`app/src/panels/notes.ts`): the `gallery` variant drops the pillarbox wrapper, so the `<video controls>` spans the entire frame and the native timeline gets its full width.
- **Each slide's frame adopts its media's own ratio**: new `frameRatio()` reads the `ratio` field core already stamps on every media entry (`"9:16"` for videos, `"3:4"` for images — `core/src/sites/xhs/tools.rs:1358`) and sets it inline per pre-rendered slide. No more gray bars beside portrait video; mixed video+image carousels keep the right shape per slide.
- **Taller panel for all notes** (`app/src/styles.css`): panel max-height goes from `min(620px, 90vh)` to `min(800px, 90vh)` unconditionally — media viewing wants the vertical room, and for portrait video the height also drives the width past WebKit's full-controls threshold (~400px).

### 2. Timeline rich card: carousel corner chip renders broken

**Root cause:** `coverInner` passed `count` into `mediaFrame`, so multi-image notes stacked the static `▣ n` count badge (top 6px/right 6px) under the `1/2` carousel idx chip (top 7px/right 7px) — two overlapping translucent pills, with the stale count peeking out as the index advanced.

Per the design handoff (`notes.jsx` `NoteCardCover`): a carouselling **rich** cover owns its corner with the idx chip alone; the count badge belongs to **static** covers. Rich covers now drop the count badge; compact cards (currently unused in-app) get the design's static cover with the count badge and no carousel controls.

### 3. On-image badges illegible against cover images

**Root cause:** the idx chip, count badge, and video duration badge paired their component class with the `.t-mono` utility. Both set `color` and `font-size` at equal specificity, and the type-scale section sits **after** the notes section in the app's single `styles.css` — so `.t-mono` won: 13px `--fg-muted` gray instead of the design's 10px `--ink-9` white. (The handoff loads `notes.css` after `styles.css`, so the prototype never showed this.)

The three badges drop `t-mono` and set the mono face/letter-spacing directly in their own rules — styling no longer depends on sheet order.

## What a reviewer should know

- Gallery thumbs and citation dots keep the universal 3:4 pillarbox design — unchanged.
- Merged with #175's pre-rendered slides: navigation still only toggles `hidden`; the per-slide inline aspect-ratio composes with it (no re-render on switch).
- The fallback `aspect-ratio: 3 / 4` on `.note-gallery__frame` stays in CSS; the inline style from `galleryStage` always overrides it.
- Verified with `tsc && vite build` (clean). Not visually verified in the running app — this worktree needed a full Rust rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)