### PR TITLE
chore: add clean-targets skill for pruning cargo target dirs

### DIFF
--- a/.claude/skills/clean-targets/SKILL.md
+++ b/.claude/skills/clean-targets/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: clean-targets
+description: Reclaim disk space by deleting cargo target/ build directories across the main checkout and every git worktree of this repo. Use whenever the user wants to clean up build artifacts, free disk space, run "cargo clean" everywhere, prune worktree build caches, or complains that the repo or its worktrees are eating gigabytes of disk. Safely skips any target dir that a running build or dev session (cargo, rustc, tauri dev) is using.
+---
+
+# clean-targets
+
+Delete cargo `target/` directories across every checkout of this repo — the
+main checkout and all git worktrees — in one pass. Deleting `target/` is
+exactly what `cargo clean` does; the difference is this covers every checkout
+at once and refuses to touch a target that a live build is writing to.
+
+## How to run
+
+From anywhere inside any checkout of the repo:
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.claude/skills/clean-targets/scripts/clean-targets.sh" --dry-run
+```
+
+Run with `--dry-run` first and show the user what would be deleted and what is
+being kept (and why). If the plan looks as expected, run it again without the
+flag to actually delete. Report the total freed at the end, plus current free
+disk (`df -h /`).
+
+## What the script does
+
+- Discovers all checkouts with `git worktree list --porcelain` — nothing is
+  hardcoded, so it works on any machine and any worktree layout.
+- Detects target dirs by cargo's `CACHEDIR.TAG` marker file, not by directory
+  name, so unrelated directories that happen to be called `target` are never
+  touched.
+- Skips any target whose path appears in a running process's command line
+  (active `rustc`/`cargo` compile, a dev binary running out of `target/debug`,
+  a `tauri dev` session). Tell the user which ones were kept and that they can
+  re-run after stopping those sessions.
+
+## Notes
+
+- A skipped "in use" target usually means an active `pnpm exec tauri dev` in
+  that worktree. Never work around the skip by killing the process yourself —
+  surface it and let the user decide.
+- Everything deleted is a rebuildable cache; the next `cargo build` in that
+  checkout just starts cold. No source files, git state, or `node_modules` are
+  touched.

--- a/.claude/skills/clean-targets/scripts/clean-targets.sh
+++ b/.claude/skills/clean-targets/scripts/clean-targets.sh
@@ -23,9 +23,21 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   exit 1
 fi
 
+# Human-readable size from a KB count (shared by per-target and total lines).
+human() {
+  awk "BEGIN { kb = $1; if (kb >= 1048576) printf \"%.1f GB\", kb / 1048576; else if (kb >= 1024) printf \"%.0f MB\", kb / 1024; else printf \"%d KB\", kb }"
+}
+
 # One process snapshot up front; a target path appearing anywhere in a command
 # line (rustc --out-dir, a binary running from target/debug, ...) means in use.
-PROCS=$(ps -axo command || true)
+# Fail closed: without a snapshot the in-use check is blind, and deleting a
+# target mid-build is the one thing this script must never do. `set -e`
+# aborts if ps itself fails; the emptiness guard catches a silent no-op.
+PROCS=$(ps -axo command)
+if [ -z "$PROCS" ]; then
+  echo "error: empty process snapshot; refusing to delete without in-use protection" >&2
+  exit 1
+fi
 
 # Collect candidate target dirs from every checkout. maxdepth 4 reaches
 # nested workspaces (e.g. app/src-tauri/target) without descending into
@@ -46,8 +58,11 @@ fi
 freed_kb=0
 skipped=0
 while IFS= read -r t; do
-  size_kb=$(du -sk "$t" 2>/dev/null | cut -f1)
-  size_h=$(du -sh "$t" 2>/dev/null | cut -f1)
+  size_kb=$(du -sk "$t" 2>/dev/null | cut -f1 || true)
+  if [ -z "$size_kb" ]; then
+    continue  # vanished between discovery and now (e.g. a concurrent clean)
+  fi
+  size_h=$(human "$size_kb")
   if printf '%s\n' "$PROCS" | grep -qF "$t"; then
     echo "skip (in use)   ${size_h}  ${t}"
     skipped=$((skipped + 1))
@@ -63,7 +78,7 @@ while IFS= read -r t; do
 done <<< "$TARGETS"
 
 echo "--"
-freed_h=$(awk "BEGIN { kb = ${freed_kb}; if (kb >= 1048576) printf \"%.1f GB\", kb / 1048576; else printf \"%.0f MB\", kb / 1024 }")
+freed_h=$(human "$freed_kb")
 if [ "$DRY_RUN" -eq 1 ]; then
   echo "dry run: would free ${freed_h} (${skipped} in use, kept)"
 else

--- a/.claude/skills/clean-targets/scripts/clean-targets.sh
+++ b/.claude/skills/clean-targets/scripts/clean-targets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# clean-targets.sh — remove cargo target/ build dirs across every checkout of this repo.
+#
+# Checkouts (main + all worktrees) are discovered via `git worktree list`, so
+# nothing is hardcoded to one machine's directory layout. Cargo target dirs are
+# identified by the CACHEDIR.TAG marker cargo writes into each one — safer than
+# matching on the name "target" alone. Any target referenced by a running
+# process (an active rustc/cargo build, a dev binary launched from
+# target/debug, a `tauri dev` session) is skipped, because deleting it
+# mid-build corrupts the build or kills the session.
+#
+# Usage: clean-targets.sh [--dry-run|-n]
+
+set -euo pipefail
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+  DRY_RUN=1
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "error: run from inside a git checkout of the repo" >&2
+  exit 1
+fi
+
+# One process snapshot up front; a target path appearing anywhere in a command
+# line (rustc --out-dir, a binary running from target/debug, ...) means in use.
+PROCS=$(ps -axo command || true)
+
+# Collect candidate target dirs from every checkout. maxdepth 4 reaches
+# nested workspaces (e.g. app/src-tauri/target) without descending into
+# worktrees-inside-worktrees, which are enumerated on their own. Deduped in
+# case layouts overlap anyway.
+TARGETS=$(
+  git worktree list --porcelain | sed -n 's/^worktree //p' | while IFS= read -r wt; do
+    [ -d "$wt" ] || continue
+    find "$wt" -maxdepth 4 -path '*/target/CACHEDIR.TAG' 2>/dev/null || true
+  done | sed 's|/CACHEDIR.TAG$||' | sort -u
+)
+
+if [ -z "$TARGETS" ]; then
+  echo "no cargo target directories found — nothing to clean"
+  exit 0
+fi
+
+freed_kb=0
+skipped=0
+while IFS= read -r t; do
+  size_kb=$(du -sk "$t" 2>/dev/null | cut -f1)
+  size_h=$(du -sh "$t" 2>/dev/null | cut -f1)
+  if printf '%s\n' "$PROCS" | grep -qF "$t"; then
+    echo "skip (in use)   ${size_h}  ${t}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "would delete    ${size_h}  ${t}"
+  else
+    rm -rf "$t"
+    echo "deleted         ${size_h}  ${t}"
+  fi
+  freed_kb=$((freed_kb + size_kb))
+done <<< "$TARGETS"
+
+echo "--"
+freed_h=$(awk "BEGIN { kb = ${freed_kb}; if (kb >= 1048576) printf \"%.1f GB\", kb / 1048576; else printf \"%.0f MB\", kb / 1024 }")
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "dry run: would free ${freed_h} (${skipped} in use, kept)"
+else
+  echo "freed ${freed_h} (${skipped} in use, kept)"
+fi


### PR DESCRIPTION
## Summary
- Add a `clean-targets` project skill (`.claude/skills/clean-targets/`) that deletes cargo `target/` build dirs across the main checkout and every git worktree in one pass — the multi-worktree equivalent of `cargo clean`.
- `SKILL.md` instructs the agent to dry-run first, show the plan, then delete and report freed space; `scripts/clean-targets.sh` does the deterministic work and supports `--dry-run`.

## Design
- **No hardcoded paths**: checkouts are discovered via `git worktree list --porcelain`, so it works with any worktree layout on any machine.
- **Safe target detection**: dirs are identified by cargo's `CACHEDIR.TAG` marker file, not by the name `target`, so unrelated directories can never be deleted.
- **Live-build protection**: any target whose path appears in a running process's command line (active `rustc`/`cargo` compile, a binary running from `target/debug`, a `tauri dev` session) is skipped and reported.

## Testing
- End-to-end in an isolated scratch repo: main-checkout target deleted, nested `app/src-tauri/target` in a worktree deleted, a simulated in-use target kept, and a decoy `target/` without `CACHEDIR.TAG` left untouched.
- Dry-run against the real repo: correctly found the one existing target and flagged it in-use (a `socai __daemon` was running from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)