### PR TITLE
feat: track LLM usage, caching, and estimated cost

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,6 +91,10 @@ pnpm --dir app sync-models                                # official APIs if key
 The sync script prefers official provider `/models` APIs, then pi's generated
 `@earendil-works/pi-ai` catalog, then socai fallback entries. AI agents should
 use the `socai-model-sync` skill for model-list refreshes and validation.
+Catalog entries can also carry per-million-token pricing used for the estimated
+cost in `llm/*.response.json`, `run.json`, the CLI summary, and desktop task
+metadata. Token counts are provider-reported; cost is an estimate at the
+catalog rate, not a provider invoice.
 
 ### Website
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use socai_core::agent::{
     catalog_models_for, configured_default_model_for, configured_default_provider,
     desktop_agent_tools, make_run_dir, mark_agent_run_status, provider_credential_kind,
     resolve_provider, save_default_model, AgentEvent, Conversation, CredentialKind,
-    ModelCatalogEntry, Provider,
+    ModelCatalogEntry, Provider, TokenUsage,
 };
 use socai_core::runtime::{
     create_llm_provider_for, ensure_llm_provider_configured_for,
@@ -134,6 +134,50 @@ fn title_safe(value: &str) -> String {
     compact.chars().take(48).collect()
 }
 
+fn read_run_usage(run_dir: &str) -> Option<TokenUsage> {
+    let value: Value =
+        serde_json::from_slice(&std::fs::read(PathBuf::from(run_dir).join("run.json")).ok()?)
+            .ok()?;
+    serde_json::from_value(value.get("usage")?.clone()).ok()
+}
+
+fn with_usage_telemetry(mut properties: Value, usage: Option<&TokenUsage>) -> Value {
+    let (Some(map), Some(usage)) = (properties.as_object_mut(), usage) else {
+        return properties;
+    };
+    map.insert("input_tokens".into(), json!(usage.input_tokens));
+    map.insert(
+        "uncached_input_tokens".into(),
+        json!(usage.uncached_input_tokens),
+    );
+    map.insert("output_tokens".into(), json!(usage.output_tokens));
+    if let Some(tokens) = usage.reasoning_output_tokens {
+        map.insert("reasoning_output_tokens".into(), json!(tokens));
+    }
+    map.insert(
+        "cached_input_tokens".into(),
+        json!(usage.cache_read_input_tokens),
+    );
+    map.insert(
+        "cache_creation_input_tokens".into(),
+        json!(usage.cache_creation_input_tokens),
+    );
+    if let Some(cost) = &usage.cost {
+        map.insert("estimated_input_cost".into(), json!(cost.input));
+        map.insert("estimated_output_cost".into(), json!(cost.output));
+        map.insert("estimated_cache_read_cost".into(), json!(cost.cache_read));
+        map.insert(
+            "estimated_cache_creation_cost".into(),
+            json!(cost.cache_creation),
+        );
+        map.insert("estimated_cost".into(), json!(cost.total));
+        map.insert("cost_currency".into(), json!(cost.currency));
+        map.insert("cost_estimated".into(), json!(cost.estimated));
+        map.insert("cost_pricing_source".into(), json!(cost.pricing_source));
+    }
+    properties
+}
+
 // ── Agent tasks ────────────────────────────────────────────────────────────
 
 #[derive(serde::Serialize, Clone)]
@@ -144,6 +188,12 @@ pub struct AgentRunOutcome {
     final_text: String,
     input_tokens: u64,
     output_tokens: u64,
+    cached_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    estimated_cost: Option<f64>,
+    cost_currency: Option<String>,
+    #[serde(skip)]
+    usage: TokenUsage,
 }
 
 #[tauri::command]
@@ -196,6 +246,7 @@ pub async fn agent_list_models() -> Result<Vec<Value>, String> {
                     display_name: Some(selected_model.clone()),
                     source: Some("saved-default".into()),
                     recommended: false,
+                    pricing: None,
                 },
             );
         }
@@ -484,6 +535,10 @@ pub async fn agent_task_reply(
             snapshot.steps = None;
             snapshot.input_tokens = None;
             snapshot.output_tokens = None;
+            snapshot.cached_input_tokens = None;
+            snapshot.cache_creation_input_tokens = None;
+            snapshot.estimated_cost = None;
+            snapshot.cost_currency = None;
             snapshot.current_message = Some(message_text.clone());
         })
         .await
@@ -648,6 +703,7 @@ pub async fn agent_task_cancel(
         let _ = runtime.close_target(&target_id).await;
     }
     if changed {
+        let usage = snapshot.run_dir.as_deref().and_then(read_run_usage);
         if let Some(run_dir) = snapshot.run_dir.as_deref() {
             let _ = mark_agent_run_status(run_dir, "cancelled", None);
             // The aborted run future's drop guard wrote trace.json with
@@ -661,17 +717,18 @@ pub async fn agent_task_cancel(
         record_desktop_session(&snapshot, "[cancelled by user]", "cancelled");
         telemetry.capture(
             "socai_agent_task_end",
-            json!({
-                "task_id": task_id.clone(),
-                "provider": snapshot.provider.clone(),
-                "run_id": snapshot.run_id.clone(),
-                "model": snapshot.model.clone(),
-                "outcome": "cancelled",
-                "steps": snapshot.steps,
-                "input_tokens": snapshot.input_tokens,
-                "output_tokens": snapshot.output_tokens,
-                "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
-            }),
+            with_usage_telemetry(
+                json!({
+                    "task_id": task_id.clone(),
+                    "provider": snapshot.provider.clone(),
+                    "run_id": snapshot.run_id.clone(),
+                    "model": snapshot.model.clone(),
+                    "outcome": "cancelled",
+                    "steps": snapshot.steps,
+                    "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
+                }),
+                usage.as_ref(),
+            ),
         );
         emit_task_event(
             &app,
@@ -835,23 +892,29 @@ async fn run_agent_task_background(
                     snapshot.steps = Some(outcome.steps);
                     snapshot.input_tokens = Some(outcome.input_tokens);
                     snapshot.output_tokens = Some(outcome.output_tokens);
+                    snapshot.cached_input_tokens = Some(outcome.cached_input_tokens);
+                    snapshot.cache_creation_input_tokens =
+                        Some(outcome.cache_creation_input_tokens);
+                    snapshot.estimated_cost = outcome.estimated_cost;
+                    snapshot.cost_currency = outcome.cost_currency.clone();
                 })
                 .await
             {
                 record_desktop_session(&snapshot, &outcome.final_text, "completed");
                 telemetry.capture(
                     "socai_agent_task_end",
-                    json!({
-                        "task_id": task_id.clone(),
-                        "run_id": outcome.run_id.clone(),
-                        "provider": provider.clone(),
-                        "model": model.clone(),
-                        "outcome": "completed",
-                        "steps": outcome.steps,
-                        "input_tokens": outcome.input_tokens,
-                        "output_tokens": outcome.output_tokens,
-                        "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
-                    }),
+                    with_usage_telemetry(
+                        json!({
+                            "task_id": task_id.clone(),
+                            "run_id": outcome.run_id.clone(),
+                            "provider": provider.clone(),
+                            "model": model.clone(),
+                            "outcome": "completed",
+                            "steps": outcome.steps,
+                            "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
+                        }),
+                        Some(&outcome.usage),
+                    ),
                 );
                 emit_task_event(
                     &app,
@@ -874,20 +937,26 @@ async fn run_agent_task_background(
                 })
                 .await
             {
+                let usage = snapshot.run_dir.as_deref().and_then(read_run_usage);
                 if let Some(run_dir) = snapshot.run_dir.as_deref() {
                     let _ = mark_agent_run_status(run_dir, "failed", Some(&error));
+                    let _ = mark_run_trace_status(run_dir, "failed");
+                    telemetry.upload_run_trace(run_dir);
                 }
                 record_desktop_session(&snapshot, &format!("[task failed: {error}]"), "failed");
                 telemetry.capture(
                     "socai_agent_task_end",
-                    json!({
-                        "task_id": task_id.clone(),
-                        "provider": provider.clone(),
-                        "model": model.clone(),
-                        "outcome": "failed",
-                        "error": short_error(&error),
-                        "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
-                    }),
+                    with_usage_telemetry(
+                        json!({
+                            "task_id": task_id.clone(),
+                            "provider": provider.clone(),
+                            "model": model.clone(),
+                            "outcome": "failed",
+                            "error": short_error(&error),
+                            "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
+                        }),
+                        usage.as_ref(),
+                    ),
                 );
                 emit_task_event(&app, &registry, &task_id, "failed", error, Some(snapshot)).await;
             }
@@ -1025,13 +1094,21 @@ async fn run_agent_task_on_shared_page(
         let outcome = outcome?;
         telemetry.upload_run_trace(&outcome.run_dir);
 
+        let usage = outcome.usage;
+        let estimated_cost = usage.cost.as_ref().map(|cost| cost.total);
+        let cost_currency = usage.cost.as_ref().map(|cost| cost.currency.clone());
         Ok::<AgentRunOutcome, anyhow::Error>(AgentRunOutcome {
             run_id: outcome.run_id,
             run_dir: outcome.run_dir.display().to_string(),
             steps: outcome.steps,
             final_text: outcome.final_text,
-            input_tokens: outcome.total_input_tokens,
-            output_tokens: outcome.total_output_tokens,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cached_input_tokens: usage.cache_read_input_tokens,
+            cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            estimated_cost,
+            cost_currency,
+            usage,
         })
     }
     .await;

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -47,6 +47,10 @@ pub struct AgentTaskSnapshot {
     pub(crate) steps: Option<u32>,
     pub(crate) input_tokens: Option<u64>,
     pub(crate) output_tokens: Option<u64>,
+    pub(crate) cached_input_tokens: Option<u64>,
+    pub(crate) cache_creation_input_tokens: Option<u64>,
+    pub(crate) estimated_cost: Option<f64>,
+    pub(crate) cost_currency: Option<String>,
     // The text driving the in-flight/most recent run — distinct from `task`,
     // which stays the thread's original title across replies. Not persisted
     // to tasks.json (Option fields default to None on load, which is the
@@ -134,6 +138,10 @@ impl AgentTaskRegistry {
             steps: None,
             input_tokens: None,
             output_tokens: None,
+            cached_input_tokens: None,
+            cache_creation_input_tokens: None,
+            estimated_cost: None,
+            cost_currency: None,
         };
         guard.tasks.push(snapshot.clone());
         persist_task_index(&guard.tasks);
@@ -408,6 +416,17 @@ fn hydrate_task_snapshot(mut snapshot: AgentTaskSnapshot) -> AgentTaskSnapshot {
                 snapshot.input_tokens = run.pointer("/usage/input_tokens").and_then(Value::as_u64);
                 snapshot.output_tokens =
                     run.pointer("/usage/output_tokens").and_then(Value::as_u64);
+                snapshot.cached_input_tokens = run
+                    .pointer("/usage/cache_read_input_tokens")
+                    .and_then(Value::as_u64);
+                snapshot.cache_creation_input_tokens = run
+                    .pointer("/usage/cache_creation_input_tokens")
+                    .and_then(Value::as_u64);
+                snapshot.estimated_cost = run.pointer("/usage/cost/total").and_then(Value::as_f64);
+                snapshot.cost_currency = run
+                    .pointer("/usage/cost/currency")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
             }
         }
     }

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -320,10 +320,42 @@ export function formatStepCount(count: number): string {
 export function formatTokenUsage(
   inputTokens: number,
   outputTokens: number,
+  cachedInputTokens: number | null = null,
+  cacheCreationInputTokens = 0,
+  estimatedCost: number | null = null,
+  costCurrency: string | null = null,
 ): string {
-  if (currentLanguage === "zh")
-    return `输入 ${inputTokens} / 输出 ${outputTokens} tokens`;
-  return `in ${inputTokens} / out ${outputTokens} tokens`;
+  const locale = getLocale();
+  const number = (value: number) => value.toLocaleString(locale);
+  const parts = currentLanguage === "zh"
+    ? [`输入 ${number(inputTokens)} / 输出 ${number(outputTokens)} tokens`]
+    : [`in ${number(inputTokens)} / out ${number(outputTokens)} tokens`];
+  if (cachedInputTokens !== null) {
+    const ratio = inputTokens > 0 ? ` (${(cachedInputTokens / inputTokens * 100).toFixed(1)}%)` : "";
+    parts.push(currentLanguage === "zh"
+      ? `缓存命中 ${number(cachedInputTokens)}${ratio}`
+      : `cache hit ${number(cachedInputTokens)}${ratio}`);
+  }
+  if (cacheCreationInputTokens > 0) {
+    parts.push(currentLanguage === "zh"
+      ? `缓存写入 ${number(cacheCreationInputTokens)}`
+      : `cache write ${number(cacheCreationInputTokens)}`);
+  }
+  if (estimatedCost !== null && costCurrency) {
+    let amount: string;
+    try {
+      amount = new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: costCurrency,
+        minimumFractionDigits: 4,
+        maximumFractionDigits: 6,
+      }).format(estimatedCost);
+    } catch {
+      amount = `${estimatedCost.toFixed(6)} ${costCurrency}`;
+    }
+    parts.push(currentLanguage === "zh" ? `估算 ${amount}` : `est. ${amount}`);
+  }
+  return parts.join(" · ");
 }
 
 // Task timestamps read as "today 14:30" / "yesterday 09:15" for the last two

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -58,6 +58,10 @@ export interface AgentTaskSnapshot {
   steps: number | null;
   input_tokens: number | null;
   output_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  estimated_cost: number | null;
+  cost_currency: string | null;
 }
 
 export interface TimelineEntity {

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -208,7 +208,14 @@ function renderTurn(
       const duration = formatDuration(task);
       if (duration) metaBits.push(duration);
       if (task.input_tokens !== null && task.output_tokens !== null) {
-        metaBits.push(formatTokenUsage(task.input_tokens, task.output_tokens));
+        metaBits.push(formatTokenUsage(
+          task.input_tokens,
+          task.output_tokens,
+          task.cached_input_tokens,
+          task.cache_creation_input_tokens ?? 0,
+          task.estimated_cost,
+          task.cost_currency,
+        ));
       }
     } else if (task.error) {
       answer = `<pre class="conv-error">${esc(task.error)}</pre>`;

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -1056,6 +1056,11 @@ export namespace agentPanel {
       steps: incoming.steps ?? existing.steps,
       input_tokens: incoming.input_tokens ?? existing.input_tokens,
       output_tokens: incoming.output_tokens ?? existing.output_tokens,
+      cached_input_tokens: incoming.cached_input_tokens ?? existing.cached_input_tokens,
+      cache_creation_input_tokens:
+        incoming.cache_creation_input_tokens ?? existing.cache_creation_input_tokens,
+      estimated_cost: incoming.estimated_cost ?? existing.estimated_cost,
+      cost_currency: incoming.cost_currency ?? existing.cost_currency,
     };
   }
 

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -354,6 +354,7 @@ fn model_options() -> Vec<ModelOption> {
                         display_name: Some(selected_model.clone()),
                         source: Some("saved-default".into()),
                         recommended: false,
+                        pricing: None,
                     },
                 );
             }
@@ -720,9 +721,20 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     println!();
     println!("{}", outcome.final_text.trim());
     println!();
+    let cost = outcome
+        .usage
+        .cost
+        .as_ref()
+        .map(|cost| format!(" estimated_cost={:.6}_{}", cost.total, cost.currency))
+        .unwrap_or_default();
     println!(
-        "[socai] run_id={} steps={} input_tokens={} output_tokens={}",
-        outcome.run_id, outcome.steps, outcome.total_input_tokens, outcome.total_output_tokens
+        "[socai] run_id={} steps={} input_tokens={} output_tokens={} cached_input_tokens={}{}",
+        outcome.run_id,
+        outcome.steps,
+        outcome.usage.input_tokens,
+        outcome.usage.output_tokens,
+        outcome.usage.cache_read_input_tokens,
+        cost,
     );
     println!("[socai] run_dir={}", outcome.run_dir.display());
     println!();

--- a/core/src/agent/llm.rs
+++ b/core/src/agent/llm.rs
@@ -9,9 +9,11 @@ use serde_json::Value;
 
 pub mod anthropic;
 pub mod openai;
+pub mod usage;
 
 pub use self::anthropic::AnthropicBackend;
 pub use self::openai::OpenAICompatBackend;
+pub use self::usage::{TokenUsage, UsageCost};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -152,8 +154,11 @@ pub struct LLMResponse {
     pub text_blocks: Vec<String>,
     pub tool_calls: Vec<ToolCall>,
     pub stop_reason: StopReason,
-    pub input_tokens: u64,
-    pub output_tokens: u64,
+    pub usage: TokenUsage,
+    /// The provider's usage object before normalization. This keeps new or
+    /// provider-specific counters available in persisted step responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_usage: Option<Value>,
     /// Reasoning trace surfaced by Kimi K2.6 / Qwen. Empty for providers
     /// that don't expose it.
     pub reasoning_content: String,

--- a/core/src/agent/llm/anthropic.rs
+++ b/core/src/agent/llm/anthropic.rs
@@ -8,12 +8,12 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use crate::agent::api_errors::format_http_error;
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, StopReason, ThinkingBlock, ToolCall, ToolResultContent,
-    ToolSchema,
+    Backend, Block, LLMResponse, Message, StopReason, ThinkingBlock, TokenUsage, ToolCall,
+    ToolResultContent, ToolSchema,
 };
 use crate::agent::provider::{config_for, load_api_key, Provider};
 
@@ -217,7 +217,7 @@ struct WireResponse {
     usage: WireUsage,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 struct WireUsage {
     #[serde(default)]
     input_tokens: u64,
@@ -227,6 +227,8 @@ struct WireUsage {
     cache_read_input_tokens: u64,
     #[serde(default)]
     cache_creation_input_tokens: u64,
+    #[serde(flatten)]
+    extra: Map<String, Value>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -333,16 +335,15 @@ impl Backend for AnthropicBackend {
             .collect::<Vec<_>>()
             .join("\n\n");
 
-        let input_total = parsed.usage.input_tokens
-            + parsed.usage.cache_creation_input_tokens
-            + parsed.usage.cache_read_input_tokens;
+        let provider_usage = serde_json::to_value(&parsed.usage)?;
+        let usage = TokenUsage::from_anthropic(Provider::Anthropic, &self.model, &provider_usage);
 
         Ok(LLMResponse {
             text_blocks,
             tool_calls,
             stop_reason: parse_stop_reason(parsed.stop_reason.as_deref()),
-            input_tokens: input_total,
-            output_tokens: parsed.usage.output_tokens,
+            usage,
+            provider_usage: Some(provider_usage),
             reasoning_content,
             thinking_blocks,
             reasoning_items: Vec::new(),

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -13,7 +13,8 @@ use serde_json::{json, Map, Value};
 
 use crate::agent::api_errors::format_http_error;
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, StopReason, ToolCall, ToolResultContent, ToolSchema,
+    Backend, Block, LLMResponse, Message, StopReason, TokenUsage, ToolCall, ToolResultContent,
+    ToolSchema,
 };
 use crate::agent::provider::{
     config_for, load_api_key, load_openai_credential, Credential, Provider, ProviderConfig,
@@ -202,15 +203,16 @@ event: response.completed
 data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output_tokens":5}}}
 "#;
 
-        let parsed = parse_responses_sse(body).expect("sse should parse");
+        let parsed =
+            parse_responses_sse(body, Provider::OpenAI, "gpt-5.5", true).expect("sse should parse");
         assert_eq!(parsed.text_blocks, vec!["hello"]);
         assert_eq!(parsed.tool_calls.len(), 1);
         assert_eq!(parsed.tool_calls[0].id, "call_1");
         assert_eq!(parsed.tool_calls[0].name, "lookup");
         assert_eq!(parsed.tool_calls[0].input["key"], "abc");
         assert_eq!(parsed.stop_reason, StopReason::ToolUse);
-        assert_eq!(parsed.input_tokens, 3);
-        assert_eq!(parsed.output_tokens, 5);
+        assert_eq!(parsed.usage.input_tokens, 3);
+        assert_eq!(parsed.usage.output_tokens, 5);
     }
 
     #[test]
@@ -512,15 +514,7 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
 struct WireResponse {
     choices: Vec<WireChoice>,
     #[serde(default)]
-    usage: WireUsage,
-}
-
-#[derive(Deserialize, Default)]
-struct WireUsage {
-    #[serde(default)]
-    prompt_tokens: u64,
-    #[serde(default)]
-    completion_tokens: u64,
+    usage: Value,
 }
 
 #[derive(Deserialize)]
@@ -595,13 +589,17 @@ struct ResponsesRequest {
     include: Vec<&'static str>,
 }
 
-fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
+fn parse_responses_sse(
+    body: &str,
+    provider: Provider,
+    model: &str,
+    estimate_cost: bool,
+) -> anyhow::Result<LLMResponse> {
     let mut text = String::new();
     let mut tool_calls = Vec::new();
     let mut reasoning_items: Vec<Value> = Vec::new();
     let mut reasoning_texts: Vec<String> = Vec::new();
-    let mut input_tokens = 0;
-    let mut output_tokens = 0;
+    let mut provider_usage: Option<Value> = None;
     let mut completed = false;
 
     for line in body.lines() {
@@ -659,19 +657,8 @@ fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
             }
             Some("response.completed") => {
                 completed = true;
-                if let Some(usage) = value
-                    .get("response")
-                    .and_then(|r| r.get("usage"))
-                    .and_then(Value::as_object)
-                {
-                    input_tokens = usage
-                        .get("input_tokens")
-                        .and_then(Value::as_u64)
-                        .unwrap_or_default();
-                    output_tokens = usage
-                        .get("output_tokens")
-                        .and_then(Value::as_u64)
-                        .unwrap_or_default();
+                if let Some(usage) = value.get("response").and_then(|r| r.get("usage")) {
+                    provider_usage = Some(usage.clone());
                 }
             }
             Some("response.failed") | Some("response.incomplete") => {
@@ -695,12 +682,14 @@ fn parse_responses_sse(body: &str) -> anyhow::Result<LLMResponse> {
     } else {
         StopReason::ToolUse
     };
+    let provider_usage = provider_usage.unwrap_or_else(|| json!({}));
+    let usage = TokenUsage::from_openai_compatible(provider, model, &provider_usage, estimate_cost);
     Ok(LLMResponse {
         text_blocks,
         tool_calls,
         stop_reason,
-        input_tokens,
-        output_tokens,
+        usage,
+        provider_usage: Some(provider_usage),
         reasoning_content: reasoning_texts.join("\n\n"),
         thinking_blocks: Vec::new(),
         reasoning_items,
@@ -741,7 +730,9 @@ impl Backend for OpenAICompatBackend {
         max_tokens: u32,
     ) -> anyhow::Result<LLMResponse> {
         if self.provider == Provider::OpenAI {
-            return self.send_responses(system, messages, tools, max_tokens).await;
+            return self
+                .send_responses(system, messages, tools, max_tokens)
+                .await;
         }
 
         let body = self.build_chat_request(system, messages, tools, max_tokens);
@@ -765,6 +756,7 @@ impl Backend for OpenAICompatBackend {
         }
 
         let parsed: WireResponse = response.json().await?;
+        let provider_usage = parsed.usage.clone();
         let choice = parsed
             .choices
             .into_iter()
@@ -789,12 +781,14 @@ impl Backend for OpenAICompatBackend {
             });
         }
 
+        let usage =
+            TokenUsage::from_openai_compatible(self.provider, &self.model, &provider_usage, true);
         Ok(LLMResponse {
             text_blocks,
             tool_calls,
             stop_reason: parse_stop_reason(choice.finish_reason.as_deref()),
-            input_tokens: parsed.usage.prompt_tokens,
-            output_tokens: parsed.usage.completion_tokens,
+            usage,
+            provider_usage: Some(provider_usage),
             reasoning_content: choice.message.reasoning_content.unwrap_or_default(),
             thinking_blocks: Vec::new(),
             reasoning_items: Vec::new(),
@@ -825,7 +819,10 @@ impl OpenAICompatBackend {
         self.parse_responses_response(response).await
     }
 
-    async fn send_responses_once(&self, body: &ResponsesRequest) -> anyhow::Result<reqwest::Response> {
+    async fn send_responses_once(
+        &self,
+        body: &ResponsesRequest,
+    ) -> anyhow::Result<reqwest::Response> {
         let credential = &self.credential;
         let request = self.client.post(self.responses_url());
         let request = match credential {
@@ -858,6 +855,11 @@ impl OpenAICompatBackend {
             }
             anyhow::bail!(format_http_error(label, status.as_u16(), &text));
         }
-        parse_responses_sse(&text)
+        parse_responses_sse(
+            &text,
+            Provider::OpenAI,
+            &self.model,
+            !matches!(self.credential, Credential::CodexOAuth { .. }),
+        )
     }
 }

--- a/core/src/agent/llm/usage.rs
+++ b/core/src/agent/llm/usage.rs
@@ -1,0 +1,204 @@
+//! Provider usage normalization and best-effort token-cost estimation.
+//!
+//! Token counts always come from the provider response. Cost is an estimate
+//! from the generated model catalog and is intentionally absent when no rate
+//! is known (or when OpenAI is reached through a subscription credential).
+
+use std::ops::AddAssign;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::agent::provider::{catalog_model_pricing, ModelPricingTier, Provider};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenUsage {
+    /// Total logical input tokens, including cache reads and cache writes.
+    pub input_tokens: u64,
+    /// Input tokens processed normally rather than read from or written to cache.
+    pub uncached_input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_output_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<UsageCost>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageCost {
+    pub currency: String,
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+    pub cache_creation: f64,
+    pub total: f64,
+    pub estimated: bool,
+    pub pricing_source: String,
+    /// Present for a single call when one pricing tier applies. Run aggregates
+    /// drop this field if different calls crossed pricing tiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rates_per_million_tokens: Option<ModelPricingTier>,
+}
+
+impl TokenUsage {
+    /// OpenAI Responses and OpenAI-compatible Chat Completions count cached
+    /// tokens inside the reported input total. Provider-specific aliases are
+    /// accepted so the raw usage object remains useful across all backends.
+    pub fn from_openai_compatible(
+        provider: Provider,
+        model: &str,
+        raw: &Value,
+        estimate_cost: bool,
+    ) -> Self {
+        let input_tokens = first_u64(raw, &["/prompt_tokens", "/input_tokens"]);
+        let output_tokens = first_u64(raw, &["/completion_tokens", "/output_tokens"]);
+        let cache_read_input_tokens = first_u64(
+            raw,
+            &[
+                "/prompt_tokens_details/cached_tokens",
+                "/input_tokens_details/cached_tokens",
+                "/cached_tokens",
+                "/prompt_cache_hit_tokens",
+                "/cache_read_input_tokens",
+            ],
+        );
+        let cache_creation_input_tokens = first_u64(
+            raw,
+            &[
+                "/prompt_tokens_details/cache_creation_input_tokens",
+                "/input_tokens_details/cache_creation_input_tokens",
+                "/cache_creation_input_tokens",
+            ],
+        );
+        let reported_miss = first_u64(raw, &["/prompt_cache_miss_tokens"]);
+        let uncached_input_tokens = if raw.pointer("/prompt_cache_miss_tokens").is_some() {
+            reported_miss
+        } else {
+            input_tokens
+                .saturating_sub(cache_read_input_tokens.saturating_add(cache_creation_input_tokens))
+        };
+        let reasoning_output_tokens = optional_u64(
+            raw,
+            &[
+                "/completion_tokens_details/reasoning_tokens",
+                "/output_tokens_details/reasoning_tokens",
+            ],
+        );
+        let mut usage = Self {
+            input_tokens,
+            uncached_input_tokens,
+            output_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            reasoning_output_tokens,
+            cost: None,
+        };
+        if estimate_cost {
+            usage.estimate_cost(provider, model);
+        }
+        usage
+    }
+
+    /// Anthropic reports ordinary input, cache reads, and cache writes as three
+    /// disjoint counters, so the logical input total is their sum.
+    pub fn from_anthropic(provider: Provider, model: &str, raw: &Value) -> Self {
+        let uncached_input_tokens = first_u64(raw, &["/input_tokens"]);
+        let output_tokens = first_u64(raw, &["/output_tokens"]);
+        let cache_read_input_tokens = first_u64(raw, &["/cache_read_input_tokens"]);
+        let cache_creation_input_tokens = first_u64(raw, &["/cache_creation_input_tokens"]);
+        let mut usage = Self {
+            input_tokens: uncached_input_tokens
+                .saturating_add(cache_read_input_tokens)
+                .saturating_add(cache_creation_input_tokens),
+            uncached_input_tokens,
+            output_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            reasoning_output_tokens: None,
+            cost: None,
+        };
+        usage.estimate_cost(provider, model);
+        usage
+    }
+
+    fn estimate_cost(&mut self, provider: Provider, model: &str) {
+        let Some(pricing) = catalog_model_pricing(provider, model) else {
+            return;
+        };
+        let Some(rates) = pricing.tier_for_input(self.input_tokens).cloned() else {
+            return;
+        };
+        let per_million = |tokens: u64, rate: f64| tokens as f64 * rate / 1_000_000.0;
+        let input = per_million(self.uncached_input_tokens, rates.input_per_million);
+        let output = per_million(self.output_tokens, rates.output_per_million);
+        let cache_read = per_million(self.cache_read_input_tokens, rates.cache_read_per_million);
+        let cache_creation = per_million(
+            self.cache_creation_input_tokens,
+            rates.cache_write_per_million,
+        );
+        self.cost = Some(UsageCost {
+            currency: pricing.currency,
+            input,
+            output,
+            cache_read,
+            cache_creation,
+            total: input + output + cache_read + cache_creation,
+            estimated: true,
+            pricing_source: pricing.source,
+            rates_per_million_tokens: Some(rates),
+        });
+    }
+}
+
+impl AddAssign<&TokenUsage> for TokenUsage {
+    fn add_assign(&mut self, rhs: &TokenUsage) {
+        self.input_tokens = self.input_tokens.saturating_add(rhs.input_tokens);
+        self.uncached_input_tokens = self
+            .uncached_input_tokens
+            .saturating_add(rhs.uncached_input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(rhs.output_tokens);
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(rhs.cache_read_input_tokens);
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(rhs.cache_creation_input_tokens);
+        self.reasoning_output_tokens =
+            match (self.reasoning_output_tokens, rhs.reasoning_output_tokens) {
+                (Some(left), Some(right)) => Some(left.saturating_add(right)),
+                (Some(left), None) => Some(left),
+                (None, Some(right)) => Some(right),
+                (None, None) => None,
+            };
+        match (&mut self.cost, &rhs.cost) {
+            (Some(left), Some(right))
+                if left.currency == right.currency
+                    && left.pricing_source == right.pricing_source =>
+            {
+                left.input += right.input;
+                left.output += right.output;
+                left.cache_read += right.cache_read;
+                left.cache_creation += right.cache_creation;
+                left.total += right.total;
+                if left.rates_per_million_tokens != right.rates_per_million_tokens {
+                    left.rates_per_million_tokens = None;
+                }
+            }
+            (slot @ None, Some(right)) => *slot = Some(right.clone()),
+            (Some(_), Some(_)) => self.cost = None,
+            _ => {}
+        }
+    }
+}
+
+fn first_u64(value: &Value, pointers: &[&str]) -> u64 {
+    optional_u64(value, pointers).unwrap_or_default()
+}
+
+fn optional_u64(value: &Value, pointers: &[&str]) -> Option<u64> {
+    pointers
+        .iter()
+        .find_map(|pointer| value.pointer(pointer).and_then(Value::as_u64))
+}

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -29,7 +29,8 @@ use tracing::{debug, info, warn};
 
 use crate::agent::compaction::{compress_text_maybe_json, TOOL_RESULT_TEXT_MAX_CHARS};
 use crate::agent::llm::{
-    Backend, Block, LLMResponse, Message, StopReason, ToolCall, ToolResultContent, ToolSchema,
+    Backend, Block, LLMResponse, Message, StopReason, TokenUsage, ToolCall, ToolResultContent,
+    ToolSchema,
 };
 use crate::agent::memory::prepare_messages_for_context;
 use crate::agent::report::report_with_artifacts;
@@ -131,8 +132,7 @@ pub struct AgentOutcome {
     pub run_dir: PathBuf,
     pub steps: u32,
     pub final_text: String,
-    pub total_input_tokens: u64,
-    pub total_output_tokens: u64,
+    pub usage: TokenUsage,
 }
 
 pub async fn run_agent(
@@ -204,8 +204,7 @@ pub async fn run_agent_with_events(
 
     let mut step = 0u32;
     let mut final_text = String::new();
-    let mut total_input_tokens = 0u64;
-    let mut total_output_tokens = 0u64;
+    let mut usage = TokenUsage::default();
     let mut context_memory: Vec<String> = Vec::new();
     let mut tool_call_history: BTreeMap<String, Vec<u32>> = BTreeMap::new();
     let mut completed = false;
@@ -277,8 +276,7 @@ pub async fn run_agent_with_events(
             }
         };
 
-        total_input_tokens += response.input_tokens;
-        total_output_tokens += response.output_tokens;
+        usage += &response.usage;
 
         // Split text_blocks into visible vs "[Thinking] "-prefixed thinking.
         // Some hosts (Anthropic without extended-thinking enabled) ask the
@@ -518,8 +516,7 @@ pub async fn run_agent_with_events(
                     &messages[traced_len..],
                     &response,
                 );
-                total_input_tokens += response.input_tokens;
-                total_output_tokens += response.output_tokens;
+                usage += &response.usage;
                 let (visible_texts, _) = split_thinking(&response.text_blocks);
                 for text in &visible_texts {
                     emit(
@@ -573,28 +570,15 @@ pub async fn run_agent_with_events(
     } else {
         "completed"
     };
-    run_recorder.finish(
-        status,
-        step,
-        total_input_tokens,
-        total_output_tokens,
-        terminal_error.as_deref(),
-    )?;
-    run_trace.finish(
-        status,
-        step,
-        total_input_tokens,
-        total_output_tokens,
-        terminal_error.as_deref(),
-    );
+    run_recorder.finish(status, step, &usage, terminal_error.as_deref())?;
+    run_trace.finish(status, step, &usage, terminal_error.as_deref());
 
     Ok(AgentOutcome {
         run_id,
         run_dir,
         steps: step,
         final_text,
-        total_input_tokens,
-        total_output_tokens,
+        usage,
     })
 }
 

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -23,14 +23,14 @@ pub mod tool;
 pub use self::file_bash_tools::{desktop_agent_tools, local_agent_tools, BashTool, ReadFileTool};
 pub use self::llm::{
     AnthropicBackend, Backend, Block, LLMResponse, Message, MessageContent, MessageRole,
-    OpenAICompatBackend, StopReason, ToolCall, ToolResultContent, ToolSchema,
+    OpenAICompatBackend, StopReason, TokenUsage, ToolCall, ToolResultContent, ToolSchema, UsageCost,
 };
 pub use self::provider::{
     catalog_model_display_name, catalog_models_for, config_for, configured_default_model_for,
     configured_default_provider, default_model_for, list_available_providers, load_api_key,
     load_openai_credential, load_provider_credential, provider_credential_kind, resolve_provider,
-    save_api_key, save_default_model, Credential, CredentialKind, ModelCatalogEntry, Provider,
-    ProviderConfig, PROVIDERS,
+    save_api_key, save_default_model, Credential, CredentialKind, ModelCatalogEntry, ModelPricing,
+    ModelPricingTier, Provider, ProviderConfig, PROVIDERS,
 };
 pub use self::conversation::{default_sessions_root, Conversation, Run};
 pub use self::r#loop::{run_agent, run_agent_with_events, AgentEvent, AgentOptions, AgentOutcome};

--- a/core/src/agent/model_catalog.generated.json
+++ b/core/src/agent/model_catalog.generated.json
@@ -6,424 +6,1574 @@
         "id": "claude-sonnet-5",
         "display_name": "Claude Sonnet 5",
         "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.2,
+              "cache_write_per_million": 2.5
+            }
+          ]
+        },
         "recommended": true
       },
       {
         "id": "claude-fable-5",
         "display_name": "Claude Fable 5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 10,
+              "output_per_million": 50,
+              "cache_read_per_million": 1,
+              "cache_write_per_million": 12.5
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-8",
         "display_name": "Claude Opus 4.8",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 25,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 6.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-7",
         "display_name": "Claude Opus 4.7",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 25,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 6.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-6",
         "display_name": "Claude Opus 4.6",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 25,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 6.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-sonnet-4-6",
         "display_name": "Claude Sonnet 4.6",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-5-20251101",
         "display_name": "Claude Opus 4.5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 25,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 6.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-haiku-4-5-20251001",
         "display_name": "Claude Haiku 4.5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1,
+              "output_per_million": 5,
+              "cache_read_per_million": 0.1,
+              "cache_write_per_million": 1.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-sonnet-4-5-20250929",
         "display_name": "Claude Sonnet 4.5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-5",
         "display_name": "Claude Opus 4.5 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 25,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 6.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-sonnet-4-5",
         "display_name": "Claude Sonnet 4.5 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-haiku-4-5",
         "display_name": "Claude Haiku 4.5 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1,
+              "output_per_million": 5,
+              "cache_read_per_million": 0.1,
+              "cache_write_per_million": 1.25
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-1-20250805",
         "display_name": "Claude Opus 4.1",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 75,
+              "cache_read_per_million": 1.5,
+              "cache_write_per_million": 18.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-1",
         "display_name": "Claude Opus 4.1 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 75,
+              "cache_read_per_million": 1.5,
+              "cache_write_per_million": 18.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-20250514",
         "display_name": "Claude Opus 4",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 75,
+              "cache_read_per_million": 1.5,
+              "cache_write_per_million": 18.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-sonnet-4-20250514",
         "display_name": "Claude Sonnet 4",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-opus-4-0",
         "display_name": "Claude Opus 4 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 75,
+              "cache_read_per_million": 1.5,
+              "cache_write_per_million": 18.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-sonnet-4-0",
         "display_name": "Claude Sonnet 4 (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-7-sonnet-20250219",
         "display_name": "Claude Sonnet 3.7",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-5-sonnet-20241022",
         "display_name": "Claude Sonnet 3.5 v2",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-5-sonnet-20240620",
         "display_name": "Claude Sonnet 3.5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 3.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-haiku-20240307",
         "display_name": "Claude Haiku 3",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.25,
+              "output_per_million": 1.25,
+              "cache_read_per_million": 0.03,
+              "cache_write_per_million": 0.3
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-opus-20240229",
         "display_name": "Claude Opus 3",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 75,
+              "cache_read_per_million": 1.5,
+              "cache_write_per_million": 18.75
+            }
+          ]
+        }
       },
       {
         "id": "claude-3-sonnet-20240229",
         "display_name": "Claude Sonnet 3",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.3,
+              "cache_write_per_million": 0.3
+            }
+          ]
+        }
       }
     ],
     "openai": [
       {
         "id": "gpt-5.5-pro",
         "display_name": "GPT-5.5 Pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 30,
+              "output_per_million": 180,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.5",
         "display_name": "GPT-5.5",
         "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 30,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 0
+            }
+          ]
+        },
         "recommended": true
       },
       {
         "id": "gpt-5.4-pro",
         "display_name": "GPT-5.4 Pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 30,
+              "output_per_million": 180,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.4-mini",
         "display_name": "GPT-5.4 mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.75,
+              "output_per_million": 4.5,
+              "cache_read_per_million": 0.075,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.4-nano",
         "display_name": "GPT-5.4 nano",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.2,
+              "output_per_million": 1.25,
+              "cache_read_per_million": 0.02,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.4",
         "display_name": "GPT-5.4",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2.5,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.25,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.3-codex-spark",
         "display_name": "GPT-5.3 Codex Spark",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.3-codex",
         "display_name": "GPT-5.3 Codex",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.3-chat-latest",
         "display_name": "GPT-5.3 Chat (latest)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.2-pro",
         "display_name": "GPT-5.2 Pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 21,
+              "output_per_million": 168,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.2-codex",
         "display_name": "GPT-5.2 Codex",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.2-chat-latest",
         "display_name": "GPT-5.2 Chat",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.2",
         "display_name": "GPT-5.2",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.75,
+              "output_per_million": 14,
+              "cache_read_per_million": 0.175,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.1-codex-max",
         "display_name": "GPT-5.1 Codex Max",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.1-codex-mini",
         "display_name": "GPT-5.1 Codex mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.25,
+              "output_per_million": 2,
+              "cache_read_per_million": 0.025,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.1-codex",
         "display_name": "GPT-5.1 Codex",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.1-chat-latest",
         "display_name": "GPT-5.1 Chat",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5.1",
         "display_name": "GPT-5.1",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5-pro",
         "display_name": "GPT-5 Pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 120,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5-codex",
         "display_name": "GPT-5-Codex",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5-mini",
         "display_name": "GPT-5 Mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.25,
+              "output_per_million": 2,
+              "cache_read_per_million": 0.025,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5-nano",
         "display_name": "GPT-5 Nano",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.05,
+              "output_per_million": 0.4,
+              "cache_read_per_million": 0.005,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5-chat-latest",
         "display_name": "GPT-5 Chat Latest",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-5",
         "display_name": "GPT-5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.25,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.125,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o4-mini",
         "display_name": "o4-mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.1,
+              "output_per_million": 4.4,
+              "cache_read_per_million": 0.275,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o3-pro",
         "display_name": "o3-pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 20,
+              "output_per_million": 80,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o3-mini",
         "display_name": "o3-mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.1,
+              "output_per_million": 4.4,
+              "cache_read_per_million": 0.55,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o3",
         "display_name": "o3",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2,
+              "output_per_million": 8,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o1-pro",
         "display_name": "o1-pro",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 150,
+              "output_per_million": 600,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "o1",
         "display_name": "o1",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 15,
+              "output_per_million": 60,
+              "cache_read_per_million": 7.5,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4o-2024-11-20",
         "display_name": "GPT-4o (2024-11-20)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2.5,
+              "output_per_million": 10,
+              "cache_read_per_million": 1.25,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4o-2024-08-06",
         "display_name": "GPT-4o (2024-08-06)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2.5,
+              "output_per_million": 10,
+              "cache_read_per_million": 1.25,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4o-2024-05-13",
         "display_name": "GPT-4o (2024-05-13)",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 5,
+              "output_per_million": 15,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4o-mini",
         "display_name": "GPT-4o mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.15,
+              "output_per_million": 0.6,
+              "cache_read_per_million": 0.075,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4o",
         "display_name": "GPT-4o",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2.5,
+              "output_per_million": 10,
+              "cache_read_per_million": 1.25,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4.1-mini",
         "display_name": "GPT-4.1 mini",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.4,
+              "output_per_million": 1.6,
+              "cache_read_per_million": 0.1,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4.1-nano",
         "display_name": "GPT-4.1 nano",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.1,
+              "output_per_million": 0.4,
+              "cache_read_per_million": 0.025,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4.1",
         "display_name": "GPT-4.1",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2,
+              "output_per_million": 8,
+              "cache_read_per_million": 0.5,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4-turbo",
         "display_name": "GPT-4 Turbo",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 10,
+              "output_per_million": 30,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "gpt-4",
         "display_name": "GPT-4",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 30,
+              "output_per_million": 60,
+              "cache_read_per_million": 0,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       }
     ],
     "kimi": [
       {
         "id": "kimi-k2.7-code-highspeed",
         "display_name": "Kimi K2.7 Code HighSpeed",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.9,
+              "output_per_million": 8,
+              "cache_read_per_million": 0.38,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2.7-code",
         "display_name": "Kimi K2.7 Code",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.95,
+              "output_per_million": 4,
+              "cache_read_per_million": 0.19,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2.6",
         "display_name": "Kimi K2.6",
         "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.95,
+              "output_per_million": 4,
+              "cache_read_per_million": 0.16,
+              "cache_write_per_million": 0
+            }
+          ]
+        },
         "recommended": true
       },
       {
         "id": "kimi-k2.5",
         "display_name": "Kimi K2.5",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.6,
+              "output_per_million": 3,
+              "cache_read_per_million": 0.1,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2-0905-preview",
         "display_name": "Kimi K2 0905",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.6,
+              "output_per_million": 2.5,
+              "cache_read_per_million": 0.15,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2-0711-preview",
         "display_name": "Kimi K2 0711",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.6,
+              "output_per_million": 2.5,
+              "cache_read_per_million": 0.15,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2-turbo-preview",
         "display_name": "Kimi K2 Turbo",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 2.4,
+              "output_per_million": 10,
+              "cache_read_per_million": 0.6,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2-thinking-turbo",
         "display_name": "Kimi K2 Thinking Turbo",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 1.15,
+              "output_per_million": 8,
+              "cache_read_per_million": 0.15,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "kimi-k2-thinking",
         "display_name": "Kimi K2 Thinking",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.6,
+              "output_per_million": 2.5,
+              "cache_read_per_million": 0.15,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       }
     ],
     "qwen": [
       {
         "id": "qwen3.7-max",
         "display_name": "Qwen 3.7 Max",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 1000000,
+              "input_per_million": 12,
+              "output_per_million": 36,
+              "cache_read_per_million": 2.4,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 1000000,
+                  "input_per_million": 18.736,
+                  "output_per_million": 56.207,
+                  "cache_read_per_million": 3.7472,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        }
       },
       {
         "id": "qwen3.7-plus",
         "display_name": "Qwen 3.7 Plus",
         "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 256000,
+              "input_per_million": 2,
+              "output_per_million": 8,
+              "cache_read_per_million": 0.4,
+              "cache_write_per_million": 0
+            },
+            {
+              "max_input_tokens": 1000000,
+              "input_per_million": 6,
+              "output_per_million": 24,
+              "cache_read_per_million": 1.2,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 256000,
+                  "input_per_million": 2.998,
+                  "output_per_million": 11.991,
+                  "cache_read_per_million": 0.5996,
+                  "cache_write_per_million": 0
+                },
+                {
+                  "max_input_tokens": 1000000,
+                  "input_per_million": 8.993,
+                  "output_per_million": 35.972,
+                  "cache_read_per_million": 1.7986,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        },
         "recommended": true
       },
       {
         "id": "qwen3.6-plus-2026-04-02",
         "display_name": "Qwen 3.6 Plus (2026-04-02)",
-        "source": "fallback"
+        "source": "fallback",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 256000,
+              "input_per_million": 2,
+              "output_per_million": 12,
+              "cache_read_per_million": 0.4,
+              "cache_write_per_million": 0
+            },
+            {
+              "max_input_tokens": 1000000,
+              "input_per_million": 8,
+              "output_per_million": 48,
+              "cache_read_per_million": 1.6,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 256000,
+                  "input_per_million": 3.7471,
+                  "output_per_million": 22.4826,
+                  "cache_read_per_million": 0.74942,
+                  "cache_write_per_million": 0
+                },
+                {
+                  "max_input_tokens": 1000000,
+                  "input_per_million": 14.9884,
+                  "output_per_million": 44.965,
+                  "cache_read_per_million": 2.99768,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        }
       },
       {
         "id": "qwen3.6-max-preview",
         "display_name": "Qwen 3.6 Max Preview",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 128000,
+              "input_per_million": 9,
+              "output_per_million": 54,
+              "cache_read_per_million": 1.8,
+              "cache_write_per_million": 0
+            },
+            {
+              "max_input_tokens": 256000,
+              "input_per_million": 15,
+              "output_per_million": 90,
+              "cache_read_per_million": 3,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 128000,
+                  "input_per_million": 9.742,
+                  "output_per_million": 58.455,
+                  "cache_read_per_million": 1.9484,
+                  "cache_write_per_million": 0
+                },
+                {
+                  "max_input_tokens": 256000,
+                  "input_per_million": 14.988,
+                  "output_per_million": 89.93,
+                  "cache_read_per_million": 2.9976,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        }
       },
       {
         "id": "qwen3.6-plus",
         "display_name": "Qwen 3.6 Plus",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 256000,
+              "input_per_million": 2,
+              "output_per_million": 12,
+              "cache_read_per_million": 0.4,
+              "cache_write_per_million": 0
+            },
+            {
+              "max_input_tokens": 1000000,
+              "input_per_million": 8,
+              "output_per_million": 48,
+              "cache_read_per_million": 1.6,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 256000,
+                  "input_per_million": 3.7471,
+                  "output_per_million": 22.4826,
+                  "cache_read_per_million": 0.74942,
+                  "cache_write_per_million": 0
+                },
+                {
+                  "max_input_tokens": 1000000,
+                  "input_per_million": 14.9884,
+                  "output_per_million": 44.965,
+                  "cache_read_per_million": 2.99768,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        }
       },
       {
         "id": "qwen3.6-flash",
         "display_name": "Qwen 3.6 Flash",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+          "tiers": [
+            {
+              "max_input_tokens": 256000,
+              "input_per_million": 1.2,
+              "output_per_million": 7.2,
+              "cache_read_per_million": 0.24,
+              "cache_write_per_million": 0
+            },
+            {
+              "max_input_tokens": 1000000,
+              "input_per_million": 4.8,
+              "output_per_million": 28.8,
+              "cache_read_per_million": 0.96,
+              "cache_write_per_million": 0
+            }
+          ],
+          "overrides": {
+            "qwen-intl": {
+              "currency": "CNY",
+              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
+              "tiers": [
+                {
+                  "max_input_tokens": 256000,
+                  "input_per_million": 1.87355,
+                  "output_per_million": 11.2413,
+                  "cache_read_per_million": 0.37471,
+                  "cache_write_per_million": 0
+                },
+                {
+                  "max_input_tokens": 1000000,
+                  "input_per_million": 7.4942,
+                  "output_per_million": 29.9758,
+                  "cache_read_per_million": 1.49884,
+                  "cache_write_per_million": 0
+                }
+              ]
+            }
+          }
+        }
       }
     ],
     "doubao": [
       {
         "id": "doubao-seed-2-1-pro-260628",
         "display_name": "Doubao Seed 2.1 Pro (260628)",
-        "source": "fallback"
+        "source": "fallback",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://www.volcengine.com/product/doubao",
+          "tiers": [
+            {
+              "input_per_million": 6,
+              "output_per_million": 30,
+              "cache_read_per_million": 1.2,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "doubao-seed-2-1-turbo-260628",
         "display_name": "Doubao Seed 2.1 Turbo (260628)",
         "source": "fallback",
-        "recommended": true
+        "recommended": true,
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://www.volcengine.com/product/doubao",
+          "tiers": [
+            {
+              "input_per_million": 3,
+              "output_per_million": 15,
+              "cache_read_per_million": 0.6,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       },
       {
         "id": "doubao-seed-evolving",
         "display_name": "Doubao Seed Evolving",
-        "source": "fallback"
+        "source": "fallback",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://www.volcengine.com/product/doubao",
+          "tiers": [
+            {
+              "input_per_million": 6,
+              "output_per_million": 30,
+              "cache_read_per_million": 1.2,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       }
     ],
     "deepseek": [
@@ -431,12 +1581,36 @@
         "id": "deepseek-v4-pro",
         "display_name": "DeepSeek V4 Pro",
         "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.435,
+              "output_per_million": 0.87,
+              "cache_read_per_million": 0.003625,
+              "cache_write_per_million": 0
+            }
+          ]
+        },
         "recommended": true
       },
       {
         "id": "deepseek-v4-flash",
         "display_name": "DeepSeek V4 Flash",
-        "source": "pi-ai"
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "USD",
+          "source": "pi-ai",
+          "tiers": [
+            {
+              "input_per_million": 0.14,
+              "output_per_million": 0.28,
+              "cache_read_per_million": 0.0028,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
       }
     ]
   }

--- a/core/src/agent/provider.rs
+++ b/core/src/agent/provider.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -88,6 +88,29 @@ pub struct ModelCatalogEntry {
     pub source: Option<String>,
     #[serde(default)]
     pub recommended: bool,
+    #[serde(default)]
+    pub pricing: Option<ModelPricing>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPricing {
+    pub currency: String,
+    pub source: String,
+    pub tiers: Vec<ModelPricingTier>,
+    #[serde(default)]
+    pub overrides: HashMap<String, ModelPricing>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelPricingTier {
+    #[serde(default)]
+    pub max_input_tokens: Option<u64>,
+    pub input_per_million: f64,
+    pub output_per_million: f64,
+    #[serde(default)]
+    pub cache_read_per_million: f64,
+    #[serde(default)]
+    pub cache_write_per_million: f64,
 }
 
 impl ModelCatalogEntry {
@@ -105,7 +128,24 @@ impl ModelCatalogEntry {
             display_name: Some(display_name.into()),
             source: Some("compiled-default".into()),
             recommended: true,
+            pricing: None,
         }
+    }
+}
+
+impl ModelPricing {
+    pub fn for_provider(&self, provider: Provider) -> &Self {
+        self.overrides.get(provider.as_str()).unwrap_or(self)
+    }
+
+    pub fn tier_for_input(&self, input_tokens: u64) -> Option<&ModelPricingTier> {
+        self.tiers
+            .iter()
+            .find(|tier| {
+                tier.max_input_tokens
+                    .is_none_or(|limit| input_tokens <= limit)
+            })
+            .or_else(|| self.tiers.last())
     }
 }
 
@@ -252,6 +292,14 @@ pub fn catalog_model_display_name(provider: Provider, model_id: &str) -> String 
         .find(|model| model.id == trimmed)
         .map(|model| model.label().to_string())
         .unwrap_or_else(|| trimmed.to_string())
+}
+
+pub fn catalog_model_pricing(provider: Provider, model_id: &str) -> Option<ModelPricing> {
+    catalog_models_for(provider)
+        .into_iter()
+        .find(|model| model.id == model_id.trim())
+        .and_then(|model| model.pricing)
+        .map(|pricing| pricing.for_provider(provider).clone())
 }
 
 #[derive(Debug, Deserialize)]

--- a/core/src/agent/run_logging.rs
+++ b/core/src/agent/run_logging.rs
@@ -20,7 +20,7 @@ use chrono::{Local, Utc};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::agent::llm::LLMResponse;
+use crate::agent::llm::{LLMResponse, TokenUsage};
 use crate::agent::tool::ToolResultBlock;
 
 fn timestamp() -> String {
@@ -189,20 +189,10 @@ impl AgentRunRecorder {
         // show them live mid-run; `finish` overwrites with the final figures.
         {
             let mut manifest = self.manifest.lock().expect("poisoned");
-            let input = manifest
-                .pointer("/usage/input_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(0)
-                + response.input_tokens;
-            let output = manifest
-                .pointer("/usage/output_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(0)
-                + response.output_tokens;
-            manifest["usage"] = json!({
-                "input_tokens": input,
-                "output_tokens": output,
-            });
+            let mut usage =
+                serde_json::from_value::<TokenUsage>(manifest["usage"].clone()).unwrap_or_default();
+            usage += &response.usage;
+            manifest["usage"] = serde_json::to_value(usage).map_err(std::io::Error::other)?;
             manifest["steps"] = json!(step);
             write_json_atomic(&self.manifest_path, &manifest)?;
         }
@@ -243,18 +233,14 @@ impl AgentRunRecorder {
         &self,
         status: &str,
         steps: u32,
-        input_tokens: u64,
-        output_tokens: u64,
+        usage: &TokenUsage,
         error: Option<&str>,
     ) -> std::io::Result<()> {
         let mut manifest = self.manifest.lock().expect("poisoned");
         manifest["status"] = json!(status);
         manifest["duration_ms"] = json!(self.started.elapsed().as_millis() as u64);
         manifest["steps"] = json!(steps);
-        manifest["usage"] = json!({
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-        });
+        manifest["usage"] = serde_json::to_value(usage).map_err(std::io::Error::other)?;
         if let Some(error) = error {
             manifest["error"] = json!(error);
         }

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 use super::tool_call::{summarize_tool_args, summarize_tool_result};
 use super::{chat_text_enabled, query_text_enabled};
 use crate::agent::llm::{
-    Block, LLMResponse, Message, MessageContent, MessageRole, ToolResultContent,
+    Block, LLMResponse, Message, MessageContent, MessageRole, TokenUsage, ToolResultContent,
 };
 use crate::agent::r#loop::THINKING_TEXT_PREFIX;
 use crate::agent::signature::md5_hex;
@@ -112,8 +112,7 @@ pub struct RunTraceBuilder {
     /// Running figures for the drop guard; `finish` overwrites them with the
     /// loop's authoritative totals.
     steps_seen: u32,
-    input_tokens: u64,
-    output_tokens: u64,
+    usage: TokenUsage,
     /// Remaining chat-content bytes for this run's upload; once spent, later
     /// spans carry `socai.chat_text_dropped` instead of content.
     chat_bytes_left: usize,
@@ -157,8 +156,7 @@ impl RunTraceBuilder {
             spans: Vec::new(),
             dropped_spans: 0,
             steps_seen: 0,
-            input_tokens: 0,
-            output_tokens: 0,
+            usage: TokenUsage::default(),
             chat_bytes_left: CHAT_BUDGET_BYTES,
             last_system_hash: String::new(),
             finalized: false,
@@ -177,17 +175,15 @@ impl RunTraceBuilder {
         response: &LLMResponse,
     ) {
         self.steps_seen = self.steps_seen.max(step);
-        self.input_tokens += response.input_tokens;
-        self.output_tokens += response.output_tokens;
+        self.usage += &response.usage;
         let mut attrs = vec![
             attr_str("gen_ai.operation.name", "chat"),
             attr_str("gen_ai.request.model", &self.model),
             attr_int("socai.step", step as i64),
             attr_str("socai.stop_reason", stop_reason_str(response)),
             attr_int("socai.tool_calls", response.tool_calls.len() as i64),
-            attr_int("gen_ai.usage.input_tokens", response.input_tokens as i64),
-            attr_int("gen_ai.usage.output_tokens", response.output_tokens as i64),
         ];
+        push_usage_attrs(&mut attrs, &response.usage);
         self.push_chat_attrs(&mut attrs, system, new_messages, Some(response));
         self.push_span(
             format!("chat {}", self.model),
@@ -326,16 +322,9 @@ impl RunTraceBuilder {
 
     /// Close the root span and write the OTLP `ExportTraceServiceRequest` to
     /// `run_dir/trace.json` (best-effort, like every other telemetry write).
-    pub fn finish(
-        &mut self,
-        status: &str,
-        steps: u32,
-        input_tokens: u64,
-        output_tokens: u64,
-        error: Option<&str>,
-    ) {
+    pub fn finish(&mut self, status: &str, steps: u32, usage: &TokenUsage, error: Option<&str>) {
         self.finalized = true;
-        let payload = self.build_payload(status, steps, input_tokens, output_tokens, error);
+        let payload = self.build_payload(status, steps, usage, error);
         self.write_trace_file(&payload);
     }
 
@@ -343,8 +332,7 @@ impl RunTraceBuilder {
         &mut self,
         status: &str,
         steps: u32,
-        input_tokens: u64,
-        output_tokens: u64,
+        usage: &TokenUsage,
         error: Option<&str>,
     ) -> Value {
         let end_ns = now_ns();
@@ -356,9 +344,8 @@ impl RunTraceBuilder {
             attr_str("socai.task_text", &self.task_text),
             attr_str("socai.status", status),
             attr_int("socai.steps", steps as i64),
-            attr_int("gen_ai.usage.input_tokens", input_tokens as i64),
-            attr_int("gen_ai.usage.output_tokens", output_tokens as i64),
         ];
+        push_usage_attrs(&mut attrs, usage);
         if let Some(session_id) = &self.session_id {
             // Desktop session ids embed the first task's slug (conversation
             // dir name), so scrub the uploaded attribute; the trace id was
@@ -471,13 +458,8 @@ impl Drop for RunTraceBuilder {
         if self.finalized {
             return;
         }
-        let payload = self.build_payload(
-            "interrupted",
-            self.steps_seen,
-            self.input_tokens,
-            self.output_tokens,
-            None,
-        );
+        let usage = self.usage.clone();
+        let payload = self.build_payload("interrupted", self.steps_seen, &usage, None);
         self.write_trace_file(&payload);
     }
 }
@@ -549,6 +531,53 @@ fn attr_int(key: &str, value: i64) -> Value {
 
 fn attr_bool(key: &str, value: bool) -> Value {
     json!({ "key": key, "value": { "boolValue": value } })
+}
+
+fn attr_double(key: &str, value: f64) -> Value {
+    json!({ "key": key, "value": { "doubleValue": value } })
+}
+
+/// Attach the same normalized usage contract to both per-call chat spans and
+/// the aggregate agent-run span. Raw provider usage stays in local run files;
+/// telemetry only carries bounded numeric totals and pricing provenance.
+fn push_usage_attrs(attrs: &mut Vec<Value>, usage: &TokenUsage) {
+    attrs.extend([
+        attr_int("gen_ai.usage.input_tokens", usage.input_tokens as i64),
+        attr_int(
+            "gen_ai.usage.uncached_input_tokens",
+            usage.uncached_input_tokens as i64,
+        ),
+        attr_int("gen_ai.usage.output_tokens", usage.output_tokens as i64),
+        attr_int(
+            "gen_ai.usage.cache_read_input_tokens",
+            usage.cache_read_input_tokens as i64,
+        ),
+        attr_int(
+            "gen_ai.usage.cache_creation_input_tokens",
+            usage.cache_creation_input_tokens as i64,
+        ),
+    ]);
+    if let Some(tokens) = usage.reasoning_output_tokens {
+        attrs.push(attr_int(
+            "gen_ai.usage.reasoning_output_tokens",
+            tokens as i64,
+        ));
+    }
+    if let Some(cost) = &usage.cost {
+        attrs.extend([
+            attr_double("gen_ai.usage.estimated_input_cost", cost.input),
+            attr_double("gen_ai.usage.estimated_output_cost", cost.output),
+            attr_double("gen_ai.usage.estimated_cache_read_cost", cost.cache_read),
+            attr_double(
+                "gen_ai.usage.estimated_cache_creation_cost",
+                cost.cache_creation,
+            ),
+            attr_double("gen_ai.usage.estimated_cost", cost.total),
+            attr_bool("gen_ai.usage.cost_estimated", cost.estimated),
+            attr_str("gen_ai.usage.cost_currency", &cost.currency),
+            attr_str("gen_ai.usage.cost_pricing_source", &cost.pricing_source),
+        ]);
+    }
 }
 
 /// Last-line size gate on the assembled payload: the chat budget bounds

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -50,7 +50,9 @@ The session root is `SOCAI_SESSIONS_DIR`, then `SOCAI_HOME/sessions`, then
 - run id and optional parent session id;
 - task and model;
 - status, start time, and total duration;
-- turn count and aggregate token usage;
+- step count and aggregate usage: logical/uncached input tokens, output tokens,
+  cache reads, cache writes, reasoning tokens when reported, and estimated cost
+  when the selected model has catalog pricing;
 - an error only for failed/interrupted runs.
 
 `report.md` is the single durable copy of the final user-facing answer.
@@ -61,9 +63,14 @@ headers. Its shape therefore follows the active API (Anthropic Messages,
 OpenAI-compatible Chat Completions, or Responses).
 
 The matching response contains text, exposed reasoning, tool calls, stop
-reason, token usage, request duration, and completion time. An unsuccessful
-request contains its duration, completion time, and error. Authentication
-headers, credentials, and raw response bytes are not recorded.
+reason, normalized `usage`, the provider's original `usage` object, request
+duration, and completion time. Normalized usage separates ordinary input,
+cache-read input, cache-creation input, output, and reasoning output where the
+provider exposes it. Estimated cost includes its currency, per-component
+breakdown, rates, and pricing source; it is omitted when no catalog price is
+known or the credential is subscription-based rather than metered API billing.
+An unsuccessful request contains its duration, completion time, and error.
+Authentication headers, credentials, and raw response bytes are not recorded.
 
 The LLM files are also the canonical ordered execution trace. Socai does not
 write a parallel event log or span log: LLM duration lives on the response,

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -166,7 +166,7 @@ and model in use are captured on `socai_agent_task_start`.
 | --- | --- | --- |
 | `socai_browser_connect` | User connects Chrome | — |
 | `socai_agent_task_start` | A task begins running | `task_id`, `provider`, `model`, `task_len`, `task_text` |
-| `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `turns`, `input_tokens`, `output_tokens`, `duration_ms`, `error` |
+| `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `steps`, token/cache usage, estimated cost breakdown, `duration_ms`, `error` |
 | `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, `query_text`, `query_len`, `metadata`, `note_id_present` |
 
 Desktop field semantics:
@@ -178,8 +178,18 @@ Desktop field semantics:
 | `provider` | string | LLM provider requested for the task. |
 | `model` | string | Model id requested for the task. |
 | `outcome` | string | Terminal state: `completed`, `failed`, `cancelled`, or `interrupted`. |
-| `turns` | number | Agent loop turns when known. |
-| `input_tokens` / `output_tokens` | number | Token usage for the run when known. |
+| `steps` | number | Agent loop steps when known. |
+| `input_tokens` / `output_tokens` | number | Token usage for the run when known. Input includes cached input. |
+| `uncached_input_tokens` | number | Input tokens processed normally rather than read from or written to cache. |
+| `reasoning_output_tokens` | number | Reasoning tokens when the provider reports a separate count. |
+| `cached_input_tokens` | number | Input tokens served from a provider prompt cache. |
+| `cache_creation_input_tokens` | number | Input tokens written to a provider prompt cache. |
+| `estimated_input_cost` / `estimated_output_cost` | number | Best-effort ordinary input and output cost components. |
+| `estimated_cache_read_cost` / `estimated_cache_creation_cost` | number | Best-effort cache cost components. |
+| `estimated_cost` | number | Sum of the estimated cost components; this is not a provider invoice. |
+| `cost_currency` | string | ISO currency code used by `estimated_cost`. |
+| `cost_estimated` | boolean | Always true for catalog-derived costs. |
+| `cost_pricing_source` | string | Model catalog pricing provenance. |
 | `task_len` | number | Agent prompt length in Unicode scalar values. |
 | `task_text` | string | Full agent prompt. Always sent on desktop; see privacy boundaries. |
 | `turn` / `sequence` | number | Position of a tool call within the run. |
@@ -274,8 +284,13 @@ pipeline for reading what an agent actually did:
 - `execute_tool` spans — the argument summary (query text under the
   `SOCAI_TELEMETRY_QUERY_TEXT` gate), count-only result metrics, and
   `socai.notes`: id/title/caption/stats summaries of notes the tool returned.
-- root span — `socai.task_text` (capped at 8,000 chars) plus run status, step
-  count, and token totals.
+- every `chat` span and the root span carry normalized usage: logical and
+  uncached input tokens, output and optional reasoning tokens, cache reads and
+  writes, plus estimated input/output/cache cost components, total, currency,
+  and pricing source. The root values aggregate the run; `chat` values describe
+  one provider call.
+- root span — `socai.task_text` (capped at 8,000 chars) plus run status and step
+  count.
 
 Never uploaded, regardless of settings: image bytes/screenshots, Anthropic
 thinking signatures, encrypted reasoning items, and browser cookies/session

--- a/scripts/sync-model-catalog.mjs
+++ b/scripts/sync-model-catalog.mjs
@@ -14,6 +14,35 @@ const shouldCheck = args.has("--check");
 const noOfficial = args.has("--no-official") || process.env.SOCAI_MODEL_SYNC_OFFLINE === "1";
 const noPi = args.has("--no-pi");
 
+const QWEN_PRICING_SOURCE = "https://help.aliyun.com/zh/model-studio/model-pricing";
+const DOUBAO_PRICING_SOURCE = "https://www.volcengine.com/product/doubao";
+
+function pricing(currency, source, tiers, overrides = undefined) {
+  return {
+    currency,
+    source,
+    tiers,
+    ...(overrides ? { overrides } : {}),
+  };
+}
+
+function priceTier(maxInputTokens, input, output, cacheRead = 0, cacheWrite = 0) {
+  return {
+    ...(maxInputTokens ? { max_input_tokens: maxInputTokens } : {}),
+    input_per_million: input,
+    output_per_million: output,
+    cache_read_per_million: cacheRead,
+    cache_write_per_million: cacheWrite,
+  };
+}
+
+// Qwen implicit-cache reads are billed at 20% of the stable list input rate.
+// Derive that rate from the input column so it cannot accidentally be copied
+// from one of the two output-price columns in Alibaba's Plus pricing tables.
+function qwenPriceTier(maxInputTokens, input, output) {
+  return priceTier(maxInputTokens, input, output, Number((input * 0.2).toFixed(6)));
+}
+
 const FALLBACK = {
   anthropic: [
     entry("claude-sonnet-5", "Claude Sonnet 5", "fallback", true),
@@ -37,16 +66,66 @@ const FALLBACK = {
     entry("kimi-k2-thinking", "Kimi K2 Thinking"),
   ],
   qwen: [
-    entry("qwen3.7-plus", "Qwen 3.7 Plus", "fallback", true),
-    entry("qwen3.6-plus-2026-04-02", "Qwen 3.6 Plus (2026-04-02)"),
-    entry("qwen3.7-max", "Qwen 3.7 Max"),
-    entry("qwen3.6-plus", "Qwen 3.6 Plus"),
-    entry("qwen3.6-max-preview", "Qwen 3.6 Max Preview"),
+    entry("qwen3.7-plus", "Qwen 3.7 Plus", "fallback", true, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(256000, 2, 8),
+      qwenPriceTier(1000000, 6, 24),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(256000, 2.998, 11.991),
+        qwenPriceTier(1000000, 8.993, 35.972),
+      ]),
+    })),
+    entry("qwen3.6-plus-2026-04-02", "Qwen 3.6 Plus (2026-04-02)", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(256000, 2, 12),
+      qwenPriceTier(1000000, 8, 48),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(256000, 3.7471, 22.4826),
+        qwenPriceTier(1000000, 14.9884, 44.965),
+      ]),
+    })),
+    entry("qwen3.7-max", "Qwen 3.7 Max", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(1000000, 12, 36),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(1000000, 18.736, 56.207),
+      ]),
+    })),
+    entry("qwen3.6-plus", "Qwen 3.6 Plus", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(256000, 2, 12),
+      qwenPriceTier(1000000, 8, 48),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(256000, 3.7471, 22.4826),
+        qwenPriceTier(1000000, 14.9884, 44.965),
+      ]),
+    })),
+    entry("qwen3.6-max-preview", "Qwen 3.6 Max Preview", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(128000, 9, 54),
+      qwenPriceTier(256000, 15, 90),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(128000, 9.742, 58.455),
+        qwenPriceTier(256000, 14.988, 89.93),
+      ]),
+    })),
+    entry("qwen3.6-flash", "Qwen 3.6 Flash", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
+      qwenPriceTier(256000, 1.2, 7.2),
+      qwenPriceTier(1000000, 4.8, 28.8),
+    ], {
+      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
+        qwenPriceTier(256000, 1.87355, 11.2413),
+        qwenPriceTier(1000000, 7.4942, 29.9758),
+      ]),
+    })),
   ],
   doubao: [
-    entry("doubao-seed-2-1-turbo-260628", "Doubao Seed 2.1 Turbo (260628)", "fallback", true),
-    entry("doubao-seed-2-1-pro-260628", "Doubao Seed 2.1 Pro (260628)"),
-    entry("doubao-seed-evolving", "Doubao Seed Evolving"),
+    entry("doubao-seed-2-1-turbo-260628", "Doubao Seed 2.1 Turbo (260628)", "fallback", true,
+      pricing("CNY", DOUBAO_PRICING_SOURCE, [priceTier(undefined, 3, 15, 0.6)])),
+    entry("doubao-seed-2-1-pro-260628", "Doubao Seed 2.1 Pro (260628)", "fallback", false,
+      pricing("CNY", DOUBAO_PRICING_SOURCE, [priceTier(undefined, 6, 30, 1.2)])),
+    entry("doubao-seed-evolving", "Doubao Seed Evolving", "fallback", false,
+      pricing("CNY", DOUBAO_PRICING_SOURCE, [priceTier(undefined, 6, 30, 1.2)])),
   ],
   deepseek: [
     entry("deepseek-v4-pro", "DeepSeek V4 Pro", "fallback", true),
@@ -106,8 +185,28 @@ const PROVIDERS = {
   },
 };
 
-function entry(id, displayName = titleFromId(id), source = "fallback", recommended = false) {
-  return { id, display_name: displayName, source, ...(recommended ? { recommended: true } : {}) };
+function entry(id, displayName = titleFromId(id), source = "fallback", recommended = false, modelPricing = undefined) {
+  return {
+    id,
+    display_name: displayName,
+    source,
+    ...(recommended ? { recommended: true } : {}),
+    ...(modelPricing ? { pricing: modelPricing } : {}),
+  };
+}
+
+function pricingFromPi(cost) {
+  if (!cost || typeof cost !== "object") return undefined;
+  const input = Number(cost.input);
+  const output = Number(cost.output);
+  if (!Number.isFinite(input) || !Number.isFinite(output)) return undefined;
+  return pricing("USD", "pi-ai", [priceTier(
+    undefined,
+    input,
+    output,
+    Number(cost.cacheRead) || 0,
+    Number(cost.cacheWrite) || 0,
+  )]);
 }
 
 function bearer(key) {
@@ -231,7 +330,7 @@ function piEntriesForProvider(pi, provider, cfg) {
       if (!id) continue;
       if (cfg.include && !cfg.include(id)) continue;
       if (cfg.exclude && cfg.exclude(id)) continue;
-      out.push(entry(id, model.name || titleFromId(id), "pi-ai"));
+      out.push(entry(id, model.name || titleFromId(id), "pi-ai", false, pricingFromPi(model.cost)));
     }
     if (out.length > 0) break;
   }
@@ -278,14 +377,21 @@ function markRecommended(provider, models) {
 }
 
 function dedupe(entries) {
-  const seen = new Set();
+  const seen = new Map();
   const out = [];
   for (const item of entries) {
     const id = item.id.trim();
-    if (!id || seen.has(id)) continue;
-    seen.add(id);
+    if (!id) continue;
+    if (seen.has(id)) {
+      const existing = seen.get(id);
+      if (!existing.pricing && item.pricing) existing.pricing = item.pricing;
+      if (!existing.recommended && item.recommended) existing.recommended = true;
+      continue;
+    }
     const clean = { id, display_name: item.display_name || titleFromId(id), source: item.source || "unknown" };
     if (item.recommended) clean.recommended = true;
+    if (item.pricing) clean.pricing = item.pricing;
+    seen.set(id, clean);
     out.push(clean);
   }
   return out;


### PR DESCRIPTION
## Summary

- Normalize per-call token usage across Anthropic and OpenAI-compatible providers while preserving provider raw usage.
- Persist detailed input, output, reasoning, cache-read, cache-write, and estimated-cost metrics for every LLM call and aggregate them at run/task level.
- Display run tokens, cache hit rate, and estimated cost in desktop task metadata and the CLI/TUI.
- Export the new usage and cost fields through run events and OTLP telemetry.
- Correct stable Qwen 3.7/3.6 list pricing and region-specific catalog overrides; promotional pricing is intentionally excluded.

<img width="686" height="194" alt="Screenshot 2026-07-15 at 10 17 21 PM" src="https://github.com/user-attachments/assets/1634accd-9c39-4a07-97f3-0a0d53209fca" />

## Why

The runtime previously retained only partial token totals: cache usage was inconsistent across providers, raw provider usage was not preserved end to end, and there was no cost estimate for debugging context-window and prompt-caching behavior. The Qwen Plus catalog also interpreted output-price columns as input prices, producing incorrect estimates.

## Impact

- Each recorded LLM step now contains detailed usage and estimated cost.
- Run summaries expose aggregate usage at each task level without changing the agent's model behavior.
- Desktop users can inspect totals immediately at task completion, while output files and telemetry retain the detailed breakdown for later analysis.
- Cost remains explicitly estimated and depends on the configured catalog price and provider-reported usage.

## Screenshot

Desktop task completion metadata after this change (screenshot will be attached here before review).

## Validation

- `cargo test --workspace` — 98 passed, 2 ignored
- `pnpm --dir app run build`
- `node scripts/sync-model-catalog.mjs --no-official --check`
- Rust formatting check for changed files
- `git diff --check`

