### PR TITLE
fix(core): thinking-aware agent loop — max_tokens truncation guard, anthropic thinking replay, gpt via Responses API

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,10 +44,10 @@ binary, backed by `socai-core`).
 Run everything below from `app/`:
 
 ```bash
-pnpm install                          # one-time
-pnpm exec tauri dev                   # daily dev loop (Vite HMR + Rust hot recompile)
-pnpm run dev:desktop:local            # dev loop, but write records/artifacts under the repo
-pnpm exec tauri build --bundles app   # → target/release/bundle/macos/socai.app
+pnpm install                            # one-time
+pnpm exec tauri dev                     # daily dev loop (Vite HMR + Rust hot recompile)
+pnpm run dev:desktop:local -- --release # dev loop, but write records/artifacts under the repo
+pnpm exec tauri build --bundles app     # → target/release/bundle/macos/socai.app
 ```
 
 `dev:desktop:local` points `SOCAI_HOME` / `SOCAI_RUNS_DIR` at the repo's

--- a/core/src/agent/llm.rs
+++ b/core/src/agent/llm.rs
@@ -49,6 +49,14 @@ pub enum Block {
     ReasoningContent {
         text: String,
     },
+    /// Anthropic native thinking block (adaptive thinking). Must be echoed
+    /// back verbatim — text and signature untouched — when continuing the
+    /// conversation on the same Anthropic model; the API rejects modified
+    /// blocks. Other backends drop it on the wire.
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -123,6 +131,14 @@ pub enum StopReason {
     Other,
 }
 
+/// One Anthropic thinking block from a response, kept verbatim (text +
+/// signature) so it can be replayed on the next turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThinkingBlock {
+    pub thinking: String,
+    pub signature: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LLMResponse {
     pub text_blocks: Vec<String>,
@@ -133,15 +149,27 @@ pub struct LLMResponse {
     /// Reasoning trace surfaced by Kimi K2.6 / Qwen. Empty for providers
     /// that don't expose it.
     pub reasoning_content: String,
+    /// Anthropic thinking blocks, in response order, for verbatim replay.
+    /// Empty for non-Anthropic providers.
+    #[serde(default)]
+    pub thinking_blocks: Vec<ThinkingBlock>,
 }
 
 impl LLMResponse {
     /// Reconstruct the assistant content we'll append to history.
-    /// reasoning_content first (if any, only when there are tool calls —
-    /// some providers reject it alone), text, then tool_use blocks.
+    /// Thinking / reasoning first, text, then tool_use blocks.
     pub fn to_assistant_blocks(&self) -> Vec<Block> {
         let mut blocks: Vec<Block> = Vec::new();
-        if !self.reasoning_content.trim().is_empty() && !self.tool_calls.is_empty() {
+        for tb in &self.thinking_blocks {
+            blocks.push(Block::Thinking {
+                thinking: tb.thinking.clone(),
+                signature: tb.signature.clone(),
+            });
+        }
+        if self.thinking_blocks.is_empty()
+            && !self.reasoning_content.trim().is_empty()
+            && !self.tool_calls.is_empty()
+        {
             blocks.push(Block::ReasoningContent {
                 text: self.reasoning_content.clone(),
             });

--- a/core/src/agent/llm.rs
+++ b/core/src/agent/llm.rs
@@ -57,6 +57,14 @@ pub enum Block {
         thinking: String,
         signature: String,
     },
+    /// OpenAI Responses API reasoning item, kept as raw JSON. With
+    /// `store: false` the encrypted reasoning must be replayed verbatim in
+    /// the next request's `input`, or the model loses its chain of thought
+    /// between tool calls. Other backends drop it on the wire.
+    #[serde(rename = "openai_reasoning")]
+    OpenAIReasoning {
+        item: Value,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -153,6 +161,10 @@ pub struct LLMResponse {
     /// Empty for non-Anthropic providers.
     #[serde(default)]
     pub thinking_blocks: Vec<ThinkingBlock>,
+    /// OpenAI Responses API reasoning items (raw JSON), in response order,
+    /// for verbatim replay. Empty for other providers.
+    #[serde(default)]
+    pub reasoning_items: Vec<Value>,
 }
 
 impl LLMResponse {
@@ -160,6 +172,9 @@ impl LLMResponse {
     /// Thinking / reasoning first, text, then tool_use blocks.
     pub fn to_assistant_blocks(&self) -> Vec<Block> {
         let mut blocks: Vec<Block> = Vec::new();
+        for item in &self.reasoning_items {
+            blocks.push(Block::OpenAIReasoning { item: item.clone() });
+        }
         for tb in &self.thinking_blocks {
             blocks.push(Block::Thinking {
                 thinking: tb.thinking.clone(),
@@ -167,6 +182,7 @@ impl LLMResponse {
             });
         }
         if self.thinking_blocks.is_empty()
+            && self.reasoning_items.is_empty()
             && !self.reasoning_content.trim().is_empty()
             && !self.tool_calls.is_empty()
         {

--- a/core/src/agent/llm/anthropic.rs
+++ b/core/src/agent/llm/anthropic.rs
@@ -154,6 +154,7 @@ fn block_to_wire(block: &Block) -> Option<Value> {
             "thinking": thinking,
             "signature": signature,
         })),
+        Block::OpenAIReasoning { .. } => None,
         Block::ToolUse { id, name, input } => Some(json!({
             "type": "tool_use",
             "id": id,
@@ -344,6 +345,7 @@ impl Backend for AnthropicBackend {
             output_tokens: parsed.usage.output_tokens,
             reasoning_content,
             thinking_blocks,
+            reasoning_items: Vec::new(),
         })
     }
 }

--- a/core/src/agent/llm/anthropic.rs
+++ b/core/src/agent/llm/anthropic.rs
@@ -12,7 +12,8 @@ use serde_json::{json, Value};
 
 use crate::agent::api_errors::format_http_error;
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, StopReason, ToolCall, ToolResultContent, ToolSchema,
+    Backend, Block, LLMResponse, Message, StopReason, ThinkingBlock, ToolCall, ToolResultContent,
+    ToolSchema,
 };
 use crate::agent::provider::{config_for, load_api_key, Provider};
 
@@ -92,7 +93,7 @@ impl AnthropicBackend {
                 map.insert("cache_control".into(), json!({"type": "ephemeral"}));
             }
         }
-        json!({
+        let mut body = json!({
             "model": self.model,
             "max_tokens": max_tokens,
             "system": system_value,
@@ -101,8 +102,32 @@ impl AnthropicBackend {
                 "content": message.content,
             })).collect::<Vec<_>>(),
             "tools": wire_tools,
-        })
+        });
+        if supports_adaptive_thinking(&self.model) {
+            // display: "summarized" — the default ("omitted") returns thinking
+            // blocks with empty text, so nothing could be surfaced in the UI.
+            body["thinking"] = json!({"type": "adaptive", "display": "summarized"});
+        }
+        body
     }
+}
+
+/// Models that accept `thinking: {type: "adaptive"}`. Older models
+/// (Haiku 4.5, Sonnet 4.5, Claude 3.x, …) reject it with a 400, so the
+/// parameter is only sent where it's supported. Note that Sonnet 5 and
+/// Fable 5 run adaptive thinking even when the parameter is omitted — the
+/// explicit config is still needed there for `display: "summarized"`.
+fn supports_adaptive_thinking(model: &str) -> bool {
+    const PREFIXES: [&str; 7] = [
+        "claude-fable-5",
+        "claude-mythos",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-sonnet-5",
+    ];
+    PREFIXES.iter().any(|p| model.starts_with(p))
 }
 
 fn block_to_wire(block: &Block) -> Option<Value> {
@@ -117,12 +142,18 @@ fn block_to_wire(block: &Block) -> Option<Value> {
             },
         })),
         Block::ReasoningContent { .. } => {
-            // Anthropic's "thinking" block has a different shape (signed
-            // signature etc.) — and we don't currently surface it from the
-            // response. Drop reasoning content when sending to Anthropic so
-            // we don't have to fake a signature.
+            // Kimi/Qwen-style reasoning trace — has no signature, so it can't
+            // be faked as an Anthropic thinking block. Drop it on this wire.
             None
         }
+        Block::Thinking {
+            thinking,
+            signature,
+        } => Some(json!({
+            "type": "thinking",
+            "thinking": thinking,
+            "signature": signature,
+        })),
         Block::ToolUse { id, name, input } => Some(json!({
             "type": "tool_use",
             "id": id,
@@ -208,6 +239,12 @@ enum WireResponseBlock {
         name: String,
         input: Value,
     },
+    Thinking {
+        #[serde(default)]
+        thinking: String,
+        #[serde(default)]
+        signature: String,
+    },
     #[serde(other)]
     Other,
 }
@@ -269,15 +306,31 @@ impl Backend for AnthropicBackend {
 
         let mut text_blocks = Vec::new();
         let mut tool_calls = Vec::new();
+        let mut thinking_blocks: Vec<ThinkingBlock> = Vec::new();
         for block in parsed.content {
             match block {
                 WireResponseBlock::Text { text } => text_blocks.push(text),
                 WireResponseBlock::ToolUse { id, name, input } => {
                     tool_calls.push(ToolCall { id, name, input })
                 }
+                WireResponseBlock::Thinking {
+                    thinking,
+                    signature,
+                } => thinking_blocks.push(ThinkingBlock {
+                    thinking,
+                    signature,
+                }),
                 WireResponseBlock::Other => {}
             }
         }
+        // Surface the thinking summary through the same channel Kimi/Qwen
+        // use, so the UI reasoning stream lights up identically.
+        let reasoning_content = thinking_blocks
+            .iter()
+            .map(|tb| tb.thinking.trim())
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
 
         let input_total = parsed.usage.input_tokens
             + parsed.usage.cache_creation_input_tokens
@@ -289,7 +342,8 @@ impl Backend for AnthropicBackend {
             stop_reason: parse_stop_reason(parsed.stop_reason.as_deref()),
             input_tokens: input_total,
             output_tokens: parsed.usage.output_tokens,
-            reasoning_content: String::new(),
+            reasoning_content,
+            thinking_blocks,
         })
     }
 }

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -269,7 +269,7 @@ fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: b
                                 },
                             }));
                         }
-                        Block::ToolResult { .. } => {}
+                        Block::ToolResult { .. } | Block::Thinking { .. } => {}
                     }
                 }
                 let content_str = text_parts.join("\n").trim().to_string();
@@ -315,7 +315,9 @@ fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: b
                                 "content": flatten_tool_result_content(&content),
                             }));
                         }
-                        Block::ReasoningContent { .. } | Block::ToolUse { .. } => {}
+                        Block::ReasoningContent { .. }
+                        | Block::ToolUse { .. }
+                        | Block::Thinking { .. } => {}
                     }
                 }
                 let joined = user_text_parts.join("\n").trim().to_string();
@@ -396,7 +398,10 @@ fn responses_content_parts(blocks: Vec<Block>, output: bool) -> Vec<Value> {
                     "image_url": format!("data:{media_type};base64,{data}"),
                 }));
             }
-            Block::ReasoningContent { .. } | Block::ToolUse { .. } | Block::ToolResult { .. } => {}
+            Block::ReasoningContent { .. }
+            | Block::ToolUse { .. }
+            | Block::ToolResult { .. }
+            | Block::Thinking { .. } => {}
             Block::Image { .. } => {}
         }
     }
@@ -423,7 +428,8 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
                         }
                         Block::Image { .. }
                         | Block::ReasoningContent { .. }
-                        | Block::ToolResult { .. } => {}
+                        | Block::ToolResult { .. }
+                        | Block::Thinking { .. } => {}
                     }
                 }
                 let content = responses_content_parts(text_blocks, true);
@@ -446,7 +452,9 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
                             }));
                         }
                         Block::Text { .. } | Block::Image { .. } => message_blocks.push(block),
-                        Block::ReasoningContent { .. } | Block::ToolUse { .. } => {}
+                        Block::ReasoningContent { .. }
+                        | Block::ToolUse { .. }
+                        | Block::Thinking { .. } => {}
                     }
                 }
                 let content = responses_content_parts(message_blocks, false);
@@ -633,6 +641,7 @@ fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
         input_tokens,
         output_tokens,
         reasoning_content: String::new(),
+        thinking_blocks: Vec::new(),
     })
 }
 
@@ -725,6 +734,7 @@ impl Backend for OpenAICompatBackend {
             input_tokens: parsed.usage.prompt_tokens,
             output_tokens: parsed.usage.completion_tokens,
             reasoning_content: choice.message.reasoning_content.unwrap_or_default(),
+            thinking_blocks: Vec::new(),
         })
     }
 }

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -1,9 +1,11 @@
-//! OpenAI-compatible chat-completions backend.
+//! OpenAI-compatible backend.
 //!
-//! Used for OpenAI, Kimi (Moonshot), and Qwen (DashScope). Each provider
-//! supplies a different `base_url` via `ProviderConfig`. Some providers
-//! expose reasoning tokens via `reasoning_content` or need an
-//! `extra_body`-style toggle — those quirks live here.
+//! OpenAI proper always goes through the Responses API — the official
+//! `/v1/responses` endpoint with an API key, or the ChatGPT Codex endpoint
+//! with Codex OAuth — because chat completions never returns reasoning
+//! content. Kimi (Moonshot) and Qwen (DashScope) use chat completions with
+//! their own `base_url` via `ProviderConfig`; their quirks (the
+//! `reasoning_content` field, thinking toggles) live here too.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -76,8 +78,13 @@ impl OpenAICompatBackend {
         format!("{}/chat/completions", self.base_url)
     }
 
-    fn codex_responses_url(&self) -> String {
-        "https://chatgpt.com/backend-api/codex/responses".to_string()
+    fn responses_url(&self) -> String {
+        match &self.credential {
+            Credential::CodexOAuth { .. } => {
+                "https://chatgpt.com/backend-api/codex/responses".to_string()
+            }
+            Credential::ApiKey(_) => format!("{}/responses", self.base_url),
+        }
     }
 
     /// Provider-specific extra fields merged into the request body.
@@ -92,13 +99,6 @@ impl OpenAICompatBackend {
             }
             Provider::Qwen | Provider::QwenIntl => {
                 extra.insert("enable_thinking".into(), Value::Bool(false));
-            }
-            // Reasoning on by default for OpenAI reasoning models — newer
-            // GPT-5.x releases default reasoning_effort to "none". Chat
-            // completions never returns the reasoning content, but the model
-            // still reasons (tokens count against max_completion_tokens).
-            Provider::OpenAI if is_openai_reasoning_model(&self.model) => {
-                extra.insert("reasoning_effort".into(), json!("medium"));
             }
             _ => {}
         }
@@ -124,17 +124,10 @@ impl OpenAICompatBackend {
     ) -> OutgoingRequest {
         let chat_tools = tools_to_wire(tools);
         let has_tools = !chat_tools.is_empty();
-        let (max_tokens_field, max_completion_tokens_field) =
-            if matches!(self.provider, Provider::OpenAI) {
-                (None, Some(max_tokens))
-            } else {
-                (Some(max_tokens), None)
-            };
         OutgoingRequest {
             model: self.model.clone(),
             messages: build_chat_messages(system, messages, self.preserve_reasoning_content()),
-            max_tokens: max_tokens_field,
-            max_completion_tokens: max_completion_tokens_field,
+            max_tokens,
             tools: chat_tools,
             tool_choice: if has_tools { Some("auto") } else { None },
             extra: self.extra_body(has_tools),
@@ -146,7 +139,19 @@ impl OpenAICompatBackend {
         system: &str,
         messages: &[Message],
         tools: &[ToolSchema],
+        max_tokens: u32,
     ) -> ResponsesRequest {
+        // Reasoning on by default — newer GPT-5.x releases default the
+        // effort to "none". summary: "auto" surfaces the summary text;
+        // encrypted_content is what store:false replay needs. Non-reasoning
+        // models (gpt-4o, the -chat variants) reject the parameter.
+        let reasoning = is_openai_reasoning_model(&self.model)
+            .then(|| json!({"effort": "medium", "summary": "auto"}));
+        let include = if reasoning.is_some() {
+            vec!["reasoning.encrypted_content"]
+        } else {
+            Vec::new()
+        };
         ResponsesRequest {
             model: self.model.clone(),
             instructions: system.to_string(),
@@ -156,17 +161,21 @@ impl OpenAICompatBackend {
             parallel_tool_calls: true,
             stream: true,
             store: false,
-            // All Codex models reason. summary: "auto" surfaces the summary
-            // text; encrypted_content is what store:false replay needs.
-            reasoning: json!({"effort": "medium", "summary": "auto"}),
-            include: vec!["reasoning.encrypted_content"],
+            // The Codex endpoint manages output limits itself; only the
+            // official API gets an explicit cap.
+            max_output_tokens: match self.credential {
+                Credential::CodexOAuth { .. } => None,
+                Credential::ApiKey(_) => Some(max_tokens),
+            },
+            reasoning,
+            include,
         }
     }
 }
 
-/// OpenAI models that accept the `reasoning_effort` chat-completions
-/// parameter. The `-chat` variants (gpt-5-chat-latest, …) are the
-/// non-reasoning conversational builds and reject it.
+/// OpenAI models that accept the Responses API `reasoning` parameter.
+/// The `-chat` variants (gpt-5-chat-latest, …) are the non-reasoning
+/// conversational builds and reject it, as do gpt-4o/gpt-4.x.
 fn is_openai_reasoning_model(model: &str) -> bool {
     if model.contains("-chat") {
         return false;
@@ -558,10 +567,7 @@ fn parse_stop_reason(s: Option<&str>) -> StopReason {
 struct OutgoingRequest {
     model: String,
     messages: Vec<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_completion_tokens: Option<u32>,
+    max_tokens: u32,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -582,7 +588,11 @@ struct ResponsesRequest {
     parallel_tool_calls: bool,
     stream: bool,
     store: bool,
-    reasoning: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     include: Vec<&'static str>,
 }
 
@@ -715,8 +725,8 @@ impl Backend for OpenAICompatBackend {
         tools: &[ToolSchema],
         max_tokens: u32,
     ) -> anyhow::Result<Value> {
-        if matches!(self.credential, Credential::CodexOAuth { .. }) {
-            serde_json::to_value(self.build_responses_request(system, messages, tools))
+        if self.provider == Provider::OpenAI {
+            serde_json::to_value(self.build_responses_request(system, messages, tools, max_tokens))
                 .map_err(Into::into)
         } else {
             serde_json::to_value(self.build_chat_request(system, messages, tools, max_tokens))
@@ -731,8 +741,8 @@ impl Backend for OpenAICompatBackend {
         tools: &[ToolSchema],
         max_tokens: u32,
     ) -> anyhow::Result<LLMResponse> {
-        if matches!(self.credential, Credential::CodexOAuth { .. }) {
-            return self.send_codex_responses(system, messages, tools).await;
+        if self.provider == Provider::OpenAI {
+            return self.send_responses(system, messages, tools, max_tokens).await;
         }
 
         let body = self.build_chat_request(system, messages, tools, max_tokens);
@@ -803,56 +813,51 @@ impl OpenAICompatBackend {
         }
     }
 
-    async fn send_codex_responses(
+    async fn send_responses(
         &self,
         system: &str,
         messages: &[Message],
         tools: &[ToolSchema],
+        max_tokens: u32,
     ) -> anyhow::Result<LLMResponse> {
-        let body = self.build_responses_request(system, messages, tools);
+        let body = self.build_responses_request(system, messages, tools, max_tokens);
 
-        let response = self.send_codex_responses_once(&body, None).await?;
-        self.parse_codex_responses_response(response).await
+        let response = self.send_responses_once(&body).await?;
+        self.parse_responses_response(response).await
     }
 
-    async fn send_codex_responses_once(
-        &self,
-        body: &ResponsesRequest,
-        refreshed_credential: Option<Credential>,
-    ) -> anyhow::Result<reqwest::Response> {
-        let credential = refreshed_credential.as_ref().unwrap_or(&self.credential);
-        let Credential::CodexOAuth {
-            access_token,
-            account_id,
-            ..
-        } = credential
-        else {
-            anyhow::bail!("Codex Responses auth requires Codex OAuth credentials");
+    async fn send_responses_once(&self, body: &ResponsesRequest) -> anyhow::Result<reqwest::Response> {
+        let credential = &self.credential;
+        let request = self.client.post(self.responses_url());
+        let request = match credential {
+            Credential::CodexOAuth {
+                access_token,
+                account_id,
+                ..
+            } => request
+                .bearer_auth(access_token)
+                .header("ChatGPT-Account-ID", account_id),
+            Credential::ApiKey(api_key) => request.bearer_auth(api_key),
         };
-        Ok(self
-            .client
-            .post(self.codex_responses_url())
-            .bearer_auth(access_token)
-            .header("ChatGPT-Account-ID", account_id)
-            .json(body)
-            .send()
-            .await?)
+        Ok(request.json(body).send().await?)
     }
 
-    async fn parse_codex_responses_response(
+    async fn parse_responses_response(
         &self,
         response: reqwest::Response,
     ) -> anyhow::Result<LLMResponse> {
+        let is_codex = matches!(self.credential, Credential::CodexOAuth { .. });
+        let label = if is_codex { "openai-codex" } else { "openai" };
         let status = response.status();
         let text = response.text().await.unwrap_or_default();
         if !status.is_success() {
-            if status == reqwest::StatusCode::UNAUTHORIZED {
+            if status == reqwest::StatusCode::UNAUTHORIZED && is_codex {
                 anyhow::bail!(
                     "{}\nHint: run `codex login`, then retry socai.",
-                    format_http_error("openai-codex", status.as_u16(), &text)
+                    format_http_error(label, status.as_u16(), &text)
                 );
             }
-            anyhow::bail!(format_http_error("openai-codex", status.as_u16(), &text));
+            anyhow::bail!(format_http_error(label, status.as_u16(), &text));
         }
         parse_responses_sse(&text)
     }

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -93,6 +93,13 @@ impl OpenAICompatBackend {
             Provider::Qwen | Provider::QwenIntl => {
                 extra.insert("enable_thinking".into(), Value::Bool(false));
             }
+            // Reasoning on by default for OpenAI reasoning models — newer
+            // GPT-5.x releases default reasoning_effort to "none". Chat
+            // completions never returns the reasoning content, but the model
+            // still reasons (tokens count against max_completion_tokens).
+            Provider::OpenAI if is_openai_reasoning_model(&self.model) => {
+                extra.insert("reasoning_effort".into(), json!("medium"));
+            }
             _ => {}
         }
         extra
@@ -149,8 +156,25 @@ impl OpenAICompatBackend {
             parallel_tool_calls: true,
             stream: true,
             store: false,
+            // All Codex models reason. summary: "auto" surfaces the summary
+            // text; encrypted_content is what store:false replay needs.
+            reasoning: json!({"effort": "medium", "summary": "auto"}),
+            include: vec!["reasoning.encrypted_content"],
         }
     }
+}
+
+/// OpenAI models that accept the `reasoning_effort` chat-completions
+/// parameter. The `-chat` variants (gpt-5-chat-latest, …) are the
+/// non-reasoning conversational builds and reject it.
+fn is_openai_reasoning_model(model: &str) -> bool {
+    if model.contains("-chat") {
+        return false;
+    }
+    model.starts_with("gpt-5")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4")
 }
 
 #[cfg(test)]
@@ -269,7 +293,9 @@ fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: b
                                 },
                             }));
                         }
-                        Block::ToolResult { .. } | Block::Thinking { .. } => {}
+                        Block::ToolResult { .. }
+                        | Block::Thinking { .. }
+                        | Block::OpenAIReasoning { .. } => {}
                     }
                 }
                 let content_str = text_parts.join("\n").trim().to_string();
@@ -317,7 +343,8 @@ fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: b
                         }
                         Block::ReasoningContent { .. }
                         | Block::ToolUse { .. }
-                        | Block::Thinking { .. } => {}
+                        | Block::Thinking { .. }
+                        | Block::OpenAIReasoning { .. } => {}
                     }
                 }
                 let joined = user_text_parts.join("\n").trim().to_string();
@@ -401,7 +428,8 @@ fn responses_content_parts(blocks: Vec<Block>, output: bool) -> Vec<Value> {
             Block::ReasoningContent { .. }
             | Block::ToolUse { .. }
             | Block::ToolResult { .. }
-            | Block::Thinking { .. } => {}
+            | Block::Thinking { .. }
+            | Block::OpenAIReasoning { .. } => {}
             Block::Image { .. } => {}
         }
     }
@@ -418,6 +446,10 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
                 for block in blocks {
                     match block {
                         Block::Text { .. } => text_blocks.push(block),
+                        // Replay the reasoning item exactly as received —
+                        // required with store:false to keep the model's chain
+                        // of thought across tool calls.
+                        Block::OpenAIReasoning { item } => out.push(item),
                         Block::ToolUse { id, name, input } => {
                             out.push(json!({
                                 "type": "function_call",
@@ -454,7 +486,8 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
                         Block::Text { .. } | Block::Image { .. } => message_blocks.push(block),
                         Block::ReasoningContent { .. }
                         | Block::ToolUse { .. }
-                        | Block::Thinking { .. } => {}
+                        | Block::Thinking { .. }
+                        | Block::OpenAIReasoning { .. } => {}
                     }
                 }
                 let content = responses_content_parts(message_blocks, false);
@@ -549,11 +582,15 @@ struct ResponsesRequest {
     parallel_tool_calls: bool,
     stream: bool,
     store: bool,
+    reasoning: Value,
+    include: Vec<&'static str>,
 }
 
 fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
     let mut text = String::new();
     let mut tool_calls = Vec::new();
+    let mut reasoning_items: Vec<Value> = Vec::new();
+    let mut reasoning_texts: Vec<String> = Vec::new();
     let mut input_tokens = 0;
     let mut output_tokens = 0;
     let mut completed = false;
@@ -574,6 +611,21 @@ fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
             }
             Some("response.output_item.done") => {
                 if let Some(item) = value.get("item").and_then(Value::as_object) {
+                    if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+                        for part in item
+                            .get("summary")
+                            .and_then(Value::as_array)
+                            .map(Vec::as_slice)
+                            .unwrap_or_default()
+                        {
+                            if let Some(t) = part.get("text").and_then(Value::as_str) {
+                                if !t.trim().is_empty() {
+                                    reasoning_texts.push(t.trim().to_string());
+                                }
+                            }
+                        }
+                        reasoning_items.push(Value::Object(item.clone()));
+                    }
                     if item.get("type").and_then(Value::as_str) == Some("function_call") {
                         let id = item
                             .get("call_id")
@@ -640,8 +692,9 @@ fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
         stop_reason,
         input_tokens,
         output_tokens,
-        reasoning_content: String::new(),
+        reasoning_content: reasoning_texts.join("\n\n"),
         thinking_blocks: Vec::new(),
+        reasoning_items,
     })
 }
 
@@ -735,6 +788,7 @@ impl Backend for OpenAICompatBackend {
             output_tokens: parsed.usage.completion_tokens,
             reasoning_content: choice.message.reasoning_content.unwrap_or_default(),
             thinking_blocks: Vec::new(),
+            reasoning_items: Vec::new(),
         })
     }
 }

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -29,7 +29,7 @@ use tracing::{debug, info, warn};
 
 use crate::agent::compaction::{compress_text_maybe_json, TOOL_RESULT_TEXT_MAX_CHARS};
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, ToolCall, ToolResultContent, ToolSchema,
+    Backend, Block, LLMResponse, Message, StopReason, ToolCall, ToolResultContent, ToolSchema,
 };
 use crate::agent::memory::prepare_messages_for_context;
 use crate::agent::report::report_with_artifacts;
@@ -112,7 +112,7 @@ impl Default for AgentOptions {
     fn default() -> Self {
         Self {
             max_turns: 30,
-            max_tokens: 8192,
+            max_tokens: 16000,
             extra_instructions: String::new(),
             run_dir: None,
             enabled_sites: Vec::new(),
@@ -188,6 +188,7 @@ pub async fn run_agent_with_events(
     let mut tool_call_history: BTreeMap<String, Vec<u32>> = BTreeMap::new();
     let mut completed = false;
     let mut terminal_error: Option<String> = None;
+    let mut truncation_retries = 0u32;
     let mut last_system: String = build_system_prompt(&[], &options.extra_instructions);
 
     while turn < options.max_turns {
@@ -276,6 +277,45 @@ pub async fn run_agent_with_events(
                 },
             );
         }
+
+        // A response cut off by max_tokens with no tool calls must not be
+        // mistaken for completion: with thinking models the entire budget can
+        // go to (possibly empty-text) thinking blocks, leaving no visible
+        // output at all. Discard the truncated turn — a partial turn can't be
+        // replayed reliably — and ask the model to redo it, bounded so a
+        // pathological loop still terminates.
+        if response.stop_reason == StopReason::MaxTokens && response.tool_calls.is_empty() {
+            truncation_retries += 1;
+            warn!(
+                turn,
+                truncation_retries, "response truncated by max_tokens with no tool calls"
+            );
+            if truncation_retries > 2 {
+                let msg = format!(
+                    "model output was truncated by the max_tokens limit ({}) {} times in a row",
+                    options.max_tokens, truncation_retries
+                );
+                emit(
+                    &events,
+                    AgentEvent::ApiError {
+                        turn,
+                        message: msg.clone(),
+                    },
+                );
+                final_text = format!("Error: {msg}");
+                terminal_error = Some(msg);
+                break;
+            }
+            messages.push(Message::user(
+                "[Note: your previous response was cut off by the output token limit and \
+                 has been discarded. Respond again, more concisely. If you were producing \
+                 the final answer, write the complete final answer now — prioritize \
+                 covering the full structure over verbose detail.]"
+                    .to_string(),
+            ));
+            continue;
+        }
+        truncation_retries = 0;
 
         // Build the assistant block list manually instead of using
         // LLMResponse::to_assistant_blocks() so we can:
@@ -687,9 +727,21 @@ fn split_thinking(text_blocks: &[String]) -> (Vec<String>, Vec<String>) {
 fn build_assistant_blocks(response: &LLMResponse, visible_texts: &[String]) -> Vec<Block> {
     use crate::agent::compaction::{truncate, ASSISTANT_TEXT_MAX_CHARS};
     let mut blocks: Vec<Block> = Vec::new();
+    // Anthropic thinking blocks go first, verbatim (never truncated) — the
+    // API rejects modified blocks on replay. When present they already carry
+    // the reasoning text, so the ReasoningContent mirror is skipped.
+    for tb in &response.thinking_blocks {
+        blocks.push(Block::Thinking {
+            thinking: tb.thinking.clone(),
+            signature: tb.signature.clone(),
+        });
+    }
     // Preserve reasoning_content alongside tool_calls so providers that
     // require it round-tripped (Kimi/Qwen) get it on the next turn.
-    if !response.reasoning_content.trim().is_empty() && !response.tool_calls.is_empty() {
+    if response.thinking_blocks.is_empty()
+        && !response.reasoning_content.trim().is_empty()
+        && !response.tool_calls.is_empty()
+    {
         blocks.push(Block::ReasoningContent {
             text: response.reasoning_content.clone(),
         });

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -727,9 +727,13 @@ fn split_thinking(text_blocks: &[String]) -> (Vec<String>, Vec<String>) {
 fn build_assistant_blocks(response: &LLMResponse, visible_texts: &[String]) -> Vec<Block> {
     use crate::agent::compaction::{truncate, ASSISTANT_TEXT_MAX_CHARS};
     let mut blocks: Vec<Block> = Vec::new();
-    // Anthropic thinking blocks go first, verbatim (never truncated) — the
-    // API rejects modified blocks on replay. When present they already carry
-    // the reasoning text, so the ReasoningContent mirror is skipped.
+    // Provider-native reasoning goes first, verbatim (never truncated):
+    // OpenAI Responses reasoning items and Anthropic thinking blocks must be
+    // replayed unmodified. When present they already carry the reasoning
+    // text, so the ReasoningContent mirror is skipped.
+    for item in &response.reasoning_items {
+        blocks.push(Block::OpenAIReasoning { item: item.clone() });
+    }
     for tb in &response.thinking_blocks {
         blocks.push(Block::Thinking {
             thinking: tb.thinking.clone(),
@@ -739,6 +743,7 @@ fn build_assistant_blocks(response: &LLMResponse, visible_texts: &[String]) -> V
     // Preserve reasoning_content alongside tool_calls so providers that
     // require it round-tripped (Kimi/Qwen) get it on the next turn.
     if response.thinking_blocks.is_empty()
+        && response.reasoning_items.is_empty()
         && !response.reasoning_content.trim().is_empty()
         && !response.tool_calls.is_empty()
     {

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -314,7 +314,10 @@ impl Default for AgentRunConfig {
     fn default() -> Self {
         Self {
             max_turns: 30,
-            max_tokens: 4096,
+            // Thinking tokens count against max_tokens on Anthropic thinking
+            // models (Sonnet 5 thinks by default), so 4096 starves the final
+            // report. 16000 is the recommended non-streaming ceiling.
+            max_tokens: 16000,
             keep_recent_messages: 12,
             memory_max_chars: 6000,
             extra_instructions: String::new(),

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -72,12 +72,10 @@ Shared options (same meaning for both):
 
 - `num_notes=N` — how many notes to collect (default 10); raise only when the
   question needs broader evidence.
-- `num_comments=N` — how many comments to load per note (default 8). The comment
-  area is scrolled and reply threads ("展开 N 条回复") are expanded until the count
-  is reached or the thread ends; **replies count toward N**. Each parent keeps its
-  replies as a nested `sub_comments`/`replies` array. Raising this adds latency per
-  note (more scroll + expand rounds), so lift it only when the question is about
-  the discussion itself. `0` skips comments. Ignored in `preview` mode. 
+- `num_comments=N` — how many comments to load per note (default 8; replies
+  count toward N). Use the default unless the question is about the discussion itself.
+  N ≤ 12 usually loads without extra scrolling, larger values add scroll/expand rounds 
+  and latency. `0` skips comments. Ignored in `preview` mode.
 - `preview=true` — fast cards-only pass (titles/likes/covers), without opening
   any note. `download_media` is ignored in this mode.
 - `download_media=true` — download note images/videos into the run dir; use when


### PR DESCRIPTION
## Summary

Fixes the bug where a Sonnet 5 run wrote an intermediate transition sentence as `report.md`, and brings reasoning/thinking support to both Anthropic and OpenAI backends.

**Root cause**: claude-sonnet-5 runs adaptive thinking by default; thinking tokens count against `max_tokens`, so a 4096 budget could be consumed entirely by (invisible) thinking blocks. The truncated response parsed to zero text and zero tool calls, which the agent loop mistook for completion — writing the previous turn's transition text as the final report.

### Changes

- **loop.rs**: a `max_tokens`-truncated response with no tool calls now discards the turn and asks the model to redo it (2 consecutive retries, then the run fails loudly instead of emitting a stale report)
- **max_tokens defaults**: 4096/8192 → 16000 (engine + loop); thinking tokens count against the budget
- **anthropic**: send `thinking: {adaptive, summarized}` on models that support it; parse thinking blocks into the shared reasoning stream (same UI channel as Kimi/Qwen); replay them verbatim on subsequent turns
- **openai**: OpenAI proper now always uses the Responses API (official `/v1/responses` with api key, ChatGPT Codex endpoint with OAuth) — chat completions never returns reasoning content. Reasoning on by default for reasoning models (`reasoning: {effort: medium, summary: auto}` + `include: reasoning.encrypted_content`); reasoning items surfaced and replayed verbatim so gpt keeps its chain of thought across tool calls with `store: false`
- run-dir `llm/*.json` records now include thinking/reasoning content in both requests and responses
- docs: `--release` flag for `dev:desktop:local`; tightened `num_comments` guidance

### Test plan

- 89 existing unit tests pass; clippy clean on changed files
- Live smoke against the real APIs: anthropic (sonnet 5) thinking block parsed + replayed with tool use, second turn accepted; openai codex (gpt-5.5) reasoning item with encrypted_content parsed + replayed, second turn accepted
- Payload-shape checks: `reasoning`/`include` present for gpt-5.5, absent for gpt-5-chat-latest / gpt-4o; anthropic `thinking` param gated to adaptive-capable models

🤖 Generated with [Claude Code](https://claude.com/claude-code)