### PR TITLE
feat: add Doubao model provider

### DIFF
--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -39,6 +39,7 @@ const PROVIDER_ORDER: &[Provider] = &[
     Provider::Kimi,
     Provider::Qwen,
     Provider::QwenIntl,
+    Provider::Doubao,
     Provider::DeepSeek,
     Provider::OpenAI,
     Provider::Anthropic,
@@ -543,7 +544,8 @@ async fn ensure_any_llm_key() -> Result<()> {
     if !io::stdin().is_terminal() {
         anyhow::bail!(
             "No LLM credential found. Set OPENAI_API_KEY / ANTHROPIC_API_KEY / \
-             KIMI_API_KEY / QWEN_API_KEY, run `codex login`, or run `socai tui` \
+             KIMI_API_KEY / QWEN_API_KEY / DOUBAO_API_KEY / DEEPSEEK_API_KEY, \
+             run `codex login`, or run `socai tui` \
              in a terminal to save one."
         );
     }

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -105,13 +105,13 @@ impl OpenAICompatBackend {
         extra
     }
 
-    /// Some providers (Kimi, Qwen) want `reasoning_content` round-tripped
+    /// Some providers (Kimi, Qwen, Doubao) want `reasoning_content` round-tripped
     /// in the assistant message when tool_calls are present. Others
     /// (OpenAI proper) ignore it. Toggle is per-provider.
     fn preserve_reasoning_content(&self) -> bool {
         matches!(
             self.provider,
-            Provider::Kimi | Provider::Qwen | Provider::QwenIntl
+            Provider::Kimi | Provider::Qwen | Provider::QwenIntl | Provider::Doubao
         )
     }
 

--- a/core/src/agent/model_catalog.generated.json
+++ b/core/src/agent/model_catalog.generated.json
@@ -408,6 +408,24 @@
         "source": "pi-ai"
       }
     ],
+    "doubao": [
+      {
+        "id": "doubao-seed-2-1-pro-260628",
+        "display_name": "Doubao Seed 2.1 Pro (260628)",
+        "source": "fallback"
+      },
+      {
+        "id": "doubao-seed-2-1-turbo-260628",
+        "display_name": "Doubao Seed 2.1 Turbo (260628)",
+        "source": "fallback",
+        "recommended": true
+      },
+      {
+        "id": "doubao-seed-evolving",
+        "display_name": "Doubao Seed Evolving",
+        "source": "fallback"
+      }
+    ],
     "deepseek": [
       {
         "id": "deepseek-v4-pro",

--- a/core/src/agent/provider.rs
+++ b/core/src/agent/provider.rs
@@ -24,6 +24,8 @@ pub enum Provider {
     /// Qwen via international DashScope (dashscope-intl.aliyuncs.com),
     /// keyed from modelstudio.console.alibabacloud.com.
     QwenIntl,
+    /// Doubao via its OpenAI-compatible API.
+    Doubao,
     DeepSeek,
 }
 
@@ -35,6 +37,7 @@ impl Provider {
             Provider::Kimi => "kimi",
             Provider::Qwen => "qwen",
             Provider::QwenIntl => "qwen-intl",
+            Provider::Doubao => "doubao",
             Provider::DeepSeek => "deepseek",
         }
     }
@@ -46,6 +49,7 @@ impl Provider {
             "kimi" | "moonshot" => Some(Self::Kimi),
             "qwen" | "dashscope" => Some(Self::Qwen),
             "qwen-intl" | "qwen_intl" | "dashscope-intl" => Some(Self::QwenIntl),
+            "doubao" => Some(Self::Doubao),
             "deepseek" => Some(Self::DeepSeek),
             _ => None,
         }
@@ -178,6 +182,14 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         // intentionally resolves to the mainland entry; the international
         // deployment is reached by explicit provider selection.
         model_prefixes: &[],
+    },
+    ProviderConfig {
+        provider: Provider::Doubao,
+        display_name: "Doubao",
+        default_model: "doubao-seed-2-1-turbo-260628",
+        env_keys: &["DOUBAO_API_KEY"],
+        base_url: Some("https://ark.cn-beijing.volces.com/api/v3"),
+        model_prefixes: &["doubao-"],
     },
     ProviderConfig {
         provider: Provider::DeepSeek,
@@ -576,6 +588,7 @@ mod tests {
         assert_eq!(Provider::from_name("MOONSHOT"), Some(Provider::Kimi));
         assert_eq!(Provider::from_name("DashScope"), Some(Provider::Qwen));
         assert_eq!(Provider::from_name("qwen-intl"), Some(Provider::QwenIntl));
+        assert_eq!(Provider::from_name("doubao"), Some(Provider::Doubao));
         assert_eq!(Provider::from_name("DeepSeek"), Some(Provider::DeepSeek));
         assert_eq!(Provider::from_name("nope"), None);
     }
@@ -588,6 +601,7 @@ mod tests {
             Provider::Kimi,
             Provider::Qwen,
             Provider::QwenIntl,
+            Provider::Doubao,
             Provider::DeepSeek,
         ] {
             let cfg = config_for(p);

--- a/scripts/sync-model-catalog.mjs
+++ b/scripts/sync-model-catalog.mjs
@@ -43,6 +43,11 @@ const FALLBACK = {
     entry("qwen3.6-plus", "Qwen 3.6 Plus"),
     entry("qwen3.6-max-preview", "Qwen 3.6 Max Preview"),
   ],
+  doubao: [
+    entry("doubao-seed-2-1-turbo-260628", "Doubao Seed 2.1 Turbo (260628)", "fallback", true),
+    entry("doubao-seed-2-1-pro-260628", "Doubao Seed 2.1 Pro (260628)"),
+    entry("doubao-seed-evolving", "Doubao Seed Evolving"),
+  ],
   deepseek: [
     entry("deepseek-v4-pro", "DeepSeek V4 Pro", "fallback", true),
     entry("deepseek-v4-flash", "DeepSeek V4 Flash"),
@@ -83,6 +88,14 @@ const PROVIDERS = {
     include: (id) => /^(qwen|qwq-|qvq-)/i.test(id),
     piProviders: [],
   },
+  doubao: {
+    env: ["DOUBAO_API_KEY"],
+    url: "https://ark.cn-beijing.volces.com/api/v3/models",
+    auth: bearer,
+    data: (json) => json?.data,
+    include: (id) => /^doubao-/i.test(id),
+    piProviders: [],
+  },
   deepseek: {
     env: ["DEEPSEEK_API_KEY"],
     url: "https://api.deepseek.com/v1/models",
@@ -116,6 +129,8 @@ function titleFromId(id) {
     .replace(/^accounts\/fireworks\/models\//, "")
     .replace(/[-_/]+/g, " ")
     .replace(/\bqwen(\d)/gi, "Qwen $1")
+    .replace(/\bdoubao\b/gi, "Doubao")
+    .replace(/\bseed\b/gi, "Seed")
     .replace(/\bgpt\b/gi, "GPT")
     .replace(/\bkimi\b/gi, "Kimi")
     .replace(/\bdeepseek\b/gi, "DeepSeek")
@@ -126,6 +141,7 @@ function titleFromId(id) {
     .replace(/\bplus\b/gi, "Plus")
     .replace(/\bmax\b/gi, "Max")
     .replace(/\bflash\b/gi, "Flash")
+    .replace(/\bturbo\b/gi, "Turbo")
     .replace(/\bpro\b/gi, "Pro")
     .replace(/\bpreview\b/gi, "Preview")
     .replace(/\s+/g, " ")
@@ -310,6 +326,7 @@ function versionParts(provider, lower) {
     openai: /gpt-(\d+)(?:[.-](\d+|o))?/,
     kimi: /kimi-k(\d+)(?:[.-](\d+))?/,
     qwen: /qwen(\d+)(?:[.-](\d+))?/,
+    doubao: /doubao-seed-(\d+)(?:[.-](\d+))?/,
     deepseek: /deepseek-v(\d+)(?:[.-](\d+))?/,
   };
   const match = lower.match(matchers[provider]) || lower.match(/(\d+)(?:[.-](\d+))?/);


### PR DESCRIPTION
## Summary

- add Doubao as an OpenAI-compatible provider in the shared Rust runtime
- expose Doubao in the desktop and TUI model pickers with DOUBAO_API_KEY credentials
- include Doubao Seed 2.1 Turbo, Seed 2.1 Pro, and Seed Evolving in the generated catalog
- preserve reasoning content across multi-turn tool calls and sync models from the provider API when credentials are available

## Validation

- cargo check -p socai-core -p socai-cli -p socai_app
- cargo test -p socai-core agent::provider::tests
- node scripts/sync-model-catalog.mjs --no-official --check
- git diff --check
- live API smoke tests: model discovery, Turbo tool call plus tool-result continuation, Evolving image URL input, and Turbo base64 data URL input