### PR TITLE
fix(app): relaunch reliably after auto-update on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,7 +5049,6 @@ dependencies = [
  "socai-core",
  "tauri",
  "tauri-build",
- "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
 ]
@@ -5537,16 +5536,6 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
-]
-
-[[package]]
-name = "tauri-plugin-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
-dependencies = [
- "tauri",
- "tauri-plugin",
 ]
 
 [[package]]

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",
-    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "dompurify": "^3.4.8",
     "marked": "^18.0.5"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
-      '@tauri-apps/plugin-process':
-        specifier: ^2.3.1
-        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
@@ -625,9 +622,6 @@ packages:
     resolution: {integrity: sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==}
     engines: {node: '>= 10'}
     hasBin: true
-
-  '@tauri-apps/plugin-process@2.3.1':
-    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -1485,10 +1479,6 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
-
-  '@tauri-apps/plugin-process@2.3.1':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -14,7 +14,6 @@ tauri-build = { version = "2.5.6", features = [] }
 [dependencies]
 tauri = { version = "2.11.1", features = ["protocol-asset"] }
 tauri-plugin-updater = "2.10.1"
-tauri-plugin-process = "2.3.1"
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true }

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "updater:default",
-    "process:default"
+    "updater:default"
   ]
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -22,7 +22,7 @@ use socai_core::telemetry::trace::mark_run_trace_status;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 const TAURI_AGENT_PREAMBLE: &str =
     "You are running inside the socai desktop app as a conversational, multi-turn agent. \
@@ -86,6 +86,20 @@ pub async fn cdp_status(runtime: State<'_, SocaiRuntime>) -> Result<BrowserStatu
 #[tauri::command]
 pub async fn cdp_refresh(_runtime: State<'_, SocaiRuntime>) -> Result<(), String> {
     Ok(())
+}
+
+// ── App lifecycle ───────────────────────────────────────────────────────────
+
+/// Relaunch into a staged update. The process plugin's `relaunch()` routes the
+/// respawn through event-loop teardown (`request_restart`), and on macOS the
+/// process dies before the replacement finishes spawning — the app quits and
+/// never comes back (tauri-apps/tauri#11392). Spawn the replacement while the
+/// app is still fully alive instead, after the same browser cleanup quit does.
+#[tauri::command]
+pub async fn app_relaunch(app: AppHandle) {
+    app.state::<SocaiRuntime>().disconnect_browser().await;
+    app.cleanup_before_exit();
+    tauri::process::restart(&app.env());
 }
 
 async fn require_connected(runtime: &SocaiRuntime) -> Result<(), String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -53,7 +53,6 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init())
         .manage(runtime)
         .manage(AgentTaskRegistry::default())
         .manage(telemetry)
@@ -146,6 +145,7 @@ pub fn run() {
             commands::cdp_disconnect,
             commands::cdp_status,
             commands::cdp_refresh,
+            commands::app_relaunch,
             commands::open_external,
             commands::agent_list_models,
             commands::agent_set_default_model,

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -4,7 +4,6 @@ import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 
 import { applyLanguageToDocument, formatTabs, t } from "./lib/i18n";
@@ -402,8 +401,12 @@ function bindUpdateChip(): void {
   });
 }
 
+// Custom command, not the process plugin's relaunch(): that one respawns
+// during event-loop teardown and on macOS the process dies before the new
+// instance finishes spawning — the app quits and never reopens
+// (tauri-apps/tauri#11392).
 function doRelaunch(): void {
-  relaunch().catch((e) => console.error("relaunch failed:", e));
+  invoke("app_relaunch").catch((e) => console.error("relaunch failed:", e));
 }
 
 // Download + install the update in the background. The chip announces the


### PR DESCRIPTION
## What

After an auto-update, clicking the "restart to finish" chip quit the app but never reopened it — the user had to relaunch manually.

- Replace the process plugin's `relaunch()` with a custom `app_relaunch` command: it runs the same browser cleanup quit does (`disconnect_browser`), calls `cleanup_before_exit()`, then `tauri::process::restart()` — spawning the replacement **while the process is still fully alive**, then exiting.
- Remove `tauri-plugin-process` entirely (Cargo + npm + plugin registration + capability): `relaunch()` was its only use.

## Why

The plugin's `relaunch()` maps to `AppHandle::request_restart()`, which only spawns the replacement binary during event-loop teardown (`RunEvent::Exit`), deep in AppKit termination. On macOS the process can die before that spawn completes — a known, still-open upstream bug (tauri-apps/tauri#11392, tauri-apps/tauri#13923, unfixed as of tauri 2.11.5). Tauri v1 didn't have this failure because it spawned first and exited second; this PR restores that ordering at the app level.

## Verification

Built release bundles with a temporary env-gated trigger (stripped from this diff) and drove the relaunch for real:

- Launched via `open -n` (launchd parent, same as Finder), swapped the bundle mid-run exactly like the updater does (atomic rename + backup deletion + `touch`), then fired the new path: the app respawned every time, and `lsof` confirmed the child was executing the **swapped** binary's inode — the post-update scenario end-to-end.
- Normal quit is untouched: the `ExitRequested` cleanup handler still runs on Cmd+Q.
- Caveat, honestly: the *old* path did not fail under local ad-hoc builds (the upstream race is timing-dependent), so there's no local red-to-green A/B; the fix removes the racy ordering by construction.

## Reviewer notes

- The relaunch code that runs during an update belongs to the **old** version, so the next release-to-release update still uses the broken path one last time; updates after that get the fix.
- `app_relaunch` runs on a tokio worker; `cleanup_before_exit()` + `process::restart()` from a non-main thread is the same sequence upstream's own `restart()` error path uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)