### PR TITLE
Improve agent context-window efficiency

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,6 +116,7 @@ in [Website deployment](docs/website-deployment.md).
 | Doc | Covers |
 | --- | --- |
 | [Data model](docs/data-model.md) | Run artifacts, desktop task index, and timeline replay. |
+| [Context window management](docs/context-window-management.md) | Agent turns, tool-result bounds, sawtooth compaction, prompt caching, and artifact evidence retention. |
 | [CLI telemetry schema](docs/telemetry-schema.md) | Telemetry schema, privacy, and configuration contract for the CLI daemon. |
 | [Telemetry runbook](docs/development/telemetry-runbook.md) | Maintainer runbook for operating CLI telemetry. |
 | [Release flow](docs/release-flow.md) | GitHub Release workflow, platform build graph, assets, and installer smoke tests. |

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -317,6 +317,17 @@ export function formatStepCount(count: number): string {
   return `${count} step${count === 1 ? "" : "s"}`;
 }
 
+function formatTokenCount(value: number): string {
+  const compact = (divisor: number, suffix: string) => {
+    const scaled = value / divisor;
+    const digits = scaled >= 100 ? 0 : 1;
+    return `${Number(scaled.toFixed(digits))}${suffix}`;
+  };
+  if (value > 1_000_000) return compact(1_000_000, "M");
+  if (value > 1_000) return compact(1_000, "K");
+  return value.toLocaleString(getLocale());
+}
+
 export function formatTokenUsage(
   inputTokens: number,
   outputTokens: number,
@@ -326,7 +337,7 @@ export function formatTokenUsage(
   costCurrency: string | null = null,
 ): string {
   const locale = getLocale();
-  const number = (value: number) => value.toLocaleString(locale);
+  const number = formatTokenCount;
   const parts = currentLanguage === "zh"
     ? [`输入 ${number(inputTokens)} / 输出 ${number(outputTokens)} tokens`]
     : [`in ${number(inputTokens)} / out ${number(outputTokens)} tokens`];
@@ -342,16 +353,17 @@ export function formatTokenUsage(
       : `cache write ${number(cacheCreationInputTokens)}`);
   }
   if (estimatedCost !== null && costCurrency) {
+    const cents = Math.trunc(estimatedCost * 100) / 100;
     let amount: string;
     try {
       amount = new Intl.NumberFormat(locale, {
         style: "currency",
         currency: costCurrency,
-        minimumFractionDigits: 4,
-        maximumFractionDigits: 6,
-      }).format(estimatedCost);
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(cents);
     } catch {
-      amount = `${estimatedCost.toFixed(6)} ${costCurrency}`;
+      amount = `${cents.toFixed(2)} ${costCurrency}`;
     }
     parts.push(currentLanguage === "zh" ? `估算 ${amount}` : `est. ${amount}`);
   }

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -32,7 +32,10 @@ use crate::agent::llm::{
     Backend, Block, LLMResponse, Message, StopReason, TokenUsage, ToolCall, ToolResultContent,
     ToolSchema,
 };
-use crate::agent::memory::prepare_messages_for_context;
+use crate::agent::memory::{
+    compact_messages_for_context, DEFAULT_COMPACT_AFTER_MESSAGES,
+    DEFAULT_KEEP_RECENT_MESSAGES,
+};
 use crate::agent::report::report_with_artifacts;
 use crate::agent::run_logging::{make_run_dir, AgentRunRecorder};
 use crate::agent::run_state::RunState;
@@ -98,10 +101,10 @@ pub struct AgentOptions {
     pub run_dir: Option<PathBuf>,
     /// Site names to pre-enable in ToolContext (gates `defer_until_site` tools).
     pub enabled_sites: Vec<String>,
-    /// Recent-message window kept verbatim when history is condensed.
+    /// Full-message count that triggers deterministic transcript compaction.
+    pub compact_after_messages: usize,
+    /// Recent full-message window kept verbatim after compaction.
     pub keep_recent_messages: usize,
-    /// Memory budget for the condensed context_block.
-    pub memory_max_chars: usize,
     /// Prior chat-level messages to seed the conversation with, so a reply can
     /// continue an ongoing conversation. The current task is appended as
     /// the final user message. Empty = a fresh, single-shot run.
@@ -118,8 +121,8 @@ impl Default for AgentOptions {
             extra_instructions: String::new(),
             run_dir: None,
             enabled_sites: Vec::new(),
-            keep_recent_messages: 12,
-            memory_max_chars: 6000,
+            compact_after_messages: DEFAULT_COMPACT_AFTER_MESSAGES,
+            keep_recent_messages: DEFAULT_KEEP_RECENT_MESSAGES,
             seed_messages: Vec::new(),
             session_id: None,
         }
@@ -205,7 +208,6 @@ pub async fn run_agent_with_events(
     let mut step = 0u32;
     let mut final_text = String::new();
     let mut usage = TokenUsage::default();
-    let mut context_memory: Vec<String> = Vec::new();
     let mut tool_call_history: BTreeMap<String, Vec<u32>> = BTreeMap::new();
     let mut completed = false;
     let mut terminal_error: Option<String> = None;
@@ -222,13 +224,18 @@ pub async fn run_agent_with_events(
         let tool_names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
         let system = build_system_prompt(&tool_names, &options.extra_instructions);
         last_system = system.clone();
-        let request_messages = prepare_messages_for_context(
-            &messages,
-            Some(&run_state),
-            &context_memory,
+        if compact_messages_for_context(
+            &mut messages,
+            options.compact_after_messages,
             options.keep_recent_messages,
-            options.memory_max_chars,
-        );
+        ) {
+            // The trace is an append-only diagnostic record. The rewritten
+            // transcript is local context management, so restart its cursor
+            // rather than attempting to represent the synthetic summary as a
+            // normal user message in the trace.
+            traced_len = messages.len();
+        }
+        let request_messages = messages.clone();
         let request_payload =
             backend.request_payload(&system, &request_messages, &schemas, options.max_tokens)?;
         run_recorder.record_llm_request(step, &request_payload)?;
@@ -465,17 +472,6 @@ pub async fn run_agent_with_events(
                 content: history_content,
             });
 
-            context_memory.push(format!(
-                "- step {step} {name}({}): {summary}",
-                truncate_summary(
-                    &serde_json::to_string(&effective_input).unwrap_or_default(),
-                    160,
-                )
-            ));
-            if context_memory.len() > 80 {
-                let overflow = context_memory.len() - 80;
-                context_memory.drain(0..overflow);
-            }
             ctx.active_tool_name.clear();
         }
         messages.push(Message::user_blocks(tool_result_blocks));
@@ -491,13 +487,14 @@ pub async fn run_agent_with_events(
              what is missing, and give your best-effort conclusion.",
             options.max_steps
         )));
-        let request_messages = prepare_messages_for_context(
-            &messages,
-            Some(&run_state),
-            &context_memory,
+        if compact_messages_for_context(
+            &mut messages,
+            options.compact_after_messages,
             options.keep_recent_messages,
-            options.memory_max_chars,
-        );
+        ) {
+            traced_len = messages.len();
+        }
+        let request_messages = messages.clone();
         let request_payload =
             backend.request_payload(&last_system, &request_messages, &[], options.max_tokens)?;
         run_recorder.record_llm_request(step + 1, &request_payload)?;

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -201,10 +201,14 @@ fn extract_markdown_evidence(markdown: &str) -> (BTreeSet<(String, String)>, BTr
 
     while let Some(open_offset) = markdown[cursor..].find('[') {
         let open = cursor + open_offset;
-        let Some(close_offset) = markdown[open + 1..].find("](") else {
+        let Some(close_offset) = markdown[open + 1..].find(']') else {
             break;
         };
         let close = open + 1 + close_offset;
+        if markdown.as_bytes().get(close + 1) != Some(&b'(') {
+            cursor = close + 1;
+            continue;
+        }
         let target_start = close + 2;
         let Some(target_offset) = markdown[target_start..].find(')') else {
             break;

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -9,11 +9,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
 
-use crate::agent::llm::{Block, Message, MessageContent, ToolResultContent};
+use crate::agent::llm::{Block, Message, MessageContent, MessageRole, ToolResultContent};
 
 pub const DEFAULT_COMPACT_AFTER_MESSAGES: usize = 20;
 pub const DEFAULT_KEEP_RECENT_MESSAGES: usize = 10;
-const EVIDENCE_HEADING: &str = "# Earlier tool evidence";
+const TURN_MARKDOWN_MAX_CHARS: usize = 2_000;
+const USER_REQUEST_MAX_CHARS: usize = 500;
+const COMPACT_CONTEXT_HEADING: &str = "# Earlier compacted context";
+const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 
 /// Rewrite the transcript only when it has grown beyond `compact_after` full
 /// messages. The original first message remains, the last `keep_recent`
@@ -53,14 +56,33 @@ pub fn compact_messages_for_context(
 fn compact_older_messages(messages: &[Message]) -> String {
     let mut inherited = Vec::new();
     let mut artifacts: BTreeMap<String, BTreeSet<(String, String)>> = BTreeMap::new();
+    let mut turns = Vec::new();
+    let mut pending_user: Option<String> = None;
 
     for message in messages {
-        if let MessageContent::Text(text) = &message.content {
-            if text.starts_with(EVIDENCE_HEADING) {
-                inherited.push(text.trim().to_string());
+        match (&message.role, &message.content) {
+            (MessageRole::User, MessageContent::Text(text)) => {
+                if text.starts_with(COMPACT_CONTEXT_HEADING)
+                    || text.starts_with(LEGACY_EVIDENCE_HEADING)
+                {
+                    inherited.push(text.trim().to_string());
+                } else {
+                    pending_user = Some(text.trim().to_string());
+                }
+                continue;
             }
-            continue;
+            (MessageRole::Assistant, _) => {
+                if let Some(markdown) = assistant_report_markdown(message) {
+                    turns.push(compact_turn_markdown(
+                        pending_user.take().as_deref(),
+                        &markdown,
+                    ));
+                    continue;
+                }
+            }
+            _ => {}
         }
+
         let MessageContent::Blocks(blocks) = &message.content else {
             continue;
         };
@@ -80,10 +102,20 @@ fn compact_older_messages(messages: &[Message]) -> String {
         }
     }
 
-    let mut sections = inherited;
+    let mut rendered = if inherited.is_empty() {
+        COMPACT_CONTEXT_HEADING.to_string()
+    } else {
+        inherited.join("\n\n")
+    };
+    if !turns.is_empty() {
+        rendered.push_str("\n\n## Earlier conversation turns\n");
+        for (index, turn) in turns.iter().enumerate() {
+            rendered.push_str(&format!("\n### Turn {}\n{}", index + 1, turn));
+        }
+    }
     if !artifacts.is_empty() {
-        let mut rendered = String::from(EVIDENCE_HEADING);
-        rendered.push_str("\nFull data is available in the listed artifacts.\n");
+        rendered.push_str("\n\n## Earlier tool evidence\n");
+        rendered.push_str("Full data is available in the listed artifacts.\n");
         for (path, entities) in artifacts {
             rendered.push_str(&format!("\n## Artifact: {path}\n"));
             for (id, title) in entities {
@@ -94,9 +126,118 @@ fn compact_older_messages(messages: &[Message]) -> String {
                 }
             }
         }
-        sections.push(rendered);
     }
-    sections.join("\n\n")
+    rendered
+}
+
+fn assistant_report_markdown(message: &Message) -> Option<String> {
+    if !matches!(message.role, MessageRole::Assistant) {
+        return None;
+    }
+    match &message.content {
+        MessageContent::Text(text) => (!text.trim().is_empty()).then(|| text.trim().to_string()),
+        MessageContent::Blocks(blocks) => {
+            if blocks
+                .iter()
+                .any(|block| !matches!(block, Block::Text { .. }))
+            {
+                return None;
+            }
+            let markdown = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    Block::Text { text } => Some(text.trim()),
+                    _ => None,
+                })
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            (!markdown.is_empty()).then_some(markdown)
+        }
+    }
+}
+
+fn compact_turn_markdown(user: Option<&str>, markdown: &str) -> String {
+    let mut rendered = String::new();
+    if let Some(user) = user.filter(|text| !text.trim().is_empty()) {
+        rendered.push_str("User request:\n");
+        rendered.push_str(&truncate_chars(user, USER_REQUEST_MAX_CHARS));
+        rendered.push_str("\n\n");
+    }
+    rendered.push_str("Assistant report excerpt:\n");
+    rendered.push_str(&truncate_chars(markdown, TURN_MARKDOWN_MAX_CHARS));
+
+    let (notes, artifacts) = extract_markdown_evidence(markdown);
+    if !notes.is_empty() || !artifacts.is_empty() {
+        rendered.push_str("\n\nExtracted evidence:\n");
+        for (id, title) in notes {
+            if title.is_empty() {
+                rendered.push_str(&format!("- note_id: {id}\n"));
+            } else {
+                rendered.push_str(&format!("- note_id: {id}; title: {title}\n"));
+            }
+        }
+        for path in artifacts {
+            rendered.push_str(&format!("- artifact: {path}\n"));
+        }
+    }
+    rendered
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= max_chars {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(max_chars).collect();
+    out.push_str("\n\n[truncated; full report remains in the run artifact]");
+    out
+}
+
+fn extract_markdown_evidence(markdown: &str) -> (BTreeSet<(String, String)>, BTreeSet<String>) {
+    let mut notes = BTreeSet::new();
+    let mut artifacts = BTreeSet::new();
+    let mut cursor = 0;
+
+    while let Some(open_offset) = markdown[cursor..].find('[') {
+        let open = cursor + open_offset;
+        let Some(close_offset) = markdown[open + 1..].find("](") else {
+            break;
+        };
+        let close = open + 1 + close_offset;
+        let target_start = close + 2;
+        let Some(target_offset) = markdown[target_start..].find(')') else {
+            break;
+        };
+        let target_end = target_start + target_offset;
+        let title = markdown[open + 1..close].trim();
+        let target = markdown[target_start..target_end].trim();
+
+        if let Some(note_id) = target.strip_prefix("note:") {
+            let note_id = note_id.trim();
+            if !note_id.is_empty() {
+                notes.insert((note_id.to_string(), title.to_string()));
+            }
+        } else if is_artifact_link(target) {
+            artifacts.insert(target.to_string());
+        }
+        cursor = target_end + 1;
+    }
+
+    (notes, artifacts)
+}
+
+fn is_artifact_link(target: &str) -> bool {
+    let normalized = target.replace('\\', "/");
+    normalized.contains("/.socai/runs/")
+        || normalized.starts_with("artifacts/")
+        || normalized.contains("/artifacts/")
+        || normalized.starts_with("tools/")
+        || normalized.contains("/tools/")
+        || normalized.starts_with("snapshots/")
+        || normalized.contains("/snapshots/")
+        || normalized.starts_with("site_media/")
+        || normalized.contains("/site_media/")
 }
 
 fn collect_artifact_evidence(

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -1,104 +1,142 @@
-//! Context-window management for long agent runs.
+//! Deterministic, artifact-first context compaction for long agent runs.
 //!
-//! When the history is short, send it as-is. When it gets long, replace
-//! the older half with a single user-role message containing:
-//!   - the run-state context block (working memory render, capped)
-//!   - a condensed list of recent tool events
-//!
-//! This is deliberately deterministic and local — no extra summarizer call.
+//! Keep a growing tail of full messages so the provider can reuse its prompt
+//! cache. Once that tail reaches its limit, replace only the older tool
+//! results with durable evidence locators (post/author id, title, artifact
+//! path), then start growing the tail again.
 
-use std::sync::Arc;
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::agent::llm::{Block, Message, MessageContent, MessageRole};
-use crate::agent::run_state::RunState;
+use serde_json::Value;
 
-pub fn prepare_messages_for_context(
-    messages: &[Message],
-    run_state: Option<&Arc<RunState>>,
-    memory_entries: &[String],
+use crate::agent::llm::{Block, Message, MessageContent, ToolResultContent};
+
+pub const DEFAULT_COMPACT_AFTER_MESSAGES: usize = 20;
+pub const DEFAULT_KEEP_RECENT_MESSAGES: usize = 10;
+const EVIDENCE_HEADING: &str = "# Earlier tool evidence";
+
+/// Rewrite the transcript only when it has grown beyond `compact_after` full
+/// messages. The original first message remains, the last `keep_recent`
+/// messages remain verbatim, and the older tool outputs become artifact
+/// locators. Mutating the transcript, rather than rebuilding a summary for
+/// every request, leaves the request prefix stable until the next sawtooth
+/// compaction point and therefore friendly to provider prompt caches.
+pub fn compact_messages_for_context(
+    messages: &mut Vec<Message>,
+    compact_after: usize,
     keep_recent: usize,
-    memory_max_chars: usize,
-) -> Vec<Message> {
-    if messages.len() <= keep_recent + 2 {
-        return messages.to_vec();
-    }
-    let mut sections: Vec<String> = Vec::new();
-    if let Some(state) = run_state {
-        let block = state.context_block(memory_max_chars.max(1200) / 2);
-        if !block.trim().is_empty() {
-            sections.push(format!(
-                "Structured run state from earlier steps:\n\n{block}"
-            ));
-        }
-    }
-    let memory = compact_memory_entries(memory_entries, memory_max_chars);
-    if !memory.is_empty() {
-        sections.push(format!(
-            "Condensed event memory from earlier steps:\n\n{memory}"
-        ));
-    }
-    if sections.is_empty() {
-        return messages.to_vec();
-    }
-
-    let mut recent: Vec<Message> = messages.iter().rev().take(keep_recent).cloned().collect();
-    recent.reverse();
-    while recent.first().map(is_tool_result_message).unwrap_or(false) {
-        recent.remove(0);
-    }
-    let mut out = Vec::with_capacity(2 + recent.len());
-    out.push(messages[0].clone());
-    out.push(Message::user(sections.join("\n\n")));
-    out.extend(recent);
-    out
-}
-
-/// Detect whether a message looks like a tool-result wrapper. The windowing
-/// routine uses this to avoid stripping the user-side half of a
-/// tool_call/tool_result pair (the assistant step would then refer to a
-/// tool_call_id the model has lost context for).
-pub fn is_tool_result_message(message: &Message) -> bool {
-    if !matches!(message.role, MessageRole::User) {
+) -> bool {
+    if compact_after == 0
+        || keep_recent == 0
+        || keep_recent >= compact_after
+        || messages.len() <= compact_after
+    {
         return false;
     }
-    match &message.content {
-        MessageContent::Blocks(blocks) => {
-            blocks.iter().any(|b| matches!(b, Block::ToolResult { .. }))
-        }
-        _ => false,
+
+    let recent_start = messages.len() - keep_recent;
+    let original = messages[0].clone();
+    let older = &messages[1..recent_start];
+    let recent = messages[recent_start..].to_vec();
+    let evidence = compact_older_messages(older);
+
+    let mut compacted = Vec::with_capacity(2 + recent.len());
+    compacted.push(original);
+    if !evidence.is_empty() {
+        compacted.push(Message::user(evidence));
     }
+    compacted.extend(recent);
+    *messages = compacted;
+    true
 }
 
-pub fn compact_memory_entries(entries: &[String], max_chars: usize) -> String {
-    if entries.is_empty() || max_chars == 0 {
-        return String::new();
-    }
-    let mut selected: Vec<&String> = Vec::new();
-    let mut total = 0usize;
-    for entry in entries.iter().rev() {
-        let trimmed = entry.trim();
-        if trimmed.is_empty() {
+fn compact_older_messages(messages: &[Message]) -> String {
+    let mut inherited = Vec::new();
+    let mut artifacts: BTreeMap<String, BTreeSet<(String, String)>> = BTreeMap::new();
+
+    for message in messages {
+        if let MessageContent::Text(text) = &message.content {
+            if text.starts_with(EVIDENCE_HEADING) {
+                inherited.push(text.trim().to_string());
+            }
             continue;
         }
-        let projected = total + trimmed.len() + 1;
-        if !selected.is_empty() && projected > max_chars {
-            break;
-        }
-        selected.push(entry);
-        total = projected.min(max_chars);
-        if total >= max_chars {
-            break;
+        let MessageContent::Blocks(blocks) = &message.content else {
+            continue;
+        };
+        for block in blocks {
+            let Block::ToolResult { content, .. } = block else {
+                continue;
+            };
+            for item in content {
+                let ToolResultContent::Text { text } = item else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_str::<Value>(text) else {
+                    continue;
+                };
+                collect_artifact_evidence(&value, &mut artifacts);
+            }
         }
     }
-    selected.reverse();
-    let joined = selected
-        .into_iter()
-        .map(|s| s.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
-    if joined.chars().count() > max_chars {
-        joined.chars().take(max_chars).collect()
-    } else {
-        joined
+
+    let mut sections = inherited;
+    if !artifacts.is_empty() {
+        let mut rendered = String::from(EVIDENCE_HEADING);
+        rendered.push_str("\nFull data is available in the listed artifacts.\n");
+        for (path, entities) in artifacts {
+            rendered.push_str(&format!("\n## Artifact: {path}\n"));
+            for (id, title) in entities {
+                if title.is_empty() {
+                    rendered.push_str(&format!("- {id}\n"));
+                } else {
+                    rendered.push_str(&format!("- {id} — {title}\n"));
+                }
+            }
+        }
+        sections.push(rendered);
+    }
+    sections.join("\n\n")
+}
+
+fn collect_artifact_evidence(
+    value: &Value,
+    artifacts: &mut BTreeMap<String, BTreeSet<(String, String)>>,
+) {
+    let Some(path) = value
+        .pointer("/artifact/path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return;
+    };
+    let entities = artifacts.entry(path.to_string()).or_default();
+
+    if let Some(author_id) = value.get("author_id").and_then(Value::as_str) {
+        let title = value
+            .pointer("/profile/nickname")
+            .or_else(|| value.pointer("/profile/display_name"))
+            .or_else(|| value.pointer("/profile/name"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        entities.insert((format!("author:{author_id}"), title.to_string()));
+    }
+
+    for key in ["notes", "cards"] {
+        let Some(items) = value.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        for item in items {
+            let entity = item.get("entity").unwrap_or(item);
+            let id = entity
+                .get("note_id")
+                .or_else(|| entity.get("id"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let title = entity.get("title").and_then(Value::as_str).unwrap_or("");
+            if !id.is_empty() || !title.is_empty() {
+                entities.insert((id.to_string(), title.to_string()));
+            }
+        }
     }
 }

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -7,6 +7,7 @@ from tool output, and finish with a concise report when the task is complete.\n\
 \n\
 Rules:\n\
 - Prefer high-level task/site tools over low-level manual actions when both exist.\n\
+- Issue at most two tool calls in one assistant step. If more work remains, wait for those results and continue in the next step.\n\
 - Do not invent observations. Use tool results as evidence.\n\
 - If a tool fails, explain the failure and choose a smaller recovery step.\n\
 - When enough evidence has been collected, stop calling tools and answer.\n";

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -300,8 +300,8 @@ pub fn ensure_llm_provider_configured_for(
 pub struct AgentRunConfig {
     pub max_steps: u32,
     pub max_tokens: u32,
+    pub compact_after_messages: usize,
     pub keep_recent_messages: usize,
-    pub memory_max_chars: usize,
     pub extra_instructions: String,
     pub enabled_sites: Vec<String>,
     pub run_dir: Option<PathBuf>,
@@ -318,8 +318,8 @@ impl Default for AgentRunConfig {
             // models (Sonnet 5 thinks by default), so 4096 starves the final
             // report. 16000 is the recommended non-streaming ceiling.
             max_tokens: 16000,
-            keep_recent_messages: 12,
-            memory_max_chars: 6000,
+            compact_after_messages: crate::agent::memory::DEFAULT_COMPACT_AFTER_MESSAGES,
+            keep_recent_messages: crate::agent::memory::DEFAULT_KEEP_RECENT_MESSAGES,
             extra_instructions: String::new(),
             enabled_sites: Vec::new(),
             run_dir: None,
@@ -346,8 +346,8 @@ pub async fn run_agent_task(
         extra_instructions: config.extra_instructions,
         run_dir: config.run_dir,
         enabled_sites: config.enabled_sites,
+        compact_after_messages: config.compact_after_messages,
         keep_recent_messages: config.keep_recent_messages,
-        memory_max_chars: config.memory_max_chars,
         seed_messages: config.seed_messages,
         session_id: config.session_id,
     };

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -78,7 +78,7 @@ Shared options (same meaning for both):
 
 - `num_notes=N` — how many notes to collect (default 10); raise only when the
   question needs broader evidence.
-- `num_comments=N` — how many comments to load per note (default 8; replies
+- `num_comments=N` — how many comments to load per note (default 5; replies
   count toward N). Use the default unless the question is about the discussion itself.
   N ≤ 12 usually loads without extra scrolling, larger values add scroll/expand rounds 
   and latency. `0` skips comments. Ignored in `preview` mode.

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -47,6 +47,11 @@ const SEARCH_WAIT_SECONDS: f64 = 2.0;
 /// (one extra JS read, no extra navigation), so every note read includes them.
 const TOP_COMMENTS_PER_NOTE: i64 = 8;
 
+/// Default comment depth for the agent's composite search tools. Keep this
+/// lower than the CLI's top-level default so multi-note agent runs spend less
+/// context and latency on comment threads.
+const AGENT_TOP_COMMENTS_PER_NOTE: i64 = 5;
+
 /// XHS macro-agent playbook for the single app/TUI agent interface. Embedded
 /// at compile time so the agent prompt always carries the latest copy.
 pub const XHS_KNOWLEDGE: &str = include_str!("knowledge.md");
@@ -3034,7 +3039,7 @@ impl Tool for SearchTool {
                 "num_comments": {
                     "type": "integer",
                     "description": "Comments to load per note. Scrolls the comment area and expands reply threads to reach this many; replies count toward the total. Higher values add latency per note. Ignored in preview mode.",
-                    "default": TOP_COMMENTS_PER_NOTE,
+                    "default": AGENT_TOP_COMMENTS_PER_NOTE,
                     "minimum": 0
                 },
                 "download_media": {
@@ -3259,7 +3264,7 @@ impl Tool for SearchTool {
                 "sampling": {
                     "num_notes": num_notes,
                     "selected": 0,
-                    "comments_per_note": TOP_COMMENTS_PER_NOTE,
+                    "comments_per_note": AGENT_TOP_COMMENTS_PER_NOTE,
                     "include_media": include_media,
                     "download_media": download_media,
                     "ocr": ocr,
@@ -3280,7 +3285,7 @@ impl Tool for SearchTool {
         // Every sampled note is read with the same extraction level (body +
         // top comments).
         let level = "deep";
-        let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
+        let comment_count = get_i64(&input, "num_comments", AGENT_TOP_COMMENTS_PER_NOTE).max(0);
         let want = num_notes.max(1) as usize;
 
         // Read top-to-bottom: pull cards from the results state (which only
@@ -3588,7 +3593,7 @@ impl Tool for AuthorScanTool {
                 "num_comments": {
                     "type": "integer",
                     "description": "Comments to load per note. Scrolls the comment area and expands reply threads to reach this many; replies count toward the total. Higher values add latency per note. Ignored in preview mode.",
-                    "default": TOP_COMMENTS_PER_NOTE,
+                    "default": AGENT_TOP_COMMENTS_PER_NOTE,
                     "minimum": 0
                 },
                 "preview": {
@@ -3658,7 +3663,7 @@ impl Tool for AuthorScanTool {
             .and_then(Value::as_i64)
             .filter(|n| *n > 0)
             .map(|n| n as usize);
-        let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
+        let comment_count = get_i64(&input, "num_comments", AGENT_TOP_COMMENTS_PER_NOTE).max(0);
 
         // Media processor only needed when downloading note media (no vision,
         // so no LLM provider required).

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -1988,15 +1988,17 @@ fn attach_note_audio_transcript(entity: &mut Value) {
     }
 }
 
-/// Surface OCR text on the entity as `ocr_text`: an array of one string per
-/// OCR'd image, cover-first. For an image note that's the carousel in image
-/// order (image 0 is the cover); for a video note it's the poster's OCR (the
-/// poster is the cover, and the only OCR surface). Each entry is that image's
-/// recognized text ("" when an image has none). No-op when nothing produced
-/// any text. Called only during lean trimming (see [`lean_scan_note`]) so the
-/// artifact keeps only the per-image / poster OCR; this is the lean,
-/// index-aligned view that survives images and video being dropped from the
-/// returned notes.
+/// Number of cover-first image OCR entries kept per note in the LLM-facing
+/// lean result. The scan and its artifact still retain OCR for every image.
+const LEAN_NOTE_OCR_MAX_IMAGES: usize = 2;
+
+/// Surface OCR text on the entity as `ocr_text`: up to two cover-first OCR'd
+/// image strings. For an image note these are the first carousel images; for a
+/// video note it's the poster's OCR (the cover, and the only OCR surface).
+/// Each entry is that image's recognized text ("" when an image has none).
+/// No-op when nothing produced any text. Called only during lean trimming (see
+/// [`lean_scan_note`]) so the artifact retains the complete per-image / poster
+/// OCR while the returned result stays bounded.
 fn attach_note_ocr_summary(entity: &mut Value) {
     let mut texts: Vec<Value> = Vec::new();
     if let Some(poster) = entity
@@ -2007,7 +2009,8 @@ fn attach_note_ocr_summary(entity: &mut Value) {
         texts.push(Value::String(truncate(poster, 1200)));
     }
     if let Some(images) = entity.get("images").and_then(Value::as_array) {
-        texts.extend(images.iter().map(|image| {
+        let remaining = LEAN_NOTE_OCR_MAX_IMAGES.saturating_sub(texts.len());
+        texts.extend(images.iter().take(remaining).map(|image| {
             let text = image
                 .get("ocr_text")
                 .and_then(Value::as_str)
@@ -3041,7 +3044,7 @@ impl Tool for SearchTool {
                 },
                 "ocr": {
                     "type": "boolean",
-                    "description": "Run local OCR (PP-OCRv6 small). Full scan: OCR each opened note — every carousel image, or a video note's cover — downloading what it reads (video files still require download_media); each returned note gets ocr_text as an array of per-image strings (image order, cover first). Preview: OCR each card's cover image and attach its ocr_text. Per-image ocr_text/ocr_ms and OCR diagnostics are kept in the artifact.",
+                    "description": "Run local OCR (PP-OCRv6 small). Full scan: OCR each opened note — every carousel image, or a video note's cover — downloading what it reads (video files still require download_media); returned notes expose OCR for at most their first two cover-first images. Preview: OCR each card's cover image and attach its ocr_text. Full per-image ocr_text/ocr_ms and OCR diagnostics are kept in the artifact.",
                     "default": false
                 },
                 "transcribe_audio": {
@@ -3600,7 +3603,7 @@ impl Tool for AuthorScanTool {
                 },
                 "ocr": {
                     "type": "boolean",
-                    "description": "Run local OCR (PP-OCRv6 small) on each opened note — every carousel image, or a video note's cover — attaching per-image ocr_text in the artifact and a joined per-note ocr_text in the returned notes. Downloads what it reads on its own; video files still require download_media. In preview mode, OCRs each note card's cover instead.",
+                    "description": "Run local OCR (PP-OCRv6 small) on each opened note — every carousel image, or a video note's cover — retaining per-image ocr_text in the artifact and returning at most the first two cover-first image texts per note. Downloads what it reads on its own; video files still require download_media. In preview mode, OCRs each note card's cover instead.",
                     "default": false
                 },
                 "transcribe_audio": {

--- a/docs/context-window-management.md
+++ b/docs/context-window-management.md
@@ -1,0 +1,136 @@
+# Context Window Management
+
+This document describes how socai builds, bounds, and compacts the agent
+context used by the CLI/TUI and desktop app. The shared implementation lives in
+`core/src/agent/` and is used by every entrypoint.
+
+## Terminology
+
+- A **conversation turn** is one persisted user request and its final assistant
+  report. A follow-up turn seeds the next agent run with two messages per prior
+  turn: the user request and the assistant Markdown report.
+- A **step** is one iteration of the in-run agent loop and normally corresponds
+  to one LLM request and response.
+- A **tool call** is one action requested by the model inside a step. One step
+  may contain multiple tool calls.
+
+When a step contains tool calls, socai appends one assistant message containing
+all `tool_use` blocks, executes the tools sequentially in model-specified order,
+and appends one user message containing all matching `tool_result` blocks. The
+next step receives all of those results together. A tool-using step therefore
+adds two full messages regardless of whether it contains one or several tool
+calls.
+
+The base system prompt tells the model to issue at most two tool calls in one
+assistant step and to wait for their results before planning more work. This is
+a model-visible scheduling policy, not a parallel executor or a hard runtime
+truncation rule. The runtime remains sequential and does not silently discard
+additional calls if a provider violates the instruction.
+
+## Context layers
+
+The request context has four relevant layers:
+
+1. The system prompt, site playbook, current date, available tool names, and
+   entrypoint-specific instructions.
+2. Seed messages from earlier conversation turns.
+3. Full assistant/tool-result messages from the current agent run.
+4. A deterministic compacted-context message after the history crosses the
+   sawtooth threshold.
+
+Run artifacts are the durable evidence store. Context compaction changes only
+what is replayed to the model; it does not rewrite or truncate the JSON, media,
+LLM request/response, or tool-call records saved under the run directory.
+
+## Tool-result bounds before history compaction
+
+Every raw tool result is written to its tool-call directory before the result is
+bounded for model history. The LLM-facing text has a 30,000-character ceiling.
+If an oversized result is JSON, degradation happens in this order:
+
+1. Cap each `ocr_text` value to 1,000 characters in total. For string arrays,
+   keep complete leading entries until the budget is exhausted and mark the
+   truncation.
+2. Replace `top_comments` with an artifact pointer marker if the result is still
+   too large.
+3. Compact JSON objects, arrays, and string leaves while keeping note body text
+   longer than generic strings.
+4. Apply a final character truncation only as a last resort.
+
+Xiaohongshu search and author-scan results are already artifact-first before
+this generic limit runs. Their full artifacts retain per-image OCR. The lean
+tool result exposes OCR from at most the first two cover-first images per note,
+with each returned image text capped at 1,200 characters.
+
+## Sawtooth message window
+
+The default window uses two values:
+
+- compact after the transcript grows beyond 20 full messages;
+- retain the most recent 10 full messages verbatim.
+
+For a fresh run with one initial user message and one tool-using step at a time,
+the transcript grows as `1 + 2 * steps`. Ten completed tool-using steps produce
+21 messages, so compaction runs immediately before the next model request.
+
+At a compaction point, socai rewrites the in-memory transcript to:
+
+1. the original first message;
+2. one deterministic compacted-context message;
+3. the most recent 10 full messages.
+
+The recent tail then grows normally until the next threshold. Rewriting only at
+these points creates a sawtooth window and keeps the request prefix stable
+between compactions, which is friendlier to provider prompt caching than
+regenerating a different summary before every request.
+
+## Compacting earlier conversation turns
+
+Prior turns are seeded as user text followed by an assistant Markdown report.
+When those messages move into the compacted region, socai emits compact Markdown
+for each recognized report containing:
+
+- up to 500 characters of its associated user request, when available;
+- the first 2,000 characters of the assistant report;
+- every note citation found in the full report using the canonical
+  `[title](note:NOTE_ID)` form;
+- artifact links found in the full report when their targets point into known
+  run artifact locations such as `artifacts/`, `tools/`, `snapshots/`,
+  `site_media/`, or an absolute `.socai/runs/` path.
+
+Evidence extraction scans the complete Markdown report, not only its
+2,000-character excerpt. Earlier compacted Markdown is carried forward when the
+next sawtooth compaction occurs.
+
+Markdown without canonical note links cannot yield a reliable note ID or title.
+Likewise, a run path that never appears as a Markdown link is not inferred from
+free-form prose. The desktop/TUI conversation preamble separately lists earlier
+run directories and `notes.json` evidence so the agent can use `read_file` when
+it needs full cross-turn details.
+
+## Compacting earlier structured tool results
+
+Older `tool_result` text is parsed as JSON. When the result contains an
+`artifact.path`, the compacted context retains:
+
+- the artifact path;
+- note IDs and titles from `notes` or `cards`, accepting either direct entities
+  or `{ "entity": ... }` wrappers;
+- an author ID and available profile name for author-scan results.
+
+Body text, OCR, comments, timing details, engagement metadata, and other large
+fields are omitted from this compact representation because the artifact path
+is the durable lookup key. Duplicate entity entries are removed
+deterministically.
+
+## Source locations
+
+- `core/src/agent/loop.rs`: message lifecycle, sequential tool execution, and
+  compaction trigger points.
+- `core/src/agent/memory.rs`: sawtooth rewrite and compact Markdown/JSON evidence
+  extraction.
+- `core/src/agent/compaction.rs`: per-tool-result character and JSON bounds.
+- `core/src/agent/conversation.rs`: persisted turns and seed-message creation.
+- `core/src/agent/system_prompt.rs`: model-visible two-tool-call policy.
+- `core/src/sites/xhs/tools.rs`: artifact-first XHS result shaping and OCR lean
+  output.

--- a/docs/context-window-management.md
+++ b/docs/context-window-management.md
@@ -14,6 +14,13 @@ context used by the CLI/TUI and desktop app. The shared implementation lives in
 - A **tool call** is one action requested by the model inside a step. One step
   may contain multiple tool calls.
 
+| Concept | Concrete example | Messages added to the active transcript |
+| --- | --- | ---: |
+| Conversation turn | User asks a question and receives the final Markdown report | Two seed messages in the next turn |
+| Step without tools | Model returns the final answer | The run ends |
+| Step with one tool | Model calls `search`, then receives its result | Two messages |
+| Step with two tools | Model calls `search` and `author_scan` together | Still two messages |
+
 When a step contains tool calls, socai appends one assistant message containing
 all `tool_use` blocks, executes the tools sequentially in model-specified order,
 and appends one user message containing all matching `tool_result` blocks. The
@@ -27,6 +34,25 @@ a model-visible scheduling policy, not a parallel executor or a hard runtime
 truncation rule. The runtime remains sequential and does not silently discard
 additional calls if a provider violates the instruction.
 
+For example, two calls in one step are scheduled like this:
+
+```mermaid
+sequenceDiagram
+    participant M as Model
+    participant R as Agent runtime
+    participant S as search
+    participant A as author_scan
+    M->>R: assistant message: search + author_scan
+    R->>S: execute call 1
+    S-->>R: result 1
+    R->>A: execute call 2
+    A-->>R: result 2
+    R-->>M: one user message containing both results
+```
+
+The model chooses the calls. The prompt asks it to choose no more than two;
+the runtime executes those calls in order rather than concurrently.
+
 ## Context layers
 
 The request context has four relevant layers:
@@ -37,6 +63,14 @@ The request context has four relevant layers:
 3. Full assistant/tool-result messages from the current agent run.
 4. A deterministic compacted-context message after the history crosses the
    sawtooth threshold.
+
+| Layer | Typical contents | Can compaction shorten it? |
+| --- | --- | --- |
+| System | Rules, date, tool names, site instructions | No |
+| Earlier turns | User requests and final Markdown reports | Yes, after they enter the old region |
+| Recent in-run history | Assistant tool calls and tool results | No; the newest 10 messages stay verbatim |
+| Older in-run history | Earlier tool calls and structured results | Yes, to IDs, titles, and artifact paths |
+| Run artifacts | Full JSON, OCR, media, requests, responses | No |
 
 Run artifacts are the durable evidence store. Context compaction changes only
 what is replayed to the model; it does not rewrite or truncate the JSON, media,
@@ -62,6 +96,14 @@ this generic limit runs. Their full artifacts retain per-image OCR. The lean
 tool result exposes OCR from at most the first two cover-first images per note,
 with each returned image text capped at 1,200 characters.
 
+Example for a three-image note:
+
+| Location | OCR retained |
+| --- | --- |
+| `artifacts/search/*.json` | Images 1, 2, and 3, including their complete per-image OCR fields |
+| LLM-facing `search` result | OCR summaries for images 1 and 2 only, each capped at 1,200 characters |
+| Later compacted context | Note ID, title, and artifact path; OCR text is removed |
+
 ## Sawtooth message window
 
 The default window uses two values:
@@ -84,6 +126,28 @@ these points creates a sawtooth window and keeps the request prefix stable
 between compactions, which is friendlier to provider prompt caching than
 regenerating a different summary before every request.
 
+The first two compaction cycles look like this when every step uses tools:
+
+| Moment | Full-message count before the request | Action |
+| --- | ---: | --- |
+| Initial task | 1 | Send unchanged |
+| Step 10 | 19 | Send unchanged; its tool call and result grow history to 21 |
+| Step 11 | 21 | Compact to 12, then send |
+| Step 15 | 20 | Send unchanged; its tool call and result grow history to 22 |
+| Step 16 | 22 | Compact to 12 again, then send |
+
+```mermaid
+flowchart LR
+    A[1 message] --> B[3] --> C[...] --> D[19]
+    D --> E[21]
+    E -->|compact before next request| F[12]
+    F --> G[14] --> H[16] --> I[18] --> J[20] --> K[22]
+    K -->|compact before next request| L[12]
+```
+
+The post-compaction count is 12: the original message, one compacted-context
+message, and 10 recent messages.
+
 ## Compacting earlier conversation turns
 
 Prior turns are seeded as user text followed by an assistant Markdown report.
@@ -101,6 +165,35 @@ for each recognized report containing:
 Evidence extraction scans the complete Markdown report, not only its
 2,000-character excerpt. Earlier compacted Markdown is carried forward when the
 next sawtooth compaction occurs.
+
+For example, suppose an older turn ends with a 3,000-character report whose
+last section contains these links:
+
+```markdown
+[A useful note](note:note-123)
+[Full search result](artifacts/search/coffee.json)
+```
+
+Its compact representation is shaped like this:
+
+```markdown
+### Turn 1
+User request:
+<first 500 characters>
+
+Assistant report excerpt:
+<first 2,000 characters>
+
+[truncated; full report remains in the run artifact]
+
+Extracted evidence:
+- note_id: note-123; title: A useful note
+- artifact: artifacts/search/coffee.json
+```
+
+The links are retained even though they appeared after character 2,000 because
+evidence extraction scans the complete report. Ordinary Markdown such as a task
+checkbox (`[x]`) is ignored and cannot consume a later link's title.
 
 Markdown without canonical note links cannot yield a reliable note ID or title.
 Likewise, a run path that never appears as a Markdown link is not inferred from
@@ -122,6 +215,27 @@ Body text, OCR, comments, timing details, engagement metadata, and other large
 fields are omitted from this compact representation because the artifact path
 is the durable lookup key. Duplicate entity entries are removed
 deterministically.
+
+For example, this older tool result:
+
+```json
+{
+  "artifact": { "path": "artifacts/search/coffee.json" },
+  "notes": [
+    { "note_id": "note-123", "title": "A useful note", "ocr_text": ["..."] }
+  ]
+}
+```
+
+becomes approximately:
+
+```markdown
+## Artifact: artifacts/search/coffee.json
+- note-123 — A useful note
+```
+
+The model can reopen the artifact if it needs the omitted body, comments, or
+OCR rather than carrying those fields through every later step.
 
 ## Source locations
 


### PR DESCRIPTION
## Summary

- use a 20/10 sawtooth message window so context prefixes stay stable between compaction points
- compact older structured tool results to note/author IDs, titles, and artifact paths
- compact prior-turn Markdown reports to 2,000-character excerpts while extracting canonical note citations and artifact links from the full report
- tell the agent to issue at most two tool calls per step while retaining the existing sequential executor and combined result handoff
- reduce XHS agent defaults to five comments per note and expose only the first two images of OCR in the lean tool result while preserving complete artifacts
- compact desktop token counts with `K`/`M` suffixes and display estimated cost to cents
- document the context-window model with concrete examples, tables, and sequence/sawtooth diagrams

## Why

Long multi-step runs could accumulate full OCR, comments, and repeatedly regenerated context summaries, increasing token use and weakening prompt-cache reuse. The first sawtooth implementation also handled structured in-run tool JSON but did not preserve older conversation-turn Markdown reports. This change keeps a stable recent window, retains durable evidence locators, and gives cross-turn reports their own compact representation.

The two-tool-call rule belongs in the global agent prompt because it is a cross-tool planning constraint. The runtime remains sequential, so browser and filesystem tools keep their established ordering and no parallel execution machinery is introduced.

Local validation also found that a Markdown task checkbox such as `[x]` could be paired with a later note link by the original evidence scanner, corrupting the extracted title. The parser now accepts only adjacent `[title](target)` syntax.

## Impact

- lower and more predictable context growth in long desktop/CLI agent runs
- better prompt-cache-friendly prefixes between compaction points
- preserved cross-turn report excerpts and note/artifact references
- shorter OCR/comment payloads without losing full on-disk evidence
- more readable usage and cost metadata in the desktop conversation UI
- a more concrete reference for understanding turns, steps, sequential tool calls, OCR layers, and compaction cycles

## Validation

- `cargo test -p socai-core --lib` — 91 passed, 2 ignored
- `pnpm --dir app build`
- `rustfmt --edition 2021 --check core/src/agent/memory.rs core/src/agent/system_prompt.rs`
- `git diff --check`
