### PR TITLE
feat(telemetry): trace agent runs into axiom as otel spans

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -975,7 +975,8 @@ async fn run_agent_task_on_shared_page(
         let mut tools = agent_tools(page.clone(), llm_provider.clone()).await?;
         tools.extend(desktop_agent_tools());
         let (tx, rx) = tokio::sync::broadcast::channel::<AgentEvent>(256);
-        let pump = pump_agent_task_events(app, registry.clone(), task_id.clone(), telemetry, rx);
+        let pump =
+            pump_agent_task_events(app, registry.clone(), task_id.clone(), telemetry.clone(), rx);
 
         let agent_instructions = site
             .default_agent_instructions
@@ -996,6 +997,7 @@ async fn run_agent_task_on_shared_page(
         let outcome = run_agent_with_tools(task, llm_provider, tools, config, tx).await;
         let _ = pump.await;
         let outcome = outcome?;
+        telemetry.upload_run_trace(&outcome.run_dir);
 
         Ok::<AgentRunOutcome, anyhow::Error>(AgentRunOutcome {
             run_id: outcome.run_id,

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde_json::Value;
 use socai_core::telemetry::{telemetry_enabled, Telemetry, TelemetrySource};
 
@@ -28,6 +30,14 @@ impl DesktopTelemetry {
     pub(crate) fn capture(&self, name: &str, properties: Value) {
         if let Some(telemetry) = &self.0 {
             telemetry.capture(name, properties);
+        }
+    }
+
+    /// Upload a completed run's `trace.json` to the traces proxy. No-op when
+    /// telemetry is off or the file is missing (e.g. cancelled runs).
+    pub(crate) fn upload_run_trace(&self, run_dir: impl AsRef<Path>) {
+        if let Some(telemetry) = &self.0 {
+            telemetry.upload_run_trace(run_dir.as_ref());
         }
     }
 }

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -38,6 +38,7 @@ use crate::agent::run_state::RunState;
 use crate::agent::signature::tool_call_signature;
 use crate::agent::system_prompt::build_system_prompt;
 use crate::agent::tool::{SharedTool, ToolContext, ToolResult, ToolResultBlock};
+use crate::telemetry::trace::RunTraceBuilder;
 
 /// Events streamed to subscribers while the agent is running.
 #[derive(Debug, Clone)]
@@ -162,6 +163,12 @@ pub async fn run_agent_with_events(
         task,
         backend.model(),
     )?;
+    let mut run_trace = RunTraceBuilder::new(
+        &run_id,
+        task,
+        backend.model(),
+        options.session_id.as_deref(),
+    );
 
     let mut ctx = ToolContext::new(&run_id, &run_dir).with_run_state(Arc::clone(&run_state));
     for site in &options.enabled_sites {
@@ -218,20 +225,16 @@ pub async fn run_agent_with_events(
             .await
         {
             Ok(response) => {
-                run_recorder.record_llm_response(
-                    step,
-                    &response,
-                    llm_started.elapsed().as_millis() as u64,
-                )?;
+                let duration_ms = llm_started.elapsed().as_millis() as u64;
+                run_recorder.record_llm_response(step, &response, duration_ms)?;
+                run_trace.record_llm(step, duration_ms, &response);
                 response
             }
             Err(e) => {
                 let msg = format!("{e:#}");
-                run_recorder.record_llm_error(
-                    step,
-                    &msg,
-                    llm_started.elapsed().as_millis() as u64,
-                )?;
+                let duration_ms = llm_started.elapsed().as_millis() as u64;
+                run_recorder.record_llm_error(step, &msg, duration_ms)?;
+                run_trace.record_llm_error(step, duration_ms, &msg);
                 warn!(step, error = %msg, "backend error");
                 emit(
                     &events,
@@ -384,6 +387,15 @@ pub async fn run_agent_with_events(
 
             let result_content = tool_result_to_content(&result);
             let content = content_for_log(&result_content);
+            run_trace.record_tool(
+                step,
+                sequence,
+                name,
+                duration_ms,
+                &effective_input,
+                &content,
+                error.as_deref(),
+            );
             let flat = result.flat_text();
             let summary = truncate_summary(&flat, 240);
             emit(
@@ -466,11 +478,9 @@ pub async fn run_agent_with_events(
             .await
         {
             Ok(response) => {
-                run_recorder.record_llm_response(
-                    step + 1,
-                    &response,
-                    llm_started.elapsed().as_millis() as u64,
-                )?;
+                let duration_ms = llm_started.elapsed().as_millis() as u64;
+                run_recorder.record_llm_response(step + 1, &response, duration_ms)?;
+                run_trace.record_llm(step + 1, duration_ms, &response);
                 total_input_tokens += response.input_tokens;
                 total_output_tokens += response.output_tokens;
                 let (visible_texts, _) = split_thinking(&response.text_blocks);
@@ -487,11 +497,9 @@ pub async fn run_agent_with_events(
             }
             Err(e) => {
                 let msg = format!("{e:#}");
-                run_recorder.record_llm_error(
-                    step + 1,
-                    &msg,
-                    llm_started.elapsed().as_millis() as u64,
-                )?;
+                let duration_ms = llm_started.elapsed().as_millis() as u64;
+                run_recorder.record_llm_error(step + 1, &msg, duration_ms)?;
+                run_trace.record_llm_error(step + 1, duration_ms, &msg);
                 warn!(step = step + 1, error = %msg, "forced summary error");
                 emit(
                     &events,
@@ -517,17 +525,28 @@ pub async fn run_agent_with_events(
     let enriched_report = report_with_artifacts(&final_text, Some(&run_state));
     let _ = std::fs::write(run_dir.join("report.md"), &enriched_report);
 
+    let status = if terminal_error.is_some() {
+        "failed"
+    } else {
+        "completed"
+    };
     run_recorder.finish(
-        if terminal_error.is_some() {
-            "failed"
-        } else {
-            "completed"
-        },
+        status,
         step,
         total_input_tokens,
         total_output_tokens,
         terminal_error.as_deref(),
     )?;
+    let trace_payload = run_trace.finish(
+        status,
+        step,
+        total_input_tokens,
+        total_output_tokens,
+        terminal_error.as_deref(),
+    );
+    if let Ok(bytes) = serde_json::to_vec(&trace_payload) {
+        let _ = std::fs::write(run_dir.join("trace.json"), bytes);
+    }
 
     Ok(AgentOutcome {
         run_id,

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -168,6 +168,7 @@ pub async fn run_agent_with_events(
         task,
         backend.model(),
         options.session_id.as_deref(),
+        options.seed_messages.len(),
     );
 
     let mut ctx = ToolContext::new(&run_id, &run_dir).with_run_state(Arc::clone(&run_state));

--- a/core/src/agent/signature.rs
+++ b/core/src/agent/signature.rs
@@ -63,6 +63,17 @@ fn md5_hex_short(bytes: &[u8]) -> String {
     s
 }
 
+/// Full 32-hex md5 of the input — stable id derivation (e.g. a conversation's
+/// shared trace id), not a security boundary.
+pub(crate) fn md5_hex(bytes: &[u8]) -> String {
+    let digest = md5_compute(bytes);
+    let mut s = String::with_capacity(32);
+    for byte in &digest {
+        s.push_str(&format!("{byte:02x}"));
+    }
+    s
+}
+
 // RFC 1321 MD5 — non-crypto purpose. Collisions here would mean we
 // fail to spot a repeat call, not a security boundary.
 fn md5_compute(input: &[u8]) -> [u8; 16] {

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -10,9 +10,11 @@ use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
 pub mod tool_call;
+pub mod trace;
 
 const EVENT_SCHEMA_VERSION: u32 = 1;
 const TELEMETRY_ENDPOINT: &str = "https://socai.io/v1/events";
+const TRACES_ENDPOINT: &str = "https://socai.io/v1/traces";
 const CHANNEL_CAPACITY: usize = 512;
 const REMOTE_BATCH_SIZE: usize = 25;
 const REMOTE_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
@@ -43,7 +45,14 @@ impl TelemetrySource {
 
 #[derive(Clone)]
 pub struct Telemetry {
-    sender: mpsc::Sender<QueuedEvent>,
+    sender: mpsc::Sender<QueuedItem>,
+}
+
+#[derive(Debug)]
+enum QueuedItem {
+    Event(QueuedEvent),
+    /// Path to a run's `trace.json`; the worker reads, enriches, and uploads it.
+    TraceFile(PathBuf),
 }
 
 #[derive(Debug)]
@@ -95,10 +104,18 @@ impl Telemetry {
     }
 
     pub fn capture(&self, name: impl Into<String>, properties: Value) {
-        let _ = self.sender.try_send(QueuedEvent {
+        let _ = self.sender.try_send(QueuedItem::Event(QueuedEvent {
             name: name.into(),
             properties,
-        });
+        }));
+    }
+
+    /// Fire-and-forget upload of a completed run's `trace.json` (written by the
+    /// agent loop). Missing file — e.g. a cancelled run — is a silent no-op.
+    pub fn upload_run_trace(&self, run_dir: &Path) {
+        let _ = self
+            .sender
+            .try_send(QueuedItem::TraceFile(run_dir.join("trace.json")));
     }
 }
 
@@ -107,7 +124,7 @@ impl Telemetry {
 /// `Telemetry` from a plain synchronous `fn run()` with no ambient runtime — it
 /// owns a dedicated current-thread runtime so `capture()` stays fire-and-forget
 /// regardless of the caller's context.
-fn spawn_worker(receiver: mpsc::Receiver<QueuedEvent>, config: WorkerConfig) {
+fn spawn_worker(receiver: mpsc::Receiver<QueuedItem>, config: WorkerConfig) {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
             handle.spawn(worker_loop(receiver, config));
@@ -128,7 +145,7 @@ fn spawn_worker(receiver: mpsc::Receiver<QueuedEvent>, config: WorkerConfig) {
     }
 }
 
-async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerConfig) {
+async fn worker_loop(mut receiver: mpsc::Receiver<QueuedItem>, config: WorkerConfig) {
     let client = reqwest::Client::new();
     let mut remote_batch: Vec<Value> = Vec::new();
     let mut flush_tick = tokio::time::interval(REMOTE_FLUSH_INTERVAL);
@@ -136,18 +153,25 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerCo
 
     loop {
         tokio::select! {
-            maybe_event = receiver.recv() => {
-                let Some(event) = maybe_event else {
+            maybe_item = receiver.recv() => {
+                let Some(item) = maybe_item else {
                     break;
                 };
-                let timestamp_ms = now_ms();
-                let properties = enrich_properties(event.properties, &config, timestamp_ms);
-                let row = local_row(&event.name, &config.install_id, timestamp_ms, &properties);
-                let _ = append_jsonl(&config.local_path, &row).await;
+                match item {
+                    QueuedItem::Event(event) => {
+                        let timestamp_ms = now_ms();
+                        let properties = enrich_properties(event.properties, &config, timestamp_ms);
+                        let row = local_row(&event.name, &config.install_id, timestamp_ms, &properties);
+                        let _ = append_jsonl(&config.local_path, &row).await;
 
-                remote_batch.push(remote_event(&event.name, &config.install_id, &properties));
-                if remote_batch.len() >= REMOTE_BATCH_SIZE {
-                    flush_remote(&client, &mut remote_batch).await;
+                        remote_batch.push(remote_event(&event.name, &config.install_id, &properties));
+                        if remote_batch.len() >= REMOTE_BATCH_SIZE {
+                            flush_remote(&client, &mut remote_batch).await;
+                        }
+                    }
+                    QueuedItem::TraceFile(path) => {
+                        upload_trace_file(&client, &config, &path).await;
+                    }
                 }
             }
             _ = flush_tick.tick() => {
@@ -157,6 +181,52 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedEvent>, config: WorkerCo
     }
 
     flush_remote(&client, &mut remote_batch).await;
+}
+
+/// Read a run's `trace.json`, append identity resource attributes, and POST it
+/// to the traces proxy. Best-effort at every step: a missing/invalid file or a
+/// failed upload is dropped silently, matching the events contract.
+async fn upload_trace_file(client: &reqwest::Client, config: &WorkerConfig, path: &Path) {
+    let Ok(bytes) = tokio::fs::read(path).await else {
+        return;
+    };
+    let Ok(mut payload) = serde_json::from_slice::<Value>(&bytes) else {
+        return;
+    };
+    enrich_trace_resource(&mut payload, config);
+    let _ = client.post(traces_endpoint()).json(&payload).send().await;
+}
+
+/// The on-disk trace stays identity-free so run dirs can be shared; the
+/// uploaded copy carries the same source/install identity as events.
+fn enrich_trace_resource(payload: &mut Value, config: &WorkerConfig) {
+    let Some(attributes) = payload
+        .get_mut("resourceSpans")
+        .and_then(Value::as_array_mut)
+        .and_then(|spans| spans.first_mut())
+        .and_then(|resource_spans| resource_spans.get_mut("resource"))
+        .and_then(|resource| resource.get_mut("attributes"))
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    for (key, value) in [
+        ("socai.source", config.source.as_str()),
+        ("socai.install_id", config.install_id.as_str()),
+        ("socai.app_session_id", config.session_id.as_str()),
+    ] {
+        attributes.push(json!({ "key": key, "value": { "stringValue": value } }));
+    }
+}
+
+/// `SOCAI_TRACES_ENDPOINT` overrides the production proxy for local testing
+/// (e.g. a `vercel dev` instance of the site).
+fn traces_endpoint() -> String {
+    std::env::var("SOCAI_TRACES_ENDPOINT")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| TRACES_ENDPOINT.to_string())
 }
 
 fn enrich_properties(properties: Value, config: &WorkerConfig, timestamp_ms: u64) -> Value {

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -172,14 +172,15 @@ impl RunTraceBuilder {
             attrs.push(attr_int("socai.spans_dropped", self.dropped_spans as i64));
         }
 
-        // Task snippet in the name so a trace list reads like a task list —
-        // two turns of one conversation are otherwise indistinguishable
-        // without opening attributes. Aggregations key on
-        // gen_ai.operation.name, not the span name, so cardinality is fine.
+        // Keep the span name low-cardinality (OTel GenAI convention:
+        // `invoke_agent {agent}`): Axiom's operations panel groups by span
+        // name, so putting the task in the name mints one "operation" per
+        // task. The task lives in socai.task_text; turns within a
+        // conversation trace are told apart by that attribute.
         let mut root = json!({
             "traceId": self.trace_id,
             "spanId": self.root_span_id,
-            "name": format!("invoke_agent socai · {}", task_snippet(&self.task_text)),
+            "name": "invoke_agent socai",
             "kind": SPAN_KIND_INTERNAL,
             "startTimeUnixNano": self.started_ns.to_string(),
             "endTimeUnixNano": end_ns.to_string(),
@@ -297,12 +298,6 @@ fn stop_reason_str(response: &LLMResponse) -> &'static str {
         StopReason::MaxTokens => "max_tokens",
         StopReason::Other => "other",
     }
-}
-
-/// Single-line, whitespace-compacted task excerpt for the root span name.
-fn task_snippet(task: &str) -> String {
-    let compact = task.split_whitespace().collect::<Vec<_>>().join(" ");
-    truncate_chars(&compact, 40)
 }
 
 fn new_span_id() -> String {

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -1,0 +1,294 @@
+//! OTLP-JSON trace assembly for one agent run.
+//!
+//! The agent loop records each LLM call and tool call as it completes;
+//! `finish` closes the root span and returns an OTLP/HTTP
+//! `ExportTraceServiceRequest` JSON value. The loop writes it to
+//! `run_dir/trace.json`; entrypoints upload it fire-and-forget via
+//! [`super::Telemetry::upload_run_trace`], which appends identity resource
+//! attributes (source, install id) so the on-disk file stays shareable.
+//!
+//! Span attributes follow the OpenTelemetry GenAI semantic conventions
+//! (`gen_ai.*`) — Axiom promotes those to first-class trace columns — with
+//! socai-specific context under `socai.*`. Payload policy matches the
+//! `socai_tool_call` event: tool args go through `summarize_tool_args` (query
+//! text gated by `SOCAI_TELEMETRY_QUERY_TEXT`), tool output through the
+//! count-only `summarize_tool_result`, and LLM text/reasoning never leaves the
+//! machine — only token counts, stop reasons, and timings.
+
+use serde_json::{json, Map, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use super::query_text_enabled;
+use super::tool_call::{summarize_tool_args, summarize_tool_result};
+use crate::agent::llm::LLMResponse;
+
+/// Safety net for pathological runs; a default run (30 steps) stays far below.
+const MAX_CHILD_SPANS: usize = 400;
+/// Matches the proxy's `task_text` cap on the events route.
+const TASK_TEXT_MAX_CHARS: usize = 8000;
+const ERROR_MAX_CHARS: usize = 240;
+const VALUE_JSON_MAX_CHARS: usize = 500;
+
+const SPAN_KIND_INTERNAL: u32 = 1;
+const SPAN_KIND_CLIENT: u32 = 3;
+const STATUS_CODE_ERROR: u32 = 2;
+
+pub struct RunTraceBuilder {
+    trace_id: String,
+    root_span_id: String,
+    run_id: String,
+    task_text: String,
+    model: String,
+    session_id: Option<String>,
+    started_ns: u64,
+    spans: Vec<Value>,
+    dropped_spans: u64,
+}
+
+impl RunTraceBuilder {
+    pub fn new(run_id: &str, task: &str, model: &str, session_id: Option<&str>) -> Self {
+        Self {
+            trace_id: Uuid::new_v4().simple().to_string(),
+            root_span_id: new_span_id(),
+            run_id: run_id.to_string(),
+            task_text: truncate_chars(task, TASK_TEXT_MAX_CHARS),
+            model: model.to_string(),
+            session_id: session_id.map(ToOwned::to_owned),
+            started_ns: now_ns(),
+            spans: Vec::new(),
+            dropped_spans: 0,
+        }
+    }
+
+    pub fn record_llm(&mut self, step: u32, duration_ms: u64, response: &LLMResponse) {
+        let attrs = vec![
+            attr_str("gen_ai.operation.name", "chat"),
+            attr_str("gen_ai.request.model", &self.model),
+            attr_int("socai.step", step as i64),
+            attr_str("socai.stop_reason", stop_reason_str(response)),
+            attr_int("socai.tool_calls", response.tool_calls.len() as i64),
+            attr_int("gen_ai.usage.input_tokens", response.input_tokens as i64),
+            attr_int("gen_ai.usage.output_tokens", response.output_tokens as i64),
+        ];
+        self.push_span(
+            format!("chat {}", self.model),
+            SPAN_KIND_CLIENT,
+            duration_ms,
+            attrs,
+            None,
+        );
+    }
+
+    pub fn record_llm_error(&mut self, step: u32, duration_ms: u64, error: &str) {
+        let attrs = vec![
+            attr_str("gen_ai.operation.name", "chat"),
+            attr_str("gen_ai.request.model", &self.model),
+            attr_int("socai.step", step as i64),
+        ];
+        self.push_span(
+            format!("chat {}", self.model),
+            SPAN_KIND_CLIENT,
+            duration_ms,
+            attrs,
+            Some(error),
+        );
+    }
+
+    pub fn record_tool(
+        &mut self,
+        step: u32,
+        sequence: u32,
+        name: &str,
+        duration_ms: u64,
+        input: &Value,
+        output: &Value,
+        error: Option<&str>,
+    ) {
+        let mut attrs = vec![
+            attr_str("gen_ai.operation.name", "execute_tool"),
+            attr_str("gen_ai.tool.name", name),
+            attr_int("socai.step", step as i64),
+            attr_int("socai.sequence", sequence as i64),
+            attr_bool("socai.ok", error.is_none()),
+        ];
+        extend_prefixed(&mut attrs, summarize_tool_args(input, query_text_enabled()));
+        extend_prefixed(&mut attrs, summarize_tool_result(output));
+        self.push_span(
+            format!("execute_tool {name}"),
+            SPAN_KIND_INTERNAL,
+            duration_ms,
+            attrs,
+            error,
+        );
+    }
+
+    /// Close the root span and return the OTLP `ExportTraceServiceRequest`.
+    pub fn finish(
+        self,
+        status: &str,
+        steps: u32,
+        input_tokens: u64,
+        output_tokens: u64,
+        error: Option<&str>,
+    ) -> Value {
+        let end_ns = now_ns();
+        let mut attrs = vec![
+            attr_str("gen_ai.operation.name", "invoke_agent"),
+            attr_str("gen_ai.agent.name", "socai"),
+            attr_str("gen_ai.request.model", &self.model),
+            attr_str("socai.run_id", &self.run_id),
+            attr_str("socai.task_text", &self.task_text),
+            attr_str("socai.status", status),
+            attr_int("socai.steps", steps as i64),
+            attr_int("gen_ai.usage.input_tokens", input_tokens as i64),
+            attr_int("gen_ai.usage.output_tokens", output_tokens as i64),
+        ];
+        if let Some(session_id) = &self.session_id {
+            attrs.push(attr_str("socai.session_id", session_id));
+        }
+        if self.dropped_spans > 0 {
+            attrs.push(attr_int("socai.spans_dropped", self.dropped_spans as i64));
+        }
+
+        let mut root = json!({
+            "traceId": self.trace_id,
+            "spanId": self.root_span_id,
+            "name": "invoke_agent socai",
+            "kind": SPAN_KIND_INTERNAL,
+            "startTimeUnixNano": self.started_ns.to_string(),
+            "endTimeUnixNano": end_ns.to_string(),
+            "attributes": attrs,
+        });
+        if let Some(error) = error {
+            root["status"] = json!({
+                "code": STATUS_CODE_ERROR,
+                "message": truncate_chars(error, ERROR_MAX_CHARS),
+            });
+        }
+
+        let mut spans = self.spans;
+        spans.insert(0, root);
+
+        json!({
+            "resourceSpans": [{
+                "resource": {
+                    "attributes": [
+                        attr_str("service.name", "socai"),
+                        attr_str("service.version", env!("CARGO_PKG_VERSION")),
+                        attr_str("os.type", std::env::consts::OS),
+                    ],
+                },
+                "scopeSpans": [{
+                    "scope": {
+                        "name": "socai-core",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                    "spans": spans,
+                }],
+            }],
+        })
+    }
+
+    /// Append a completed child span. Start time is derived from the duration
+    /// so call sites only need the `Instant`-measured `duration_ms` they
+    /// already have for the run recorder.
+    fn push_span(
+        &mut self,
+        name: String,
+        kind: u32,
+        duration_ms: u64,
+        attributes: Vec<Value>,
+        error: Option<&str>,
+    ) {
+        if self.spans.len() >= MAX_CHILD_SPANS {
+            self.dropped_spans += 1;
+            return;
+        }
+        let end_ns = now_ns();
+        let start_ns = end_ns.saturating_sub(duration_ms.saturating_mul(1_000_000));
+        let mut span = json!({
+            "traceId": self.trace_id,
+            "spanId": new_span_id(),
+            "parentSpanId": self.root_span_id,
+            "name": name,
+            "kind": kind,
+            "startTimeUnixNano": start_ns.to_string(),
+            "endTimeUnixNano": end_ns.to_string(),
+            "attributes": attributes,
+        });
+        if let Some(error) = error {
+            span["status"] = json!({
+                "code": STATUS_CODE_ERROR,
+                "message": truncate_chars(error, ERROR_MAX_CHARS),
+            });
+        }
+        self.spans.push(span);
+    }
+}
+
+/// Flatten a summarizer map (`summarize_tool_args` / `summarize_tool_result`)
+/// into `socai.`-prefixed OTLP attributes. Nested objects (the args `metadata`)
+/// are carried as a capped JSON string.
+fn extend_prefixed(attrs: &mut Vec<Value>, props: Map<String, Value>) {
+    for (key, value) in props {
+        if let Some(attr) = otlp_attr(&format!("socai.{key}"), &value) {
+            attrs.push(attr);
+        }
+    }
+}
+
+fn otlp_attr(key: &str, value: &Value) -> Option<Value> {
+    let encoded = match value {
+        Value::Null => return None,
+        Value::Bool(flag) => json!({ "boolValue": flag }),
+        Value::Number(number) if number.is_i64() || number.is_u64() => {
+            json!({ "intValue": number.to_string() })
+        }
+        Value::Number(number) => json!({ "doubleValue": number.as_f64() }),
+        Value::String(text) => json!({ "stringValue": text }),
+        other => json!({ "stringValue": truncate_chars(&other.to_string(), VALUE_JSON_MAX_CHARS) }),
+    };
+    Some(json!({ "key": key, "value": encoded }))
+}
+
+fn attr_str(key: &str, value: &str) -> Value {
+    json!({ "key": key, "value": { "stringValue": value } })
+}
+
+fn attr_int(key: &str, value: i64) -> Value {
+    json!({ "key": key, "value": { "intValue": value.to_string() } })
+}
+
+fn attr_bool(key: &str, value: bool) -> Value {
+    json!({ "key": key, "value": { "boolValue": value } })
+}
+
+fn stop_reason_str(response: &LLMResponse) -> &'static str {
+    use crate::agent::llm::StopReason;
+    match response.stop_reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::ToolUse => "tool_use",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::Other => "other",
+    }
+}
+
+fn new_span_id() -> String {
+    Uuid::new_v4().simple().to_string()[..16].to_string()
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or_default()
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_chars).collect();
+    format!("{truncated}…")
+}

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use super::query_text_enabled;
 use super::tool_call::{summarize_tool_args, summarize_tool_result};
 use crate::agent::llm::LLMResponse;
+use crate::agent::signature::md5_hex;
 
 /// Safety net for pathological runs; a default run (30 steps) stays far below.
 const MAX_CHILD_SPANS: usize = 400;
@@ -57,8 +58,16 @@ impl RunTraceBuilder {
         session_id: Option<&str>,
         seed_messages: usize,
     ) -> Self {
+        // One conversation = one trace: every run of a conversation derives
+        // the same trace id from its session id, so follow-up turns join the
+        // first turn's trace as additional root-level spans. Runs without a
+        // session get their own single-run trace.
+        let trace_id = match session_id.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(session) => md5_hex(format!("socai-conversation:{session}").as_bytes()),
+            None => Uuid::new_v4().simple().to_string(),
+        };
         Self {
-            trace_id: Uuid::new_v4().simple().to_string(),
+            trace_id,
             root_span_id: new_span_id(),
             run_id: run_id.to_string(),
             task_text: truncate_chars(task, TASK_TEXT_MAX_CHARS),

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -41,13 +41,22 @@ pub struct RunTraceBuilder {
     task_text: String,
     model: String,
     session_id: Option<String>,
+    /// Prior chat messages seeding this run — non-zero marks a conversation
+    /// follow-up rather than a fresh task.
+    seed_messages: usize,
     started_ns: u64,
     spans: Vec<Value>,
     dropped_spans: u64,
 }
 
 impl RunTraceBuilder {
-    pub fn new(run_id: &str, task: &str, model: &str, session_id: Option<&str>) -> Self {
+    pub fn new(
+        run_id: &str,
+        task: &str,
+        model: &str,
+        session_id: Option<&str>,
+        seed_messages: usize,
+    ) -> Self {
         Self {
             trace_id: Uuid::new_v4().simple().to_string(),
             root_span_id: new_span_id(),
@@ -55,6 +64,7 @@ impl RunTraceBuilder {
             task_text: truncate_chars(task, TASK_TEXT_MAX_CHARS),
             model: model.to_string(),
             session_id: session_id.map(ToOwned::to_owned),
+            seed_messages,
             started_ns: now_ns(),
             spans: Vec::new(),
             dropped_spans: 0,
@@ -147,6 +157,8 @@ impl RunTraceBuilder {
         if let Some(session_id) = &self.session_id {
             attrs.push(attr_str("socai.session_id", session_id));
         }
+        attrs.push(attr_bool("socai.follow_up", self.seed_messages > 0));
+        attrs.push(attr_int("socai.seed_messages", self.seed_messages as i64));
         if self.dropped_spans > 0 {
             attrs.push(attr_int("socai.spans_dropped", self.dropped_spans as i64));
         }

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -163,10 +163,14 @@ impl RunTraceBuilder {
             attrs.push(attr_int("socai.spans_dropped", self.dropped_spans as i64));
         }
 
+        // Task snippet in the name so a trace list reads like a task list —
+        // two turns of one conversation are otherwise indistinguishable
+        // without opening attributes. Aggregations key on
+        // gen_ai.operation.name, not the span name, so cardinality is fine.
         let mut root = json!({
             "traceId": self.trace_id,
             "spanId": self.root_span_id,
-            "name": "invoke_agent socai",
+            "name": format!("invoke_agent socai · {}", task_snippet(&self.task_text)),
             "kind": SPAN_KIND_INTERNAL,
             "startTimeUnixNano": self.started_ns.to_string(),
             "endTimeUnixNano": end_ns.to_string(),
@@ -284,6 +288,12 @@ fn stop_reason_str(response: &LLMResponse) -> &'static str {
         StopReason::MaxTokens => "max_tokens",
         StopReason::Other => "other",
     }
+}
+
+/// Single-line, whitespace-compacted task excerpt for the root span name.
+fn task_snippet(task: &str) -> String {
+    let compact = task.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_chars(&compact, 40)
 }
 
 fn new_span_id() -> String {

--- a/site/api/traces.js
+++ b/site/api/traces.js
@@ -1,0 +1,240 @@
+// OTLP/HTTP JSON trace proxy: socai clients POST one ExportTraceServiceRequest
+// per completed agent run; we sanitize and forward it to Axiom's native OTLP
+// traces endpoint so spans land parsed (trace_id/span_id/duration columns).
+// Mirrors api/telemetry.js: no Axiom token in clients, best-effort forwarding.
+
+const DEFAULT_AXIOM_URL = 'https://api.axiom.co';
+const DEFAULT_DATASET = 'socai-traces-prod';
+const MAX_BODY_BYTES = 512 * 1024;
+const MAX_SPANS_PER_REQUEST = 500;
+const MAX_ATTRIBUTES_PER_SPAN = 64;
+// task_text rides in a span attribute; matches the events route's widest cap.
+const MAX_STRING_CHARS = 8_000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 120;
+
+const rateLimits = new Map();
+
+export default async function handler(req, res) {
+  setSecurityHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS');
+    res.status(405).json({ ok: false, error: 'method_not_allowed' });
+    return;
+  }
+
+  let payload;
+  try {
+    payload = await readJsonBody(req);
+  } catch (error) {
+    res.status(error.statusCode || 400).json({ ok: false, error: error.code || 'invalid_json' });
+    return;
+  }
+
+  const resourceSpans = payload && typeof payload === 'object' ? payload.resourceSpans : undefined;
+  if (!Array.isArray(resourceSpans) || resourceSpans.length === 0) {
+    res.status(400).json({ ok: false, error: 'no_resource_spans' });
+    return;
+  }
+  // Same spirit as the events route's `socai_` name gate: only forward traces
+  // that identify as ours.
+  if (resourceAttribute(resourceSpans[0], 'service.name') !== 'socai') {
+    res.status(400).json({ ok: false, error: 'unknown_service' });
+    return;
+  }
+  if (countSpans(resourceSpans) > MAX_SPANS_PER_REQUEST) {
+    res.status(413).json({ ok: false, error: 'too_many_spans' });
+    return;
+  }
+
+  if (!consumeRateLimit(rateLimitKey(req, resourceSpans))) {
+    res.status(429).json({ ok: false, error: 'rate_limited' });
+    return;
+  }
+
+  sanitizeResourceSpans(resourceSpans);
+
+  try {
+    await forwardToAxiom({ resourceSpans });
+  } catch (error) {
+    // Best-effort, same as events: the client has handed the trace off; proxy
+    // or Axiom outages must not create retry storms or leak backend details.
+    console.error('trace forward failed', error);
+  }
+
+  res.status(202).json({ ok: true });
+}
+
+async function readJsonBody(req) {
+  if (req.body !== undefined && req.body !== null) {
+    return typeof req.body === 'string' ? parseJson(req.body) : req.body;
+  }
+
+  let size = 0;
+  const chunks = [];
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > MAX_BODY_BYTES) {
+      const error = new Error('body_too_large');
+      error.statusCode = 413;
+      error.code = 'body_too_large';
+      throw error;
+    }
+    chunks.push(buffer);
+  }
+
+  return parseJson(Buffer.concat(chunks).toString('utf8'));
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text || 'null');
+  } catch {
+    const error = new Error('invalid_json');
+    error.statusCode = 400;
+    error.code = 'invalid_json';
+    throw error;
+  }
+}
+
+function countSpans(resourceSpans) {
+  let count = 0;
+  for (const resourceSpan of resourceSpans) {
+    for (const scopeSpan of scopeSpansOf(resourceSpan)) {
+      if (Array.isArray(scopeSpan.spans)) {
+        count += scopeSpan.spans.length;
+      }
+    }
+  }
+  return count;
+}
+
+function scopeSpansOf(resourceSpan) {
+  return resourceSpan && Array.isArray(resourceSpan.scopeSpans) ? resourceSpan.scopeSpans : [];
+}
+
+function resourceAttribute(resourceSpan, key) {
+  const attributes = resourceSpan?.resource?.attributes;
+  if (!Array.isArray(attributes)) {
+    return undefined;
+  }
+  const match = attributes.find((attribute) => attribute?.key === key);
+  return match?.value?.stringValue;
+}
+
+// Cap attribute counts and string lengths in place. The OTLP shape itself is
+// left intact — Axiom's endpoint validates the protocol; we only bound what a
+// hostile client could inflate.
+function sanitizeResourceSpans(resourceSpans) {
+  for (const resourceSpan of resourceSpans) {
+    truncateAttributes(resourceSpan?.resource?.attributes);
+    for (const scopeSpan of scopeSpansOf(resourceSpan)) {
+      if (!Array.isArray(scopeSpan.spans)) {
+        continue;
+      }
+      for (const span of scopeSpan.spans) {
+        if (Array.isArray(span?.attributes) && span.attributes.length > MAX_ATTRIBUTES_PER_SPAN) {
+          span.attributes.length = MAX_ATTRIBUTES_PER_SPAN;
+        }
+        truncateAttributes(span?.attributes);
+        if (typeof span?.name === 'string') {
+          span.name = truncateString(span.name, 256);
+        }
+        if (typeof span?.status?.message === 'string') {
+          span.status.message = truncateString(span.status.message, 1_000);
+        }
+      }
+    }
+  }
+}
+
+function truncateAttributes(attributes) {
+  if (!Array.isArray(attributes)) {
+    return;
+  }
+  for (const attribute of attributes) {
+    const value = attribute?.value;
+    if (value && typeof value.stringValue === 'string') {
+      value.stringValue = truncateString(value.stringValue, MAX_STRING_CHARS);
+    }
+  }
+}
+
+function truncateString(value, maxChars) {
+  const cleaned = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+  return cleaned.length > maxChars ? `${cleaned.slice(0, maxChars)}…` : cleaned;
+}
+
+function rateLimitKey(req, resourceSpans) {
+  const installId = resourceAttribute(resourceSpans[0], 'socai.install_id');
+  if (installId) {
+    return `install:${truncateString(installId, 80)}`;
+  }
+  const forwardedFor = String(req.headers['x-forwarded-for'] || '').split(',')[0].trim();
+  return `ip:${forwardedFor || req.socket?.remoteAddress || 'unknown'}`;
+}
+
+function consumeRateLimit(key) {
+  const now = Date.now();
+  for (const [existingKey, bucket] of rateLimits) {
+    if (now - bucket.startedAt > RATE_LIMIT_WINDOW_MS * 2) {
+      rateLimits.delete(existingKey);
+    }
+  }
+
+  const bucket = rateLimits.get(key);
+  if (!bucket || now - bucket.startedAt > RATE_LIMIT_WINDOW_MS) {
+    rateLimits.set(key, { startedAt: now, count: 1 });
+    return true;
+  }
+
+  bucket.count += 1;
+  return bucket.count <= RATE_LIMIT_MAX_REQUESTS;
+}
+
+async function forwardToAxiom(payload) {
+  const token = process.env.AXIOM_TRACES_TOKEN || process.env.AXIOM_TOKEN;
+  if (!token) {
+    console.warn('AXIOM_TRACES_TOKEN is not configured; dropping trace');
+    return;
+  }
+
+  const dataset = process.env.AXIOM_TRACES_DATASET || DEFAULT_DATASET;
+  const baseUrl = (process.env.AXIOM_URL || DEFAULT_AXIOM_URL).replace(/\/+$/, '');
+  const response = await fetch(`${baseUrl}/v1/traces`, {
+    method: 'POST',
+    headers: axiomHeaders(token, dataset),
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Axiom trace ingest failed: ${response.status} ${body.slice(0, 300)}`);
+  }
+}
+
+function axiomHeaders(token, dataset) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'X-Axiom-Dataset': dataset,
+    'Content-Type': 'application/json',
+  };
+  if (process.env.AXIOM_ORG_ID) {
+    headers['X-Axiom-Org-ID'] = process.env.AXIOM_ORG_ID;
+  }
+  return headers;
+}
+
+function setSecurityHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Cache-Control', 'no-store');
+}

--- a/site/api/traces.js
+++ b/site/api/traces.js
@@ -1,15 +1,18 @@
 // OTLP/HTTP JSON trace proxy: socai clients POST one ExportTraceServiceRequest
-// per completed agent run; we sanitize and forward it to Axiom's native OTLP
-// traces endpoint so spans land parsed (trace_id/span_id/duration columns).
+// per completed agent run; we forward it to Axiom's native OTLP traces
+// endpoint so spans land parsed (trace_id/span_id/duration columns).
 // Mirrors api/telemetry.js: no Axiom token in clients, best-effort forwarding.
+//
+// Transport-only by design: the proxy guards the pipe (shape gate, body-size
+// cap, rate limit) and never inspects span contents. Payload shaping — which
+// attributes exist, string caps, span-count bounds — is the client's
+// responsibility (see RunTraceBuilder), so clients can evolve the schema
+// without a proxy deploy. Same philosophy as the events route's no-allowlist
+// cleanup.
 
 const DEFAULT_AXIOM_URL = 'https://api.axiom.co';
 const DEFAULT_DATASET = 'socai-traces-prod';
 const MAX_BODY_BYTES = 512 * 1024;
-const MAX_SPANS_PER_REQUEST = 500;
-const MAX_ATTRIBUTES_PER_SPAN = 64;
-// task_text rides in a span attribute; matches the events route's widest cap.
-const MAX_STRING_CHARS = 8_000;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 120;
 
@@ -48,17 +51,10 @@ export default async function handler(req, res) {
     res.status(400).json({ ok: false, error: 'unknown_service' });
     return;
   }
-  if (countSpans(resourceSpans) > MAX_SPANS_PER_REQUEST) {
-    res.status(413).json({ ok: false, error: 'too_many_spans' });
-    return;
-  }
-
   if (!consumeRateLimit(rateLimitKey(req, resourceSpans))) {
     res.status(429).json({ ok: false, error: 'rate_limited' });
     return;
   }
-
-  sanitizeResourceSpans(resourceSpans);
 
   try {
     await forwardToAxiom({ resourceSpans });
@@ -104,22 +100,6 @@ function parseJson(text) {
   }
 }
 
-function countSpans(resourceSpans) {
-  let count = 0;
-  for (const resourceSpan of resourceSpans) {
-    for (const scopeSpan of scopeSpansOf(resourceSpan)) {
-      if (Array.isArray(scopeSpan.spans)) {
-        count += scopeSpan.spans.length;
-      }
-    }
-  }
-  return count;
-}
-
-function scopeSpansOf(resourceSpan) {
-  return resourceSpan && Array.isArray(resourceSpan.scopeSpans) ? resourceSpan.scopeSpans : [];
-}
-
 function resourceAttribute(resourceSpan, key) {
   const attributes = resourceSpan?.resource?.attributes;
   if (!Array.isArray(attributes)) {
@@ -129,53 +109,10 @@ function resourceAttribute(resourceSpan, key) {
   return match?.value?.stringValue;
 }
 
-// Cap attribute counts and string lengths in place. The OTLP shape itself is
-// left intact — Axiom's endpoint validates the protocol; we only bound what a
-// hostile client could inflate.
-function sanitizeResourceSpans(resourceSpans) {
-  for (const resourceSpan of resourceSpans) {
-    truncateAttributes(resourceSpan?.resource?.attributes);
-    for (const scopeSpan of scopeSpansOf(resourceSpan)) {
-      if (!Array.isArray(scopeSpan.spans)) {
-        continue;
-      }
-      for (const span of scopeSpan.spans) {
-        if (Array.isArray(span?.attributes) && span.attributes.length > MAX_ATTRIBUTES_PER_SPAN) {
-          span.attributes.length = MAX_ATTRIBUTES_PER_SPAN;
-        }
-        truncateAttributes(span?.attributes);
-        if (typeof span?.name === 'string') {
-          span.name = truncateString(span.name, 256);
-        }
-        if (typeof span?.status?.message === 'string') {
-          span.status.message = truncateString(span.status.message, 1_000);
-        }
-      }
-    }
-  }
-}
-
-function truncateAttributes(attributes) {
-  if (!Array.isArray(attributes)) {
-    return;
-  }
-  for (const attribute of attributes) {
-    const value = attribute?.value;
-    if (value && typeof value.stringValue === 'string') {
-      value.stringValue = truncateString(value.stringValue, MAX_STRING_CHARS);
-    }
-  }
-}
-
-function truncateString(value, maxChars) {
-  const cleaned = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
-  return cleaned.length > maxChars ? `${cleaned.slice(0, maxChars)}…` : cleaned;
-}
-
 function rateLimitKey(req, resourceSpans) {
   const installId = resourceAttribute(resourceSpans[0], 'socai.install_id');
   if (installId) {
-    return `install:${truncateString(installId, 80)}`;
+    return `install:${installId.slice(0, 80)}`;
   }
   const forwardedFor = String(req.headers['x-forwarded-for'] || '').split(',')[0].trim();
   return `ip:${forwardedFor || req.socket?.remoteAddress || 'unknown'}`;

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -2,12 +2,19 @@
   "functions": {
     "api/telemetry.js": {
       "maxDuration": 10
+    },
+    "api/traces.js": {
+      "maxDuration": 10
     }
   },
   "rewrites": [
     {
       "source": "/v1/events",
       "destination": "/api/telemetry"
+    },
+    {
+      "source": "/v1/traces",
+      "destination": "/api/traces"
     }
   ],
   "redirects": [


### PR DESCRIPTION
## What

Agent runs now produce a full OpenTelemetry trace instead of only flat step events:

- **`core/src/telemetry/trace.rs`** (new) — `RunTraceBuilder` assembles an OTLP/HTTP JSON `ExportTraceServiceRequest`: root `invoke_agent socai` span (task text, run_id, session_id, status, turns, total tokens) → `chat {model}` child spans per LLM call (duration, input/output tokens, stop reason, tool-call count; API errors become ERROR-status spans) → `execute_tool {name}` spans per tool call (turn, sequence, ok/error + the same arg/result summaries as the `socai_tool_call` event).
- **`core/src/agent/loop.rs`** — records each step alongside the existing `AgentRunRecorder` and writes the identity-free payload to `run_dir/trace.json` on completion.
- **`core/src/telemetry/mod.rs`** — `Telemetry::upload_run_trace(run_dir)` ships the file through the existing fire-and-forget worker, appending `socai.source` / `socai.install_id` / `socai.app_session_id` resource attributes at upload so the on-disk file stays shareable. `SOCAI_TRACES_ENDPOINT` overrides the endpoint for local testing.
- **`app/src-tauri`** — the desktop uploads after each task. The TUI has no telemetry handle and keeps writing `trace.json` locally only.
- **`site/api/traces.js`** (new) + `vercel.json` rewrite — `/v1/traces` proxy, transport-only by design: `service.name == "socai"` gate, body-size cap, per-install rate limit, forward to Axiom's native OTLP endpoint (`AXIOM_TRACES_TOKEN`, `AXIOM_TRACES_DATASET`). Payload shaping (caps, field choice) stays in the client so the schema can evolve without a proxy deploy.

## Why

The flat events pipeline cannot reconstruct a run timeline: the proxy deliberately strips client timestamps (5s batches all land on one ingest time) and there is no per-LLM-call event, so "what did the agent do, in what order, and where did the time go" was unanswerable. Spans carry real client timestamps and hierarchy, and the GenAI semantic conventions (`gen_ai.*`) are promoted by Axiom to first-class trace columns, enabling its span waterfall and AI trace view plus APL aggregation across runs (p95 tool duration, tokens per turn by model).

## Privacy

Unchanged posture: reasoning/prompt text and tool output bodies never leave the machine. Tool args/results go through the existing shared summarizers (`query_text` still gated by `SOCAI_TELEMETRY_QUERY_TEXT`), `task_text` matches the events route cap, and `SOCAI_TELEMETRY=off` disables trace upload along with events.

## Verified

- Synthetic OTLP JSON ingested to `socai-traces-dev` directly and through the proxy handler running locally — spans parse into `trace_id` / `span_id` / `duration` columns with `gen_ai.*` promoted (traces `63bca809…`, `6a442ea9…`).
- Real end-to-end run via a scratch harness driving the actual `run_agent` loop with a real `qwen3.7-max` call, uploaded through the real worker + proxy handler: trace `92c38cc74b4840c2ba8f387444873875` in `socai-traces-dev`, correct hierarchy/tokens/timings.
- `cargo check --workspace` and the Tauri app crate both clean. No new tests per repo rules.

## Deploy notes

- `AXIOM_TRACES_TOKEN` (ingest-only, scoped to `socai-traces-dev`/`-prod`) and `AXIOM_TRACES_DATASET` are already set in Vercel production and preview envs; preview points at `socai-traces-dev`.
- The route is inert until the site deploys; clients built before then POST to a 404 and drop silently (same best-effort contract as events).
- A Vercel preview deploy of this branch + `SOCAI_TRACES_ENDPOINT=<preview-url>/v1/traces` on a local build tests the whole chain without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
