### PR TITLE
chore(site): skip vercel deployments when site/ is unchanged

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "functions": {
     "api/telemetry.js": {
       "maxDuration": 10


### PR DESCRIPTION
## Why

Most PRs here are product changes (`core/`, `cli/`, `app/`) that never touch the website, yet every PR triggered a Vercel preview deployment.

## What

Adds Vercel's [Ignored Build Step](https://vercel.com/docs/project-configuration/vercel-json#ignorecommand) to `site/vercel.json`:

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
```

- The command runs **inside the project root directory (`site/`)**, so `./` scopes the diff to the site subtree.
- Exit `0` (no changes under `site/`) → deployment is canceled: no preview build, no bot comment on product PRs.
- Exit non-zero (site changed, or `HEAD^` unresolvable) → build proceeds, so site PRs keep their previews and it fails open to building.
- Applies to production too: pushes to `main` only redeploy the site when `site/` changed.

## Notes

- `vercel.json` takes precedence over the dashboard setting; the project currently has no dashboard-side ignore command (`commandForIgnoringBuildStep: null`), so nothing conflicts.
- Repo rulesets have no required Vercel status check, so canceled deployments can't block merges.
- Known limitation of Vercel's recommended command: it diffs only the pushed head commit against its parent. If a multi-commit push ends with a product-only commit, the site change from an earlier commit in that same push won't rebuild — push again or redeploy from the dashboard in that rare case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)