### PR TITLE
feat(app): enter sends the composer, shift+enter is newline

### DIFF
--- a/app/src/lib/shortcuts.ts
+++ b/app/src/lib/shortcuts.ts
@@ -1,11 +1,11 @@
-//! Composer send shortcut: cmd+enter on macOS, ctrl+enter elsewhere. Plain
-//! enter stays a newline (textarea default). One definition so the keydown
-//! check and the hover hint can't drift apart.
+//! Composer send shortcut: enter (or cmd/ctrl+enter) sends, shift+enter is a
+//! newline. One definition so the keydown check and the hover hint can't drift.
+//!
+//! `isComposing` guards the IME: while composing a pinyin/kana candidate the
+//! enter that confirms it must NOT send — important since the UI defaults to zh.
 
-const isMac = navigator.userAgent.includes("Macintosh");
-
-export const sendShortcutLabel = isMac ? "⌘ + enter" : "ctrl + enter";
+export const sendShortcutLabel = "enter";
 
 export function isSendShortcut(e: KeyboardEvent): boolean {
-  return e.key === "Enter" && (isMac ? e.metaKey : e.ctrlKey);
+  return e.key === "Enter" && !e.shiftKey && !e.isComposing;
 }

--- a/app/src/lib/shortcuts.ts
+++ b/app/src/lib/shortcuts.ts
@@ -1,0 +1,11 @@
+//! Composer send shortcut: cmd+enter on macOS, ctrl+enter elsewhere. Plain
+//! enter stays a newline (textarea default). One definition so the keydown
+//! check and the hover hint can't drift apart.
+
+const isMac = navigator.userAgent.includes("Macintosh");
+
+export const sendShortcutLabel = isMac ? "⌘ + enter" : "ctrl + enter";
+
+export function isSendShortcut(e: KeyboardEvent): boolean {
+  return e.key === "Enter" && (isMac ? e.metaKey : e.ctrlKey);
+}

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -16,6 +16,7 @@ import type { AgentTaskEventPayload } from "../main";
 import { esc } from "../lib/html";
 import { renderNoteAnswer, renderTimelineEmbed, setNoteRegistry } from "./notes";
 import { formatSourceCount, formatTaskCount, formatTaskTimestamp, formatTokenUsage, taskStatusLabel, t } from "../lib/i18n";
+import { sendShortcutLabel } from "../lib/shortcuts";
 import type { AgentTaskView } from "./tasks";
 
 export interface SidebarProps {
@@ -151,7 +152,7 @@ function renderReplyComposer(task: AgentTaskView, props: ReplyComposerProps): st
           placeholder="${esc(t("task.replyPlaceholder"))}"
           ${props.submitting ? "disabled" : ""}
         >${esc(props.draft)}</textarea>
-        <button id="task-reply-submit" type="submit" class="btn-primary btn-compact task-reply-send" ${runDisabled ? "disabled" : ""}>
+        <button id="task-reply-submit" type="submit" class="btn-primary btn-compact task-reply-send" title="${esc(sendShortcutLabel)}" ${runDisabled ? "disabled" : ""}>
           ${props.submitting ? esc(t("task.replySending")) : esc(t("task.replySend"))}
         </button>
       </div>

--- a/app/src/panels/task_new.ts
+++ b/app/src/panels/task_new.ts
@@ -5,6 +5,7 @@
 import type { ModelInfo, Status, ShellState } from "../main";
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
+import { sendShortcutLabel } from "../lib/shortcuts";
 
 export interface ComposePaneProps {
   shell: ShellState;
@@ -58,7 +59,7 @@ function renderTaskForm(
 
       <div class="task-controls">
         ${renderAgentSummary(props.selectedModel)}
-        <button id="task-submit" type="submit" class="btn-primary" ${runDisabled ? "disabled" : ""}>
+        <button id="task-submit" type="submit" class="btn-primary" title="${esc(sendShortcutLabel)}" ${runDisabled ? "disabled" : ""}>
           ${running ? esc(t("task.starting")) : esc(t("task.new"))}
         </button>
       </div>

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -13,6 +13,7 @@ import type {
 } from "../main";
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
+import { isSendShortcut } from "../lib/shortcuts";
 import { noteRefsFromEvent, renderAgentEvent, renderConfirmDeleteDialog, renderRunMessage, renderSidebar as renderSidebarMarkup, renderTaskDetail, renderTaskMetaItems } from "./task_history";
 import type { ReplyComposerProps } from "./task_history";
 import { bindNoteInteractions, renderTimelineEmbed, setNoteRegistry } from "./notes";
@@ -654,6 +655,13 @@ export namespace agentPanel {
       draft = taskEl.value;
       updateSubmitButton(shell);
     });
+    // cmd/ctrl+enter sends; routed through the button so its disabled state
+    // (empty draft, disconnected, no model key) keeps gating submission.
+    taskEl?.addEventListener("keydown", (e) => {
+      if (!isSendShortcut(e)) return;
+      e.preventDefault();
+      document.getElementById("task-submit")?.click();
+    });
 
     // The row's open control is a native <button>, so click/Enter/Space are
     // handled for free — no hand-bound keydown, no role/tabindex.
@@ -731,6 +739,11 @@ export namespace agentPanel {
       replyDraft = replyEl.value;
       autosizeReplyInput(replyEl);
       updateReplyButton(shell);
+    });
+    replyEl?.addEventListener("keydown", (e) => {
+      if (!isSendShortcut(e)) return;
+      e.preventDefault();
+      document.getElementById("task-reply-submit")?.click();
     });
     replyForm?.addEventListener("submit", async (e) => {
       e.preventDefault();


### PR DESCRIPTION
## What

Adds a keyboard send mapping to the desktop app's two composers — the new-task box and the follow-up reply box:

- **enter → sends**
- **cmd+enter / ctrl+enter → also sends** (kept for muscle memory)
- **shift+enter → newline**
- **enter during IME composition → confirms the candidate, does _not_ send**

Hovering either send button shows the shortcut (`enter`) via a native `title` tooltip.

## How

- New `app/src/lib/shortcuts.ts` holds one shared definition: `isSendShortcut(e)` for the keydown check and `sendShortcutLabel` for the tooltip, so the two can't drift. The send condition is `e.key === "Enter" && !e.shiftKey && !e.isComposing` — one predicate covers both plain enter and cmd/ctrl+enter (neither holds shift), so no per-platform modifier branch is needed.
- The `!e.isComposing` guard is load-bearing now that plain enter sends: the UI defaults to zh, so a user hitting enter to confirm a pinyin candidate would otherwise fire the message mid-word. `isComposing` stays `true` for the whole IME session and flips to `false` on the keydown _after_ the candidate commits, so the first real enter still sends.
- The keydown handlers don't call the submit functions directly — they `preventDefault()` the newline and `.click()` the submit button. A disabled button swallows the click, so all existing gating (empty draft, chrome disconnected, missing model key, already submitting) applies to the shortcut with no duplicated logic.
- Tooltip copy skips i18n: key names stay English in the zh UI, consistent with existing copy conventions.

## Reviewer notes

- Verified with `tsc --noEmit` and `vite build` (both clean).
- The compose textarea is disabled while a task is starting, so the shortcut can't double-submit there; the reply path is gated by the button's `submitting` disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)