### PR TITLE
[codex] add Windows download support

### DIFF
--- a/.claude/skills/socai-release/SKILL.md
+++ b/.claude/skills/socai-release/SKILL.md
@@ -48,7 +48,7 @@ A helper script wraps this command, finds the created run, watches it, and print
 - Do not delete tags/releases unless the workflow failed and the user explicitly approves cleanup.
 - If local files are dirty, do not include unrelated changes in release work. The workflow publishes from the remote ref, not local uncommitted files.
 - The website redeploys automatically: Vercel Git integration is connected to `socai-io/socai` with production branch `main`, so the `chore: release socai vX.Y.Z` push triggers a production `socai-site` build with no manual step. Do not alter or rerun the release workflow to update `socai.io`.
-- Verifying `socai.io` (visible version + `/download` and `/github` redirects) is a **mandatory** part of every production release — the release is not done until the live site is confirmed serving the new version. Fall back to a manual `socai-site-deployment` redeploy only if that verification fails.
+- Verifying `socai.io` (the `/download`, `/download/windows`, and `/github` redirects) is a **mandatory** part of every production release — the release is not done until the redirects are confirmed resolving to the new tag's assets. Fall back to a manual `socai-site-deployment` redeploy only if that verification fails.
 
 ## Preflight checks
 
@@ -128,20 +128,19 @@ Use `minor` or `major` instead of `patch` only when requested.
 
 The website is **not** an optional follow-up — verifying it is a required release gate.
 
-Vercel Git integration is connected to `socai-io/socai` with production branch `main` (project `socai-site`, scope `socai-d83824c8`). The release workflow's push of `chore: release socai vX.Y.Z` to `main` therefore triggers a production `socai-site` build automatically; the site resolves the version from the bumped `app/src-tauri/tauri.conf.json` (falling back to the GitHub latest release), so no `SOCAI_RELEASE_VERSION` override is normally needed.
+Vercel Git integration is connected to `socai-io/socai` with production branch `main` (project `socai-site`, scope `socai-d83824c8`). The release workflow's push of `chore: release socai vX.Y.Z` to `main` therefore triggers a production `socai-site` build automatically, so no manual deploy is normally needed. The site does not display a version number (the hero release-meta line was removed); the `/download*` redirects always point at the GitHub **latest** release, so the site serves the new version as soon as the GitHub release is published.
 
-After the GitHub release verification, confirm the live site has caught up to the new version. The auto-deploy usually finishes within ~1 minute of the `main` push; allow for that and re-check if it is still mid-build.
+After the GitHub release verification, confirm the live site responds and every redirect resolves. The auto-deploy usually finishes within ~1 minute of the `main` push; allow for that and re-check if it is still mid-build.
 
 ```bash
-# visible version on the live pages must equal the just-published X.Y.Z
-for p in "" "contact"; do printf "/%s -> " "$p"; curl -s "https://socai.io/$p" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | sort -u | tr '\n' ' '; echo; done
-curl -sI https://socai.io/         | grep -iE '^HTTP'              # 200
-curl -sI https://www.socai.io/     | grep -iE '^HTTP|^location'   # 308 -> https://socai.io/
-curl -sI https://socai.io/download | grep -iE '^HTTP|^location'   # 307 -> GitHub latest DMG
-curl -sI https://socai.io/github   | grep -iE '^HTTP|^location'   # 307 -> github.com/socai-io/socai
+curl -sI https://socai.io/                  | grep -iE '^HTTP'             # 200
+curl -sI https://www.socai.io/              | grep -iE '^HTTP|^location'   # 308 -> https://socai.io/
+curl -sI https://socai.io/download          | grep -iE '^HTTP|^location'   # 307 -> GitHub latest DMG
+curl -sI https://socai.io/download/windows  | grep -iE '^HTTP|^location'   # 307 -> GitHub latest windows setup.exe
+curl -sI https://socai.io/github            | grep -iE '^HTTP|^location'   # 307 -> github.com/socai-io/socai
 ```
 
-The release is complete only when the live `socai.io` version equals the published `X.Y.Z` **and** all four checks above pass.
+The release is complete only when all five checks above pass **and** the `/download` + `/download/windows` targets resolve to assets of the just-published tag (see the redirect-resolution check in [Verify the published release](#verify-the-published-release)).
 
 If the site has **not** updated after the auto-deploy should have finished, fall back to a manual redeploy: switch to the `socai-site-deployment` skill and deploy the production `socai-site` project with `SOCAI_RELEASE_VERSION=X.Y.Z`. Do not rerun the GitHub release workflow to fix a site-only lag, and do not add website-deploy steps to the release workflow — the Git integration already performs the deploy.
 
@@ -214,9 +213,10 @@ tag="$(gh release view --repo socai-io/socai --json tagName --jq '.tagName')"
 curl -I https://socai.io/download
 curl -I -L --max-time 30 -o /dev/null -w 'code=%{http_code}\nfinal=%{url_effective}\n' https://socai.io/download
 curl -sSI https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg | grep -F "/releases/download/${tag}/socai-macos-universal.dmg"
+curl -sSI https://github.com/socai-io/socai/releases/latest/download/socai-windows-x86_64-setup.exe | grep -F "/releases/download/${tag}/socai-windows-x86_64-setup.exe"
 ```
 
-Expected final URL should resolve through GitHub latest release download and produce a successful response. The visible `socai.io` version updates automatically once the Git-integration site build finishes — confirm it as a mandatory step (see [Verify the website deployment](#verify-the-website-deployment-mandatory)).
+Expected final URLs should resolve through GitHub latest release download and produce a successful response. Confirm the site checks as a mandatory step (see [Verify the website deployment](#verify-the-website-deployment-mandatory)).
 
 Optional artifact check:
 
@@ -240,7 +240,7 @@ Include:
 - GitHub Actions run URL and conclusion
 - Published tag/version and release URL
 - Asset presence (`socai-macos-universal.dmg` + `socai-windows-x86_64-setup.exe`, plus updater `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json`)
-- `/download` verification summary
-- `socai.io` site verification summary (mandatory): live visible version equals `X.Y.Z`, and `/`, `www`, `/download`, `/github` all behave as expected
+- `/download` + `/download/windows` verification summary
+- `socai.io` site verification summary (mandatory): `/`, `www`, `/download`, `/download/windows`, `/github` all behave as expected, and both download redirects resolve to assets of the published tag
 - Whether the Git-integration auto-deploy was sufficient, or a manual `socai-site-deployment` redeploy fallback was needed
 - Any failures, cleanup performed, or manual blockers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1251,19 +1251,26 @@ jobs:
             throw "silent install exited with status $($install.ExitCode)"
           }
 
-          # NSIS installMode currentUser installs under LOCALAPPDATA; check
+          # The Tauri main binary keeps its crate name (socai_app.exe). NSIS
+          # installMode currentUser installs under LOCALAPPDATA; search
           # Program Files too in case the install mode ever changes.
-          $candidates = @(
-            (Join-Path $env:LOCALAPPDATA 'socai\socai.exe'),
-            (Join-Path $env:ProgramFiles 'socai\socai.exe')
-          )
-          $app = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          $roots = @($env:LOCALAPPDATA, $env:ProgramFiles) | Where-Object { $_ }
+          $app = $null
+          foreach ($root in $roots) {
+            $dir = Join-Path $root 'socai'
+            if (-not (Test-Path $dir)) { continue }
+            Write-Host "install dir ${dir}:"
+            Get-ChildItem $dir | Out-Host
+            $app = Get-ChildItem -Path $dir -Recurse -File -Include 'socai_app.exe', 'socai.exe' -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+            if ($app) { break }
+          }
           if (-not $app) {
-            throw "socai.exe not found after install; checked: $($candidates -join ', ')"
+            throw "app binary not found after install; checked $($roots -join ', ') under socai\"
           }
 
-          $productVersion = (Get-Item $app).VersionInfo.ProductVersion
-          Write-Host "installed ${app} (ProductVersion=$productVersion)"
+          $productVersion = $app.VersionInfo.ProductVersion
+          Write-Host "installed $($app.FullName) (ProductVersion=$productVersion)"
           if ($productVersion -notmatch "^$([regex]::Escape($env:VERSION))") {
             throw "expected installed app version to start with $env:VERSION, got: $productVersion"
           }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,14 +2,11 @@
 import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
-import {
-    message as messageFor,
-    formatMessage as formatMessageFor,
-} from "../lib/i18n";
-import { resolveReleaseVersion } from "../lib/release";
+import { message as messageFor } from "../lib/i18n";
 
 const githubUrl = "/github";
 const downloadPath = "/download";
+const downloadWindowsPath = "/download/windows";
 const currentYear = new Date().getFullYear();
 const siteUrl = "https://socai.io";
 const canonicalUrl = `${siteUrl}/`;
@@ -22,7 +19,7 @@ const messages = {
         meta: {
             title: "socai · Web Agent for RedNote research",
             description:
-                "socai is a Web Agent for RedNote research tasks. connect your chrome session, run focused browser tasks, and download the macOS app.",
+                "socai is a Web Agent for RedNote research tasks. connect your chrome session, run focused browser tasks, and download the app for macOS or Windows.",
             socialImageAlt: "socai app preview with a download prompt",
         },
         nav: {
@@ -41,8 +38,8 @@ const messages = {
                 "socai connects to your RedNote account via chrome CDP, and finishes tasks for you by simulating humanlike click and type events",
             actionsAria: "download and source",
             download: "download for macOS",
+            downloadWindows: "download for Windows",
             github: "view on github",
-            releaseMeta: "macOS 13+ · universal build · {version}",
         },
         preview: {
             sectionAria: "socai app preview",
@@ -83,7 +80,7 @@ const messages = {
         meta: {
             title: "socai · 小红书调研 Agent",
             description:
-                "socai 是面向小红书调研任务的 Web Agent。连接你的 chrome 会话，执行聚焦的浏览器任务，并下载 macOS app。",
+                "socai 是面向小红书调研任务的 Web Agent。连接你的 chrome 会话，执行聚焦的浏览器任务，支持 macOS 和 Windows。",
             socialImageAlt: "socai app 下载界面预览",
         },
         nav: {
@@ -102,8 +99,8 @@ const messages = {
                 "socai 通过 chrome CDP 连接你的小红书账号，模拟真实点击输入，替你完成搜索调研任务。",
             actionsAria: "下载和源码",
             download: "下载 macOS 版",
+            downloadWindows: "下载 Windows 版",
             github: "在 github 查看",
-            releaseMeta: "macOS 13+ · {version}",
         },
         preview: {
             sectionAria: "socai app 预览",
@@ -144,18 +141,11 @@ const messages = {
 
 const message = (path: string, language = defaultLanguage) =>
     messageFor(messages, path, language);
-const formatMessage = (
-    path: string,
-    values: Record<string, string | number> = {},
-    language = defaultLanguage,
-) => formatMessageFor(messages, path, values, language);
 
 const initialPrompts = messages[defaultLanguage].prompts;
 const pageTitle = message("meta.title");
 const pageDescription = message("meta.description");
 const socialImageAlt = message("meta.socialImageAlt");
-const releaseVersion = await resolveReleaseVersion();
-const releaseValues = JSON.stringify({ version: releaseVersion });
 ---
 
 <html lang={defaultHtmlLanguage} data-language={defaultLanguage}>
@@ -252,6 +242,17 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
                                 >↓</span
                             >
                         </a>
+                        <a
+                            class="button button--primary"
+                            href={downloadWindowsPath}
+                        >
+                            <span data-i18n="hero.downloadWindows"
+                                >{message("hero.downloadWindows")}</span
+                            >
+                            <span class="button__glyph" aria-hidden="true"
+                                >↓</span
+                            >
+                        </a>
                         <a class="button button--secondary" href={githubUrl}>
                             <svg
                                 viewBox="0 0 16 16"
@@ -272,19 +273,6 @@ const releaseValues = JSON.stringify({ version: releaseVersion });
                             >
                         </a>
                     </div>
-
-                    <p
-                        class="release-meta"
-                        data-release-meta
-                        data-i18n="hero.releaseMeta"
-                        data-i18n-values={releaseValues}
-                    >
-                        {
-                            formatMessage("hero.releaseMeta", {
-                                version: releaseVersion,
-                            })
-                        }
-                    </p>
                 </section>
 
                 <section

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -199,7 +199,6 @@ button:focus-visible {
   color: var(--ink-0);
 }
 
-.release-meta,
 .site-footer,
 .window-title,
 .status-pill,
@@ -312,13 +311,6 @@ html[data-language="zh"] .hero h1 {
 
 .button__external {
   color: var(--fg-soft);
-}
-
-.release-meta {
-  margin: 16px 0 0;
-  color: var(--fg-soft);
-  font-size: 11px;
-  letter-spacing: 0.02em;
 }
 
 .app-shot-section {

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -44,6 +44,11 @@
       "permanent": false
     },
     {
+      "source": "/download/windows",
+      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-windows-x86_64-setup.exe",
+      "permanent": false
+    },
+    {
       "source": "/github",
       "destination": "https://github.com/socai-io/socai",
       "permanent": false


### PR DESCRIPTION
## What changed

- add a Windows download button and /download/windows redirect
- remove the obsolete homepage release-version line
- update release verification guidance for macOS and Windows downloads
- make the Windows installer smoke check locate the actual installed executable

## Impact

Windows users can download the latest installer directly from the homepage, and release verification now covers both platform downloads.

## Validation

- pnpm --dir site build
- release workflow YAML parse
- site/vercel.json JSON parse
- git diff --check