### PR TITLE
ci: bump actions off node20 majors flagged by the runner deprecation

### DIFF
--- a/.github/workflows/model-catalog-sync.yml
+++ b/.github/workflows/model-catalog-sync.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.28.2
           run_install: false
 
       - name: set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -109,7 +109,7 @@ jobs:
 
       - name: create pull request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/model-catalog-sync
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: checkout release base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
 
@@ -265,7 +265,7 @@ jobs:
           ls -lah dist-artifacts
 
       - name: upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: socai-${{ needs.prepare.outputs.version }}-macos-cli
           path: dist-artifacts/*
@@ -280,7 +280,7 @@ jobs:
 
     steps:
       - name: checkout release base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
 
@@ -301,13 +301,13 @@ jobs:
           echo "versioned build tree ${versioned_sha}"
 
       - name: set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.28.2
           run_install: false
 
       - name: set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -648,7 +648,7 @@ jobs:
           ls -lah dist-artifacts
 
       - name: upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: socai-${{ needs.prepare.outputs.version }}-macos-app
           path: dist-artifacts/*
@@ -661,7 +661,7 @@ jobs:
 
     steps:
       - name: checkout release base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
 
@@ -794,7 +794,7 @@ jobs:
           Get-ChildItem $dist
 
       - name: upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: socai-${{ needs.prepare.outputs.version }}-windows-cli
           path: dist-artifacts/*
@@ -807,7 +807,7 @@ jobs:
 
     steps:
       - name: checkout release base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
 
@@ -827,13 +827,13 @@ jobs:
           "versioned build tree $versionedSha"
 
       - name: set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.28.2
           run_install: false
 
       - name: set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -927,7 +927,7 @@ jobs:
           Get-ChildItem $dist
 
       - name: upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: socai-${{ needs.prepare.outputs.version }}-windows-app
           path: dist-artifacts/*
@@ -946,13 +946,13 @@ jobs:
 
     steps:
       - name: checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
 
       - name: download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: socai-${{ needs.prepare.outputs.version }}-*
           merge-multiple: true


### PR DESCRIPTION
## Why

Release run [28901936457](https://github.com/socai-io/socai/actions/runs/28901936457) emitted the GitHub Actions deprecation annotation *"Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24"* ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The annotation applies to any JavaScript action whose `action.yml` declares `runs.using: node20` — I verified the declared runtime of every pinned action in `.github/workflows/` at both its current pin and candidate majors.

## What

Each flagged action is bumped to the **lowest major that natively runs on node24** (verified via each tag's `action.yml`), which silences the annotation with minimal behavior change:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | v5.0.0 is the node24 bump only |
| `actions/setup-node` | v4 | v5 | v5's breaking change is *automatic* package-manager caching; we pass explicit `cache: pnpm` + `cache-dependency-path`, so unaffected |
| `actions/upload-artifact` | v4 | v6 | v5 still defaults to node20; v6 is the first node24-default major |
| `actions/download-artifact` | v4 | v7 | v5/v6 still default to node20; v5's by-ID path break doesn't apply — we download by `pattern` + `merge-multiple: true` (documented "no action needed" case) |
| `pnpm/action-setup` | v4 | v5 | v5.0.0 is the node24 bump only; v6 only adds pnpm 11 support and we pin `version: 10.28.2` |
| `peter-evans/create-pull-request` | v7 | v8 | v8 is the node24 bump; all inputs we use (`branch`, `delete-branch`, `commit-message`, `title`, `body-path`, `add-paths`) unchanged |

Not changed:
- `Swatinem/rust-cache@v2` — the floating v2 tag already declares node24
- `dtolnay/rust-toolchain@stable` — composite action, no Node runtime

The node24 majors require runner ≥ 2.327.1, which only matters for self-hosted runners; all jobs here run on GitHub-hosted runners (`ubuntu-latest`, `macos-14`, `windows-latest`).

No workflow logic changes — the diff is 19 `uses:` version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)