### PR TITLE
Cloud-only media: remove ffmpeg & local whisper, redesign note history cache

### DIFF
--- a/core/src/cloud.rs
+++ b/core/src/cloud.rs
@@ -188,10 +188,20 @@ pub async fn transcribe_audio_file(
                         });
                     }
                     "failed" => {
-                        anyhow::bail!(
-                            "socai pro ASR failed: {}",
-                            task.error.unwrap_or_else(|| "unknown error".into())
-                        );
+                        let error = task.error.unwrap_or_else(|| "unknown error".into());
+                        // Fun-ASR reports an audio track it decoded fine but
+                        // heard no speech in (music/SFX-only videos) as a
+                        // failure. Surface the meaning, not the provider blob,
+                        // so the agent tells the user the video has no
+                        // narration instead of inventing a tooling problem.
+                        if error.contains("ASR_RESPONSE_HAVE_NO_WORDS") {
+                            anyhow::bail!(
+                                "no speech detected in the video's audio track (it likely \
+                                 contains only music or sound effects), so there is no \
+                                 spoken content to transcribe"
+                            );
+                        }
+                        anyhow::bail!("socai pro ASR failed: {}", short_error(&error));
                     }
                     _ => {}
                 }
@@ -208,6 +218,19 @@ pub async fn transcribe_audio_file(
         }
         tokio::time::sleep(ASR_TASK_POLL_INTERVAL).await;
     }
+}
+
+/// Trim a provider error to something an agent can read. Raw DashScope task
+/// dumps run to kilobytes of nested JSON with signed URLs; the leading part
+/// carries the task id + failure code, which is all a transcript_error needs.
+fn short_error(error: &str) -> String {
+    const MAX: usize = 300;
+    let trimmed = error.trim();
+    if trimmed.chars().count() <= MAX {
+        return trimmed.to_string();
+    }
+    let head: String = trimmed.chars().take(MAX).collect();
+    format!("{head}… (truncated)")
 }
 
 async fn poll_task(

--- a/core/src/media/audio.rs
+++ b/core/src/media/audio.rs
@@ -10,101 +10,48 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use symphonia::core::units::TimeBase;
-use tokio::process::Command;
 
-use crate::media::common::{
-    ensure_dir, find_in_path, nonempty, run_command, url_suffix, MediaUnavailable,
-};
+use crate::media::common::{ensure_dir, url_suffix, MediaUnavailable};
 use crate::media::processor::MediaProcessor;
 
 impl MediaProcessor {
-    pub async fn transcribe_audio(
-        &self,
-        source: &str,
-        referer: &str,
-        language: &str,
-    ) -> Result<String> {
+    /// Transcribe a video/audio source through socai pro cloud ASR — the only
+    /// transcription path (local whisper was removed as uncontrollable).
+    pub async fn transcribe_audio(&self, source: &str, referer: &str) -> Result<String> {
         let t0 = Instant::now();
-        let result = self.transcribe_audio_inner(source, referer, language).await;
-        self.timing.record("whisper_transcribe", t0.elapsed());
+        let result = self.transcribe_audio_inner(source, referer).await;
+        self.timing.record("asr_transcribe", t0.elapsed());
         result
     }
 
-    async fn transcribe_audio_inner(
-        &self,
-        source: &str,
-        referer: &str,
-        language: &str,
-    ) -> Result<String> {
-        let source_path = self.local_audio_source(source, referer).await?;
-        if self.config.use_cloud_asr {
-            // Real clip duration (the clip is already capped at
-            // max_audio_seconds); the server uses it for usage accounting.
-            let (aac, duration) = self.extract_audio_aac(&source_path).await?;
-            let duration_s = duration.ceil() as i64;
-            let result = crate::cloud::transcribe_audio_file(
-                &aac,
-                duration_s,
-                Duration::from_secs(self.config.whisper_timeout_s.max(60)),
-            )
-            .await?;
-            self.timing.record(
-                "cloud_asr_total",
-                Duration::from_millis(result.total_latency_ms as u64),
-            );
-            if result.provider_latency_ms > 0 {
-                self.timing.record(
-                    "cloud_asr_provider",
-                    Duration::from_millis(result.provider_latency_ms as u64),
-                );
-            }
-            return Ok(result.transcript.trim().to_string());
-        }
-
-        if !self.config.use_whisper {
-            anyhow::bail!(MediaUnavailable("Whisper transcription is disabled".into()));
-        }
-        if let Some(whisper_cli) = find_in_path("whisper") {
-            let out_dir = ensure_dir(&self.config.base_dir.join("transcripts"))?;
-            run_command(
-                Command::new(whisper_cli)
-                    .arg(&source_path)
-                    .arg("--language")
-                    .arg(nonempty(language, &self.config.default_language))
-                    .arg("--output_format")
-                    .arg("txt")
-                    .arg("--output_dir")
-                    .arg(&out_dir),
-                Duration::from_secs(self.config.whisper_timeout_s),
-            )
-            .await?;
-            let txt = out_dir.join(format!(
-                "{}.txt",
-                source_path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-            ));
-            return Ok(tokio::fs::read_to_string(txt)
-                .await
-                .unwrap_or_default()
-                .trim()
-                .to_string());
-        }
-
-        let whisper_cpp = find_in_path("whisper-cli").or_else(|| find_in_path("main"));
-        let whisper_model = std::env::var("SOCAI_WHISPER_MODEL").unwrap_or_default();
-        if whisper_cpp.is_some() && !whisper_model.trim().is_empty() {
-            // whisper.cpp needs 16kHz wav input; that local decode pipeline was
-            // removed when cloud ASR switched to aac passthrough.
+    async fn transcribe_audio_inner(&self, source: &str, referer: &str) -> Result<String> {
+        if !self.config.use_cloud_asr {
             anyhow::bail!(MediaUnavailable(
-                "whisper.cpp transcription is no longer supported; use cloud ASR (socai pro) or install `whisper`".into(),
+                "audio transcription requires socai pro (cloud ASR)".into()
             ));
         }
-
-        anyhow::bail!(MediaUnavailable(
-            "No whisper provider configured. Install `whisper`, or set SOCAI_WHISPER_MODEL for whisper.cpp.".into(),
-        ));
+        let source_path = self.local_audio_source(source, referer).await?;
+        // Real clip duration (the clip is already capped at
+        // max_audio_seconds); the server uses it for usage accounting.
+        let (aac, duration) = self.extract_audio_aac(&source_path).await?;
+        let duration_s = duration.ceil() as i64;
+        let result = crate::cloud::transcribe_audio_file(
+            &aac,
+            duration_s,
+            Duration::from_secs(self.config.asr_timeout_s.max(60)),
+        )
+        .await?;
+        self.timing.record(
+            "cloud_asr_total",
+            Duration::from_millis(result.total_latency_ms as u64),
+        );
+        if result.provider_latency_ms > 0 {
+            self.timing.record(
+                "cloud_asr_provider",
+                Duration::from_millis(result.provider_latency_ms as u64),
+            );
+        }
+        Ok(result.transcript.trim().to_string())
     }
 
     async fn local_audio_source(&self, source: &str, referer: &str) -> Result<PathBuf> {

--- a/core/src/media/common.rs
+++ b/core/src/media/common.rs
@@ -15,16 +15,13 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123 Safari/537.36";
 pub struct MediaConfig {
     pub base_dir: PathBuf,
     pub request_timeout_s: u64,
-    pub ffmpeg_timeout_s: u64,
     pub whisper_timeout_s: u64,
     pub max_audio_seconds: u64,
-    pub max_frame_seconds: u64,
     pub default_language: String,
     pub use_ocr: bool,
     pub use_vision: bool,
     pub use_whisper: bool,
     pub use_cloud_asr: bool,
-    pub use_ffmpeg: bool,
     pub vision_concurrency: usize,
 }
 
@@ -33,16 +30,13 @@ impl MediaConfig {
         Self {
             base_dir: base_dir.into(),
             request_timeout_s: 25,
-            ffmpeg_timeout_s: 180,
             whisper_timeout_s: 300,
             max_audio_seconds: 300,
-            max_frame_seconds: 60,
             default_language: "zh".into(),
             use_ocr: true,
             use_vision: true,
             use_whisper: true,
             use_cloud_asr: false,
-            use_ffmpeg: true,
             vision_concurrency: 3,
         }
     }

--- a/core/src/media/common.rs
+++ b/core/src/media/common.rs
@@ -1,10 +1,7 @@
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::{Map, Value};
-use tokio::process::Command;
 
 use crate::media::md5;
 
@@ -15,12 +12,11 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123 Safari/537.36";
 pub struct MediaConfig {
     pub base_dir: PathBuf,
     pub request_timeout_s: u64,
-    pub whisper_timeout_s: u64,
+    /// Wall-clock cap for one cloud ASR round trip (upload + poll).
+    pub asr_timeout_s: u64,
     pub max_audio_seconds: u64,
-    pub default_language: String,
     pub use_ocr: bool,
     pub use_vision: bool,
-    pub use_whisper: bool,
     pub use_cloud_asr: bool,
     pub vision_concurrency: usize,
 }
@@ -30,12 +26,10 @@ impl MediaConfig {
         Self {
             base_dir: base_dir.into(),
             request_timeout_s: 25,
-            whisper_timeout_s: 300,
+            asr_timeout_s: 300,
             max_audio_seconds: 300,
-            default_language: "zh".into(),
             use_ocr: true,
             use_vision: true,
-            use_whisper: true,
             use_cloud_asr: false,
             vision_concurrency: 3,
         }
@@ -136,41 +130,6 @@ pub(crate) fn insert_string(value: &mut Value, key: &str, text: impl Into<String
 pub(crate) fn insert_value(value: &mut Value, key: &str, item: Value) {
     if let Some(map) = value.as_object_mut() {
         map.insert(key.to_string(), item);
-    }
-}
-
-pub(crate) async fn run_command(command: &mut Command, timeout: Duration) -> Result<()> {
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = tokio::time::timeout(timeout, command.output())
-        .await
-        .context("command timed out")??;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("command failed: {}", stderr.trim());
-    }
-    Ok(())
-}
-
-pub(crate) fn find_in_path(name: &str) -> Option<PathBuf> {
-    if name.contains('/') {
-        let path = PathBuf::from(name);
-        return path.is_file().then_some(path);
-    }
-    let paths = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&paths) {
-        let path = dir.join(name);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    None
-}
-
-pub(crate) fn nonempty<'a>(value: &'a str, fallback: &'a str) -> &'a str {
-    if value.trim().is_empty() {
-        fallback
-    } else {
-        value
     }
 }
 

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -1,10 +1,10 @@
 //! Optional local/media processing used by site runtimes.
 //!
-//! The browser and agent core do not depend on OCR or whisper, and nothing
-//! here shells out to ffmpeg (video covers come from their own CDN URL, and
-//! cloud ASR takes the demuxed aac as-is). Site runtimes can opt into this
-//! crate for heavier media enrichment while keeping plain DOM extraction fast
-//! and portable.
+//! Nothing here shells out to external media tools: video covers come from
+//! their own CDN URL, audio transcription is cloud-only (socai pro takes the
+//! demuxed aac as-is), and OCR runs in-process. Site runtimes can opt into
+//! this crate for heavier media enrichment while keeping plain DOM extraction
+//! fast and portable.
 
 mod audio;
 mod common;

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -1,8 +1,10 @@
 //! Optional local/media processing used by site runtimes.
 //!
-//! The browser and agent core do not depend on OCR, whisper, or ffmpeg.
-//! Site runtimes can opt into this crate for heavier media enrichment while
-//! keeping plain DOM extraction fast and portable.
+//! The browser and agent core do not depend on OCR or whisper, and nothing
+//! here shells out to ffmpeg (video covers come from their own CDN URL, and
+//! cloud ASR takes the demuxed aac as-is). Site runtimes can opt into this
+//! crate for heavier media enrichment while keeping plain DOM extraction fast
+//! and portable.
 
 mod audio;
 mod common;

--- a/core/src/media/processor.rs
+++ b/core/src/media/processor.rs
@@ -4,11 +4,9 @@ use std::time::{Duration, Instant};
 
 use crate::agent::Backend as LlmProvider;
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::Value;
 
-use crate::media::common::{
-    ensure_dir, find_in_path, save_bytes, save_named_bytes, MediaConfig, USER_AGENT,
-};
+use crate::media::common::{ensure_dir, save_bytes, save_named_bytes, MediaConfig, USER_AGENT};
 use crate::media::timing::TimingRecord;
 
 #[derive(Clone)]
@@ -137,17 +135,4 @@ impl MediaProcessor {
         self.save_bytes(&payload, label, suffix)
     }
 
-    pub fn diagnostics(&self) -> Value {
-        json!({
-            "whisper_cli": find_in_path("whisper").map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
-            "whisper_cpp": find_in_path("whisper-cli")
-                .or_else(|| find_in_path("main"))
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default(),
-            "whisper_cpp_model": std::env::var("SOCAI_WHISPER_MODEL").unwrap_or_default(),
-            "mlx_whisper_model": "",
-            "rust_ocr": "",
-            "agent_vision_llm_provider": self.llm_provider.as_ref().map(|b| b.label()).unwrap_or_default(),
-        })
-    }
 }

--- a/core/src/media/processor.rs
+++ b/core/src/media/processor.rs
@@ -139,7 +139,6 @@ impl MediaProcessor {
 
     pub fn diagnostics(&self) -> Value {
         json!({
-            "ffmpeg": find_in_path("ffmpeg").map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
             "whisper_cli": find_in_path("whisper").map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
             "whisper_cpp": find_in_path("whisper-cli")
                 .or_else(|| find_in_path("main"))

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -1,16 +1,13 @@
-use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
 use serde_json::Value;
-use tokio::process::Command;
 
-use crate::media::common::{
-    ensure_dir, find_in_path, insert_string, insert_value, short, url_suffix, MediaUnavailable,
-    USER_AGENT,
-};
-use crate::media::md5;
+use crate::media::common::{insert_string, short, url_suffix};
 use crate::media::processor::MediaProcessor;
+
+/// Wall-clock cap for fetching a note's video file. Generous because XHS video
+/// CDN throughput varies; still bounded so a stalled download can't hang a scan.
+const VIDEO_DOWNLOAD_TIMEOUT_S: u64 = 180;
 
 impl MediaProcessor {
     /// OCR a video note's already-downloaded poster in place: read
@@ -142,11 +139,7 @@ impl MediaProcessor {
                 referer,
                 label,
                 &url_suffix(&source, ".mp4"),
-                Duration::from_secs(
-                    self.config
-                        .ffmpeg_timeout_s
-                        .max(self.config.request_timeout_s),
-                ),
+                Duration::from_secs(VIDEO_DOWNLOAD_TIMEOUT_S.max(self.config.request_timeout_s)),
             )
             .await
         {
@@ -209,7 +202,6 @@ impl MediaProcessor {
         note_id: &str,
         title: &str,
         referer: &str,
-        max_frames: usize,
         run_vision: bool,
     ) -> Value {
         let t_total = Instant::now();
@@ -252,9 +244,6 @@ impl MediaProcessor {
                 Ok(_) => {}
                 Err(err) => insert_string(&mut result, "transcript_error", format!("{err:#}")),
             }
-
-            self.enrich_video_frames(&mut result, &source, referer, max_frames, title, run_vision)
-                .await;
         }
 
         self.timing.record("video_enrich_total", t_total.elapsed());
@@ -301,130 +290,6 @@ impl MediaProcessor {
             Ok(_) => {}
             Err(err) => insert_string(result, "poster_download_error", format!("{err:#}")),
         }
-    }
-
-    async fn enrich_video_frames(
-        &self,
-        result: &mut Value,
-        source: &str,
-        referer: &str,
-        max_frames: usize,
-        title: &str,
-        run_vision: bool,
-    ) {
-        match self.extract_video_frames(source, referer, max_frames).await {
-            Ok(frame_paths) => {
-                let frame_values: Vec<Value> = frame_paths
-                    .iter()
-                    .map(|p| Value::String(p.to_string_lossy().to_string()))
-                    .collect();
-                insert_value(result, "frame_paths", Value::Array(frame_values));
-                let mut frame_notes = Vec::new();
-                for frame_path in frame_paths {
-                    let payload = match tokio::fs::read(&frame_path).await {
-                        Ok(bytes) => bytes,
-                        Err(_) => continue,
-                    };
-                    if run_vision && self.config.use_vision {
-                        match self
-                            .describe_image(
-                                &payload,
-                                &format!("Describe this sampled video frame for: {title}"),
-                                180,
-                            )
-                            .await
-                        {
-                            Ok(text) if !text.trim().is_empty() => frame_notes.push(text),
-                            _ => {}
-                        }
-                    } else if self.config.use_ocr {
-                        match self.ocr_image(&payload) {
-                            Ok(text) if !text.trim().is_empty() => frame_notes.push(text),
-                            _ => {}
-                        }
-                    }
-                }
-                if !frame_notes.is_empty() {
-                    insert_value(
-                        result,
-                        "frame_descriptions",
-                        Value::Array(frame_notes.iter().cloned().map(Value::String).collect()),
-                    );
-                    insert_string(
-                        result,
-                        "visual_summary",
-                        short(&frame_notes.join("\n"), 1200),
-                    );
-                }
-            }
-            Err(err) => insert_string(result, "frame_error", format!("{err:#}")),
-        }
-    }
-
-    pub async fn extract_video_frames(
-        &self,
-        source: &str,
-        referer: &str,
-        num_frames: usize,
-    ) -> Result<Vec<PathBuf>> {
-        if !self.config.use_ffmpeg {
-            anyhow::bail!(MediaUnavailable(
-                "ffmpeg frame extraction is disabled".into()
-            ));
-        }
-        if find_in_path("ffmpeg").is_none() {
-            anyhow::bail!(MediaUnavailable(
-                "ffmpeg is not installed or not on PATH".into()
-            ));
-        }
-        let t0 = Instant::now();
-        let digest = md5::md5_hex(source.as_bytes());
-        let frame_dir = ensure_dir(&self.config.base_dir.join("frames").join(&digest[..10]))?;
-        let pattern = frame_dir.join("frame_%02d.jpg");
-        let safe_frames = num_frames.max(1);
-        let safe_seconds = self.config.max_frame_seconds.max(1);
-        let interval = (safe_seconds / safe_frames as u64).max(1);
-        let mut command = Command::new("ffmpeg");
-        command.arg("-hide_banner").arg("-loglevel").arg("error");
-        if !referer.trim().is_empty()
-            && (source.starts_with("http://") || source.starts_with("https://"))
-        {
-            command.arg("-headers").arg(format!(
-                "Referer: {referer}\r\nUser-Agent: {USER_AGENT}\r\n"
-            ));
-        }
-        command
-            .arg("-t")
-            .arg(safe_seconds.to_string())
-            .arg("-i")
-            .arg(source)
-            .arg("-vf")
-            .arg(format!("fps=1/{interval},scale=min(960\\,iw):-2"))
-            .arg("-frames:v")
-            .arg(safe_frames.to_string())
-            .arg(pattern);
-        let result = crate::media::common::run_command(
-            &mut command,
-            Duration::from_secs(self.config.ffmpeg_timeout_s),
-        )
-        .await;
-        self.timing.record("video_frame_extract", t0.elapsed());
-        result?;
-
-        let mut paths = Vec::new();
-        let mut entries = tokio::fs::read_dir(frame_dir).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .is_some_and(|name| name.starts_with("frame_") && name.ends_with(".jpg"))
-            {
-                paths.push(path);
-            }
-        }
-        paths.sort();
-        Ok(paths)
     }
 }
 

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -181,7 +181,7 @@ impl MediaProcessor {
             map.remove("transcript_error");
         }
         let t0 = Instant::now();
-        match self.transcribe_audio(&path, "", "").await {
+        match self.transcribe_audio(&path, "").await {
             Ok(transcript) if !transcript.trim().is_empty() => {
                 insert_string(video, "transcript", transcript);
             }
@@ -233,11 +233,14 @@ impl MediaProcessor {
                 .await;
         }
 
-        if !source.is_empty() {
+        // Inline transcription only when cloud ASR is enabled for this run;
+        // attempting it without pro would just stamp every enriched video with
+        // a "requires socai pro" transcript_error.
+        if !source.is_empty() && self.config.use_cloud_asr {
             if let Some(map) = result.as_object_mut() {
                 map.remove("transcript_error");
             }
-            match self.transcribe_audio(&source, referer, "").await {
+            match self.transcribe_audio(&source, referer).await {
                 Ok(transcript) if !transcript.trim().is_empty() => {
                     insert_string(&mut result, "transcript", transcript);
                 }

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -36,14 +36,16 @@ pub struct HistoryEntry {
     /// True once any past read had media (vision) enabled.
     #[serde(default)]
     pub include_media: bool,
-    /// True once any past read downloaded the note's media (images/video carry
-    /// a `local_path`).
+    /// The cached entity holds downloaded media (an image or the video carries
+    /// a `local_path`). Derived from the entity on every record, so it always
+    /// states what the cache can actually serve.
     #[serde(default)]
     pub downloaded: bool,
-    /// True once any past read ran OCR (the entity carries `ocr_text`).
+    /// The cached entity holds OCR output. Derived like `downloaded`.
     #[serde(default)]
     pub ocr: bool,
-    /// True once any past read attached a non-empty video audio transcript.
+    /// The cached entity holds a non-empty video audio transcript. Derived
+    /// like `downloaded`.
     #[serde(default)]
     pub transcribed: bool,
     /// Most comments (primary + replies) ever cached for this note. Lets a later
@@ -99,7 +101,8 @@ impl XhsHistoryStore {
 
     pub fn open(path: impl AsRef<Path>) -> Self {
         let path = path.as_ref().to_path_buf();
-        let inner = load_file(&path).unwrap_or_default();
+        let mut inner = load_file(&path).unwrap_or_default();
+        normalize_loaded_entries(&mut inner);
         Self {
             path,
             inner: Mutex::new(inner),
@@ -215,9 +218,23 @@ impl XhsHistoryStore {
         HistorySnapshot { entries }
     }
 
-    /// Upsert an entry after a successful read. Never downgrades the
-    /// recorded level or media flag — once a note was read deeply, that
-    /// stays.
+    /// Upsert an entry after a read. The cache is a growing union of
+    /// information per note, kept consistent by construction:
+    ///
+    /// - `level` / `include_media` record the deepest *request* ever served
+    ///   and never downgrade.
+    /// - The cached `entity` merges the fresh read into what was already
+    ///   cached ([`merge_entities`]): fresh fields win, enrichments only a
+    ///   prior read produced (transcript, media paths, OCR text, a larger
+    ///   comment set) are carried over rather than lost.
+    /// - `downloaded` / `ocr` / `transcribed` are then *derived* from the
+    ///   merged entity, so each flag states exactly whether the cache holds
+    ///   that information. `is_satisfied_by` serves any request the flags
+    ///   cover and forces a re-read for anything more — including retries
+    ///   after failed attempts, since failures leave no information behind.
+    /// - Attempt outcomes (`*_error` fields) are never cached: an error says
+    ///   nothing durable about the note, and the absent information already
+    ///   makes the next request that needs it re-read.
     pub fn record(&self, entity: &Value, level: &str, include_media: bool) {
         let Some(note_id) = entity
             .get("note_id")
@@ -232,6 +249,8 @@ impl XhsHistoryStore {
         let title = string_field(entity, "title");
         let author = string_field(entity, "author");
         let url = string_field(entity, "url");
+        let mut fresh = entity.clone();
+        strip_error_fields(&mut fresh);
 
         let snapshot = {
             let Ok(mut guard) = self.inner.lock() else {
@@ -259,30 +278,19 @@ impl XhsHistoryStore {
             if include_media {
                 entry.include_media = true;
             }
-            // Infer the downloaded/OCR flags from the entity itself so a reused
-            // note is only short-circuited when the cache actually covers what a
-            // later run asks for.
-            if entity_has_downloaded(entity) {
-                entry.downloaded = true;
-            }
-            if entity_has_ocr(entity) {
-                entry.ocr = true;
-            }
-            if entity_has_transcript(entity) {
-                entry.transcribed = true;
-            }
-            // Track comment coverage (primary + replies) so a later, larger
-            // request re-reads instead of reusing a smaller cached set.
-            let loaded = entity_comment_count(entity);
-            if loaded > entry.comments_loaded {
-                entry.comments_loaded = loaded;
-            }
-            let total = entity_comment_total(entity);
+            let merged = match entry.entity.take() {
+                Some(prev) => merge_entities(&prev, fresh),
+                None => fresh,
+            };
+            entry.downloaded = entity_has_downloaded(&merged);
+            entry.ocr = entity_has_ocr(&merged);
+            entry.transcribed = entity_has_transcript(&merged);
+            entry.comments_loaded = entity_comment_count(&merged);
+            let total = entity_comment_total(&merged);
             if total > entry.comments_total {
                 entry.comments_total = total;
             }
-            // Cache the full entity so a later reuse returns complete data.
-            entry.entity = Some(entity.clone());
+            entry.entity = Some(merged);
             entry.analysis_count = entry.analysis_count.saturating_add(1);
             entry.last_seen_at = now;
             guard.clone()
@@ -548,6 +556,101 @@ fn entity_has_transcript(entity: &Value) -> bool {
         .and_then(|video| video.get("transcript"))
         .and_then(Value::as_str)
         .is_some_and(|text| !text.trim().is_empty())
+}
+
+/// Remove attempt outcomes (`*_error` fields) from an entity before caching:
+/// on the note itself, its `video` object, and each image. An error describes
+/// one failed attempt, not the note — caching it would keep re-serving a
+/// stale failure after the underlying cause is gone, while the *absence* of
+/// the information (via the derived flags) is what correctly drives a retry.
+fn strip_error_fields(entity: &mut Value) {
+    fn strip(obj: &mut serde_json::Map<String, Value>) {
+        obj.retain(|key, _| !key.ends_with("_error"));
+    }
+    let Some(obj) = entity.as_object_mut() else {
+        return;
+    };
+    strip(obj);
+    if let Some(video) = obj.get_mut("video").and_then(Value::as_object_mut) {
+        strip(video);
+    }
+    if let Some(images) = obj.get_mut("images").and_then(Value::as_array_mut) {
+        for image in images {
+            if let Some(image) = image.as_object_mut() {
+                strip(image);
+            }
+        }
+    }
+}
+
+/// Merge a fresh read into the previously cached entity so a lesser re-read
+/// never erases information a prior read paid for. Fresh fields win — they
+/// are newer — with three carry-overs of prior enrichment work:
+///
+/// - `video`: merged key by key; keys the fresh read didn't produce
+///   (transcript, `local_path`, `poster_ocr`, …) are kept from the cache.
+/// - `images`: kept from the cache when the fresh read collected none.
+/// - `top_comments`: kept from the cache when it holds more than the fresh
+///   read loaded.
+///
+/// The capability flags are re-derived from the merged result, so any
+/// information this merge does drop (e.g. fresh images replacing OCR'd ones)
+/// is reflected in the flags and re-acquired by the next request needing it.
+fn merge_entities(prev: &Value, mut fresh: Value) -> Value {
+    let Some(fresh_obj) = fresh.as_object_mut() else {
+        return prev.clone();
+    };
+    if let Some(prev_video) = prev.get("video").and_then(Value::as_object) {
+        let fresh_video = fresh_obj
+            .entry("video")
+            .or_insert_with(|| Value::Object(Default::default()));
+        if let Some(fresh_video) = fresh_video.as_object_mut() {
+            for (key, value) in prev_video {
+                fresh_video
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
+            }
+        }
+    }
+    let fresh_has_images = fresh_obj
+        .get("images")
+        .and_then(Value::as_array)
+        .is_some_and(|images| !images.is_empty());
+    if !fresh_has_images {
+        if let Some(prev_images) = prev
+            .get("images")
+            .and_then(Value::as_array)
+            .filter(|images| !images.is_empty())
+        {
+            fresh_obj.insert("images".into(), Value::Array(prev_images.clone()));
+            fresh_obj.insert("image_count".into(), json!(prev_images.len()));
+        }
+    }
+    if entity_comment_count(prev) > entity_comment_count(&fresh) {
+        if let Some(prev_comments) = prev.get("top_comments") {
+            if let Some(fresh_obj) = fresh.as_object_mut() {
+                fresh_obj.insert("top_comments".into(), prev_comments.clone());
+            }
+        }
+    }
+    fresh
+}
+
+/// Re-establish the cache invariants on entries written by older versions:
+/// cached entities must not carry attempt outcomes, and the information flags
+/// must state what the cached entity actually holds. In-memory only; the
+/// normalized state persists with the next regular save.
+fn normalize_loaded_entries(data: &mut HistoryFile) {
+    for entry in data.notes.values_mut() {
+        let Some(entity) = entry.entity.as_mut() else {
+            continue;
+        };
+        strip_error_fields(entity);
+        let entity = &*entity;
+        entry.downloaded = entity_has_downloaded(entity);
+        entry.ocr = entity_has_ocr(entity);
+        entry.transcribed = entity_has_transcript(entity);
+    }
 }
 
 fn load_file(path: &Path) -> Option<HistoryFile> {

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -84,6 +84,10 @@ Shared options (same meaning for both):
   pipelined behind the browse loop so it's near-free). Each note gets `ocr_text`
   as a per-image array (cover first); implies `download_media`; in `preview` mode
   it OCRs each card's cover only.
+- `transcribe_audio=true` — transcribe a video note's audio in the cloud
+  (socai pro), attaching `video.transcript`; a
+  `transcript_error` saying no speech was detected means the video genuinely
+  has no narration — report that as the answer.
 
 ### Note details
 

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -106,7 +106,6 @@ pub struct ReadNoteOptions {
     /// server. Implies `download_media` and `download_video_file` at the caller.
     pub transcribe_audio: bool,
     pub max_images: usize,
-    pub max_video_frames: usize,
     pub poster_url_fallback: String,
     pub note_id_fallback: String,
 }
@@ -121,7 +120,6 @@ impl Default for ReadNoteOptions {
             ocr: false,
             transcribe_audio: false,
             max_images: 12,
-            max_video_frames: 4,
             poster_url_fallback: String::new(),
             note_id_fallback: String::new(),
         }
@@ -1429,8 +1427,7 @@ impl<'a> XhsPageRuntime<'a> {
 
         if options.include_media {
             let t_enrich = Instant::now();
-            self.enrich_note_media(&mut note, options.max_images, options.max_video_frames)
-                .await?;
+            self.enrich_note_media(&mut note, options.max_images).await?;
             perf.insert(
                 "enrich_ms".into(),
                 json!(t_enrich.elapsed().as_millis() as u64),
@@ -1543,12 +1540,7 @@ impl<'a> XhsPageRuntime<'a> {
         Ok(())
     }
 
-    async fn enrich_note_media(
-        &self,
-        note: &mut XhsNote,
-        max_images: usize,
-        max_video_frames: usize,
-    ) -> Result<()> {
+    async fn enrich_note_media(&self, note: &mut XhsNote, max_images: usize) -> Result<()> {
         let Some(media) = &self.media else {
             if note.r#type == "video" {
                 insert_value_string(
@@ -1566,14 +1558,7 @@ impl<'a> XhsPageRuntime<'a> {
 
         if note.r#type == "video" {
             note.video = media
-                .enrich_video(
-                    &note.video,
-                    &note.note_id,
-                    &note.title,
-                    &note.url,
-                    max_video_frames,
-                    true,
-                )
+                .enrich_video(&note.video, &note.note_id, &note.title, &note.url, true)
                 .await;
             return Ok(());
         }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -723,7 +723,6 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
         ocr,
         transcribe_audio,
         max_images: get_i64(input, "max_images", 12).max(1) as usize,
-        max_video_frames: get_i64(input, "max_video_frames", 4).max(1) as usize,
         poster_url_fallback: get_str(input, "poster_url_fallback")
             .unwrap_or("")
             .to_string(),
@@ -1078,7 +1077,6 @@ async fn scan_card_note(
                 // Pure downloads are cheap compared with OCR/vision, so allow
                 // full XHS carousels instead of the enrichment-oriented default.
                 max_images: if download_media { 100 } else { 12 },
-                max_video_frames: 4,
                 poster_url_fallback: card.cover_url.clone(),
                 note_id_fallback: card.note_id.clone(),
             },
@@ -2424,8 +2422,7 @@ impl Tool for ReadNoteTool {
                 "include_media": { "type": "boolean", "default": false },
                 "download_media": { "type": "boolean", "default": false },
                 "transcribe_audio": { "type": "boolean", "default": false },
-                "max_images": { "type": "integer", "default": 12, "minimum": 1 },
-                "max_video_frames": { "type": "integer", "default": 4, "minimum": 1 }
+                "max_images": { "type": "integer", "default": 12, "minimum": 1 }
             }
         });
         if !self.pro {
@@ -2548,8 +2545,7 @@ impl Tool for ExtractNoteTool {
                 "include_media": { "type": "boolean", "default": false },
                 "download_media": { "type": "boolean", "default": false },
                 "transcribe_audio": { "type": "boolean", "default": false },
-                "max_images": { "type": "integer", "default": 12, "minimum": 1 },
-                "max_video_frames": { "type": "integer", "default": 4, "minimum": 1 }
+                "max_images": { "type": "integer", "default": 12, "minimum": 1 }
             }
         });
         if !self.pro {


### PR DESCRIPTION
## Summary

Root-caused this week's "transcription sometimes fails with a missing-ffmpeg error" reports and removed the whole class of failures:

- **Drop ffmpeg entirely.** Video covers are downloaded straight from the note's CDN `poster_url`; mid-video frame sampling was the last ffmpeg consumer. Removes `extract_video_frames` / `enrich_video_frames` and the `max_video_frames` / `use_ffmpeg` / `ffmpeg_timeout_s` / `max_frame_seconds` plumbing. socai no longer invokes ffmpeg anywhere, so GUI launches without `/opt/homebrew/bin` on PATH can't hit "ffmpeg not found".
- **Remove local whisper; transcription is cloud-only.** The whisper CLI / whisper.cpp fallbacks depended on uncontrollable local installs. Transcription now always goes through socai pro cloud ASR and fails fast with `MediaUnavailable` without pro. Also drops the now-dead `run_command` / `find_in_path` / `nonempty` helpers and the unused whisper diagnostics — the media module no longer spawns any subprocess.
- **Redesign note history as an information-merging cache.** One rule instead of per-field patches: `record()` merges each fresh read into the cached entity (fresh core data wins; prior enrichments — transcript, media paths, OCR text, larger comment sets — carry over), and `downloaded` / `ocr` / `transcribed` are derived from the merged entity so each flag states exactly what the cache holds. Lesser repeat requests are served from cache; anything more (including retries after failures) re-reads and re-merges. Attempt outcomes (`*_error`) are never cached — stale "ffmpeg not found" errors from long-removed pipelines were being re-served to the agent verbatim. Old history files are normalized to these invariants on load.
- **Truthful ASR error semantics.** Fun-ASR reports a decodable audio track with no speech (music/SFX-only videos) as `ASR_RESPONSE_HAVE_NO_WORDS`; the client now surfaces "no speech detected" instead of a failure, and truncates other provider errors to 300 chars (the raw DashScope task dump repeats a signed OSS URL four times across ~2KB of nested JSON).
- **Document `transcribe_audio` in the XHS knowledge** so the agent reliably requests transcription when the user asks for a video's 文案 and reports a no-speech result as the answer instead of improvising workarounds (observed: the model shelling out to a nonexistent ffmpeg via bash).

## Verification

- `cargo check --workspace` clean; clippy warning count unchanged from main (13).
- All 91 existing socai-core tests pass; each commit builds independently.
- Diagnosed against production traces (Axiom `socai-traces-prod`) and three local 0.4.9 reproduction runs; the no-speech case was confirmed by decoding the uploaded aac locally (audio energy present, no narration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)