### PR TITLE
fix(xhs): type search queries with real key events for the new AI composer

### DIFF
--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -241,6 +241,32 @@ impl PageSession {
         Ok(())
     }
 
+    /// Type `text` as a stream of per-character key events (keyDown with the
+    /// char's `text` payload, then keyUp), the way a human keyboard does.
+    /// `type_text`'s single `Input.insertText` fires an `input` event with no
+    /// keydown/keyup around it — XHS's search composer treats that signature
+    /// as bot input and dead-ends the whole widget (submit click and Enter
+    /// both stop responding). Per-char key events keep the page's key-driven
+    /// behaviours (suggestion fetch, submit arming) working.
+    pub async fn type_chars(&self, text: &str) -> anyhow::Result<()> {
+        self.snapshot_before().await;
+        for ch in text.chars() {
+            let ch = ch.to_string();
+            self.execute(
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyDown", "key": ch, "text": ch }),
+            )
+            .await?;
+            self.execute(
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyUp", "key": ch }),
+            )
+            .await?;
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        }
+        Ok(())
+    }
+
     pub async fn press_key(&self, key: &str) -> anyhow::Result<()> {
         self.snapshot_before().await;
         let (vk, code, text) = key_definition(key);

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -43,6 +43,7 @@ const XHS_PAGE_SCRIPT_FUNCTIONS: &[&str] = &[
     "loginState",
     "searchCards",
     "searchInput",
+    "selectSearchInput",
     "setSearchInput",
     "searchState",
     "searchFilterTrigger",
@@ -321,19 +322,43 @@ impl<'a> XhsPageRuntime<'a> {
             sleep_ms(150).await;
         }
 
-        let set_result = self
-            .expect_object("setSearchInput", Some(&json!({ "query": query })))
-            .await?;
-        if !script_ok(&set_result) {
-            return Ok(json!({
-                "ok": false,
-                "strategy": "set_search_input_failed",
-                "state": set_result,
-                "error": set_result
-                    .get("error")
-                    .and_then(Value::as_str)
-                    .unwrap_or("Search input did not accept the requested keyword"),
-            }));
+        // Type the query as per-char CDP key events instead of a synthetic JS
+        // `input` event: the 2026-07 home-feed AI composer ignores untrusted
+        // events, so the old native-setter write left its framework state
+        // empty — Enter no-oped for the full transition timeout and the
+        // submit click then searched the rotating placeholder hot-word. (A
+        // single Input.insertText is not enough either: its keyless input
+        // event reads as bot input and dead-ends the composer — see
+        // `type_chars`.) `selectSearchInput` selects any existing text so the
+        // first keystroke replaces it wholesale; the JS value write stays as
+        // a fallback for inputs the typing couldn't reach.
+        let selected = self.expect_object("selectSearchInput", None).await?;
+        let mut typed_ok = false;
+        if script_ok(&selected) {
+            self.page.type_chars(query).await?;
+            sleep_ms(150).await;
+            let state = self.expect_object("searchState", None).await?;
+            let visible = state
+                .get("input_keyword")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            typed_ok = normalize_keyword(visible) == normalize_keyword(query);
+        }
+        if !typed_ok {
+            let set_result = self
+                .expect_object("setSearchInput", Some(&json!({ "query": query })))
+                .await?;
+            if !script_ok(&set_result) {
+                return Ok(json!({
+                    "ok": false,
+                    "strategy": "set_search_input_failed",
+                    "state": set_result,
+                    "error": set_result
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .unwrap_or("Search input did not accept the requested keyword"),
+                }));
+            }
         }
 
         sleep_ms(150).await;
@@ -344,7 +369,7 @@ impl<'a> XhsPageRuntime<'a> {
         if search_transition_ok(&state, query) {
             return Ok(json!({
                 "ok": true,
-                "strategy": "click_input_set_value_enter",
+                "strategy": if typed_ok { "click_input_type_enter" } else { "click_input_set_value_enter" },
                 "state": state,
                 "url": self.current_url().await?,
             }));

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -95,10 +95,46 @@ const SocaiXhsPageScripts = (() => {
     for (const sel of SEARCH_INPUT_SELECTORS) {
       for (const el of $$(sel)) {
         if (!(el instanceof HTMLElement)) continue;
+        // 2026-07: two decoys can outrank the real composer. The header
+        // carries a display:none duplicate (#search-input inside
+        // .ai-header-container) — zero width, already filtered. Browser
+        // extensions also overlay a near-transparent aria-hidden clone
+        // (data-hp-kind, opacity 1e-05) that has full width, so filter
+        // on aria-hidden and computed opacity too.
+        if (el.getAttribute('aria-hidden') === 'true') continue;
+        if (parseFloat(window.getComputedStyle(el).opacity) < 0.1) continue;
         if (el.getBoundingClientRect().width >= 120) return el;
       }
     }
     return undefined;
+  }
+
+  // Focus the search input and select any existing text, so trusted CDP
+  // per-char typing replaces it wholesale. The 2026-07 home-feed AI
+  // composer ("aiSearchTextarea") ignores synthetic input events:
+  // setSearchInput's native-setter write leaves the framework state empty,
+  // the submit button stays `disabled`, and Enter no-ops — so Rust now
+  // types the query with real CDP key events and keeps setSearchInput only
+  // as a legacy fallback.
+  function selectSearchInput() {
+    const input = findSearchInput();
+    if (!input) return { ok: false, error: 'search_input_not_found' };
+    input.focus();
+    let value = '';
+    if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+      value = String(input.value || '');
+      input.setSelectionRange(0, value.length);
+    } else if (input.isContentEditable) {
+      value = String(input.textContent || '');
+      const range = document.createRange();
+      range.selectNodeContents(input);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    } else {
+      return { ok: false, error: 'unsupported_search_input' };
+    }
+    return { ok: true, value };
   }
 
   function setSearchInput(arg) {
@@ -1335,6 +1371,7 @@ const SocaiXhsPageScripts = (() => {
     loginState,
     searchCards,
     searchInput,
+    selectSearchInput,
     setSearchInput,
     searchState,
     searchFilterTrigger,


### PR DESCRIPTION
## Problem

The Xiaohongshu homepage search widget was redesigned into a chat-style AI composer (`aiSearchTextarea`, results land on `/search_result_ai`). The first search submitted from the homepage failed every time: socai ground through its retry chain for ~25s and Xiaohongshu ended up searching the rotating placeholder hot-search phrase instead of the requested keyword. Searches submitted from the result page kept working, which masked the root cause.

## Root cause (verified frame-by-frame with `--debug-snapshot`)

1. The new composer ignores untrusted (synthetic JS) input events — the old native-setter write left the framework state empty, so the submit button stayed `disabled` and Enter no-oped.
2. A single CDP `Input.insertText` is not enough either: an `input` event with no keydown/keyup around it reads as bot input, after which the whole widget (submit click and Enter) stops responding.
3. Submitting with an empty composer state makes XHS search the placeholder phrase — which now rotates trending hot-search keywords, producing the observed garbage searches.
4. The page also carries invisible decoy copies of the search input/submit elements (`aria-hidden`, opacity ≈ 0, plus a `display:none` header composer) that naive selectors can pick over the real ones.

## Fix

- `core/src/cdp/session.rs`: add `type_chars()` — per-character trusted keyDown/keyUp dispatch (30ms cadence), matching real keyboard typing at the event level.
- `core/src/sites/xhs/page_scripts.js`: add `selectSearchInput()` (focus + select-all so the first keystroke replaces a leftover keyword wholesale, e.g. on the search-result page); `findSearchInput` now skips `aria-hidden`/near-transparent decoys and the hidden header composer.
- `core/src/sites/xhs/page.rs`: `submit_search` now clicks the input, selects, types via `type_chars`, verifies the readback, then presses Enter — the same sequence a human performs. The legacy JS value write and the search-button click remain as fallbacks for older UI variants.

## Verification

- Cold-start homepage first search: multiple keywords (中文 / mixed CN-EN), submits within ~5s of page load, correct results on `/search_result_ai`.
- Follow-up search from the result page: correct replacement of the previous keyword, ~3s.
- Manual side-by-side in Chrome confirmed the fixed event sequence matches human typing (Enter submits normally after real per-char keystrokes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)