### PR TITLE
feat(app): one universal conversation measure, widened to 1120px

### DIFF
--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -275,8 +275,6 @@ function renderActivity(
     ? `<div class="act-row act-row--working"><span class="act-row__glyph"><i class="badge-dot badge-dot-ink badge-dot-pulse" aria-hidden="true"></i></span><span class="act-row__text">${esc(t("task.working"))}</span></div>`
     : "";
 
-  // The notes render OUTSIDE the wrap: the wrap stays on the centered prose
-  // column while the card strips take the pane's full width.
   return `
     <div class="activity-wrap">
       <button
@@ -291,8 +289,8 @@ function renderActivity(
         ${meta}
       </button>
       ${open ? `<div class="activity activity--transcript">${body.map(renderEventRow).join("")}${workingRow}</div>` : ""}
+      ${notesHtml ? `<div class="activity-notes">${notesHtml}</div>` : ""}
     </div>
-    ${notesHtml ? `<div class="activity-notes">${notesHtml}</div>` : ""}
   `;
 }
 

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -213,18 +213,16 @@ export namespace agentPanel {
   }
 
   // The last turn's activity-notes container — where streamed note groups and
-  // the live strip land. A sibling of the activity fold (so the strips span
-  // the pane while the fold keeps the prose column), created on demand: a
-  // turn renders without one until its first search result arrives.
+  // the live strip land. Created on demand: a turn renders without one until
+  // its first search result arrives.
   function lastTurnNotesContainer(stream: HTMLDivElement): HTMLDivElement | null {
     const turn = stream.querySelector<HTMLDivElement>(".thread-inner > .turn:last-child");
-    if (!turn) return null;
-    let notes = turn.querySelector<HTMLDivElement>(":scope > .activity-notes");
+    const wrap = turn?.querySelector<HTMLDivElement>(".activity-wrap");
+    if (!wrap) return null;
+    let notes = wrap.querySelector<HTMLDivElement>(".activity-notes");
     if (!notes) {
-      const wrap = turn.querySelector<HTMLDivElement>(":scope > .activity-wrap");
-      if (!wrap) return null;
-      wrap.insertAdjacentHTML("afterend", `<div class="activity-notes"></div>`);
-      notes = turn.querySelector<HTMLDivElement>(":scope > .activity-notes");
+      wrap.insertAdjacentHTML("beforeend", `<div class="activity-notes"></div>`);
+      notes = wrap.querySelector<HTMLDivElement>(".activity-notes");
     }
     return notes;
   }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -59,6 +59,12 @@
   --sp-9: 96px;
   --sp-10: 128px;
 
+  /* ── Measures ─────────────────────────────────────────────────── */
+  /* One shared column for the conversation: thread content, composer, and
+     the new-task compose all sit on this measure. With the thread's --sp-5
+     side padding it fits exactly five rich note cards per strip row. */
+  --measure-conv: 1120px;
+
   /* ── Radii ────────────────────────────────────────────────────── */
   --r-1: 2px;
   --r-2: 4px;
@@ -949,23 +955,14 @@ body.has-paper > * { position: relative; z-index: 1; }
   overflow-x: hidden;
   scrollbar-gutter: stable;
 }
-/* Fluid canvas: the thread spans the pane so media strips can use the full
-   width; prose-shaped pieces (bubble, activity fold, answer, meta) pin
-   themselves back onto the centered 760px column shared with the composer. */
+/* One universal centered column (--measure-conv) for everything in the
+   thread — prose, note strips, and the composer share the same measure. */
 .thread-inner {
-  width: 100%;
-  padding: var(--sp-6) var(--sp-6) var(--sp-5);
+  width: min(100%, var(--measure-conv));
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-5) var(--sp-5);
   display: flex;
   flex-direction: column;
-}
-.conv-user,
-.activity-wrap,
-.conv-answer,
-.conv-error,
-.conv-meta {
-  width: 100%;
-  max-width: 760px;
-  margin-inline: auto;
 }
 /* ── one turn (a run: prompt → work → answer) ─────────────────────── */
 .turn { display: flex; flex-direction: column; }
@@ -1092,14 +1089,12 @@ body.has-paper > * { position: relative; z-index: 1; }
 .act-row--working .act-row__glyph { display: inline-flex; align-items: center; }
 .act-row--working .act-row__text { color: var(--fg-muted); }
 
-/* ── per-search note previews (small cards), always visible ─────────
-   Full pane width — a sibling of the centered activity fold, so many
-   results get the room the prose column doesn't need. */
+/* ── per-search note previews (small cards), always visible ────────── */
 .activity-notes {
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
-  margin-top: var(--sp-2);
+  margin-top: 2px;
 }
 .search-group { display: flex; flex-direction: column; gap: 6px; }
 .search-group__label {
@@ -1138,7 +1133,7 @@ body.has-paper > * { position: relative; z-index: 1; }
 .conv-answer .note-cite { font-size: 0.82em; }
 
 .conv-error {
-  margin: var(--sp-4) auto 0;
+  margin: var(--sp-4) 0 0;
   padding: var(--sp-3);
   background: var(--canvas);
   border: var(--hairline);
@@ -1172,7 +1167,7 @@ body.has-paper > * { position: relative; z-index: 1; }
   padding: var(--sp-3) var(--sp-5) var(--sp-4);
 }
 .composer {
-  width: min(100%, 760px);
+  width: min(100%, var(--measure-conv));
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -1286,7 +1281,7 @@ body.has-paper > * { position: relative; z-index: 1; }
   padding: var(--sp-6) var(--sp-5);
 }
 .new-task-compose {
-  width: min(100%, 760px);
+  width: min(100%, var(--measure-conv));
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);


### PR DESCRIPTION
## What

Follow-up to #199. The mixed layout there — prose pinned to a 760px column while note-card strips ran full-bleed — read as two competing compositions. This reverts to **one centered column for everything** (thread content, note strips, composer, and the new-task compose pane) and widens the measure from 760px to **1120px**, introduced as the `--measure-conv` design token.

1120 isn't arbitrary: minus the thread's side padding it fits **exactly five rich note cards per strip row**, so media-heavy results use the width that motivated the original complaint without breaking the column.

Structurally, the notes container moves back inside the activity wrap (matching the design prototype's markup — being a sibling only existed to serve the breakout), and the live-strip/streamed-group plumbing follows.

## Reviewer notes

- CSS-only change plus the small markup/selector revert; no behavior changes to streaming, fold state, or auto-follow.
- Verified in headless Chrome against the built bundle: thread and composer both measure exactly 1120px with identical left edges, content row width 1072px (= five cards), notes container back inside `.activity-wrap`; `tsc` strict + `vite build` clean.
- Future width tweaks are a one-token edit (`--measure-conv` in `styles.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)