### PR TITLE
fix(core): stub local OCR on intel macs — ort ships no x86_64-apple-darwin prebuilt

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,10 +22,15 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 # Image compositing/resizing for batching note images into 2x2 vision grids.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+
 # Local OCR engine (PP-OCRv6 tiny via ONNX Runtime). Default features pull a
 # prebuilt ONNX Runtime at build time (download-binaries) + SIMD CPU kernels.
 # CPU-only by design: benchmarks showed CoreML/DirectML run PP-OCR slower, so we
 # don't compile in those execution providers.
+# Excluded on Intel macOS: ort ships no x86_64-apple-darwin prebuilt (upstream
+# ONNX Runtime dropped that platform), so the x86_64 slice of the universal
+# binary builds `media/ocr_stub.rs` instead and reports OCR as unavailable.
+[target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]
 oar-ocr = "0.7"
 
 [dev-dependencies]

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -8,6 +8,12 @@ mod audio;
 mod common;
 mod image;
 mod md5;
+// ort has no x86_64-apple-darwin prebuilt, so the Intel slice of the macOS
+// universal binary compiles a same-surface stub that reports OCR unavailable.
+#[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+mod ocr;
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+#[path = "ocr_stub.rs"]
 mod ocr;
 mod processor;
 mod timing;

--- a/core/src/media/ocr_stub.rs
+++ b/core/src/media/ocr_stub.rs
@@ -1,0 +1,58 @@
+//! OCR stub for Intel macOS (`x86_64-apple-darwin`).
+//!
+//! ort ships no prebuilt ONNX Runtime for this target (upstream ONNX Runtime
+//! dropped Intel macOS), so `oar-ocr` cannot build and the real `ocr` module
+//! is excluded from this slice of the universal binary. This stub keeps the
+//! same public surface: every OCR request resolves to a per-item error —
+//! the shape callers already handle — and diagnostics report OCR as
+//! unavailable instead of a model identity.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+const UNAVAILABLE: &str =
+    "local ocr is unavailable on intel macs (no x86_64-apple-darwin onnx runtime build)";
+
+/// Mirror of the real module's batch result: per-image text outcomes plus the
+/// wall time of the (never run) predict call.
+pub struct OcrBatch {
+    pub results: Vec<(usize, std::result::Result<String, String>)>,
+    pub predict: Duration,
+}
+
+/// Resolve every requested image to the unavailability error.
+pub fn ocr_images_bytes(items: Vec<(usize, Vec<u8>)>) -> OcrBatch {
+    OcrBatch {
+        results: items
+            .into_iter()
+            .map(|(idx, _)| (idx, Err(UNAVAILABLE.to_string())))
+            .collect(),
+        predict: Duration::ZERO,
+    }
+}
+
+/// No engine to warm.
+pub fn warm_up() {}
+
+/// Same key shape as the real module's diagnostics so perf records stay
+/// uniform across slices, with the model identity replaced by the reason OCR
+/// is unavailable.
+pub fn diagnostics() -> Value {
+    let machine = crate::util::machine::machine_info();
+    json!({
+        "model": null,
+        "runtime": null,
+        "execution_provider": null,
+        "available": false,
+        "reason": UNAVAILABLE,
+        "build": if cfg!(debug_assertions) { "debug" } else { "release" },
+        "machine": {
+            "os": machine.os,
+            "arch": machine.arch,
+            "cpu_model": machine.cpu_model,
+            "cpu_count": machine.cpu_count,
+            "memory_total_mb": machine.memory_total_mb,
+        },
+    })
+}


### PR DESCRIPTION
## Why

The v0.4.0 release run ([28642134125](https://github.com/socai-io/socai/actions/runs/28642134125)) failed in both macOS build jobs with:

```
error: ort-sys@2.0.0-rc.12: ort does not provide prebuilt binaries for the target `x86_64-apple-darwin` with feature set (no features).
```

`oar-ocr` (local PP-OCRv6, added in #156) pulls in `ort`, and upstream ONNX Runtime no longer publishes Intel-macOS binaries — so the x86_64 half of the universal build can't link. First release attempt since OCR landed, and x86_64-apple-darwin is only ever compiled at release time (dev machines and PR CI are arm64).

## What

- `core/Cargo.toml`: `oar-ocr` becomes a target-gated dependency, excluded on `x86_64-apple-darwin`.
- `core/src/media/ocr_stub.rs` (new): same four-item surface (`ocr_images_bytes`, `OcrBatch`, `warm_up`, `diagnostics`); every OCR request resolves to a per-item `Err` — the shape callers already handle — and diagnostics report OCR as unavailable with the reason.
- `core/src/media/mod.rs`: selects the real module or the stub by target.

No release has ever shipped OCR to Intel Macs, so nothing regresses; the Intel slice of the universal binary simply doesn't gain local OCR.

## Verification

- `cargo build -p socai-cli --release --target x86_64-apple-darwin` — passes (previously failed at `ort-sys`)
- `cargo build -p socai-cli --release --target aarch64-apple-darwin` — passes (real OCR intact)
- `cargo build -p socai_app --release --target x86_64-apple-darwin` — passes (covers the DMG job's compile)
- x86_64 binary runs under Rosetta: `socai 0.3.3`
- `Cargo.lock` unchanged (lockfiles are target-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)