### PR TITLE
feat(app): replace the timeline's answer copy with a final-answer reference card

### DIFF
--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -134,6 +134,9 @@ const messages = {
   },
   "task.deleteKeep": { en: "keep", zh: "保留" },
   "task.finalAnswer": { en: "final answer", zh: "最终答案" },
+  "task.answerInPanel": { en: "shown in the answer panel", zh: "见右侧答案面板" },
+  "task.answerBelow": { en: "see the answer below", zh: "见下方答案" },
+  "task.jumpToAnswerAria": { en: "go to the final answer", zh: "跳转到最终答案" },
   "task.timeline": { en: "timeline", zh: "时间线" },
   "task.errorLabel": { en: "error", zh: "错误" },
   "task.waitingForEvents": { en: "waiting for events…", zh: "等待事件…" },
@@ -248,6 +251,11 @@ export function formatTaskCount(count: number): string {
 export function formatTurns(count: number): string {
   if (currentLanguage === "zh") return `${count} 轮`;
   return `${count} turn${count === 1 ? "" : "s"}`;
+}
+
+export function formatSourceCount(count: number): string {
+  if (currentLanguage === "zh") return `${count} 条来源`;
+  return `${count} source${count === 1 ? "" : "s"}`;
 }
 
 export function formatTokenUsage(inputTokens: number, outputTokens: number): string {

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -5,12 +5,17 @@
 //! answer yet, or a failed task that produced only an error — it falls back to a
 //! single stacked panel. (Narrow windows fold split into a stack via CSS.)
 //!
+//! The answer lives in one place: once the answer panel has a run's final
+//! text, the timeline drops the assistant row that streamed that same text
+//! and ends with a compact reference card pointing at the panel instead
+//! (FinalAnswerRef in the SocaiV2 handoff).
+//!
 //! Below the body, a full-width filmstrip shows the notes the agent saw.
 
 import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
 import { renderNoteAnswer, renderTimelineEmbed, setNoteRegistry } from "./notes";
-import { formatTaskCount, formatTaskTimestamp, formatTokenUsage, formatTurns, taskStatusLabel, t } from "../lib/i18n";
+import { formatSourceCount, formatTaskCount, formatTaskTimestamp, formatTokenUsage, formatTurns, taskStatusLabel, t } from "../lib/i18n";
 import type { AgentTaskView } from "./tasks";
 
 export interface SidebarProps {
@@ -144,14 +149,74 @@ function renderDetailHead(task: AgentTaskView, running: boolean): string {
 
 function renderTimelinePanel(task: AgentTaskView): string {
   const hasEvents = task.events.length > 0;
+  const duplicateIndex = finalAnswerEventIndex(task);
   const rows = hasEvents
-    ? task.events.map(renderAgentEvent).join("")
+    ? task.events
+        .filter((_, index) => index !== duplicateIndex)
+        .map(renderAgentEvent)
+        .join("")
     : `<p class="t-small placeholder" data-events-placeholder>${esc(t("task.waitingForEvents"))}</p>`;
+  const answerRef = task.final_text ? renderFinalAnswerRef(task) : "";
   return `
     <div class="result-block detail-panel">
       <p class="t-eyebrow result-label detail-panel-label">${esc(t("task.timeline"))}</p>
-      <div class="event-stream" data-agent-events="${esc(task.task_id)}">${rows}</div>
+      <div class="event-stream" data-agent-events="${esc(task.task_id)}">${rows}${answerRef}</div>
     </div>
+  `;
+}
+
+// The shell caps event text at 8k chars and marks the cut with this suffix.
+const EVENT_TRUNCATION_SUFFIX = "\n... [truncated]";
+
+// The timeline's copy of the final answer: the last assistant event, but only
+// when the answer panel is showing the same text. The panel hydrates from
+// report.md — the loop's final text plus an optional artifacts appendix — and
+// the event may be truncated, so "same" means the event text prefixes the
+// panel text, not equality. A failed run's panel holds an error string that
+// matches no assistant text, so commentary before a failure stays readable.
+// While a task runs, final_text is unset and the answer streams here in full.
+function finalAnswerEventIndex(task: AgentTaskView): number {
+  const finalText = task.final_text?.trim();
+  if (!finalText) return -1;
+  for (let index = task.events.length - 1; index >= 0; index -= 1) {
+    const ev = task.events[index];
+    if (ev.kind !== "assistant") continue;
+    let text = ev.text;
+    if (text.endsWith(EVENT_TRUNCATION_SUFFIX)) {
+      text = text.slice(0, -EVENT_TRUNCATION_SUFFIX.length);
+    }
+    text = text.trim();
+    return text && finalText.startsWith(text) ? index : -1;
+  }
+  return -1;
+}
+
+// The timeline's terminal element (FinalAnswerRef in the SocaiV2 handoff):
+// stands in for the answer the stream no longer repeats — names it, gives a
+// light signal (source count), and points at the answer panel. The handoff
+// picks hint + arrow from a layout prop; the shipped app folds split→stacked
+// in CSS, so both variants render and the fold's breakpoint picks one.
+// Clicking rewinds the answer's scroll and flashes the panel; bound in
+// tasks.ts via [data-answer-ref].
+function renderFinalAnswerRef(task: AgentTaskView): string {
+  const sources = task.notes?.length ?? 0;
+  const count = sources > 0
+    ? `<span class="final-answer-ref__count">${esc(formatSourceCount(sources))}</span>`
+    : "";
+  return `
+    <button type="button" class="final-answer-ref" data-answer-ref aria-label="${esc(t("task.jumpToAnswerAria"))}">
+      <span class="final-answer-ref__glyph" aria-hidden="true">✓</span>
+      <span class="final-answer-ref__body">
+        <span class="final-answer-ref__label">${esc(t("task.finalAnswer"))}</span>
+        <span class="final-answer-ref__hint">
+          ${count}
+          <span class="final-answer-ref__cta final-answer-ref__cta--split">${esc(t("task.answerInPanel"))}</span>
+          <span class="final-answer-ref__cta final-answer-ref__cta--stacked">${esc(t("task.answerBelow"))}</span>
+        </span>
+      </span>
+      <span class="final-answer-ref__arrow final-answer-ref__arrow--split" aria-hidden="true">→</span>
+      <span class="final-answer-ref__arrow final-answer-ref__arrow--stacked" aria-hidden="true">↓</span>
+    </button>
   `;
 }
 

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -173,6 +173,8 @@ export namespace agentPanel {
   // position here and the post-render bind restores it. No entry, or a pinned
   // entry, means auto-follow: keep the stream glued to its newest row.
   const streamScroll = new Map<string, { top: number; pinned: boolean }>();
+  // Pending removal of the answer panel's jump-flash ring (one at a time).
+  let answerFlashTimer: number | undefined;
 
   function isPinnedToBottom(stream: HTMLDivElement): boolean {
     return stream.scrollTop + stream.clientHeight >= stream.scrollHeight - 8;
@@ -642,6 +644,22 @@ export namespace agentPanel {
     // Note interactions (viewer, card carousel, citation hover, external links)
     // are wired once via delegation on document.
     bindNoteInteractions();
+    // The timeline's final-answer card is a pointer, not a copy: activating
+    // it rewinds the answer panel's scroll (so the reader lands at the top of
+    // the answer) and flashes a ring on it so the eye finds the real content.
+    document.querySelectorAll<HTMLButtonElement>("[data-answer-ref]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const outcome = document.querySelector<HTMLElement>(".agent-outcome");
+        if (!outcome) return;
+        const scroller = outcome.querySelector<HTMLElement>(".result-pre");
+        if (scroller) scroller.scrollTop = 0;
+        outcome.classList.remove("answer-flash");
+        void outcome.offsetWidth; // restart the ring on repeat clicks
+        outcome.classList.add("answer-flash");
+        if (answerFlashTimer) window.clearTimeout(answerFlashTimer);
+        answerFlashTimer = window.setTimeout(() => outcome.classList.remove("answer-flash"), 1300);
+      });
+    });
     document.querySelectorAll<HTMLButtonElement>("[data-cancel-task]").forEach((btn) => {
       btn.addEventListener("click", async () => {
         const taskId = btn.dataset.cancelTask;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1128,6 +1128,93 @@ body.has-paper > * { position: relative; z-index: 1; }
 .event-api_error .event-glyph { color: var(--status-error-fg); }
 .event-done .event-glyph { color: var(--ink-0); }
 
+/* ── Final-answer reference (timeline terminal) ────────────────────
+   From the SocaiV2 handoff. The timeline's last item no longer repeats the
+   answer text; it shows a compact card that names the answer and points at
+   the answer panel. Sits inside the mono .event-stream, so it deliberately
+   breaks to sans + a card surface to read as a distinct terminal element. */
+.final-answer-ref {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  margin-top: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border: var(--hairline);
+  border-radius: var(--r-3);
+  background: var(--surface);
+  color: var(--fg);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+.final-answer-ref:hover { border-color: var(--line-strong); background: var(--ink-7); }
+.final-answer-ref:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 1px; }
+.final-answer-ref__glyph {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--r-pill);
+  background: var(--ink-0);
+  color: var(--ink-9);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+.final-answer-ref__body { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.final-answer-ref__label {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink-1);
+}
+.final-answer-ref__hint {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 8px;
+  row-gap: 1px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.01em;
+  color: var(--fg-soft);
+}
+.final-answer-ref__count { color: var(--fg-faint); }
+.final-answer-ref__cta { min-width: 0; }
+.final-answer-ref__arrow {
+  flex: 0 0 auto;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  transition: transform var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+.final-answer-ref:hover .final-answer-ref__arrow { color: var(--ink-0); transform: translateX(2px); }
+/* The handoff picks hint + arrow from a layout prop; here both variants
+   render and the .detail-split fold's breakpoint picks one. */
+.final-answer-ref__cta--stacked,
+.final-answer-ref__arrow--stacked { display: none; }
+@media (max-width: 900px) {
+  .final-answer-ref__cta--split,
+  .final-answer-ref__arrow--split { display: none; }
+  .final-answer-ref__cta--stacked { display: inline; }
+  .final-answer-ref__arrow--stacked { display: inline; }
+}
+
+/* Activating the reference flashes a ring on the answer body so the eye lands
+   on the real content (used in split/stacked, where the panel is visible). */
+.agent-outcome.answer-flash .result-pre { animation: answerFlash 1.3s var(--ease); }
+@keyframes answerFlash {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.30); }
+  28%  { box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.20); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); }
+}
+
 .agent-outcome {
   flex: 2 1 0;               /* the payoff: 2 shares of the pane vs the logs' 1 */
   min-height: 96px;


### PR DESCRIPTION
## What

On a completed task, the timeline's last assistant row repeated the entire final answer — the same text the answer panel beside it renders properly (markdown + citation pills), but raw and up to 8k chars. The timeline now:

- **drops the duplicate assistant row**, detected by a truncation-aware prefix match against `task.final_text` (the panel hydrates from `report.md` = the loop's final text + an optional artifacts appendix; the event stream caps text with a `... [truncated]` suffix — so "same" means prefix, not equality), and
- **ends with the SocaiV2 handoff's `FinalAnswerRef` card**: ✓ badge, sans `final answer` label, mono hint with a source count (`12 sources`) and a layout-aware CTA + arrow — `shown in the answer panel →` in the split, `see the answer below ↓` once the layout folds. Clicking rewinds the answer panel's scroll to the top and flashes a ring on it (handoff keyframes).

<img width="3984" height="2696" alt="CleanShot 2026-07-06 at 15 49 01@2x" src="https://github.com/user-attachments/assets/37f17d7a-3259-46c6-887d-710dc99bf8a5" />


## Why

The duplication made the timeline's tail noise: a wall of raw markdown/`[[note:id]]` tokens directly next to the rendered version. The handoff designed this exact component ("final-answer reference — timeline terminal"); this ports it. The answer now lives in one place, and the timeline reads as a run log that *ends at* the answer.

## Notes for review

- **Streaming is untouched.** While a task runs there is no answer panel (`final_text` only hydrates once `report.md` exists), so assistant text still streams into the timeline live. The card appears on the full re-render triggered by the completed snapshot.
- **Failed runs keep their commentary.** Their `final_text` is an error report that matches no assistant event, so no row is dropped; the card still points at whatever the panel shows.
- The handoff picks hint/arrow from a React `layout` prop ("focused" tabs don't exist in the shipped app) — here both variants render and the same 900px media query that folds `.detail-split` picks one. The `FinalAnswerInline` comparison variant from the handoff was deliberately not ported.
- The jump flash uses the handoff's box-shadow ring. AGENTS.md reserves shadows for popovers; I followed the design spec since it's a transient focus cue, not structural separation — happy to swap for a border pulse if we'd rather keep the rule absolute.
- en/zh strings and the aria-label come verbatim from the handoff's `i18n.js`.

## Verification

- `tsc --noEmit` and `vite build` pass.
- A Node smoke test over the real `renderTaskDetail` (esbuild + linkedom, not committed) covered 14 assertions: card renders once and is the stream's terminal element; answer text appears only in the panel; interim assistant rows survive; truncated events still dedup; failed runs drop nothing; running tasks show no card; source count and both CTA/arrow variants present.
- Headless-Chrome screenshots of both layouts against the real stylesheet:

| split (>900px) | stacked (≤900px) |
| --- | --- |
| card ends the timeline, `12 sources · shown in the answer panel →` | `see the answer below ↓`, panel directly beneath |

🤖 Generated with [Claude Code](https://claude.com/claude-code)