### PR TITLE
fix(cdp): evict managed-profile squatters and fail fast on chrome singleton handoff

### DIFF
--- a/core/src/cdp/launch.rs
+++ b/core/src/cdp/launch.rs
@@ -21,11 +21,15 @@ use anyhow::{anyhow, Context};
 use tokio::process::{Child, Command};
 use tokio::time::Instant;
 use tracing::info;
+#[cfg(unix)]
+use tracing::warn;
 
 use crate::cdp::endpoint::{self, Endpoint};
 
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(150);
+#[cfg(unix)]
+const EVICT_GRACE: Duration = Duration::from_secs(5);
 
 /// Owns a managed Chrome child process. Killed on drop, so a disconnect,
 /// reconnect, or daemon shutdown tears down the socai-launched browser —
@@ -57,6 +61,16 @@ pub(crate) async fn launch_managed_chrome(
              SOCAI_CHROME_EXECUTABLE / CHROME to its path."
         )
     })?;
+
+    // Chrome enforces a per-profile process singleton: if another chrome
+    // already owns this profile, the one we spawn below silently forwards its
+    // arguments to that instance and exits without ever writing
+    // `DevToolsActivePort`. The caller already tried (and failed) to attach
+    // via the active-port marker, so any live singleton holder at this point
+    // is unreachable — typically an orphaned automation chrome squatting the
+    // socai-owned profile. Evict it so the launch below owns the profile.
+    #[cfg(unix)]
+    evict_profile_singleton_holder(user_data_dir).await;
 
     // Remove any stale DevToolsActivePort before launching. We kill managed
     // chrome with SIGKILL (see `ChromeProcess::drop`), which leaves the marker
@@ -90,9 +104,9 @@ pub(crate) async fn launch_managed_chrome(
     let child = command
         .spawn()
         .with_context(|| format!("failed to launch chrome at {}", executable.display()))?;
-    let process = ChromeProcess { child };
+    let mut process = ChromeProcess { child };
 
-    let endpoint = wait_for_active_port(user_data_dir, LAUNCH_TIMEOUT).await?;
+    let endpoint = wait_for_active_port(user_data_dir, &mut process.child, LAUNCH_TIMEOUT).await?;
     Ok((
         endpoint::mark_managed_endpoint(endpoint, user_data_dir),
         process,
@@ -100,12 +114,30 @@ pub(crate) async fn launch_managed_chrome(
 }
 
 /// Poll `<user_data_dir>/DevToolsActivePort` until chrome has written its
-/// chosen port, or `timeout` elapses.
-async fn wait_for_active_port(user_data_dir: &Path, timeout: Duration) -> anyhow::Result<Endpoint> {
+/// chosen port, or `timeout` elapses. Also watches the spawned process: a
+/// chrome that finds the profile's singleton already held hands its arguments
+/// to that instance and exits almost immediately, so the marker would never
+/// appear — fail fast with a diagnosis instead of burning the full timeout.
+async fn wait_for_active_port(
+    user_data_dir: &Path,
+    child: &mut Child,
+    timeout: Duration,
+) -> anyhow::Result<Endpoint> {
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(endpoint) = endpoint::endpoint_from_active_port(user_data_dir).await {
             return Ok(endpoint);
+        }
+        if let Some(status) = child
+            .try_wait()
+            .context("failed to poll managed chrome process state")?
+        {
+            return Err(anyhow!(
+                "managed chrome exited during startup ({status}) without exposing a \
+                 debugging endpoint. another chrome instance likely owns the managed \
+                 profile ({}); quit chrome processes using that profile and retry.",
+                user_data_dir.display()
+            ));
         }
         if Instant::now() >= deadline {
             return Err(anyhow!(
@@ -115,6 +147,98 @@ async fn wait_for_active_port(user_data_dir: &Path, timeout: Duration) -> anyhow
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+/// Terminate a live chrome that holds this profile's process singleton.
+///
+/// The `SingletonLock` symlink target is `<hostname>-<pid>`. We only signal
+/// when that pid is alive AND its command line references this exact
+/// `--user-data-dir`, so a recycled pid, an unrelated process, or a lock
+/// inherited from another machine (shared home dir) is never touched. Stale
+/// locks from dead processes are left alone — chrome detects and replaces
+/// them itself, and `ChromeProcess::drop` (SIGKILL) leaves that state behind
+/// routinely. Best-effort: on any doubt we skip, and the child-exit check in
+/// `wait_for_active_port` reports the conflict instead.
+///
+/// SIGTERM first so chrome cleans up its `Singleton*` files, escalating to
+/// SIGKILL after a grace period (a SIGKILLed holder leaves stale lock files,
+/// which the relaunch handles as above).
+///
+/// Unix only: Windows chrome uses a named mutex, not a `SingletonLock`
+/// symlink, so there is nothing to inspect there.
+#[cfg(unix)]
+async fn evict_profile_singleton_holder(user_data_dir: &Path) {
+    let lock = user_data_dir.join("SingletonLock");
+    let Ok(target) = tokio::fs::read_link(&lock).await else {
+        return; // no lock (or not a symlink): nothing holds the profile
+    };
+    // Target looks like "<hostname>-<pid>"; hostnames may themselves
+    // contain '-', so split from the right.
+    let Some(pid) = target
+        .to_str()
+        .and_then(|t| t.rsplit_once('-'))
+        .and_then(|(_, pid)| pid.parse::<i32>().ok())
+        .filter(|pid| *pid > 0)
+    else {
+        return;
+    };
+    let expected = format!("--user-data-dir={}", user_data_dir.display());
+    match process_args(pid).await {
+        Some(args) if args.contains(&expected) => {}
+        _ => return, // dead pid, or recycled to something that isn't chrome-on-this-profile
+    }
+    warn!(
+        pid,
+        profile = %user_data_dir.display(),
+        "terminating foreign chrome holding the managed profile singleton"
+    );
+    signal(pid, libc::SIGTERM);
+    let deadline = Instant::now() + EVICT_GRACE;
+    while Instant::now() < deadline {
+        if !process_alive(pid) {
+            return;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    warn!(pid, "chrome ignored SIGTERM; escalating to SIGKILL");
+    signal(pid, libc::SIGKILL);
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while Instant::now() < deadline && process_alive(pid) {
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Full command line of `pid`, via `ps` (portable across macOS/Linux; macOS
+/// has no /proc). `None` when the pid is gone or `ps` fails.
+#[cfg(unix)]
+async fn process_args(pid: i32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "args="])
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let args = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!args.is_empty()).then_some(args)
+}
+
+#[cfg(unix)]
+fn signal(pid: i32, sig: libc::c_int) {
+    // SAFETY: plain kill(2); pid was parsed from the singleton lock and
+    // verified against a live process's command line before any signal.
+    unsafe { libc::kill(pid, sig) };
+}
+
+#[cfg(unix)]
+fn process_alive(pid: i32) -> bool {
+    // kill(pid, 0) probes existence without delivering a signal. EPERM (alive
+    // but unsignalable) is reported as dead, which is fine: we could not have
+    // terminated such a process anyway, and the child-exit check downstream
+    // still surfaces the conflict.
+    unsafe { libc::kill(pid, 0) == 0 }
 }
 
 /// Resolve the chrome/chromium executable: explicit env override first


### PR DESCRIPTION
## Problem

Incident 2026-07-08: an orphaned headless Chrome (launched by an external automation session with `--remote-debugging-port=9333`) held `~/.socai/chrome-profile`'s `SingletonLock`. Chrome enforces a per-profile process singleton, so the chrome spawned by `launch_managed_chrome` silently forwarded its arguments to the squatter and exited (status 21) without ever writing `DevToolsActivePort`. socai polled the marker for the full 30s `LAUNCH_TIMEOUT` and failed with the generic *"managed chrome did not expose a debugging endpoint within 30s"* — identically in dev, the CLI, and the deployed app — and the state never self-healed (the squatter never rewrites the marker; a fixed-port headless chrome on Chrome 150 turns out to never write one at all).

## Fix — two layers

**1. Fail fast, cross-platform.** `wait_for_active_port` now `try_wait()`s the spawned child alongside the marker poll. A singleton handoff surfaces in ~1.5s as:

> managed chrome exited during startup (exit status: 21) without exposing a debugging endpoint. another chrome instance likely owns the managed profile (`<path>`); quit chrome processes using that profile and retry.

**2. Pre-launch eviction, unix only.** Before spawning, parse `<hostname>-<pid>` from the `SingletonLock` symlink and terminate the holder — SIGTERM, escalating to SIGKILL after a 5s grace.

## Trade-offs of the eviction (why killing is right, and why it's guarded)

- **Justification:** the profile is socai-owned, and the caller (`open_managed_endpoint`) only reaches launch after failing to attach via the active-port marker. So any *live* singleton holder at that point is unreachable by design — a leaked or foreign automation chrome, not a browser anyone can use. Erroring instead would leave deployed-app users stuck with a terminal-only remedy.
- **Guard:** we signal only when the lock's pid is alive **and** its command line contains this exact `--user-data-dir`. Recycled pids, unrelated processes, and locks inherited from another host (shared home) are never touched. Stale locks from dead pids are deliberately left alone — chrome's own stale-lock recovery handles them, and our `ChromeProcess::drop` (SIGKILL) produces that state routinely.
- **On any doubt the evictor skips** (e.g. the squatter spelled the profile path differently) and layer 1 reports the conflict instead — verified below.
- **Known edge:** two socai processes racing into `launch_managed_chrome` simultaneously could evict each other's fresh chrome. That race already existed (both chromes fight the singleton and one silently loses); with this change the loser now gets a fast, accurate error instead of a 30s hang.
- **Windows:** chrome uses a named mutex there, no `SingletonLock` symlink to inspect — Windows gets layer 1 only.

## Verification (end-to-end, isolated `SOCAI_HOME=/tmp/socai-t`)

| scenario | before | after |
|---|---|---|
| decoy squatter on profile (incident shape) | 30s hang, generic error | evicted (`WARN terminating foreign chrome ... pid=50485`), relaunched, search completed in **4.4s** |
| squatter dodging the cmdline guard (`/private/tmp` vs `/tmp` spelling) | 30s hang | actionable error in **1.8s**, squatter untouched |
| clean launch with stale `Singleton*`/marker files (normal post-SIGKILL state) | works | still works (attach-reuse and relaunch paths unaffected) |

`cargo clippy -p socai-core`: no new warnings (12 pre-existing elsewhere). No new tests per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)