### PR TITLE
fix(xhs): make consecutive searches reliable and survive the AI-search route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,6 +5024,7 @@ dependencies = [
  "image",
  "libc",
  "oar-ocr",
+ "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,9 @@ reqwest.workspace = true
 base64.workspace = true
 dirs = "5"
 libc.workspace = true
+# Keyword encoding for direct search-results navigation (already in the tree
+# via reqwest).
+percent-encoding = "2"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 # Image compositing/resizing for batching note images into 2x2 vision grids.

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -252,6 +252,20 @@ impl<'a> XhsPageRuntime<'a> {
             anyhow::bail!("query is required");
         }
 
+        // Never submit from a leftover SPA state — most commonly the previous
+        // search's results page (several searches in one step, or search
+        // after search across steps). From there the transition wait can
+        // validate against the stale page (the box already shows the new
+        // query while the old grid still has cards), and a search session
+        // that never leaves the SPA accumulates renderer state that field
+        // traces show degrading into multi-minute searches and dead tabs.
+        // One cheap navigation resets both; tabs that aren't on XHS at all
+        // are handled by login_gate's own navigation below.
+        let current = self.current_url().await?;
+        if current.contains("xiaohongshu.com") && !is_xhs_home_url(&current) {
+            self.page.navigate(XHS_HOME_URL).await?;
+        }
+
         // Pre-flight login gate: if logged out, bail immediately with
         // `login_required` instead of paying the full input→Enter→click→wait
         // retry cycle (which would grind for ~30s behind the wall). Same
@@ -373,26 +387,49 @@ impl<'a> XhsPageRuntime<'a> {
             }));
         }
 
-        if let Some(submit) = loc.get("submit") {
-            let x = number(submit, "x");
-            let y = number(submit, "y");
-            if x > 0.0 && y > 0.0 {
-                self.page.click(x, y).await?;
-                let state = self
-                    .wait_for_search_transition(
-                        query,
-                        wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
-                    )
-                    .await?;
-                if search_transition_ok(&state, query) {
-                    return Ok(json!({
-                        "ok": true,
-                        "strategy": "click_search_button",
-                        "state": state,
-                        "url": self.current_url().await?,
-                    }));
+        // Skip the button when the submit was hijacked onto the AI-search
+        // route — the button coordinates belong to the page we just left,
+        // so the click would land on arbitrary AI-page UI.
+        if !on_ai_search_route(&state) {
+            if let Some(submit) = loc.get("submit") {
+                let x = number(submit, "x");
+                let y = number(submit, "y");
+                if x > 0.0 && y > 0.0 {
+                    self.page.click(x, y).await?;
+                    let state = self
+                        .wait_for_search_transition(
+                            query,
+                            wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
+                        )
+                        .await?;
+                    if search_transition_ok(&state, query) {
+                        return Ok(json!({
+                            "ok": true,
+                            "strategy": "click_search_button",
+                            "state": state,
+                            "url": self.current_url().await?,
+                        }));
+                    }
                 }
             }
+        }
+
+        // Last resort: load the classic results route directly — the same
+        // page a shared results link opens. The typed path can derail
+        // without the input being wrong: since 2026-07 some home submits get
+        // hijacked onto `/search_result_ai` (seen in field traces), and a
+        // wedged composer swallows Enter entirely.
+        self.page.navigate(&search_result_url(query)).await?;
+        let state = self
+            .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
+            .await?;
+        if search_transition_ok(&state, query) {
+            return Ok(json!({
+                "ok": true,
+                "strategy": "navigate_search_url",
+                "state": state,
+                "url": self.current_url().await?,
+            }));
         }
 
         Ok(json!({
@@ -414,6 +451,12 @@ impl<'a> XhsPageRuntime<'a> {
         while Instant::now() < deadline {
             latest = self.expect_object("searchState", None).await?;
             if search_transition_ok(&latest, query) {
+                return Ok(latest);
+            }
+            // `/search_result_ai` is terminal for this attempt: the hijacked
+            // route never becomes the classic list, so don't burn the rest
+            // of the window polling it.
+            if on_ai_search_route(&latest) {
                 return Ok(latest);
             }
             sleep_ms(150).await;
@@ -1899,11 +1942,12 @@ fn search_transition_ok(state: &Value, query: &str) -> bool {
     if !keyword.is_empty() && !visible_keyword.is_empty() && visible_keyword != keyword {
         return false;
     }
-    if !keyword.is_empty()
-        && visible_keyword.is_empty()
-        && !url_keyword.is_empty()
-        && url_keyword != keyword
-    {
+    // The URL keyword says which query the mounted results actually belong
+    // to, so a mismatch fails the transition even when the input already
+    // shows the new query: right after Enter on a previous search's results
+    // page the box holds the new text while the route still carries the old
+    // keyword — accepting that state returns the previous query's cards.
+    if !keyword.is_empty() && !url_keyword.is_empty() && url_keyword != keyword {
         return false;
     }
     if state.get("card_count").and_then(Value::as_i64).unwrap_or(0) > 0 {
@@ -1936,6 +1980,40 @@ fn normalize_image_url(value: &str) -> String {
         return String::new();
     }
     trimmed.replacen("http://", "https://", 1)
+}
+
+/// Classic results-list URL for `query` — the page the search box's Enter
+/// reaches (`source` matches an organic from-the-feed search).
+fn search_result_url(query: &str) -> String {
+    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    format!(
+        "https://www.xiaohongshu.com/search_result?keyword={}&source=web_explore_feed",
+        utf8_percent_encode(query, NON_ALPHANUMERIC)
+    )
+}
+
+/// True when a `searchState` readback shows the tab on the AI-search route
+/// (`/search_result_ai`) rather than the classic results list.
+fn on_ai_search_route(state: &Value) -> bool {
+    state
+        .get("url")
+        .and_then(Value::as_str)
+        .is_some_and(|url| url.contains("/search_result_ai"))
+}
+
+/// True when `url` is the XHS home feed itself — `/explore`, or the bare
+/// origin that redirects there. A note detail route (`/explore/<id>`) is not
+/// home.
+fn is_xhs_home_url(url: &str) -> bool {
+    let Some((_, rest)) = url.split_once("xiaohongshu.com") else {
+        return false;
+    };
+    let path = rest
+        .split(['?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('/');
+    path.is_empty() || path == "/explore"
 }
 
 /// Note id from an opened XHS detail URL (`/explore/<id>`, `/discovery/<id>`,

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -218,9 +218,14 @@ const SocaiXhsPageScripts = (() => {
     const bodyText = text(document.body);
     const loading = $$('.loading, .spinner, [class*="loading"]').some((el) => isVisible(el));
     const hasNoResults = /暂无|没有找到|无结果|换个词试试|no result/i.test(bodyText);
+    // Exactly the classic results list. `includes('/search_result')` would
+    // also match `/search_result_ai` — the AI-search page some submits get
+    // hijacked onto (its ranking differs and the filter panel is missing) —
+    // and `/search_result/<id>` detail routes.
+    const isResultsList = url.pathname.replace(/\/+$/, '') === '/search_result';
     return {
       ok: true,
-      page_state: url.pathname.includes('/search_result') ? 'search_results' : 'unknown',
+      page_state: isResultsList ? 'search_results' : 'unknown',
       url: location.href,
       url_keyword: url.searchParams.get('keyword') || '',
       input_keyword: input ? String(input.value || input.textContent || '').trim() : '',


### PR DESCRIPTION
## What

Hardens the XHS search flow for consecutive searches — the common case where the model emits several `search` tool calls in one LLM step (validated on Axiom: up to 8 per step across many users), or searches back-to-back across steps on the same tab.

- **`search_notes`**: navigate back to `/explore` before submitting whenever the tab is parked anywhere else on XHS, so every search starts from a fresh document instead of the previous query's leftover SPA state.
- **`search_transition_ok`**: fail on a URL-keyword mismatch even when the input box already matches the query (previously the URL check was skipped in that case), and require the exact `/search_result` path for `page_state` (previously `includes('/search_result')` also matched `/search_result_ai` and `/search_result/<id>` detail routes).
- **`submit_search`**: new last-resort `navigate_search_url` strategy — when the typed submit derails, load the classic results route directly (`search_result?keyword=…`). Attempts hijacked onto the AI route exit the transition poll early and skip the now-stale submit-button click.
- `percent-encoding` added as a direct dependency (already in the tree via reqwest) for the keyword encoding.

## Why

Prod traces show two failure modes for consecutive searches on the shared tab:

1. **Stale-transition race**: for the 2nd+ search, the box shows the new query (we just typed it) and the old grid still satisfies `card_count > 0`, so the transition wait could pass on the previous query's page and silently return its cards as the new query's results.
2. **SPA-debris grind**: search sessions that never leave the SPA degrade into multi-minute searches and dead tabs. Reference timeline in trace `dd321c39c5c74555259d665740803f0c`: a 5-search step ground 5m47s + 7m7s ending in `Current page is not Xiaohongshu: about:blank`, then recovered to 35s searches the moment a fresh navigation happened; later the browser wedged permanently (`Input.dispatchMouseEvent` / `Runtime.evaluate` CDP timeouts for the rest of the conversation).

While verifying live, a third issue surfaced: since ~2026-07 XHS can hijack home-box submits onto the new **`/search_result_ai`** route (with a double-encoded keyword). The old page-state check accepted that page's cards as regular search results. This is already visible in 4 prod traces from the last 14 days, so the fallback is load-bearing today, not speculative.

## Verification

- Live end-to-end on managed Chrome (CLI daemon built from this branch): two back-to-back searches (`上海 咖啡店` → `露营 装备`) both landed on the classic results route with correct, non-bleeding cards. On this machine the typed submit is AI-hijacked, so both healed via the new `navigate_search_url` strategy — without this fix every search here would return AI-page results or fail.
- `cargo check --workspace` clean; all 91 existing socai-core tests pass (no new tests per repo rules).

## Notes for review

- The `submit.strategy` field in run artifacts now reports `navigate_search_url` when the fallback fires — useful for gauging how often the typed path derails in the field.
- Douyin has the same weak transition check (no keyword validation at all); being handled separately.
- The `sort=最多点赞` per-note grind is the known stale-note-cascade issue and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)