### PR TITLE
fix(xhs): recover from search clicks opening the wrong note

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -164,6 +164,20 @@ pub fn run() {
             commands::config_unset,
             commands::pro_activate,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running socai");
+        .build(tauri::generate_context!())
+        .expect("error while building socai")
+        .run(|app_handle, event| {
+            // On quit, close socai-owned chrome tabs the same way the explicit
+            // disconnect button does. Tauri fires ExitRequested before the
+            // process tears down; block on the async cleanup so the
+            // Target.closeTarget calls actually reach chrome before we exit —
+            // otherwise the tabs socai opened linger after the app is gone.
+            // (Managed chrome is killed on drop regardless; this matters for the
+            // attach-to-existing-browser case, where only socai's own tabs
+            // should be closed, not the whole browser.)
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                let runtime = app_handle.state::<SocaiRuntime>().inner().clone();
+                tauri::async_runtime::block_on(runtime.disconnect_browser());
+            }
+        });
 }

--- a/app/src/lib/shortcuts.ts
+++ b/app/src/lib/shortcuts.ts
@@ -1,11 +1,17 @@
 //! Composer send shortcut: enter (or cmd/ctrl+enter) sends, shift+enter is a
 //! newline. One definition so the keydown check and the hover hint can't drift.
 //!
-//! `isComposing` guards the IME: while composing a pinyin/kana candidate the
-//! enter that confirms it must NOT send — important since the UI defaults to zh.
+//! Two guards keep the IME's confirm-enter from sending — important since the
+//! UI defaults to zh. `isComposing` covers Chromium, where the confirming enter
+//! still reports it. But Tauri on macOS runs WKWebView, which fires
+//! `compositionend` *before* the keydown, so `isComposing` is already false by
+//! then; there `keyCode === 229` is the sentinel that the key is still being
+//! consumed by the IME. Checking both catches the confirm-enter on either
+//! engine. (`keyCode` is deprecated but still populated and is the standard
+//! IME guard used by CodeMirror/ProseMirror for exactly this reason.)
 
 export const sendShortcutLabel = "enter";
 
 export function isSendShortcut(e: KeyboardEvent): boolean {
-  return e.key === "Enter" && !e.shiftKey && !e.isComposing;
+  return e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229;
 }

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -21,6 +21,13 @@ const SEARCH_TRANSITION_TIMEOUT_S: f64 = 12.0;
 /// Upper bound the login gate polls the sidebar for a definitive login read
 /// before falling back to "logged in" (only hit if no sidebar ever renders).
 const LOGIN_GATE_TIMEOUT_S: f64 = 6.0;
+/// How many times to re-open a search note when the cover click lands on the
+/// wrong one. XHS search is a virtualized masonry grid: the pixel coordinates
+/// `clickCard` measures can go stale before the CDP click lands (lazy content
+/// reflows the grid), so the click opens a neighbor. Each retry closes the
+/// wrong overlay and re-opens, which re-measures fresh coordinates. Capped so a
+/// genuinely un-openable target doesn't grind the scan.
+const MAX_STALE_OPEN_RETRIES: u64 = 2;
 
 /// Outcome of the pre-flight [`XhsPageRuntime::login_gate`] check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -516,8 +523,21 @@ impl<'a> XhsPageRuntime<'a> {
             .unwrap_or("cover");
 
         sleep_ms(180).await;
+        // Re-measure the target's coordinates right before clicking. The first
+        // clickCard scrolled the card into view, and the virtualized search
+        // grid keeps reflowing during the settle wait, so coordinates measured
+        // before the sleep can already point at a neighbor. clickCard relocates
+        // the card by data-note-id, so this yields the target's *current*
+        // center; clicking it immediately leaves only a single CDP round-trip
+        // (no scroll, no sleep) for the layout to shift again. Fall back to the
+        // pre-sleep coordinates if the re-measure fails (e.g. the card briefly
+        // unmounted).
+        let fresh = self
+            .expect_object("clickCard", Some(&Value::Object(click_arg.clone())))
+            .await?;
+        let click_at = if script_ok(&fresh) { &fresh } else { &target };
         self.page
-            .click(number(&target, "x"), number(&target, "y"))
+            .click(number(click_at, "x"), number(click_at, "y"))
             .await?;
         let opened = self.wait_for_note_open(per_attempt).await?;
         if note_is_open(&opened) {
@@ -669,8 +689,37 @@ impl<'a> XhsPageRuntime<'a> {
         }
         if !note_id.is_empty() || index.is_some() {
             let t_open = Instant::now();
-            let opened = self.open_note(note_id, index, wait_seconds).await?;
+            let mut opened = self.open_note(note_id, index, wait_seconds).await?;
+            // Guard against the grid opening the wrong note: compare the opened
+            // URL's note_id to the target *before* the expensive extract/
+            // download, and if it mismatches, close the wrong overlay and
+            // re-open (which re-measures fresh click coordinates). Only the
+            // note_id path can verify the target — a pure-index open has no
+            // expected id — and the extract-time check below still backstops
+            // the give-up case.
+            let mut stale_retries: u64 = 0;
+            if !note_id.is_empty() {
+                while script_ok(&opened) {
+                    let opened_id = opened
+                        .get("url")
+                        .and_then(Value::as_str)
+                        .map(opened_note_id_from_url)
+                        .unwrap_or_default();
+                    if opened_id.is_empty() || opened_id == note_id {
+                        break;
+                    }
+                    if stale_retries >= MAX_STALE_OPEN_RETRIES {
+                        break;
+                    }
+                    stale_retries += 1;
+                    let _ = self.close_note((wait_seconds / 2.0).max(0.4)).await;
+                    opened = self.open_note(note_id, index, wait_seconds).await?;
+                }
+            }
             perf.insert("open_ms".into(), json!(t_open.elapsed().as_millis() as u64));
+            if stale_retries > 0 {
+                perf.insert("open_stale_retries".into(), json!(stale_retries));
+            }
             if let Some(strategy) = opened
                 .get("strategy")
                 .and_then(Value::as_str)
@@ -1877,6 +1926,23 @@ fn normalize_image_url(value: &str) -> String {
         return String::new();
     }
     trimmed.replacen("http://", "https://", 1)
+}
+
+/// Note id from an opened XHS detail URL (`/explore/<id>`, `/discovery/<id>`,
+/// or `/search_result/<id>`), stripped of query/hash. Empty when the URL isn't
+/// a detail route, in which case the caller can't verify the opened target and
+/// proceeds to the extract-time note_id check instead.
+fn opened_note_id_from_url(url: &str) -> String {
+    let path = url.split(['?', '#']).next().unwrap_or("");
+    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
+    while let Some(segment) = segments.next() {
+        if matches!(segment, "explore" | "discovery" | "search_result") {
+            if let Some(id) = segments.next() {
+                return id.to_string();
+            }
+        }
+    }
+    String::new()
 }
 
 fn note_is_open(state: &Value) -> bool {


### PR DESCRIPTION
This branch bundles the XHS stale-note fix with two small desktop-app fixes that were already in the working tree.

## fix(xhs): recover from search clicks opening the wrong note

The XHS search feed is a virtualized masonry grid whose layout reflows between the moment `clickCard` measures a card's pixel coordinates and the moment the CDP click lands, so the click can open a neighboring note (`stale_note`). When the wrong note opens it is flagged `ok:false` and excluded from both the media manifest and background transcription — so e.g. a `num_notes=1` video search silently returns no transcript. Two complementary fixes:

- **Re-measure before click** (`open_note`): after the settle sleep, re-run `clickCard` and click the fresh coordinates. `clickCard` relocates the card by `data-note-id`, so this yields the card's *current* center, shrinking the measure→click window to a single CDP round-trip (no scroll, no sleep). Lowers the miss rate.
- **Re-open on mismatch** (`read_note_with_options`): compare the opened URL's note_id to the target *before* the expensive extract/download; on mismatch, close the wrong overlay and re-open (up to `MAX_STALE_OPEN_RETRIES`), which re-measures fresh coordinates. The existing extract-time note_id check still backstops the give-up path. Records `open_stale_retries` in the scan perf file (`stats/scan.json`) for observability.

## fix(app): close socai-owned chrome tabs on quit

Tauri fires `ExitRequested` before the process tears down; block on the async `disconnect_browser` cleanup so the `Target.closeTarget` calls actually reach chrome before exit. Matters for the attach-to-existing-browser case, where only socai's own tabs should be closed rather than left lingering.

## fix(app): guard IME confirm-enter on WKWebView

WKWebView (Tauri on macOS) fires `compositionend` before the keydown, so `isComposing` is already false on the enter that confirms a pinyin/kana candidate. Add `keyCode === 229` as a second IME guard so that confirming enter no longer sends the message. Chromium still reports `isComposing`, so checking both covers either engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)