### PR TITLE
Add tokenized Xiaohongshu note lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ cargo install --path cli --force
 ```bash
 socai xhs search "运营爆款思路" --num-notes 30 --filter publish_time=一周内 --download-media  # 搜索并逐个打开帖子，获取正文+评论，并下载图片/视频
 socai xhs author <作者id> --num-notes 10 --preview                               # 打开作者主页，拿作者简介，并逐个打开帖子读正文+评论；加 --preview 则只拿帖子概要
+socai xhs get-notes --note '<帖子id>=<xsec_token>' --note '<帖子id>=<xsec_token>'  # 用 search/author 返回的 token 批量重新读取指定帖子
 socai stop                                                             # 停止 daemon（关闭工具标签页）
 ```
 

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -438,6 +438,7 @@ pub(crate) fn agent_event_to_timeline(event: &AgentEvent) -> AgentTaskEventKind 
 pub(crate) fn user_label(name: &str) -> String {
     match name {
         "search" => "searched xiaohongshu",
+        "get_notes" => "read xiaohongshu notes",
         "extract_search_cards" => "read search cards",
         "list_search_tabs" => "listed search tabs",
         "click_search_tab" => "switched search tab",
@@ -985,6 +986,19 @@ fn normalize_entities(tool: &str, value: &Value) -> Vec<TimelineEntity> {
             .get("entity")
             .filter(|entity| entity.is_object())
             .map(|entity_value| vec![entity("xhs_note", entity_value.clone())])
+            .unwrap_or_default(),
+        "get_notes" => value
+            .get("notes")
+            .and_then(Value::as_array)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter_map(|note| note.get("entity"))
+                    .filter(|entity| entity.is_object())
+                    .cloned()
+                    .map(|entity_value| entity("xhs_note", entity_value))
+                    .collect()
+            })
             .unwrap_or_default(),
         "extract_note" => {
             if value.is_object() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,6 +140,7 @@ fn arg_to_clap(arg: &'static CommandArg) -> Arg {
     }
     match arg.kind {
         ArgKind::Str => clap_arg,
+        ArgKind::StrList => clap_arg.action(ArgAction::Append),
         ArgKind::Int => clap_arg.value_parser(clap::value_parser!(i64)),
         ArgKind::Flag => clap_arg.action(ArgAction::SetTrue),
         ArgKind::KeyValueMap => clap_arg.action(ArgAction::Append),
@@ -154,6 +155,14 @@ fn collect_args(command: &'static SiteCommand, matches: &ArgMatches) -> Result<V
             ArgKind::Str => {
                 if let Some(value) = matches.get_one::<String>(arg.key) {
                     args.insert(arg.key.to_string(), Value::String(value.clone()));
+                }
+            }
+            ArgKind::StrList => {
+                if let Some(values) = matches.get_many::<String>(arg.key) {
+                    args.insert(
+                        arg.key.to_string(),
+                        Value::Array(values.cloned().map(Value::String).collect()),
+                    );
                 }
             }
             ArgKind::Int => {

--- a/core/src/sites/registry.rs
+++ b/core/src/sites/registry.rs
@@ -70,6 +70,8 @@ pub struct CommandArg {
 
 pub enum ArgKind {
     Str,
+    /// Repeatable string flag collected into a JSON array, preserving order.
+    StrList,
     Int,
     /// Boolean `--flag`; sent as `true` only when set.
     Flag,

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -22,6 +22,7 @@ The default interactive XHS tools are intentionally high level:
 
 - `search` — the topic/keyword search macro, and the single XHS search tool.
 - `author_scan` — author/profile macro.
+- `get_notes` — revisit specific notes by previously collected note id + xsec token.
 
 Stateful micro tools such as opening/closing a current note, scrolling a note,
 extracting the current modal, or reading current page state are not part of the
@@ -29,9 +30,11 @@ normal app/TUI agent workflow.
 
 ## Anti-Bot / Rate-Limit Guardrails
 
-Macro tools navigate through search/profile/card flows because direct detail
-URLs and rapid repeated reads are more likely to trigger Xiaohongshu security
-states. If a macro reports security verification, captcha, login/session loss,
+`search` and `author_scan` keep using search/profile card clicks for first-time
+discovery. `get_notes` may navigate directly only when each note has the xsec
+token previously returned by one of those flows. Direct detail reads and rapid
+repeats can still trigger Xiaohongshu security states. If a macro reports
+security verification, captcha, login/session loss,
 blank/404/app-only detail pages, or copy such as "帖子不见了" / "内容无法展示" /
 "page unavailable", do not loop the same macro with identical inputs. Treat it
 as a platform/session/rate-limit blocker: use whatever evidence was collected,
@@ -40,7 +43,7 @@ the route, and otherwise explain the blocker to the user.
 
 ## Login Detection
 
-Both macros run a pre-flight login gate: if logged out they return
+All three macros run a pre-flight login gate: if logged out they return
 `{ok:false, reason:"login_required"}` immediately (login is read from the
 persistent sidebar, so a dismissed QR modal is never mistaken for a session).
 
@@ -67,6 +70,9 @@ artifacts, and return a compact bundle. They differ only in where they enter:
   the profile header). Use for a specific creator. Needs an `author_id` (trailing
   segment of `/user/profile/<id>`); if the user only gives a display name/handle,
   discover it with a focused `search` first or ask for the profile URL.
+
+Both flows keep opening notes by clicking their cards. Their card/note URLs
+carry the xsec token needed for a later `get_notes` call.
 
 For deep, complex topic research only, consider `author_scan` when a search
 finds a high-quality, suspicious, or representative note. A quick profile check
@@ -95,13 +101,14 @@ Shared options (same meaning for both):
   `transcript_error` saying no speech was detected means the video genuinely
   has no narration — report that as the answer.
 
-### Note details
+### `get_notes`
 
-A standalone note-snapshot macro is deferred for V1 because direct note opening
-can require tokenized URLs or source card context. Prefer note details already
-collected by `search` or `author_scan` artifacts. If note details are
-missing, run a focused `search` or `author_scan` that can reach the note via
-search/profile context.
+`get_notes(notes=[{note_id, xsec_token}, ...])` directly opens tokenized
+full-screen detail pages and returns each note's body + top comments. Batch the
+specific notes you need into one call. Only use tokens already collected from
+`search` or `author_scan`; a bare note id is insufficient. It supports the same
+`num_comments`, `download_media`, `ocr`, and `transcribe_audio` options as the
+full scan macros.
 
 ## Artifact-First Reasoning
 

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -105,6 +105,10 @@ pub struct ReadNoteOptions {
     /// Transcribe downloaded video notes through the configured cloud ASR
     /// server. Implies `download_media` and `download_video_file` at the caller.
     pub transcribe_audio: bool,
+    /// Optional hydration settle after body content first appears. Direct
+    /// full-screen note routes use this because engagement counts can mount a
+    /// fraction later than the body; modal reads keep the zero default.
+    pub settle_ms: i64,
     pub max_images: usize,
     pub poster_url_fallback: String,
     pub note_id_fallback: String,
@@ -119,6 +123,7 @@ impl Default for ReadNoteOptions {
             download_video_file: true,
             ocr: false,
             transcribe_audio: false,
+            settle_ms: 0,
             max_images: 12,
             poster_url_fallback: String::new(),
             note_id_fallback: String::new(),
@@ -1229,8 +1234,68 @@ impl<'a> XhsPageRuntime<'a> {
         Ok(cards)
     }
 
+    /// Navigate directly to a note detail route using the xsec token captured
+    /// from a search/profile card. This is the entry action for `get_notes`;
+    /// search and author scans continue to open their cards in place.
+    pub async fn open_note_direct(
+        &self,
+        note_id: &str,
+        xsec_token: &str,
+        wait_seconds: f64,
+    ) -> Result<Value> {
+        let note_id = note_id.trim();
+        let xsec_token = xsec_token.trim();
+        if note_id.is_empty() || !note_id.chars().all(|c| c.is_ascii_alphanumeric()) {
+            anyhow::bail!("note_id must be non-empty ASCII letters/digits");
+        }
+        if xsec_token.is_empty() {
+            anyhow::bail!("xsec_token is required");
+        }
+        self.ensure_xhs(true).await?;
+
+        let mut url =
+            reqwest::Url::parse(&format!("https://www.xiaohongshu.com/explore/{note_id}"))?;
+        url.query_pairs_mut()
+            .append_pair("xsec_token", xsec_token)
+            .append_pair("xsec_source", "pc_search");
+        self.set_last_note_id(String::new());
+        self.page.navigate_with_timeout(url.as_str(), 60.0).await?;
+
+        let deadline = Instant::now() + Duration::from_secs_f64(wait_seconds.max(1.0));
+        let mut state = self.expect_object("pageState", None).await?;
+        loop {
+            let kind = state.get("state").and_then(Value::as_str).unwrap_or("");
+            let login = state
+                .get("login_required")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if kind == "note_detail" || login || Instant::now() >= deadline {
+                break;
+            }
+            sleep_ms(300).await;
+            state = self.expect_object("pageState", None).await?;
+        }
+
+        let kind = state.get("state").and_then(Value::as_str).unwrap_or("");
+        let login = state
+            .get("login_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        Ok(json!({
+            "ok": kind == "note_detail" && !login,
+            "url": self.current_url().await?,
+            "reason": if login {
+                "login_required"
+            } else if kind == "note_detail" {
+                ""
+            } else {
+                "not_note_detail"
+            },
+        }))
+    }
+
     /// Navigate directly to an author's profile page by id and wait for the
-    /// page to settle on a `profile_page` state. This is the single allowed
+    /// page to settle on a `profile_page` state. This is the profile-entry
     /// direct-URL navigation — it's the entry point of an author scan; every
     /// subsequent action (scrolling, opening notes) is DOM-driven like the
     /// rest of the site. Stops early if a login wall appears.
@@ -1373,7 +1438,13 @@ impl<'a> XhsPageRuntime<'a> {
         let t_extract = Instant::now();
         let timeout_ms = (wait_seconds.max(0.5) * 1000.0) as i64;
         let raw = self
-            .run_script("noteWithWait", Some(&json!({ "timeout_ms": timeout_ms })))
+            .run_script(
+                "noteWithWait",
+                Some(&json!({
+                    "timeout_ms": timeout_ms,
+                    "settle_ms": options.settle_ms.max(0),
+                })),
+            )
             .await?;
 
         let body = raw

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -30,7 +30,10 @@ const SocaiXhsPageScripts = (() => {
 
   // ── note modal scoping (the core fix for content extraction) ─
   function getNoteOverlay() {
-    const overlay = $('.note-detail-mask, .note-overlay, .note-detail-modal, #noteContainer');
+    // `#noteContainer` is also the root of a directly navigated full-screen
+    // detail page. Only overlay wrappers count as modal state; getNoteRoot()
+    // falls back to the same note container for full-screen extraction.
+    const overlay = $('.note-detail-mask, .note-overlay, .note-detail-modal');
     return overlay && overlay.offsetHeight > 0 ? overlay : null;
   }
 
@@ -313,10 +316,28 @@ const SocaiXhsPageScripts = (() => {
     const cards = $$('section.note-item, [data-note-id], .feeds-page .note-item');
     return cards.map((card, i) => {
       const linkEl = card.querySelector('a[href*="/explore/"], a[href*="/search_result/"]') || card.closest('a') || card.querySelector('a');
-      const link = linkEl ? linkEl.href : '';
-      const idMatch = link.match(/\/(?:explore|search_result|discovery)\/([^/?#]+)/);
+      const bareLink = linkEl ? linkEl.href : '';
+      const idMatch = bareLink.match(/\/(?:explore|search_result|discovery)\/([^/?#]+)/);
       const noteId = card.dataset?.noteId || (idMatch ? idMatch[1] : '');
-      const authorEl = card.querySelector('a[href*="/user/profile/"], .author-wrapper a, .author a');
+      // Profile cards render a hidden bare /explore/<id> link plus visible
+      // cover/title links shaped /user/profile/<author>/<note>?xsec_token=… .
+      // The token belongs to the note even though that route looks like a
+      // profile URL. Resolve it from the href that contains this card's id,
+      // then expose a canonical tokenized /explore URL for get_notes handoff.
+      const tokenLink = $$('a[href*="xsec_token="]', card).find((anchor) => {
+        try {
+          const url = new URL(anchor.href || anchor.getAttribute('href'), location.href);
+          return !!url.searchParams.get('xsec_token') && (!noteId || url.pathname.includes(noteId));
+        } catch (e) { return false; }
+      });
+      let xsecToken = '';
+      if (tokenLink) {
+        try { xsecToken = new URL(tokenLink.href, location.href).searchParams.get('xsec_token') || ''; } catch (e) {}
+      }
+      const link = noteId && xsecToken
+        ? `https://www.xiaohongshu.com/explore/${noteId}?xsec_token=${encodeURIComponent(xsecToken)}&xsec_source=pc_user`
+        : bareLink;
+      const authorEl = card.querySelector('.author-wrapper a[href*="/user/profile/"], a.author[href*="/user/profile/"]');
       const authorUrl = authorEl ? absUrl(authorEl.href || authorEl.getAttribute('href')) : '';
       const authorIdMatch = authorUrl.match(/\/user\/profile\/([^/?#]+)/);
       return {
@@ -329,7 +350,7 @@ const SocaiXhsPageScripts = (() => {
         cover_url: card.querySelector('.cover img, .note-cover img, img')?.src || '',
         type: card.querySelector('video, .play-icon, .video-icon, svg[class*="video"], .duration') ? 'video' : 'image',
         position: i,
-        xsec_token: '',
+        xsec_token: xsecToken,
         link,
       };
     }).filter((c) => c.note_id || c.title || c.link);
@@ -1027,9 +1048,11 @@ const SocaiXhsPageScripts = (() => {
   function noteWithWait(opts = {}) {
     const timeoutMs = Math.max(500, Number(opts.timeout_ms) || 8000);
     const shellSettleMs = Math.max(500, Number(opts.shell_settle_ms) || 3500);
+    const contentSettleMs = Math.max(0, Number(opts.settle_ms) || 0);
     return new Promise((resolve) => {
       const startedAt = Date.now();
       let shellSeenAt = 0;
+      let contentSeenAt = 0;
       let best = null;
       let attempts = 0;
       const tick = () => {
@@ -1040,8 +1063,9 @@ const SocaiXhsPageScripts = (() => {
         const hasShell = !!(value.note_id || value.title || value.author || value.likes || value.comments_count);
         const pending = pendingHydration(root);
         if (hasShell) { best = value; if (!shellSeenAt) shellSeenAt = Date.now(); }
-        if (hasContent) {
-          resolve({ ready: true, reason: 'content_ready', waited_ms: Date.now() - startedAt, attempts, note: value });
+        if (hasContent && !contentSeenAt) contentSeenAt = Date.now();
+        if (hasContent && (contentSettleMs === 0 || Date.now() - contentSeenAt >= contentSettleMs)) {
+          resolve({ ready: true, reason: contentSettleMs > 0 ? 'content_settled' : 'content_ready', waited_ms: Date.now() - startedAt, attempts, note: value });
           return;
         }
         if (hasShell && !pending && Date.now() - shellSeenAt >= shellSettleMs) {

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -30,7 +30,7 @@ use crate::sites::xhs::entities::{parse_posted_at_ms, parse_stat_count};
 use crate::sites::xhs::media_manifest::{
     ensure_entity_note_id, search_media_manifest, write_media_manifest_file,
 };
-use crate::sites::xhs::page::XHS_SEARCH_FILTERS;
+use crate::sites::xhs::page::{LoginGate, XHS_SEARCH_FILTERS};
 use crate::sites::xhs::{
     ReadNoteOptions, XhsAuthorProfile, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
 };
@@ -64,6 +64,14 @@ pub fn xhs_tools_with_llm_provider(
     let history = Arc::new(XhsHistoryStore::open_default());
     let pro = crate::cloud::pro_activated();
     vec![
+        Arc::new(GetNotesTool {
+            page: page.clone(),
+            llm_provider: llm_provider.clone(),
+            history: history.clone(),
+            always_download_media: false,
+            always_ocr: false,
+            pro,
+        }) as Arc<dyn Tool>,
         Arc::new(ExtractSearchCardsTool {
             page: page.clone(),
             history: history.clone(),
@@ -118,6 +126,14 @@ pub fn xhs_macro_tools_with_llm_provider(
     // files are on hand for deeper analysis, and always OCRs every image; the
     // CLI keeps its --download-media / --ocr opt-ins via the full tool set above.
     vec![
+        Arc::new(GetNotesTool {
+            page: page.clone(),
+            llm_provider: llm_provider.clone(),
+            history: history.clone(),
+            always_download_media: true,
+            always_ocr: true,
+            pro,
+        }) as Arc<dyn Tool>,
         Arc::new(SearchTool {
             page: page.clone(),
             llm_provider,
@@ -176,6 +192,55 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
     agent_instructions: xhs_agent_instructions,
     default_agent_instructions: Some(xhs_agent_instructions),
     commands: &[
+        SiteCommand {
+            name: "get-notes",
+            tool_name: "get_notes",
+            about: "Read one or more Xiaohongshu notes directly by note id and xsec token.",
+            args: &[
+                CommandArg {
+                    key: "notes",
+                    long: Some("note"),
+                    value_name: "NOTE_ID=XSEC_TOKEN",
+                    help: "Note id and xsec token (repeatable).",
+                    required: true,
+                    kind: ArgKind::StrList,
+                },
+                CommandArg {
+                    key: "num_comments",
+                    long: Some("num-comments"),
+                    value_name: "N",
+                    help: "Comments to load per note. Default 8; 0 skips comments.",
+                    required: false,
+                    kind: ArgKind::Int,
+                },
+                CommandArg {
+                    key: "download_media",
+                    long: Some("download-media"),
+                    value_name: "DOWNLOAD_MEDIA",
+                    help: "Download note images/videos into the run_dir.",
+                    required: false,
+                    kind: ArgKind::Flag,
+                },
+                CommandArg {
+                    key: "ocr",
+                    long: Some("ocr"),
+                    value_name: "OCR",
+                    help: "OCR every note image, or a video note's cover, locally.",
+                    required: false,
+                    kind: ArgKind::Flag,
+                },
+                CommandArg {
+                    key: "transcribe_audio",
+                    long: Some("transcribe-audio"),
+                    value_name: "TRANSCRIBE_AUDIO",
+                    help: "For video notes, transcribe audio through socai pro.",
+                    required: false,
+                    kind: ArgKind::Flag,
+                },
+            ],
+            slow: SlowWhen::Always,
+            run: run_get_notes,
+        },
         SiteCommand {
             name: "search",
             tool_name: "search",
@@ -343,6 +408,49 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
     ],
 };
 
+fn run_get_notes(
+    page: Arc<PageSession>,
+    args: Value,
+    debug_snapshot: bool,
+    progress: Option<ToolProgressSender>,
+) -> BoxFuture<Value> {
+    Box::pin(async move {
+        let notes = args
+            .get("notes")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow::anyhow!("missing required argument: notes"))?
+            .iter()
+            .map(|item| {
+                let raw = item.as_str().unwrap_or_default();
+                let (note_id, xsec_token) = raw.split_once('=').ok_or_else(|| {
+                    anyhow::anyhow!("--note expects NOTE_ID=XSEC_TOKEN, got: {raw}")
+                })?;
+                if note_id.trim().is_empty() || xsec_token.trim().is_empty() {
+                    anyhow::bail!("--note expects non-empty NOTE_ID=XSEC_TOKEN, got: {raw}");
+                }
+                Ok::<Value, anyhow::Error>(json!({
+                    "note_id": note_id.trim(),
+                    "xsec_token": xsec_token.trim(),
+                }))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let mut input = json!({
+            "notes": notes,
+            "num_comments": args
+                .get("num_comments")
+                .and_then(Value::as_i64)
+                .unwrap_or(TOP_COMMENTS_PER_NOTE)
+                .max(0),
+        });
+        for key in ["download_media", "ocr", "transcribe_audio"] {
+            if args.get(key).and_then(Value::as_bool).unwrap_or(false) {
+                input[key] = json!(true);
+            }
+        }
+        run_xhs_tool_command(page, GET_NOTES_COMMAND, input, debug_snapshot, progress).await
+    })
+}
+
 /// `search` dispatches on `--preview`: default opens each result (full scan —
 /// body + top comments); `--preview` returns result cards only (titles/likes/
 /// covers) without opening any note.
@@ -485,6 +593,14 @@ const AUTHOR_SCAN_COMMAND: XhsCommandSpec = XhsCommandSpec {
     before: CommandPageAction::CloseOpenNote,
     after: CommandPageAction::CloseOpenNote,
     include_run_metadata: false,
+};
+
+const GET_NOTES_COMMAND: XhsCommandSpec = XhsCommandSpec {
+    command_name: "get-notes",
+    tool_name: "get_notes",
+    before: CommandPageAction::None,
+    after: CommandPageAction::None,
+    include_run_metadata: true,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -722,6 +838,7 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
         download_video_file: true,
         ocr,
         transcribe_audio,
+        settle_ms: 0,
         max_images: get_i64(input, "max_images", 12).max(1) as usize,
         poster_url_fallback: get_str(input, "poster_url_fallback")
             .unwrap_or("")
@@ -1071,6 +1188,7 @@ async fn scan_card_note(
                 // the real `transcribe_audio` flag, so a cache hit returns the
                 // already-transcribed entity.
                 transcribe_audio: false,
+                settle_ms: 0,
                 // Inline OCR only when not deferred; otherwise just download and
                 // let the caller OCR in the background.
                 ocr: ocr && !defer_ocr,
@@ -2392,6 +2510,482 @@ impl Tool for CloseNoteTool {
         let xhs = XhsPageRuntime::new(&self.page);
         let value = xhs.close_note(wait_seconds).await?;
         Ok(json_result(&value))
+    }
+}
+
+const MAX_DIRECT_NOTES: usize = 20;
+
+#[derive(Clone)]
+struct DirectNoteRef {
+    note_id: String,
+    xsec_token: String,
+}
+
+fn direct_note_refs(input: &Value) -> anyhow::Result<Vec<DirectNoteRef>> {
+    let notes = input
+        .get("notes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("notes must be an array"))?;
+    if notes.is_empty() {
+        anyhow::bail!("notes must contain at least one item");
+    }
+    if notes.len() > MAX_DIRECT_NOTES {
+        anyhow::bail!("notes accepts at most {MAX_DIRECT_NOTES} items per call");
+    }
+    notes
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let note_id = get_str(item, "note_id")
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("notes[{index}].note_id is required"))?;
+            let xsec_token = get_str(item, "xsec_token")
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("notes[{index}].xsec_token is required"))?;
+            Ok(DirectNoteRef {
+                note_id: note_id.to_string(),
+                xsec_token: xsec_token.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Open a tokenized full-screen note route, extract the same entity shape used
+/// by search/author scans, attach comments, and record it in run/history.
+#[allow(clippy::too_many_arguments)]
+async fn scan_direct_note(
+    xhs: &XhsPageRuntime<'_>,
+    history: &XhsHistoryStore,
+    ctx: &ToolContext,
+    target: &DirectNoteRef,
+    position: usize,
+    comment_count: i64,
+    download_media: bool,
+    download_media_requested: bool,
+    ocr: bool,
+    defer_ocr: bool,
+) -> Value {
+    let mut perf = Map::new();
+    let t_open = std::time::Instant::now();
+    let open = xhs
+        .open_note_direct(&target.note_id, &target.xsec_token, 8.0)
+        .await;
+    perf.insert("open_ms".into(), json!(t_open.elapsed().as_millis() as u64));
+    let open = match open {
+        Ok(value) => value,
+        Err(err) => {
+            return json!({
+                "source_position": position,
+                "ok": false,
+                "entity": { "note_id": target.note_id },
+                "error": format!("{err:#}"),
+                "scan_perf": perf,
+            });
+        }
+    };
+    if !open.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        return json!({
+            "source_position": position,
+            "ok": false,
+            "entity": {
+                "note_id": target.note_id,
+                "url": open.get("url").cloned().unwrap_or(Value::Null),
+            },
+            "error": open.get("reason").and_then(Value::as_str).unwrap_or("direct_open_failed"),
+            "open": open,
+            "scan_perf": perf,
+        });
+    }
+
+    let t_extract = std::time::Instant::now();
+    let extracted = xhs
+        .extract_note_with_options(
+            8.0,
+            ReadNoteOptions {
+                level: "deep".to_string(),
+                include_media: false,
+                download_media,
+                download_video_file: download_media_requested,
+                ocr: ocr && !defer_ocr,
+                transcribe_audio: false,
+                settle_ms: 800,
+                max_images: if download_media { 100 } else { 12 },
+                poster_url_fallback: String::new(),
+                note_id_fallback: target.note_id.clone(),
+            },
+        )
+        .await;
+    perf.insert(
+        "extract_ms".into(),
+        json!(t_extract.elapsed().as_millis() as u64),
+    );
+
+    let mut entity = match extracted {
+        Ok(note) => serde_json::to_value(note).unwrap_or(Value::Null),
+        Err(err) => {
+            return json!({
+                "source_position": position,
+                "ok": false,
+                "entity": { "note_id": target.note_id, "url": open.get("url").cloned().unwrap_or(Value::Null) },
+                "error": format!("{err:#}"),
+                "open": open,
+                "scan_perf": perf,
+            });
+        }
+    };
+
+    let actual_id = entity
+        .get("note_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if actual_id != target.note_id {
+        return json!({
+            "source_position": position,
+            "ok": false,
+            "entity": entity,
+            "error": format!("stale_note: expected {}, got {actual_id}", target.note_id),
+            "open": open,
+            "scan_perf": perf,
+        });
+    }
+    let has_detail = ["title", "author", "content"].iter().any(|key| {
+        entity
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    }) || entity
+        .get("image_count")
+        .and_then(Value::as_i64)
+        .is_some_and(|count| count > 0)
+        || entity.get("type").and_then(Value::as_str) == Some("video");
+    if !has_detail {
+        return json!({
+            "source_position": position,
+            "ok": false,
+            "entity": entity,
+            "error": "note_content_unavailable",
+            "open": open,
+            "scan_perf": perf,
+        });
+    }
+
+    if comment_count > 0 {
+        let t_comments = std::time::Instant::now();
+        if let Ok(payload) = xhs
+            .load_comments(comment_count, COMMENT_LOAD_TIMEOUT_S)
+            .await
+        {
+            let comments = payload
+                .get("comments")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(map) = entity.as_object_mut() {
+                map.insert("top_comments".into(), Value::Array(comments));
+                map.insert(
+                    "top_comments_wait".into(),
+                    json!({
+                        "ready": payload.get("ready").and_then(Value::as_bool).unwrap_or(false),
+                        "loaded_total": payload.get("loaded_total").and_then(Value::as_i64).unwrap_or(0),
+                        "returned_total": payload.get("returned_total").and_then(Value::as_i64).unwrap_or(0),
+                        "rounds": payload.get("rounds").and_then(Value::as_i64).unwrap_or(0),
+                        "stop_reason": payload.get("stop_reason").and_then(Value::as_str).unwrap_or(""),
+                    }),
+                );
+            }
+        }
+        perf.insert(
+            "comments_ms".into(),
+            json!(t_comments.elapsed().as_millis() as u64),
+        );
+    }
+
+    ctx.mark_processed_note(&target.note_id, "deep", false);
+    history.record(&entity, "deep", false);
+    let mut entry = json!({
+        "source_position": position,
+        "ok": true,
+        "entity": entity,
+    });
+    if let Some((note_id, record)) = build_note_record(&entry, ctx, "deep") {
+        ctx.record_note(&note_id, record);
+    }
+    if let Some(map) = entry.as_object_mut() {
+        map.insert("scan_perf".into(), Value::Object(perf));
+    }
+    entry
+}
+
+/// get_notes(notes) -> note detail bundle
+pub struct GetNotesTool {
+    page: Arc<PageSession>,
+    llm_provider: Option<Arc<dyn LlmProvider>>,
+    history: Arc<XhsHistoryStore>,
+    always_download_media: bool,
+    always_ocr: bool,
+    pro: bool,
+}
+
+#[async_trait]
+impl Tool for GetNotesTool {
+    fn name(&self) -> &str {
+        "get_notes"
+    }
+
+    fn description(&self) -> &str {
+        "Read one or more Xiaohongshu notes directly from note_id + xsec_token pairs. \
+         Use tokens returned by search or author_scan when you need to revisit \
+         specific notes without repeating the search/profile click flow. Opens \
+         one full-screen detail route per item and returns body + top comments; \
+         latency scales with the number of notes."
+    }
+
+    fn input_schema(&self) -> Value {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "array",
+                    "description": "Note locators previously returned by search or author_scan.",
+                    "minItems": 1,
+                    "maxItems": MAX_DIRECT_NOTES,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "note_id": { "type": "string" },
+                            "xsec_token": { "type": "string" }
+                        },
+                        "required": ["note_id", "xsec_token"],
+                        "additionalProperties": false
+                    }
+                },
+                "num_comments": {
+                    "type": "integer",
+                    "description": "Comments to load per note; replies count toward the total. 0 skips comments.",
+                    "default": TOP_COMMENTS_PER_NOTE,
+                    "minimum": 0
+                },
+                "download_media": {
+                    "type": "boolean",
+                    "description": "Download note images/videos into the run dir and include local paths.",
+                    "default": false
+                },
+                "ocr": {
+                    "type": "boolean",
+                    "description": "Run local OCR on every carousel image, or a video note's cover.",
+                    "default": false
+                },
+                "transcribe_audio": {
+                    "type": "boolean",
+                    "description": "For video notes, download the video and transcribe audio through socai pro.",
+                    "default": false
+                }
+            },
+            "required": ["notes"],
+            "additionalProperties": false
+        });
+        if !self.pro {
+            strip_pro_schema(&mut schema);
+        }
+        schema
+    }
+
+    fn effective_input(&self, input: &Value) -> Value {
+        effective_macro_input(input, None, self.always_download_media, self.always_ocr)
+    }
+
+    async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let targets = direct_note_refs(&input)?;
+        let login = XhsPageRuntime::new(&self.page).login_gate(true).await?;
+        if login == LoginGate::Required {
+            return Ok(json_result(&json!({
+                "ok": false,
+                "notes": [],
+                "reason": "login_required",
+            })));
+        }
+
+        let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
+        let ocr = self.always_ocr || get_bool(&input, "ocr", false);
+        let transcribe_audio = get_bool(&input, "transcribe_audio", false);
+        let download_media_requested = self.always_download_media
+            || get_bool(&input, "download_media", false)
+            || transcribe_audio;
+        let download_media = ocr || download_media_requested;
+        if ocr {
+            tokio::task::spawn_blocking(ocr_warm_up);
+        }
+
+        let media = media_for(
+            ctx,
+            self.llm_provider.clone(),
+            download_media,
+            transcribe_audio,
+        )?;
+        let media_baseline = media.as_ref().map(|value| value.timing().snapshot());
+        let xhs = XhsPageRuntime::new_with_media(&self.page, media.clone());
+        let mut notes = Vec::with_capacity(targets.len());
+        let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
+        let mut pending_ocr = Vec::new();
+        let asr_sem = Arc::new(tokio::sync::Semaphore::new(ASR_PIPELINE_CONCURRENCY));
+        let mut pending_transcribe = Vec::new();
+        let mut note_perfs = Vec::new();
+        let scan_progress = ScanProgress::new(ctx, targets.len());
+        let browse_t0 = std::time::Instant::now();
+        let mut stop_reason = String::new();
+
+        for (position, target) in targets.iter().enumerate() {
+            ctx.add_search_note_ids(std::slice::from_ref(&target.note_id));
+            let item_index = position + 1;
+            let title = Some(target.note_id.clone());
+            scan_progress.reading_started(item_index, title.clone());
+            let note_started_ms = browse_t0.elapsed().as_millis() as u64;
+            let entry = scan_direct_note(
+                &xhs,
+                &self.history,
+                ctx,
+                target,
+                position,
+                comment_count,
+                download_media,
+                download_media_requested,
+                ocr,
+                ocr,
+            )
+            .await;
+            let login_lost = entry
+                .get("error")
+                .and_then(Value::as_str)
+                .is_some_and(|reason| reason == "login_required");
+            notes.push(entry);
+            let idx = notes.len() - 1;
+            if ocr {
+                if let Some(handle) = spawn_note_ocr(
+                    &media,
+                    &ocr_sem,
+                    &notes[idx],
+                    browse_t0,
+                    scan_progress.clone(),
+                    item_index,
+                    title.clone(),
+                ) {
+                    pending_ocr.push((idx, handle));
+                } else {
+                    scan_progress.ocr_completed(item_index, title.clone());
+                }
+            }
+            if transcribe_audio {
+                if let Some(handle) =
+                    spawn_note_transcribe(&media, &asr_sem, &notes[idx], browse_t0)
+                {
+                    pending_transcribe.push((idx, handle));
+                }
+            }
+            scan_progress.reading_completed(item_index, title);
+            let total_ms = (browse_t0.elapsed().as_millis() as u64).saturating_sub(note_started_ms);
+            note_perfs.push(harvest_note_perf(
+                &mut notes[idx],
+                idx,
+                note_started_ms,
+                0,
+                total_ms,
+            ));
+            if login_lost {
+                stop_reason = "login_required".to_string();
+                break;
+            }
+        }
+
+        scan_progress.finish_reading(notes.len());
+        let browse_ms = browse_t0.elapsed().as_millis() as u64;
+        let ocr_timings =
+            join_note_ocr(&mut notes, pending_ocr, &self.history, "deep", false).await;
+        join_note_transcribe(
+            &mut notes,
+            pending_transcribe,
+            &mut note_perfs,
+            &self.history,
+            ctx,
+            "deep",
+            false,
+        )
+        .await;
+        write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
+        if ocr {
+            scan_progress.finish_ocr(notes.len());
+        }
+
+        let successful = notes
+            .iter()
+            .filter(|entry| entry.get("ok").and_then(Value::as_bool) == Some(true))
+            .count();
+        let mut media_timing = match (&media, &media_baseline) {
+            (Some(media), Some(before)) => timing_delta(before, &media.timing().snapshot()),
+            _ => json!({}),
+        };
+        strip_ocr_timing(&mut media_timing);
+        let media_manifest_metadata = if download_media {
+            let manifest = search_media_manifest(&notes, ctx.output_dir());
+            let count = manifest.as_array().map(Vec::len).unwrap_or_default();
+            let (path, error) = match write_media_manifest_file(ctx, &manifest) {
+                Ok(path) => (Some(path), None),
+                Err(err) => (None, Some(format!("{err:#}"))),
+            };
+            Some((count, path, error))
+        } else {
+            None
+        };
+
+        let mut payload = json!({
+            "ok": successful == targets.len() && stop_reason.is_empty(),
+            "notes": notes,
+            "sampling": {
+                "requested": targets.len(),
+                "attempted": note_perfs.len(),
+                "successful": successful,
+                "comments_per_note": comment_count,
+                "download_media": download_media,
+                "ocr": ocr,
+                "transcribe_audio": transcribe_audio,
+            },
+            "timing": { "media": media_timing },
+        });
+        if !stop_reason.is_empty() {
+            payload["reason"] = json!(stop_reason);
+        }
+        if let Some((count, path, error)) = media_manifest_metadata {
+            payload["media_manifest_count"] = json!(count);
+            if let Some(path) = path {
+                payload["media_manifest_path"] = json!(path);
+            }
+            if let Some(error) = error {
+                payload["media_manifest_error"] = json!(error);
+            }
+        }
+
+        let first_id = targets
+            .first()
+            .map(|target| target.note_id.as_str())
+            .unwrap_or("notes");
+        let artifact_path = ctx
+            .write_json_artifact(
+                &format!("xhs_get_notes_{}", sanitize_for_filename(first_id)),
+                &payload,
+                "artifacts",
+                "get_notes",
+                "json",
+                &format!("Direct note read: {successful}/{} notes", targets.len()),
+                json!({"site": "xhs", "category": "get_notes"}),
+            )
+            .ok()
+            .map(|rel| ctx.run_dir.join(rel).to_string_lossy().into_owned());
+        lean_scan_payload(&mut payload);
+        attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
+        attach_pro_skip_note(&mut payload, pro_skipped);
+        Ok(json_result(&payload))
     }
 }
 

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -826,7 +826,7 @@ fn string_field(entity: &Value, key: &str) -> String {
 /// JSON field names whose string values are scrubbed by [`redact_secrets`].
 /// Covers `~/.socai/auth.json` (every provider key lives under `api_key`)
 /// and common token envelopes a `bash`/`read_file` result could echo.
-const SECRET_JSON_FIELDS: [&str; 10] = [
+const SECRET_JSON_FIELDS: [&str; 11] = [
     "api_key",
     "apikey",
     "access_token",
@@ -837,6 +837,7 @@ const SECRET_JSON_FIELDS: [&str; 10] = [
     "authorization",
     "password",
     "secret",
+    "xsec_token",
 ];
 
 /// Client-side secret scrub applied to every chat-content string before it
@@ -870,8 +871,15 @@ pub fn redact_secrets_in_value(value: &mut Value) {
             }
         }
         Value::Object(map) => {
-            for (_, item) in map.iter_mut() {
-                redact_secrets_in_value(item);
+            for (key, item) in map.iter_mut() {
+                if SECRET_JSON_FIELDS
+                    .iter()
+                    .any(|field| key.eq_ignore_ascii_case(field))
+                {
+                    *item = Value::String("[redacted]".to_string());
+                } else {
+                    redact_secrets_in_value(item);
+                }
             }
         }
         _ => {}


### PR DESCRIPTION
## What changed

- add a default-agent `get_notes` tool that accepts ordered batches of Xiaohongshu `note_id` + `xsec_token` pairs
- expose the same flow through `socai xhs get-notes` with repeatable `--note` arguments
- parse real full-screen note pages while reusing the existing note, comment, media, OCR, transcription, history, and artifact pipeline
- preserve the existing card-click behavior for first discovery through `search` and `author_scan`
- retain tokenized note URLs from author-page cards and redact `xsec_token` from structured telemetry
- normalize returned notes in the desktop timeline and document the new CLI/tool workflow

## Why

Xiaohongshu note IDs alone cannot reliably reopen a detail page. Search and author flows already receive an `xsec_token`, but there was no efficient way for an agent or CLI user to revisit a known set of notes without repeating the waterfall-page discovery flow.

The full-screen route also uses a different DOM shape from the modal opened by clicking a card, so direct reads now distinguish those two roots and allow a short hydration settle for engagement counts.

## Impact

Agents and CLI users can batch up to 20 previously discovered notes in one call. Individual failures remain scoped to their corresponding batch item, input order is preserved, and optional comments/media/OCR/transcription behave like the existing scan tools.

## Validation

- `node --check core/src/sites/xhs/page_scripts.js`
- `cargo test -p socai-core --lib` (91 passed, 2 ignored)
- `cargo test -p socai-cli` (6 passed)
- `cargo test -p socai_app --lib` (1 passed)
- `cargo check -p socai-cli -p socai_app`
- `cargo run -q -p socai-cli -- xhs get-notes --help`
- `git diff --check`
- live default-Chrome validation for one-note reads, comments and replies, ordered two-note batches, and delayed engagement-count hydration
