### PR TITLE
fix(app): humanize tool-result timeline rows — duration units + token estimate

### DIFF
--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -720,7 +720,7 @@ fn tool_result_event(
         .map(|value| normalize_entities(name, value))
         .unwrap_or_default();
     let error = error.map(str::trim).filter(|err| !err.is_empty());
-    let (_kind, text) = format_tool_result_text(name, summary, duration_ms, error.unwrap_or(""));
+    let (_kind, text) = format_tool_result_text(name, content, duration_ms, error.unwrap_or(""));
     if let Some(error) = error {
         AgentTaskEventKind::ToolError {
             id: id.to_string(),
@@ -767,15 +767,62 @@ fn format_tool_call_text(tool: &str, input: &Value, repeat_count: u64) -> String
 
 fn format_tool_result_text(
     tool: &str,
-    summary: &str,
+    content: &Value,
     duration_ms: u64,
     error: &str,
 ) -> (&'static str, String) {
+    let duration = format_tool_duration(duration_ms);
     if !error.trim().is_empty() {
-        return ("tool_error", format!("{tool} ({duration_ms}ms): {error}"));
+        return ("tool_error", format!("{tool} ({duration}): {error}"));
     }
-    let first = summary.lines().next().unwrap_or("");
-    ("tool_result", format!("{tool} ({duration_ms}ms): {first}"))
+    let tokens = format_token_estimate(estimate_result_tokens(content));
+    ("tool_result", format!("{tool} ({duration} · {tokens})"))
+}
+
+fn format_tool_duration(duration_ms: u64) -> String {
+    if duration_ms < 1000 {
+        return format!("{:.1}s", duration_ms as f64 / 1000.0);
+    }
+    let secs = (duration_ms + 500) / 1000;
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    format!("{}m {:02}s", secs / 60, secs % 60)
+}
+
+// No provider reports per-tool-result tokens, so estimate: ~4 ASCII chars per
+// token, ~1 token per non-ASCII (CJK) char. Image blocks carry no text here.
+fn estimate_result_tokens(content: &Value) -> u64 {
+    let text = match content {
+        Value::Array(items) => items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::String(text) => text.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    };
+    let (mut ascii, mut wide) = (0u64, 0u64);
+    for ch in text.chars() {
+        if ch.is_ascii() {
+            ascii += 1;
+        } else {
+            wide += 1;
+        }
+    }
+    ascii / 4 + wide
+}
+
+fn format_token_estimate(tokens: u64) -> String {
+    if tokens >= 10_000 {
+        format!("~{}k tokens", (tokens + 500) / 1000)
+    } else if tokens >= 1_000 {
+        format!("~{:.1}k tokens", tokens as f64 / 1000.0)
+    } else {
+        format!("~{tokens} tokens")
+    }
 }
 
 fn raw_tool_result_value(content: &Value) -> Option<Value> {

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -780,8 +780,9 @@ fn format_tool_result_text(
 }
 
 fn format_tool_duration(duration_ms: u64) -> String {
-    if duration_ms < 1000 {
-        return format!("{:.1}s", duration_ms as f64 / 1000.0);
+    let tenths = (duration_ms + 50) / 100;
+    if tenths < 10 {
+        return format!("0.{tenths}s");
     }
     let secs = (duration_ms + 500) / 1000;
     if secs < 60 {
@@ -793,33 +794,43 @@ fn format_tool_duration(duration_ms: u64) -> String {
 // No provider reports per-tool-result tokens, so estimate: ~4 ASCII chars per
 // token, ~1 token per non-ASCII (CJK) char. Image blocks carry no text here.
 fn estimate_result_tokens(content: &Value) -> u64 {
-    let text = match content {
-        Value::Array(items) => items
-            .iter()
-            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
-            .filter_map(|item| item.get("text").and_then(Value::as_str))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        Value::String(text) => text.clone(),
-        Value::Null => String::new(),
-        other => other.to_string(),
-    };
-    let (mut ascii, mut wide) = (0u64, 0u64);
-    for ch in text.chars() {
-        if ch.is_ascii() {
-            ascii += 1;
-        } else {
-            wide += 1;
+    let mut ascii = 0u64;
+    let mut wide = 0u64;
+    let mut count = |text: &str| {
+        for ch in text.chars() {
+            if ch.is_ascii() {
+                ascii += 1;
+            } else {
+                wide += 1;
+            }
         }
+    };
+    match content {
+        Value::Array(items) => {
+            for item in items {
+                if item.get("type").and_then(Value::as_str) != Some("text") {
+                    continue;
+                }
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    count(text);
+                }
+            }
+        }
+        Value::String(text) => count(text),
+        Value::Null => {}
+        other => count(&other.to_string()),
     }
     ascii / 4 + wide
 }
 
 fn format_token_estimate(tokens: u64) -> String {
-    if tokens >= 10_000 {
+    // 9_950+ rounds to 10k under {:.1}, so switch to the integer-k format there.
+    if tokens >= 9_950 {
         format!("~{}k tokens", (tokens + 500) / 1000)
     } else if tokens >= 1_000 {
         format!("~{:.1}k tokens", tokens as f64 / 1000.0)
+    } else if tokens == 1 {
+        "~1 token".into()
     } else {
         format!("~{tokens} tokens")
     }


### PR DESCRIPTION
## What changed

Tool-result rows in the desktop timeline rendered the first line of the tool's result summary. Every xhs tool returns pretty-printed JSON, so that first line was always a lone `{`:

```
search (48358ms): {
```

This PR changes the row format built in `app/src-tauri/src/timeline.rs` (`format_tool_result_text`) to:

```
search (48s · ~18k tokens)
```

- **Duration** is rendered in human units: `0.3s` under a second, `48s` under a minute, `2m 05s` beyond — matching the existing `formatDuration` style in the task detail header.
- **Token usage** replaces the useless summary snippet. Providers only report tokens per LLM turn, never per tool result, so this is an estimate from the result text: ~4 chars/token for ASCII, ~1 token per CJK character (plain `chars/4` would undercount Chinese content ~4×). The `~` prefix marks it as approximate; values format as `~840 tokens` / `~3.5k tokens` / `~18k tokens`.
- **Error rows** keep the error text but get the same duration formatting: `search (48s): <error>`.

## Notes for review

- Single-file change; the frontend renders the prebuilt `text` field, so no TS changes.
- Both producers share this formatter — live events (`agent_event_to_timeline`) and replay-from-disk (`replay_task_events`) — so old task histories show the new format automatically (row text is rebuilt from `output.json` on read, never persisted).
- The estimate reads the event's full result content, which can slightly overstate what the LLM actually ingested (core caps tool results at 10k chars via `TOOL_RESULT_TEXT_MAX_CHARS` before they enter history). Raw size is the more honest "how heavy was this result" signal.
- `first_number` (used to parse `turn N` / `done in N turns` rows) does not touch tool-result rows, so the format change is safe there.
- `cargo check -p socai_app` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)