### PR TITLE
feat(llm): enable thinking by default for qwen and kimi

### DIFF
--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -88,17 +88,16 @@ impl OpenAICompatBackend {
     }
 
     /// Provider-specific extra fields merged into the request body.
-    fn extra_body(&self, has_tools: bool) -> Map<String, Value> {
+    /// Thinking is explicitly enabled where the provider has a toggle;
+    /// non-streaming thinking is supported by kimi-k2.6 and qwen3.5+.
+    fn extra_body(&self) -> Map<String, Value> {
         let mut extra = Map::new();
-        if !has_tools {
-            return extra;
-        }
         match self.provider {
             Provider::Kimi if self.model.starts_with("kimi-k2.6") => {
-                extra.insert("thinking".into(), json!({"type": "disabled"}));
+                extra.insert("thinking".into(), json!({"type": "enabled"}));
             }
             Provider::Qwen | Provider::QwenIntl => {
-                extra.insert("enable_thinking".into(), Value::Bool(false));
+                extra.insert("enable_thinking".into(), Value::Bool(true));
             }
             _ => {}
         }
@@ -130,7 +129,7 @@ impl OpenAICompatBackend {
             max_tokens,
             tools: chat_tools,
             tool_choice: if has_tools { Some("auto") } else { None },
-            extra: self.extra_body(has_tools),
+            extra: self.extra_body(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Flip the chat-completions `extra_body` from disabling thinking to explicitly enabling it: qwen (`enable_thinking: true`) and kimi-k2.6 (`thinking: {"type": "enabled"}`).
- Send the toggle on every request instead of only tool-calling ones (the old `has_tools` gate is gone).

## Verification

- `cargo check -p socai-core` passes.
- Live-tested against DashScope `qwen3.7-plus` (non-streaming, with tools): request accepted, `reasoning_content` returned, no errors. Non-streaming thinking is officially supported for qwen3.5+ commercial models.
- Kimi param name matches Moonshot docs for kimi-k2.6 (its default is already enabled); a live check was blocked by an account balance issue, not by the request format.
- Doubao and DeepSeek are intentionally untouched: both already emit reasoning by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)