### PR TITLE
fix(core): preserve recorded order in the run note archive

### DIFF
--- a/core/src/agent/note_store.rs
+++ b/core/src/agent/note_store.rs
@@ -25,8 +25,9 @@ pub fn notes_path(run_dir: &Path) -> PathBuf {
 }
 
 /// Persist the note records to `<run_dir>/notes.json` as an array, in the
-/// order given (first-recorded order). Each record carries its own `note_id`;
-/// the entry id is injected if a site-built record ever omits it.
+/// order given (first-recorded order). Each record is expected to carry its
+/// own `note_id`; the entry id is injected into object records that omit it.
+/// A non-object record has nowhere to hold an id and is written verbatim.
 ///
 /// Rewrites the whole file each call; the archive is small (tens of notes per
 /// run) and recording is sequential within a run, so this stays cheap.
@@ -69,7 +70,14 @@ pub fn load_notes(run_dir: &Path) -> Vec<Value> {
         return Vec::new();
     };
     match serde_json::from_str::<Value>(&text) {
-        Ok(Value::Object(map)) => map.into_iter().map(|(_, v)| v).collect(),
+        Ok(Value::Object(map)) => {
+            // Sort explicitly: map iteration is only key-ordered while
+            // serde_json's `preserve_order` feature stays off, and feature
+            // unification anywhere in the dependency graph could flip it.
+            let mut entries: Vec<(String, Value)> = map.into_iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            entries.into_iter().map(|(_, v)| v).collect()
+        }
         Ok(Value::Array(items)) => items,
         Ok(_) => {
             tracing::warn!(

--- a/core/src/agent/note_store.rs
+++ b/core/src/agent/note_store.rs
@@ -1,34 +1,50 @@
 //! Per-run archive of the notes the agent actually saw.
 //!
 //! As site tools fully read a note, they record it (full content + resolved
-//! local media) into `<run_dir>/notes.json` — a `{ "<note_id>": <record> }`
-//! map. This is the local, re-fetch-free source the desktop app renders as
-//! rich embedded note cards in the run timeline and the final answer.
+//! local media) into `<run_dir>/notes.json` — an array of records in the
+//! order they were first recorded (for `search`, result order). This is the
+//! local, re-fetch-free source the desktop app renders as rich embedded note
+//! cards in the run timeline and the final answer; keeping recorded order on
+//! disk is what lets the mid-run live strip and the finished result row show
+//! the same order. Older runs wrote a `{ "<note_id>": <record> }` map, which
+//! still loads (in id order).
 //!
 //! The record *shape* is site-specific and built by the site's tools (see
 //! `sites/xhs/tools.rs`); this module only owns the file path, persistence,
-//! and load. Records are keyed by note id, so re-reading a note overwrites the
-//! prior entry (latest read wins) and the archive stays deduped.
+//! and load. Entries are deduped by note id upstream (`ToolContext::
+//! record_note`): re-reading a note overwrites the prior record but keeps its
+//! position.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 /// Path to a run's note archive: `<run_dir>/notes.json`.
 pub fn notes_path(run_dir: &Path) -> PathBuf {
     run_dir.join("notes.json")
 }
 
-/// Persist the full `note_id -> record` map to `<run_dir>/notes.json`.
+/// Persist the note records to `<run_dir>/notes.json` as an array, in the
+/// order given (first-recorded order). Each record carries its own `note_id`;
+/// the entry id is injected if a site-built record ever omits it.
 ///
 /// Rewrites the whole file each call; the archive is small (tens of notes per
 /// run) and recording is sequential within a run, so this stays cheap.
-pub(crate) fn write_notes(run_dir: &Path, notes: &BTreeMap<String, Value>) -> std::io::Result<()> {
+pub(crate) fn write_notes(run_dir: &Path, notes: &[(String, Value)]) -> std::io::Result<()> {
     std::fs::create_dir_all(run_dir)?;
-    let map: Map<String, Value> = notes.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    let items: Vec<Value> = notes
+        .iter()
+        .map(|(id, record)| {
+            let mut record = record.clone();
+            if let Some(map) = record.as_object_mut() {
+                map.entry("note_id".to_string())
+                    .or_insert_with(|| Value::String(id.clone()));
+            }
+            record
+        })
+        .collect();
     let rendered =
-        serde_json::to_string_pretty(&Value::Object(map)).map_err(std::io::Error::other)?;
+        serde_json::to_string_pretty(&Value::Array(items)).map_err(std::io::Error::other)?;
     // The desktop app polls this file mid-run to show notes as they are
     // recorded, so go through a temp file + rename: readers must never see a
     // half-written JSON.
@@ -45,8 +61,9 @@ pub(crate) fn write_notes(run_dir: &Path, notes: &BTreeMap<String, Value>) -> st
 /// Load a run's recorded notes as an array of records (empty when the run
 /// recorded none or hasn't scanned yet). A missing file is normal and silent;
 /// a file that exists but fails to parse degrades to an empty list with a
-/// warning — never an error. The array form is tolerated alongside the
-/// canonical object map.
+/// warning — never an error. The legacy object-map form (older runs) is
+/// tolerated alongside the canonical array; it loads in id order since the
+/// map never carried recorded order.
 pub fn load_notes(run_dir: &Path) -> Vec<Value> {
     let Ok(text) = std::fs::read_to_string(notes_path(run_dir)) else {
         return Vec::new();

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -157,11 +157,13 @@ pub struct ToolContext {
     /// Note ids the agent has sampled via `search` in this run — useful
     /// for "show me what I've already covered" tools.
     search_note_ids: Arc<Mutex<Vec<String>>>,
-    /// Notes the agent fully read this run, keyed by note id. Archived to
-    /// `<run_dir>/notes.json` so the desktop app can render them as rich,
-    /// locally-served cards without re-fetching. The record shape is built by
-    /// the site tools; see [`crate::agent::note_store`].
-    notes_seen: Arc<Mutex<BTreeMap<String, Value>>>,
+    /// Notes the agent fully read this run, in the order they were first
+    /// recorded (the order the tool processed them — for `search`, result
+    /// order). Archived to `<run_dir>/notes.json` so the desktop app can
+    /// render them as rich, locally-served cards without re-fetching, in the
+    /// same order everywhere. The record shape is built by the site tools;
+    /// see [`crate::agent::note_store`].
+    notes_seen: Arc<Mutex<Vec<(String, Value)>>>,
 }
 
 #[derive(Default)]
@@ -202,7 +204,7 @@ impl ToolContext {
             counters: Arc::new(Mutex::new(Counters::default())),
             processed_notes: Arc::new(Mutex::new(BTreeMap::new())),
             search_note_ids: Arc::new(Mutex::new(Vec::new())),
-            notes_seen: Arc::new(Mutex::new(BTreeMap::new())),
+            notes_seen: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -300,8 +302,9 @@ impl ToolContext {
 
     /// Record a fully-read note (full content + resolved local media) into the
     /// run's note archive (`<run_dir>/notes.json`). Re-recording the same
-    /// `note_id` overwrites the prior entry (latest read wins). No-op on empty
-    /// id. The record shape is built by the caller (site tools).
+    /// `note_id` overwrites the prior entry (latest read wins) but keeps its
+    /// original position, so the archive stays in first-recorded order. No-op
+    /// on empty id. The record shape is built by the caller (site tools).
     pub fn record_note(&self, note_id: &str, record: Value) {
         if note_id.is_empty() {
             return;
@@ -309,7 +312,10 @@ impl ToolContext {
         let Ok(mut guard) = self.notes_seen.lock() else {
             return;
         };
-        guard.insert(note_id.to_string(), record);
+        match guard.iter_mut().find(|(id, _)| id == note_id) {
+            Some((_, existing)) => *existing = record,
+            None => guard.push((note_id.to_string(), record)),
+        }
         // Deliberately write while holding the lock: it keeps on-disk snapshots
         // in insertion order (clone-then-write lets an older snapshot land after
         // a newer one, dropping notes from disk until the next write). Tool

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -319,8 +319,8 @@ impl ToolContext {
         // Deliberately write while holding the lock: it keeps on-disk snapshots
         // in insertion order (clone-then-write lets an older snapshot land after
         // a newer one, dropping notes from disk until the next write). Tool
-        // calls run sequentially within a run and nothing else locks this map,
-        // so there is no contention to relieve.
+        // calls run sequentially within a run and nothing else locks the
+        // archive, so there is no contention to relieve.
         if let Err(err) = crate::agent::note_store::write_notes(&self.run_dir, &guard) {
             // Non-fatal: the in-memory copy still serves this process; only the
             // on-disk archive the desktop app reads is affected.


### PR DESCRIPTION
## What

`notes.json` (the per-run note archive) now preserves **recorded order** instead of sorting by note id:

- `ToolContext::notes_seen` is an insertion-ordered `Vec<(String, Value)>` instead of a `BTreeMap`. Re-recording a note overwrites its record in place — latest read wins, first-seen position kept.
- `write_notes` serializes the archive as a JSON **array** in that order. Each record already embeds its own `note_id`; it is injected defensively if a site-built record ever omits it.
- `load_notes` needed no change: it already tolerated the array form. Legacy object-map files from older runs still load (in id order, as before — those files never captured recorded order).

## Why

The desktop timeline shows the same rich note cards in two places, both rendered by the same component (`renderTimelineEmbed`): the mid-run **live strip** (fed by polling `notes.json`, added in #171) and the finished **tool_result row's embed** (fed by the event payload). Because the archive was a `BTreeMap`, the strip came out id-sorted while the row embed used search-result order — so cards visibly reshuffled the moment a result row claimed them.

Site tools process cards sequentially in result order, so recorded order equals payload order. Fixing the ordering once at the storage layer unifies both surfaces with **no frontend change**.

## Notes for review

- `record_note` dedupes with a linear scan; the archive is tens of entries per run and writes are sequential under the existing lock, so no ordered-map dependency is needed.
- Runs recorded before this change keep id-order when reopened mid-run — order was never stored for them.
- Verified: `cargo check --workspace` clean, all 89 existing core tests pass, plus a throwaway round-trip check (out-of-order recording → array order preserved; re-record keeps position; legacy map file still loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)