### PR TITLE
fix(app): preserve timeline scroll position across re-renders

### DIFF
--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -165,6 +165,16 @@ export namespace agentPanel {
 
   let liveStripKey = "";
 
+  // Per-task scroll memory for the event stream. A full render rebuilds the
+  // stream DOM (dropping its scroll offset), so a scroll listener records the
+  // position here and the post-render bind restores it. No entry, or a pinned
+  // entry, means auto-follow: keep the stream glued to its newest row.
+  const streamScroll = new Map<string, { top: number; pinned: boolean }>();
+
+  function isPinnedToBottom(stream: HTMLDivElement): boolean {
+    return stream.scrollTop + stream.clientHeight >= stream.scrollHeight - 8;
+  }
+
   function updateLiveStrip(task: AgentTaskView): void {
     const stream = document.querySelector<HTMLDivElement>(`[data-agent-events="${task.task_id}"]`);
     if (!stream) return;
@@ -182,7 +192,7 @@ export namespace agentPanel {
     if (refs.length === 0) return;
     const html = renderTimelineEmbed(refs, "rich");
     if (!html) return;
-    const pinned = stream.scrollTop + stream.clientHeight >= stream.scrollHeight - 8;
+    const pinned = isPinnedToBottom(stream);
     stream.insertAdjacentHTML("beforeend", html);
     stream.lastElementChild?.setAttribute("data-live-strip", "1");
     if (pinned) stream.scrollTop = stream.scrollHeight;
@@ -660,8 +670,9 @@ export namespace agentPanel {
         );
       });
 
-    // Auto-follow the selected task's timeline to the latest row after a render.
-    scrollSelectedEventsToBottom();
+    // Re-apply the selected task's timeline scroll position after a render:
+    // follow the latest row unless the user had scrolled up to read.
+    restoreSelectedEventsScroll();
     // Poll the note archive while the selected task runs (bind runs after
     // every render, so this tracks selection and status changes).
     syncNotesPolling(shell);
@@ -674,12 +685,19 @@ export namespace agentPanel {
     }
   }
 
-  // Keep the event stream pinned to its newest row when the detail (re)renders,
-  // mirroring the incremental append in `appendEventRowIfSelected`.
-  function scrollSelectedEventsToBottom(): void {
-    if (!selectedTaskId) return;
-    const stream = document.querySelector<HTMLDivElement>(`[data-agent-events="${selectedTaskId}"]`);
-    if (stream) stream.scrollTop = stream.scrollHeight;
+  // Put the freshly rebuilt event stream back where the user left it: at the
+  // saved offset when they had scrolled up, otherwise pinned to the newest row.
+  // Also (re)attaches the scroll listener that feeds `streamScroll`.
+  function restoreSelectedEventsScroll(): void {
+    const taskId = selectedTaskId;
+    if (!taskId) return;
+    const stream = document.querySelector<HTMLDivElement>(`[data-agent-events="${taskId}"]`);
+    if (!stream) return;
+    const saved = streamScroll.get(taskId);
+    stream.scrollTop = saved && !saved.pinned ? saved.top : stream.scrollHeight;
+    stream.addEventListener("scroll", () => {
+      streamScroll.set(taskId, { top: stream.scrollTop, pinned: isPinnedToBottom(stream) });
+    });
   }
 
   async function pollCodexOAuth(shell: ShellState): Promise<void> {
@@ -865,8 +883,9 @@ export namespace agentPanel {
       stream.querySelector("[data-live-strip]")?.remove();
       liveStripKey = "";
     }
+    const pinned = isPinnedToBottom(stream);
     stream.insertAdjacentHTML("beforeend", renderAgentEvent(payload));
-    stream.scrollTop = stream.scrollHeight;
+    if (pinned) stream.scrollTop = stream.scrollHeight;
     if (payload.kind === "tool_result") {
       const task = tasks.find((item) => item.task_id === payload.task_id);
       if (task) updateLiveStrip(task);


### PR DESCRIPTION
## What

When viewing a task, switching to another application and back caused the timeline to jump to the bottom, losing the reading position. Same thing happened while a task was running: each incoming event yanked the stream to the bottom.

## Why

Window `focus` / `visibilitychange` trigger `refresh()` in `main.ts`, which ends in a full `render()` — an `innerHTML` rebuild that destroys the stream's scroll offset. The post-render `bind()` then called `scrollSelectedEventsToBottom()`, which unconditionally pinned the stream to its newest row. The incremental append in `appendEventRowIfSelected` had the same unconditional pin.

## How

All in `app/src/panels/tasks.ts`; the focus-triggered re-render itself is untouched — it's just no longer destructive to scroll position.

- A module-level `streamScroll` map records each task stream's scroll offset and whether the user is pinned to the bottom, fed by a `scroll` listener attached after every render (old listeners die with the discarded DOM).
- `scrollSelectedEventsToBottom()` → `restoreSelectedEventsScroll()`: after a rebuild, restore the saved offset if the user had scrolled up; pin to bottom only when they were already there or there's no saved state (fresh task open keeps today's auto-follow default).
- `appendEventRowIfSelected` now checks pinned-ness *before* inserting the row (inserting grows `scrollHeight`, so checking after would always report not-pinned), matching the convention `updateLiveStrip` already used. That shared check is extracted into `isPinnedToBottom()`.

## Reviewer notes

- Auto-follow behavior is unchanged when the user is at the bottom — live events, the notes strip, and fresh task opens still track the newest row.
- Scroll memory is per-task, so switching between tasks in the sidebar also returns each timeline to where it was left (session-scoped, not persisted).
- Verified with `tsc --noEmit`; manual check is: open a running task, scroll up, ⌘-Tab away and back → position holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)