### PR TITLE
feat: refresh model catalog defaults

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "marked": "^18.0.5"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.80.6",
+    "@earendil-works/pi-ai": "0.80.10",
     "@tauri-apps/cli": "^2.11.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 18.0.5
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.80.6
-        version: 0.80.6(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.80.10
+        version: 0.80.10(ws@8.21.0)(zod@4.4.3)
       '@tauri-apps/cli':
         specifier: ^2.11.1
         version: 2.11.1
@@ -150,8 +150,8 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@earendil-works/pi-ai@0.80.6':
-    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
+  '@earendil-works/pi-ai@0.80.10':
+    resolution: {integrity: sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -1154,7 +1154,7 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@earendil-works/pi-ai@0.80.6(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.10(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0

--- a/core/src/agent/model_catalog.generated.json
+++ b/core/src/agent/model_catalog.generated.json
@@ -240,11 +240,6 @@
             }
           ]
         }
-      },
-      {
-        "id": "claude-3-7-sonnet-20250219",
-        "display_name": "Claude Sonnet 3.7",
-        "source": "fallback"
       }
     ],
     "openai": [
@@ -263,7 +258,8 @@
               "cache_write_per_million": 3.125
             }
           ]
-        }
+        },
+        "recommended": true
       },
       {
         "id": "gpt-5.6-sol",
@@ -331,8 +327,7 @@
               "cache_write_per_million": 0
             }
           ]
-        },
-        "recommended": true
+        }
       },
       {
         "id": "gpt-5.4-pro",
@@ -983,6 +978,23 @@
     ],
     "kimi": [
       {
+        "id": "kimi-k3",
+        "display_name": "Kimi K3",
+        "source": "pi-ai",
+        "pricing": {
+          "currency": "CNY",
+          "source": "https://platform.kimi.com/docs/pricing/chat-k3",
+          "tiers": [
+            {
+              "input_per_million": 20,
+              "output_per_million": 100,
+              "cache_read_per_million": 2,
+              "cache_write_per_million": 0
+            }
+          ]
+        }
+      },
+      {
         "id": "kimi-k2.7-code-highspeed",
         "display_name": "Kimi K2.7 Code HighSpeed",
         "source": "pi-ai",
@@ -1218,53 +1230,6 @@
           }
         },
         "recommended": true
-      },
-      {
-        "id": "qwen3.6-plus-2026-04-02",
-        "display_name": "Qwen 3.6 Plus (2026-04-02)",
-        "source": "fallback",
-        "pricing": {
-          "currency": "CNY",
-          "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
-          "tiers": [
-            {
-              "max_input_tokens": 256000,
-              "input_per_million": 2,
-              "output_per_million": 12,
-              "cache_read_per_million": 0.4,
-              "cache_write_per_million": 0
-            },
-            {
-              "max_input_tokens": 1000000,
-              "input_per_million": 8,
-              "output_per_million": 48,
-              "cache_read_per_million": 1.6,
-              "cache_write_per_million": 0
-            }
-          ],
-          "overrides": {
-            "qwen-intl": {
-              "currency": "CNY",
-              "source": "https://help.aliyun.com/zh/model-studio/model-pricing",
-              "tiers": [
-                {
-                  "max_input_tokens": 256000,
-                  "input_per_million": 3.7471,
-                  "output_per_million": 22.4826,
-                  "cache_read_per_million": 0.74942,
-                  "cache_write_per_million": 0
-                },
-                {
-                  "max_input_tokens": 1000000,
-                  "input_per_million": 14.9884,
-                  "output_per_million": 44.965,
-                  "cache_read_per_million": 2.99768,
-                  "cache_write_per_million": 0
-                }
-              ]
-            }
-          }
-        }
       },
       {
         "id": "qwen3.6-max-preview",

--- a/core/src/agent/provider.rs
+++ b/core/src/agent/provider.rs
@@ -191,7 +191,7 @@ pub static PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         provider: Provider::OpenAI,
         display_name: "OpenAI",
-        default_model: "gpt-5.5",
+        default_model: "gpt-5.6-terra",
         env_keys: &["OPENAI_API_KEY"],
         base_url: Some("https://api.openai.com/v1"),
         model_prefixes: &["gpt-", "o1", "o3", "o4", "chatgpt-"],

--- a/scripts/sync-model-catalog.mjs
+++ b/scripts/sync-model-catalog.mjs
@@ -14,6 +14,7 @@ const shouldCheck = args.has("--check");
 const noOfficial = args.has("--no-official") || process.env.SOCAI_MODEL_SYNC_OFFLINE === "1";
 const noPi = args.has("--no-pi");
 
+const KIMI_PRICING_SOURCE = "https://platform.kimi.com/docs/pricing/chat-k3";
 const QWEN_PRICING_SOURCE = "https://help.aliyun.com/zh/model-studio/model-pricing";
 const DOUBAO_PRICING_SOURCE = "https://www.volcengine.com/product/doubao";
 
@@ -50,10 +51,10 @@ const FALLBACK = {
     entry("claude-opus-4-8", "Claude Opus 4.8"),
     entry("claude-opus-4-6", "Claude Opus 4.6"),
     entry("claude-haiku-4-5", "Claude Haiku 4.5"),
-    entry("claude-3-7-sonnet-20250219", "Claude Sonnet 3.7"),
   ],
   openai: [
-    entry("gpt-5.5", "GPT-5.5", "fallback", true),
+    entry("gpt-5.6-terra", "GPT-5.6 Terra", "fallback", true),
+    entry("gpt-5.5", "GPT-5.5"),
     entry("gpt-5.4", "GPT-5.4"),
     entry("gpt-5", "GPT-5"),
     entry("gpt-4.1", "GPT-4.1"),
@@ -73,15 +74,6 @@ const FALLBACK = {
       "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
         qwenPriceTier(256000, 2.998, 11.991),
         qwenPriceTier(1000000, 8.993, 35.972),
-      ]),
-    })),
-    entry("qwen3.6-plus-2026-04-02", "Qwen 3.6 Plus (2026-04-02)", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
-      qwenPriceTier(256000, 2, 12),
-      qwenPriceTier(1000000, 8, 48),
-    ], {
-      "qwen-intl": pricing("CNY", QWEN_PRICING_SOURCE, [
-        qwenPriceTier(256000, 3.7471, 22.4826),
-        qwenPriceTier(1000000, 14.9884, 44.965),
       ]),
     })),
     entry("qwen3.7-max", "Qwen 3.7 Max", "fallback", false, pricing("CNY", QWEN_PRICING_SOURCE, [
@@ -131,6 +123,15 @@ const FALLBACK = {
     entry("deepseek-v4-pro", "DeepSeek V4 Pro", "fallback", true),
     entry("deepseek-v4-flash", "DeepSeek V4 Flash"),
   ],
+};
+
+// Keep provider-specific billing aligned with the endpoint socai actually
+// targets when pi-ai's normalized USD pricing is not the right user-facing
+// rate. Model identity and other metadata still come from pi-ai.
+const PRICING_OVERRIDES = {
+  kimi: {
+    "kimi-k3": pricing("CNY", KIMI_PRICING_SOURCE, [priceTier(undefined, 20, 100, 2)]),
+  },
 };
 
 const PROVIDERS = {
@@ -489,6 +490,10 @@ async function buildCatalog() {
     }
     const piEntries = piEntriesForProvider(pi, provider, cfg);
     const merged = dedupe([...official, ...piEntries, ...(FALLBACK[provider] || [])]);
+    for (const model of merged) {
+      const modelPricing = PRICING_OVERRIDES[provider]?.[model.id];
+      if (modelPricing) model.pricing = modelPricing;
+    }
     providers[provider] = sortEntries(provider, markRecommended(provider, merged));
     const sourceSummary = [...new Set(providers[provider].map((item) => item.source))].join(", ");
     console.error(`[model-sync] ${provider}: ${providers[provider].length} models (${sourceSummary})`);


### PR DESCRIPTION
## What changed

- upgrade pi-ai to 0.80.10 and sync Kimi K3 from its model catalog
- use mainland Kimi CNY pricing for K3 cost estimates
- make GPT-5.6 Terra the OpenAI compiled default and recommended model
- remove obsolete Claude 3.7 and dated Qwen 3.6 fallback entries

## Why

Socai primarily connects Kimi users to the mainland Moonshot endpoint, so K3 cost estimates should use that endpoint's official CNY rates. The newer pi-ai catalog now supplies the K3 model metadata directly, removing the need for a local model fallback.

## User impact

Kimi K3 is selectable with mainland pricing, and new OpenAI configurations default to GPT-5.6 Terra. Existing persisted model selections remain unchanged.

## Validation

- model catalog offline sync check
- cargo check -p socai-core
- pnpm frozen lockfile install
- git diff whitespace check
