### PR TITLE
fix(core): keep note comment-scroll off the search feed (stale_note cascade)

### DIFF
--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -1253,12 +1253,15 @@ const SocaiXhsPageScripts = (() => {
         return el.scrollHeight > el.clientHeight + 24 && ['auto', 'scroll', 'overlay'].includes(overflow);
       }
       const overlay = $('.note-detail-mask, .note-overlay, .note-detail-modal, .note-detail, #noteContainer');
+      // Scope candidates to the overlay when the note is one: a page-level
+      // match (e.g. a generic .scroll-container on the results feed) must
+      // never win the headroom sort while a note is open.
       const candidates = [
         ...$$([
           '.note-scroller', '.note-content', '.note-detail .content', '.scroll-container',
           '.note-detail', '#noteContainer',
           '.note-detail-mask [class*="scroll"]', '.note-detail-mask [class*="content"]',
-        ].join(', ')),
+        ].join(', '), overlay || document),
         overlay,
       ].filter(Boolean);
       const seen = new Set();
@@ -1282,6 +1285,18 @@ const SocaiXhsPageScripts = (() => {
             error: after !== before ? '' : 'scroll_did_not_move',
           });
         }, 900);
+      } else if ($('section.note-item, .feeds-page .note-item, .ai-feeds-page .note-item')) {
+        // Result-feed cards are mounted below the note (it's a modal): a
+        // window scroll would scroll that feed, and the virtualized grid
+        // then unmounts the cards a scan collected — every later card click
+        // opens the wrong note (stale_note cascade). A short, unscrollable
+        // note simply has nothing more to load; report instead of scrolling.
+        resolve({
+          ok: false,
+          container: 'none',
+          delta: 0,
+          error: 'note_not_scrollable',
+        });
       } else {
         const before = window.scrollY;
         window.scrollBy({ top: pixels, behavior: 'smooth' });


### PR DESCRIPTION
## What

Two guards inside `scrollInNote` (`core/src/sites/xhs/page_scripts.js`):

1. **Scope the scrollable-container search to the note overlay** when one exists, so a page-level match (e.g. a generic `.scroll-container` on the results feed) can never win the headroom sort while a note is open.
2. **Refuse instead of window-scrolling when feed cards are mounted underneath**: if no scrollable container is found and `section.note-item` / `.feeds-page .note-item` / `.ai-feeds-page .note-item` cards exist (the note is a modal over the grid), return `ok:false, error:'note_not_scrollable'`. The window fallback survives only for full-page note views, which have no feed behind them.

## Why

A `search` with `sort=最新` fills the grid with minutes-old, zero-comment notes. Their modal is too short to scroll, so each comment-load round's `scroll_in_note(1200)` fell through to `window.scrollBy(1200)` — scrolling the **virtualized results grid underneath the modal**. The collected cards unmounted, `findCardElement`'s silent index fallback then clicked whatever card occupied each position (a feed-position used as a DOM-window index), and every later read failed the `stale_note` identity check. Net effect: a `num_notes:10` search archived a single note, so the desktop timeline rendered one card while the LLM answer cited notes that never made it into the archive.

The failure is comment-dependent, which is why it looked flaky: scans whose early notes have comments keep the scroll inside the modal and never trip it.

## Verification

CLI repro from this branch, query `世界杯 结果`:

| Config | Before | After |
|---|---|---|
| `--filter sort=最新 --num-notes 6` | 5/6 stale, 2/2 runs | **0 stale, 2/2 runs**, full `notes.json` archive |
| no filters (control) | clean | unchanged |
| `--filter publish_time=一天内` only | clean | unchanged |

Mechanism confirmed by polling the managed Chrome over CDP during runs: pre-fix, `window.scrollY` climbed 0→3497 during the first zero-comment read and the DOM card window churned through the whole feed; post-fix, four consecutive zero-comment modals opened with `scrollY` pinned at 0 and the card window unchanged.

## Reviewer notes

- Both consumers tolerate the refusal result: the Rust comment loop ignores the scroll result and exits via its stall counter (~3 rounds, same wall-time as before), and the agent-facing `scroll_in_note` tool just reports the payload.
- Follow-ups deliberately not in this PR: repair `findCardElement`'s silent index fallback (feed-position vs DOM-window index mismatch), retry the intended card after a `stale_note`, and archiving stale-but-fully-read entities so answer citations resolve to cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)