### PR TITLE
fix(agent): retry transient chat errors, stop masking failed runs as completed

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1107,10 +1107,11 @@ async fn run_agent_task_on_shared_page(
         let _ = pump.await;
         let outcome = outcome?;
         if let Some(error) = outcome.error {
-            // The run died on a terminal LLM error; run.json and the trace
-            // already say "failed". Bail into the caller's failed arm — which
-            // marks the task failed and uploads the trace — instead of
-            // recording the "API error: …" placeholder as a completed task.
+            // The run ended on a terminal error (unretryable API failure,
+            // repeated truncation, or a failed forced summary); run.json and
+            // the trace already say "failed" and final_text is best-effort.
+            // Bail into the caller's failed arm — which marks the task failed
+            // and uploads the trace — instead of reporting a completed task.
             anyhow::bail!(error);
         }
         telemetry.upload_run_trace(&outcome.run_dir);

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1106,6 +1106,13 @@ async fn run_agent_task_on_shared_page(
         let outcome = run_agent_with_tools(task, llm_provider, tools, config, tx).await;
         let _ = pump.await;
         let outcome = outcome?;
+        if let Some(error) = outcome.error {
+            // The run died on a terminal LLM error; run.json and the trace
+            // already say "failed". Bail into the caller's failed arm — which
+            // marks the task failed and uploads the trace — instead of
+            // recording the "API error: …" placeholder as a completed task.
+            anyhow::bail!(error);
+        }
         telemetry.upload_run_trace(&outcome.run_dir);
 
         let usage = outcome.usage;

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -739,11 +739,12 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     println!("[socai] run_dir={}", outcome.run_dir.display());
     println!();
 
-    // A terminal API error still returns an Ok outcome (the run dir and
-    // usage are real). Record it as failed, with a short marker instead of
-    // the whole provider message in the conversation seed.
+    // A terminal error still returns an Ok outcome (the run dir and usage
+    // are real). Record it as failed, with a short marker instead of the
+    // whole provider message in the conversation seed. Generic wording: the
+    // error may also be max-token truncation or a failed forced summary.
     let (recorded, status) = if outcome.error.is_some() {
-        ("[run failed: LLM API error]".to_string(), "failed")
+        ("[run failed before producing a final answer]".to_string(), "failed")
     } else {
         (outcome.final_text.clone(), "completed")
     };

--- a/cli/src/tui.rs
+++ b/cli/src/tui.rs
@@ -739,17 +739,17 @@ async fn run_agent_task(runtime: &SocaiRuntime, task: &str, state: &mut AppState
     println!("[socai] run_dir={}", outcome.run_dir.display());
     println!();
 
-    // An API error surfaces as an Ok outcome whose final_text is the error.
-    // Record a short marker instead of dumping the whole provider message into
-    // the conversation seed.
-    let recorded = if outcome.final_text.starts_with("API error:") {
-        "[run failed: LLM API error]".to_string()
+    // A terminal API error still returns an Ok outcome (the run dir and
+    // usage are real). Record it as failed, with a short marker instead of
+    // the whole provider message in the conversation seed.
+    let (recorded, status) = if outcome.error.is_some() {
+        ("[run failed: LLM API error]".to_string(), "failed")
     } else {
-        outcome.final_text.clone()
+        (outcome.final_text.clone(), "completed")
     };
     state
         .conversation
-        .record_run(task, &recorded, &outcome.run_dir, "completed");
+        .record_run(task, &recorded, &outcome.run_dir, status);
     Ok(())
 }
 

--- a/core/src/agent/api_errors.rs
+++ b/core/src/agent/api_errors.rs
@@ -19,9 +19,11 @@ pub fn format_http_error(provider: &str, status: u16, body_text: &str) -> String
         serde_json::from_str(trimmed).ok()
     };
 
+    // Only fields actually extracted suppress the raw-body fallback: a JSON
+    // body in an unrecognized shape (e.g. codex 400s) must still surface as
+    // `body=…`, or the error reads as a bare status with nothing to act on.
     let mut had_structured = false;
     if let Some(value) = parsed.as_ref() {
-        had_structured = true;
         let err_obj = value
             .get("error")
             .and_then(Value::as_object)
@@ -35,6 +37,7 @@ pub fn format_http_error(provider: &str, status: u16, body_text: &str) -> String
                 };
                 if !rendered.is_empty() {
                     parts.push(format!("{key}={rendered}"));
+                    had_structured = true;
                 }
             }
         }
@@ -66,6 +69,37 @@ pub fn format_http_error(provider: &str, status: u16, body_text: &str) -> String
         }
     }
     cleaned.join(" | ")
+}
+
+/// Whether a chat error is worth retrying: transport-level failures
+/// (connect, timeout, mid-body decode) and overload-ish HTTP statuses
+/// (408/429/5xx, per the `status=` field [`format_http_error`] embeds).
+/// Quota exhaustion also arrives as 429 on OpenAI, so those stay permanent.
+pub fn is_transient_api_error(error: &anyhow::Error) -> bool {
+    for cause in error.chain() {
+        if let Some(e) = cause.downcast_ref::<reqwest::Error>() {
+            // Non-2xx statuses never surface as reqwest errors here (the
+            // clients read status themselves), so any reqwest error short of
+            // a builder/redirect bug is a transport failure.
+            return !(e.is_builder() || e.is_redirect());
+        }
+    }
+    let msg = format!("{error:#}");
+    if msg.contains("insufficient_quota") {
+        return false;
+    }
+    // Codex SSE stream cut off server-side before the terminal event.
+    if msg.contains("stream ended without response.completed") {
+        return true;
+    }
+    matches!(parsed_status(&msg), Some(408 | 429 | 500..=599))
+}
+
+/// First `status=NNN` embedded by [`format_http_error`], if any.
+fn parsed_status(msg: &str) -> Option<u16> {
+    let rest = &msg[msg.find("status=")? + "status=".len()..];
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
 }
 
 #[cfg(test)]

--- a/core/src/agent/api_errors.rs
+++ b/core/src/agent/api_errors.rs
@@ -72,17 +72,28 @@ pub fn format_http_error(provider: &str, status: u16, body_text: &str) -> String
 }
 
 /// Whether a chat error is worth retrying: transport-level failures
-/// (connect, timeout, mid-body decode) and overload-ish HTTP statuses
+/// (connect, timeout, mid-body I/O) and overload-ish HTTP statuses
 /// (408/429/5xx, per the `status=` field [`format_http_error`] embeds).
 /// Quota exhaustion also arrives as 429 on OpenAI, so those stay permanent.
 pub fn is_transient_api_error(error: &anyhow::Error) -> bool {
+    // Scan the whole chain before deciding: reqwest wraps a 200 response
+    // whose JSON doesn't match the wire schema (`response.json()`) as a
+    // Decode error whose *source* is serde_json — a permanent failure,
+    // unlike the transport Decode errors (mid-body timeouts) worth retrying.
+    let mut transport_failure = None;
     for cause in error.chain() {
+        if cause.downcast_ref::<serde_json::Error>().is_some() {
+            return false;
+        }
         if let Some(e) = cause.downcast_ref::<reqwest::Error>() {
             // Non-2xx statuses never surface as reqwest errors here (the
-            // clients read status themselves), so any reqwest error short of
-            // a builder/redirect bug is a transport failure.
-            return !(e.is_builder() || e.is_redirect());
+            // clients read status themselves), so short of a builder or
+            // redirect bug this is a transport failure.
+            transport_failure = Some(!(e.is_builder() || e.is_redirect()));
         }
+    }
+    if let Some(transient) = transport_failure {
+        return transient;
     }
     let msg = format!("{error:#}");
     if msg.contains("insufficient_quota") {

--- a/core/src/agent/conversation.rs
+++ b/core/src/agent/conversation.rs
@@ -97,7 +97,11 @@ impl Conversation {
     }
 
     pub fn record_run(&mut self, user: &str, assistant: &str, run_dir: &Path, status: &str) {
-        let assistant_fallback = (!run_dir.join("report.md").is_file())
+        // Completed runs seed follow-up turns from the canonical report.md.
+        // Non-completed runs keep the caller's short marker instead: their
+        // report is an error placeholder (or missing entirely), and seeding
+        // the full provider error would bloat every later turn.
+        let assistant_fallback = (status != "completed" || !run_dir.join("report.md").is_file())
             .then(|| assistant.to_string())
             .filter(|value| !value.is_empty());
         self.runs.push(Run {
@@ -115,9 +119,12 @@ impl Conversation {
         let mut messages = Vec::with_capacity(self.runs.len() * 2);
         for run in &self.runs {
             messages.push(Message::user(run.user.clone()));
-            let report = std::fs::read_to_string(Path::new(&run.run_dir).join("report.md"))
-                .ok()
-                .or_else(|| run.assistant_fallback.clone())
+            let report = run
+                .assistant_fallback
+                .clone()
+                .or_else(|| {
+                    std::fs::read_to_string(Path::new(&run.run_dir).join("report.md")).ok()
+                })
                 .unwrap_or_default();
             // Providers reject empty text blocks, so a run that produced
             // neither a report nor a fallback seeds a placeholder instead.

--- a/core/src/agent/conversation.rs
+++ b/core/src/agent/conversation.rs
@@ -1,8 +1,10 @@
 //! Persistent conversation index of agent runs.
 //!
 //! A conversation owns user-message order and references to L2 agent runs.
-//! Assistant output is read from each run's `report.md`; an inline fallback
-//! is stored only when a run did not produce a report.
+//! Completed runs read assistant output from their `report.md`; an inline
+//! fallback is stored — and preferred when seeding follow-up turns — for
+//! runs that did not complete (their report is an error placeholder, if it
+//! exists at all) or that produced no report.
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -134,10 +134,11 @@ pub struct AgentOutcome {
     pub steps: u32,
     pub final_text: String,
     pub usage: TokenUsage,
-    /// Terminal LLM error that ended the run early. When set, run.json and
-    /// the trace already carry status "failed" and `final_text` is only the
-    /// "API error: …" placeholder — callers must not report the run as
-    /// completed.
+    /// Terminal error that ended the run early: an unretryable LLM API
+    /// error, repeated max-token truncation, or a failed forced summary.
+    /// When set, run.json and the trace already carry status "failed", and
+    /// `final_text` is best-effort — an error placeholder, or partial output
+    /// from earlier steps — so callers must not report the run as completed.
     pub error: Option<String>,
 }
 

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -494,7 +494,7 @@ pub async fn run_agent_with_events(
         messages.push(Message::user_blocks(tool_result_blocks));
     }
 
-    if !completed && step >= options.max_steps {
+    if !completed && terminal_error.is_none() && step >= options.max_steps {
         info!(step, "reached max_steps, forcing final summary");
         messages.push(Message::user(format!(
             "You have reached the maximum of {} tool-using steps. Do not call any \

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -21,12 +21,13 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
+use crate::agent::api_errors::is_transient_api_error;
 use crate::agent::compaction::{compress_text_maybe_json, TOOL_RESULT_TEXT_MAX_CHARS};
 use crate::agent::llm::{
     Backend, Block, LLMResponse, Message, StopReason, TokenUsage, ToolCall, ToolResultContent,
@@ -133,6 +134,11 @@ pub struct AgentOutcome {
     pub steps: u32,
     pub final_text: String,
     pub usage: TokenUsage,
+    /// Terminal LLM error that ended the run early. When set, run.json and
+    /// the trace already carry status "failed" and `final_text` is only the
+    /// "API error: …" placeholder — callers must not report the run as
+    /// completed.
+    pub error: Option<String>,
 }
 
 pub async fn run_agent(
@@ -234,9 +240,15 @@ pub async fn run_agent_with_events(
         run_recorder.record_llm_request(step, &request_payload)?;
 
         let llm_started = Instant::now();
-        let response: LLMResponse = match backend
-            .send(&system, &request_messages, &schemas, options.max_tokens)
-            .await
+        let response: LLMResponse = match send_with_retry(
+            &backend,
+            &system,
+            &request_messages,
+            &schemas,
+            options.max_tokens,
+            step,
+        )
+        .await
         {
             Ok(response) => {
                 let duration_ms = llm_started.elapsed().as_millis() as u64;
@@ -502,9 +514,15 @@ pub async fn run_agent_with_events(
             backend.request_payload(&last_system, &request_messages, &[], options.max_tokens)?;
         run_recorder.record_llm_request(step + 1, &request_payload)?;
         let llm_started = Instant::now();
-        match backend
-            .send(&last_system, &request_messages, &[], options.max_tokens)
-            .await
+        match send_with_retry(
+            &backend,
+            &last_system,
+            &request_messages,
+            &[],
+            options.max_tokens,
+            step + 1,
+        )
+        .await
         {
             Ok(response) => {
                 let duration_ms = llm_started.elapsed().as_millis() as u64;
@@ -579,10 +597,53 @@ pub async fn run_agent_with_events(
         steps: step,
         final_text,
         usage,
+        error: terminal_error,
     })
 }
 
 // ---------- small private helpers (not core logic, kept here for locality) ----------
+
+/// Backoff schedule for transient chat failures. Two retries keeps the worst
+/// case bounded: a fully dead network adds at most two extra request
+/// timeouts before the run fails.
+const CHAT_RETRY_DELAYS: [Duration; 2] = [Duration::from_secs(2), Duration::from_secs(6)];
+
+/// `backend.send` with retries for transient failures (network transport
+/// errors, 408/429/5xx) — a multi-minute run should not die on one dropped
+/// packet. Permanent errors (auth, billing, bad request) surface on the
+/// first attempt.
+async fn send_with_retry(
+    backend: &Arc<dyn Backend>,
+    system: &str,
+    messages: &[Message],
+    schemas: &[ToolSchema],
+    max_tokens: u32,
+    step: u32,
+) -> anyhow::Result<LLMResponse> {
+    let mut attempt = 0usize;
+    loop {
+        match backend.send(system, messages, schemas, max_tokens).await {
+            Ok(response) => return Ok(response),
+            Err(error) => {
+                let Some(delay) = CHAT_RETRY_DELAYS.get(attempt).copied() else {
+                    return Err(error);
+                };
+                if !is_transient_api_error(&error) {
+                    return Err(error);
+                }
+                attempt += 1;
+                warn!(
+                    step,
+                    attempt,
+                    delay_secs = delay.as_secs(),
+                    error = %format!("{error:#}"),
+                    "transient LLM error; retrying"
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
 
 fn new_run_id() -> String {
     use chrono::Utc;

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -572,14 +572,18 @@ pub async fn run_agent_with_events(
         }
     }
 
-    emit(
-        &events,
-        AgentEvent::Done {
-            run_id: run_id.clone(),
-            steps: step,
-            final_text: final_text.clone(),
-        },
-    );
+    // Failed runs already signalled ApiError; a Done event on top would give
+    // subscribers contradictory success ("✓ done") and failure signals.
+    if terminal_error.is_none() {
+        emit(
+            &events,
+            AgentEvent::Done {
+                run_id: run_id.clone(),
+                steps: step,
+                final_text: final_text.clone(),
+            },
+        );
+    }
 
     let enriched_report = report_with_artifacts(&final_text, Some(&run_state));
     let _ = std::fs::write(run_dir.join("report.md"), &enriched_report);


### PR DESCRIPTION
## Why

Axiom prod traces (Jul 2–16) show **139 of 644 agent runs (21.6%) died on an LLM chat error**, across 28 installs — while `socai_agent_task_end` reported only 3 failures. Breakdown of the failed chat spans:

| Category | Spans | Notes |
|---|---|---|
| Network timeout / connection failure | 62 (45%) | chatgpt.com worst endpoint (30); 19 mid-stream decode timeouts, mostly deepseek-v4-pro |
| Billing / quota exhausted | ~36 | deepseek 402, qwen arrearage, codex insufficient_quota |
| Invalid api key (401) | 18 | kimi, openai, deepseek, qwen, doubao |
| Codex 400 with no body captured | 16 | single install, gpt-5.5-pro failing 20/21 attempts — undiagnosable from telemetry |

Two systemic issues made this worse: a single chat error was terminal (no retry), and the loop returned `Ok` with the error only embedded in `final_text`, so the desktop recorded these runs as **completed** tasks (hence 3 vs 139).

## What changed

1. **Retry transient chat errors** — both `backend.send` call sites in the agent loop now go through `send_with_retry`: up to 2 retries with 2s/6s backoff. `is_transient_api_error` (new, in `api_errors.rs`) classifies reqwest transport errors by downcasting the anyhow chain, and 408/429/5xx via the `status=` field our own `format_http_error` embeds. Auth/billing/`insufficient_quota`-429/bad-request errors still fail on the first attempt.
2. **Stop masking failed runs as completed** — `AgentOutcome` gains `error: Option<String>` (the terminal LLM error). Desktop bails into its existing failed arm (task snapshot `failed`, `socai_agent_task_end outcome=failed` + error, exactly one trace upload); TUI drops the `final_text.starts_with("API error:")` sniff and records the turn as `failed`.
3. **Keep unrecognized error bodies diagnosable** — `format_http_error` now only suppresses the `body=` fallback when a `message`/`code`/`type`/`param` field was actually extracted, so codex 400s stop logging as a bare `status=400`.

## Reviewer notes

- Retried attempts log `warn!` but emit no `ApiError` event, so UIs don't flash transient errors; per-step LLM duration now includes backoff time on retried calls.
- No new `#[test]`s per repo rule. Verified end-to-end with a scratch harness driving the real loop with fake backends (20/20 checks): transient-failing backend recovers after 2 retries on the 2s/6s schedule with run.json `completed`; permanently-402 backend fails fast with exactly 1 send, `outcome.error` set, run.json `failed`; classifier verified against a genuine reqwest connect-timeout plus the observed prod error strings; codex-shaped `{"detail":…}` body now surfaces as `body=…`.
- `cargo check`/`clippy`/existing tests clean on core, cli, and app crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)