### PR TITLE
build: skip debuginfo for dependencies in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,8 @@ socai-core = { path = "core" }
 [workspace.lints.clippy]
 unwrap_used = "warn"
 expect_used = "warn"
+
+# Skip debuginfo for dependencies (workspace crates keep full debuginfo).
+# Roughly halves target/ size per worktree; deps are rarely stepped through.
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
## Summary
- Add `[profile.dev.package."*"] debug = false` to the workspace root `Cargo.toml` so dependency crates compile without DWARF debuginfo in dev builds.
- Workspace crates (`core`, `cli`, `app/src-tauri`) are unaffected — the `"*"` glob only matches non-workspace packages — so backtraces and debugging in our own code keep full fidelity.

## Motivation
A dev `target/` dir here runs 1–9 GB, and with one target per git worktree this added up to ~46 GB of build artifacts on disk. Most of that bulk is debuginfo for binding-heavy dependencies (`objc2-app-kit` alone is ~223 MB of rlib+rmeta) that nobody steps through. Dropping dependency debuginfo roughly halves `target/` size per worktree and speeds up cold builds.

## Notes
- Existing `target/` dirs keep their old fat artifacts side-by-side (profile settings are part of the artifact fingerprint); run `cargo clean` once before rebuilding to avoid storing both generations.
- If dependency backtrace line numbers are ever missed, `debug = "line-tables-only"` is the middle-ground option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)