### PR TITLE
feat(app): play note videos inline in timeline cards

### DIFF
--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -162,6 +162,11 @@ function playInline(btn: HTMLElement): void {
   const video = document.createElement("video");
   video.className = "note-media__video";
   video.playsInline = true;
+  // no native controls, so the element itself is the keyboard control:
+  // focusable, Enter/Space toggling (keeps keyboard users in the loop after
+  // the play button — their focus anchor — is removed below)
+  video.tabIndex = 0;
+  video.setAttribute("aria-label", "video player");
   if (poster) video.poster = poster;
   video.src = src;
 
@@ -190,9 +195,15 @@ function playInline(btn: HTMLElement): void {
   video.addEventListener("loadedmetadata", sync);
   video.addEventListener("play", () => (glyph.hidden = true));
   video.addEventListener("pause", () => (glyph.hidden = false));
-  video.addEventListener("click", () => {
+  const toggle = () => {
     if (video.paused) video.play().catch(() => {});
     else video.pause();
+  };
+  video.addEventListener("click", toggle);
+  video.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault(); // Space must toggle, not scroll the timeline
+    toggle();
   });
   // bar clicks are seeks, never card opens (the delegated open handler sits
   // on document, so stopping propagation here is enough)
@@ -219,10 +230,14 @@ function playInline(btn: HTMLElement): void {
     if (track.hasPointerCapture(e.pointerId)) scrub(e);
   });
 
+  // removing the focused button would strand keyboard focus on <body>;
+  // hand it to the video so Enter/Space keep controlling playback
+  const hadFocus = document.activeElement === btn;
   btn.remove();
   frame.querySelector(".note-media__dur")?.remove(); // the bar shows the clock
   frame.append(video, glyph);
   barHost.appendChild(bar);
+  if (hadFocus) video.focus();
   // Called inside the click gesture, so WKWebView allows playback with sound;
   // if it still refuses, the poster, glyph and toggle remain usable.
   video.play().catch(() => {});

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -112,9 +112,18 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
         : `${posterImg}<span class="note-media__play">${IC.play()}</span>`;
       return `<span class="note-media" data-kind="video">${inner}</span>`;
     }
-    return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${
-      decorative ? "" : `<span class="note-media__play">${IC.play()}</span>`
-    }${m.dur && !decorative ? `<span class="note-media__dur">${esc(m.dur)}</span>` : ""}</span></span>`;
+    // With the file on disk the glyph is a real button and marks the whole
+    // frame as a play surface (the click handler treats any click on the
+    // frame as play; the button itself is the keyboard-focusable control).
+    // Without a file the glyph stays decorative and the click bubbles to the
+    // card (viewer opens).
+    const videoUrl = decorative ? "" : assetUrl(note, m.src);
+    const play = decorative
+      ? ""
+      : videoUrl
+        ? `<button type="button" class="note-media__play" data-note-play="${esc(videoUrl)}" aria-label="play video">${IC.play()}</button>`
+        : `<span class="note-media__play">${IC.play()}</span>`;
+    return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${play}${m.dur && !decorative ? `<span class="note-media__dur">${esc(m.dur)}</span>` : ""}</span></span>`;
   }
   const url = assetUrl(note, m.src);
   // gallery slides are pre-rendered hidden — lazy would defer them to first
@@ -124,6 +133,99 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
     : `<span class="note-media--placeholder" style="position:absolute;inset:0"></span>`;
   const badge = count > 1 && !decorative ? `<span class="note-media__count">${IC.stack()}${count}</span>` : "";
   return `<span class="note-media" data-kind="image">${img}${badge}</span>`;
+}
+
+function fmtClock(s: number): string {
+  if (!isFinite(s) || s < 0) return "0:00";
+  const total = Math.floor(s);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
+// Start inline playback in a card cover: overlay a <video> on the poster
+// (the play button's data-note-play carries the resolved asset url). The
+// poster stays in-flow underneath — it is what sizes the pillarbox, so
+// removing it would reflow the card mid-click — and it backs the letterbox
+// bars contain-fit leaves around whatever ratio the file really is.
+// The controls are ours, not the native ones: at card width WebKit's adaptive
+// controls drop the scrubber and time readout, so the card gets a slim
+// track + clock bar, click-on-video toggles play/pause, and a centered glyph
+// marks the paused state. The viewer gallery keeps native controls.
+function playInline(btn: HTMLElement): void {
+  const frame = btn.closest<HTMLElement>(".note-media__inner") ?? btn.closest<HTMLElement>(".note-media");
+  const src = btn.getAttribute("data-note-play");
+  if (!frame || !src) return;
+  // video + glyph live in the pillarbox inner; the bar spans the whole cover
+  const barHost = btn.closest<HTMLElement>(".note-media") ?? frame;
+  const poster = frame.querySelector<HTMLImageElement>("img.note-media__img")?.getAttribute("src") || "";
+  const durText = frame.querySelector(".note-media__dur")?.textContent || "0:00";
+
+  const video = document.createElement("video");
+  video.className = "note-media__video";
+  video.playsInline = true;
+  if (poster) video.poster = poster;
+  video.src = src;
+
+  // paused indicator — same glyph as the poster state, but inert (clicks fall
+  // through to the video's toggle); visible until playback actually starts,
+  // so a refused play() keeps a play affordance on screen.
+  const glyph = document.createElement("span");
+  glyph.className = "note-media__play note-media__play--hud";
+  glyph.innerHTML = IC.play();
+
+  const bar = document.createElement("span");
+  bar.className = "note-media__vbar";
+  bar.innerHTML =
+    `<span class="note-media__vtrack"><span class="note-media__vfill"></span></span>` +
+    `<span class="note-media__vtime">0:00 / ${esc(durText)}</span>`;
+  const track = bar.querySelector<HTMLElement>(".note-media__vtrack")!;
+  const fill = bar.querySelector<HTMLElement>(".note-media__vfill")!;
+  const clock = bar.querySelector<HTMLElement>(".note-media__vtime")!;
+
+  const sync = () => {
+    const d = video.duration;
+    if (isFinite(d) && d > 0) fill.style.width = `${(video.currentTime / d) * 100}%`;
+    clock.textContent = `${fmtClock(video.currentTime)} / ${isFinite(d) && d > 0 ? fmtClock(d) : durText}`;
+  };
+  video.addEventListener("timeupdate", sync);
+  video.addEventListener("loadedmetadata", sync);
+  video.addEventListener("play", () => (glyph.hidden = true));
+  video.addEventListener("pause", () => (glyph.hidden = false));
+  video.addEventListener("click", () => {
+    if (video.paused) video.play().catch(() => {});
+    else video.pause();
+  });
+  // bar clicks are seeks, never card opens (the delegated open handler sits
+  // on document, so stopping propagation here is enough)
+  bar.addEventListener("click", (e) => e.stopPropagation());
+  const scrub = (e: PointerEvent) => {
+    const r = track.getBoundingClientRect();
+    const d = video.duration;
+    if (!isFinite(d) || d <= 0 || r.width <= 0) return;
+    const ratio = Math.max(0, Math.min(1, (e.clientX - r.left) / r.width));
+    video.currentTime = ratio * d;
+    sync(); // timeupdate is throttled; reflect the seek immediately
+  };
+  track.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    scrub(e);
+    // capture only extends the drag; a failed capture must not void the seek
+    try {
+      track.setPointerCapture(e.pointerId);
+    } catch {
+      /* inactive pointer (lifted mid-gesture) — click-seek already landed */
+    }
+  });
+  track.addEventListener("pointermove", (e) => {
+    if (track.hasPointerCapture(e.pointerId)) scrub(e);
+  });
+
+  btn.remove();
+  frame.querySelector(".note-media__dur")?.remove(); // the bar shows the clock
+  frame.append(video, glyph);
+  barHost.appendChild(bar);
+  // Called inside the click gesture, so WKWebView allows playback with sound;
+  // if it still refuses, the poster, glyph and toggle remain usable.
+  video.play().catch(() => {});
 }
 
 // No shares entry: XHS exposes no share count anywhere we read, so the column
@@ -369,6 +471,10 @@ function openViewer(id: string): void {
   const note = resolveNote(id);
   if (!note) return;
   closeViewer();
+  // An inline card video would keep its audio running under the backdrop —
+  // the lightbox owns playback while open. (Runs before the viewer is
+  // appended, so only card/popover videos match.)
+  document.querySelectorAll<HTMLVideoElement>(".note-media video").forEach((v) => v.pause());
   const host = document.createElement("div");
   host.className = "note-viewer note-viewer--lightbox";
   host.innerHTML = viewerHTML(note);
@@ -386,6 +492,33 @@ export function bindNoteInteractions(): void {
   document.addEventListener("click", (e) => {
     const target = e.target as HTMLElement;
 
+    // A click inside a <video> is a native-controls interaction (play/pause,
+    // scrub, volume — WebKit retargets shadow-DOM control clicks to the video
+    // element) — never a note action like opening the viewer.
+    if (target.closest("video")) return;
+    // inline play — the whole cover is the play surface: any click on a
+    // playable video frame starts it, and during playback the pillarbox
+    // margins toggle pause. Only the card body below opens the note viewer.
+    // Frames with no play button (images, missing file, gallery, thumbs/dots)
+    // fall through to their existing handling.
+    const media = target.closest<HTMLElement>(".note-media");
+    if (media) {
+      const play = media.querySelector<HTMLElement>("[data-note-play]");
+      if (play) {
+        e.preventDefault();
+        e.stopPropagation();
+        playInline(play);
+        return;
+      }
+      const vid = media.querySelector<HTMLVideoElement>("video.note-media__video");
+      if (vid) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (vid.paused) vid.play().catch(() => {});
+        else vid.pause();
+        return;
+      }
+    }
     // external link (Tauri webview won't honour target=_blank)
     const ext = target.closest<HTMLElement>("[data-note-external]");
     if (ext) {
@@ -451,14 +584,28 @@ export function bindNoteInteractions(): void {
     // synthesize a click so the delegated click handler above does the rest.
     if (e.key !== "Enter" && e.key !== " ") return;
     const target = e.target as HTMLElement;
-    if (target.closest("input, textarea, select, [contenteditable]")) return;
+    if (target.closest("input, textarea, select, [contenteditable], video")) return;
     const actionable = target.closest<HTMLElement>(
-      "[data-note-open], [data-note-external], [data-note-nav], [data-gallery-nav], [data-gallery-thumb], [data-note-close], .note-viewer-corner",
+      "[data-note-open], [data-note-external], [data-note-nav], [data-note-play], [data-gallery-nav], [data-gallery-thumb], [data-note-close], .note-viewer-corner",
     );
     if (!actionable) return;
     e.preventDefault();
     actionable.click();
   });
+
+  // One playing note video at a time — starting any (card-inline or viewer
+  // gallery) pauses the rest. Media events don't bubble, so capture.
+  document.addEventListener(
+    "play",
+    (e) => {
+      const el = e.target;
+      if (!(el instanceof HTMLVideoElement) || !el.closest(".note-media")) return;
+      document.querySelectorAll<HTMLVideoElement>(".note-media video").forEach((v) => {
+        if (v !== el) v.pause();
+      });
+    },
+    true,
+  );
 
   // citation hover preview — the same rich card the search strips render
   // (position:fixed popover so it escapes overflow)

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -188,7 +188,8 @@ function playInline(btn: HTMLElement): void {
 
   const sync = () => {
     const d = video.duration;
-    if (isFinite(d) && d > 0) fill.style.width = `${(video.currentTime / d) * 100}%`;
+    // clamp: currentTime can drift a hair past duration at end-of-media
+    if (isFinite(d) && d > 0) fill.style.width = `${Math.min(100, Math.max(0, (video.currentTime / d) * 100))}%`;
     clock.textContent = `${fmtClock(video.currentTime)} / ${isFinite(d) && d > 0 ? fmtClock(d) : durText}`;
   };
   video.addEventListener("timeupdate", sync);
@@ -199,22 +200,35 @@ function playInline(btn: HTMLElement): void {
     if (video.paused) video.play().catch(() => {});
     else video.pause();
   };
+  const seekTo = (t: number) => {
+    const d = video.duration;
+    if (!isFinite(d) || d <= 0) return;
+    video.currentTime = Math.max(0, Math.min(d, t));
+    sync(); // timeupdate is throttled; reflect the seek immediately
+  };
   video.addEventListener("click", toggle);
+  // the focused video is the whole keyboard surface, like a native player:
+  // Enter/Space toggle, arrows seek ±5s, Home/End jump (the track itself
+  // stays pointer-only — no second tab stop per card)
   video.addEventListener("keydown", (e) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    e.preventDefault(); // Space must toggle, not scroll the timeline
-    toggle();
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault(); // Space must toggle, not scroll the timeline
+      toggle();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      seekTo(video.currentTime + (e.key === "ArrowRight" ? 5 : -5));
+    } else if (e.key === "Home" || e.key === "End") {
+      e.preventDefault();
+      seekTo(e.key === "Home" ? 0 : video.duration);
+    }
   });
   // bar clicks are seeks, never card opens (the delegated open handler sits
   // on document, so stopping propagation here is enough)
   bar.addEventListener("click", (e) => e.stopPropagation());
   const scrub = (e: PointerEvent) => {
     const r = track.getBoundingClientRect();
-    const d = video.duration;
-    if (!isFinite(d) || d <= 0 || r.width <= 0) return;
-    const ratio = Math.max(0, Math.min(1, (e.clientX - r.left) / r.width));
-    video.currentTime = ratio * d;
-    sync(); // timeupdate is throttled; reflect the seek immediately
+    if (r.width <= 0) return;
+    seekTo(((e.clientX - r.left) / r.width) * video.duration);
   };
   track.addEventListener("pointerdown", (e) => {
     e.preventDefault();

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1428,14 +1428,46 @@ body.has-paper > * { position: relative; z-index: 1; }
   padding: 1px 6px; border-radius: var(--r-2); pointer-events: none;
 }
 .note-media__play {
-  position: absolute; width: 38px; height: 38px;
+  position: absolute; width: 28px; height: 28px;
   display: inline-flex; align-items: center; justify-content: center;
   border: 0; border-radius: var(--r-pill); background: rgba(10, 10, 10, 0.55);
   color: var(--ink-9); cursor: pointer;
   transition: background var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
 }
-.note-media__play svg { width: 16px; height: 16px; margin-left: 2px; }
+.note-media__play svg { width: 12px; height: 12px; margin-left: 1.5px; }
 button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: scale(1.05); }
+/* inline playback (cards): a video overlays the poster in the same pillarbox
+   box, so the card doesn't reflow on click. Absolutely positioned: an in-flow
+   video's intrinsic size would join the sizing of the box it's supposed to
+   fill; contain-fit letterboxes any real ratio inside it. Click = play/pause
+   (the slim bar below carries scrubber + clock — at card width the native
+   controls would drop both). */
+.note-media__video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; cursor: default; }
+/* the paused HUD glyph hides while playing — the class's display beats the
+   UA's [hidden] rule, so honor the attribute explicitly */
+.note-media__play--hud { pointer-events: none; }
+.note-media__play--hud[hidden] { display: none; }
+/* full-bleed bottom strip across the whole cover (it rides over the
+   pillarbox padding, not just the video) */
+.note-media__vbar {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 9px 5px;
+  background: linear-gradient(180deg, rgba(10, 10, 10, 0), rgba(10, 10, 10, 0.58));
+}
+.note-media__vtrack { position: relative; flex: 1 1 auto; height: 14px; cursor: pointer; touch-action: none; }
+.note-media__vtrack::before {
+  content: ""; position: absolute; left: 0; right: 0; top: 50%; height: 3px; margin-top: -1.5px;
+  border-radius: var(--r-pill); background: rgba(250, 250, 249, 0.28);
+}
+.note-media__vfill {
+  position: absolute; left: 0; top: 50%; height: 3px; margin-top: -1.5px; width: 0%;
+  border-radius: var(--r-pill); background: var(--ink-9); pointer-events: none;
+}
+.note-media__vtime {
+  flex: 0 0 auto; font-family: var(--font-mono); letter-spacing: var(--ls-mono);
+  font-variant-numeric: tabular-nums; font-size: 10px; color: var(--ink-9); white-space: nowrap;
+}
 
 /* ── author + stats primitives ─────────────────────────────────────── */
 .note-author { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1442,7 +1442,8 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
    fill; contain-fit letterboxes any real ratio inside it. Click = play/pause
    (the slim bar below carries scrubber + clock — at card width the native
    controls would drop both). */
-.note-media__video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; cursor: default; }
+/* two classes: must outrank `.note-media__inner video`'s object-fit: cover */
+.note-media .note-media__video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; cursor: default; }
 /* the paused HUD glyph hides while playing — the class's display beats the
    UA's [hidden] rule, so honor the attribute explicitly */
 .note-media__play--hud { pointer-events: none; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1444,6 +1444,7 @@ button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: s
    controls would drop both). */
 /* two classes: must outrank `.note-media__inner video`'s object-fit: cover */
 .note-media .note-media__video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; cursor: default; }
+.note-media .note-media__video:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: -2px; }
 /* the paused HUD glyph hides while playing — the class's display beats the
    UA's [hidden] rule, so honor the attribute explicitly */
 .note-media__play--hud { pointer-events: none; }


### PR DESCRIPTION
## What

Video note cards in the timeline (and answer-citation previews) now play inline. Clicking anywhere on a video cover starts playback right in the card; clicking again pauses. The card body below (title, stats, author) still opens the note viewer dialog, which keeps its full native-controls player.

The inline player is custom-built:

- **Full-bleed scrub track + mono clock** (`0:37 / 1:14`) pinned to the bottom of the cover, spanning the whole card width including the pillarbox padding. Pointer-scrubbable (click or drag to seek).
- **Paused-state glyph** (28px, down from the previous 38px play badge) that hides during playback so nothing blocks the content.
- **Single playback**: starting any note video pauses the others; opening the viewer pauses card videos.
- Covers whose video file was never downloaded keep the decorative glyph and fall through to the viewer, exactly as before. Image cards, gallery, thumbs and citation dots are untouched.

## Why custom controls

At ~206px card width, WebKit's adaptive native controls silently drop the scrubber and time readout (they only show play/mute/fullscreen), and there is no way to opt back in — so a native-controls card player can never show a timeline.

## Implementation notes for review

- **The video overlays the poster instead of replacing it** ([notes.ts `playInline`](../blob/claude/timeline-inline-video-playback-40d68b/app/src/panels/notes.ts)). The in-flow poster `<img>` is what sizes the pillarbox box; removing it re-resolves the `height:100% ↔ aspect-ratio` cycle and reflows the cover ~90px mid-click. Caught by measurement during verification.
- **`target.closest("video")` guard first in the delegated click handler**: WebKit retargets shadow-DOM control clicks to the `<video>` element, so without it, interacting with the player would bubble to `[data-note-open]` and open the dialog.
- **`.note-media__play--hud[hidden] { display:none }`** is load-bearing: the class's `display:inline-flex` beats the UA `[hidden]` rule, so the attribute alone never hid the glyph.
- Seek runs before `setPointerCapture` (capture can throw for a pointer lifted mid-gesture; a failed capture must not void the seek).
- Monochrome only — the bar/glyph reuse the existing on-media overlay language (`rgba(10,10,10,…)` + `--ink-9`), no new colors.

## Verification

Driven end-to-end in a browser harness bundling the real `notes.ts` + `styles.css` with real downloaded XHS media (9:16 and 16:9 files) — only `@tauri-apps/api/core` stubbed. Covered: poster-click play, margin pause/resume toggle, scrub accuracy (25%/50%/80% → exact currentTime), clock sync, no card reflow on swap, glyph computed-`display` across play/pause, single-playback, viewer open/close interplay, no-file fallback, image-card regression, carousel slide destroy/restore, keyboard Enter. Zero console errors.

Known seam: WKWebView may refuse the auto-`play()` on first click (policy) — the card then shows the paused glyph and a tap on the video starts it; worth one manual click in `pnpm exec tauri dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)