### PR TITLE
fix(agent): stop treating bare / and // tokens as paths in bash confinement

### DIFF
--- a/core/src/agent/file_bash_tools.rs
+++ b/core/src/agent/file_bash_tools.rs
@@ -82,12 +82,16 @@ fn within_roots(path: &Path, roots: &[PathBuf], cwd: &Path) -> bool {
 /// Best-effort scan for path-like tokens in a shell command line. Not a
 /// parser — quoting, variable expansion, and encoded payloads can defeat it —
 /// but it catches the straightforward `cat /etc/passwd` / `rm -rf ~/Documents`
-/// style asks a prompt-injected note might make.
+/// style asks a prompt-injected note might make. Tokens that are nothing but
+/// slashes (`/`, `//`) are skipped: in practice they are division operators in
+/// an inline python/awk snippet, not references to the filesystem root.
 fn command_escapes_roots(command: &str, roots: &[PathBuf], cwd: &Path) -> Option<String> {
     for raw_token in command.split_whitespace() {
         let token = raw_token.trim_matches(|c| c == '"' || c == '\'' || c == ';' || c == ',');
-        let looks_like_path =
-            token.starts_with('/') || token.starts_with('~') || token.starts_with("./") || token.starts_with("../");
+        let looks_like_path = (token.starts_with('/') && token.chars().any(|c| c != '/'))
+            || token.starts_with('~')
+            || token.starts_with("./")
+            || token.starts_with("../");
         if !looks_like_path {
             continue;
         }


### PR DESCRIPTION
## What

`command_escapes_roots()` in `core/src/agent/file_bash_tools.rs` treated any whitespace-delimited token starting with `/` as a filesystem path to check against the desktop confinement roots. A bare `/` or `//` — division operators inside an inline `python3 << EOF` heredoc — was flagged as a reference to the filesystem root, and the whole command was rejected before execution.

A `/`-prefixed token now only counts as path-like if it contains at least one non-slash character (i.e. it has an actual path segment). `~`, `./`, and `../` handling is unchanged, and the deliberate exclusion is recorded in the function's doc comment.

## Why

Confirmed in prod: axiom trace `95bfde2a7515176fd2443408f0d0f741` (socai-traces-prod) shows 4 of 30 agent steps rejected for exactly this (steps 8, 9, 11, 12 — python heredocs doing timestamp arithmetic like `posted / (365.25 * 24 * 3600 * 1000)` and its `//` floor variant), forcing the model into awkward workarounds.

## Reviewer notes

- Verified end-to-end through the public `BashTool::scoped_to` API with a throwaway harness (not committed, per the repo's no-new-tests rule): the prod heredoc now runs and computes correctly; `python3 /tmp/analyze_notes.py` and `cat /etc/passwd` are still rejected; in-root reads/writes still run. The file's two existing tests pass.
- Deliberate contract change: a bare `/` used as a genuine path argument (`ls /`, `find / -name x`, `rm -rf /`) now slips past this lexical filter. That's consistent with the filter's documented best-effort threat model (it's already bypassable via quoting/expansion), but it is a real narrowing worth a conscious ack.
- History note: this branch briefly also carried the telemetry commit that merged separately as #196; it was dropped in a rebase once #196 landed, so this PR is confinement-only again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
