### PR TITLE
fix(xhs): wait for hydrated note details

### DIFF
--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -97,6 +97,27 @@ pub(super) fn ensure_entity_note_id(entity: &mut Value, card: &XhsNoteCard) {
     map.insert("note_id".into(), Value::String(fallback_note_id));
 }
 
+/// Preserve trustworthy search-card identity/count fields when the detail DOM
+/// is still partially hydrated. Detail values win whenever they are present.
+pub(super) fn fill_entity_from_card(entity: &mut Value, card: &XhsNoteCard) {
+    let Some(map) = entity.as_object_mut() else {
+        return;
+    };
+    for (key, fallback) in [
+        ("title", card.title.as_str()),
+        ("author", card.author.as_str()),
+        ("author_id", card.author_id.as_str()),
+        ("author_url", card.author_url.as_str()),
+        ("likes", card.likes.as_str()),
+        ("type", card.r#type.as_str()),
+    ] {
+        let current = map.get(key).and_then(Value::as_str).unwrap_or("").trim();
+        if current.is_empty() && !fallback.trim().is_empty() {
+            map.insert(key.into(), Value::String(fallback.trim().to_string()));
+        }
+    }
+}
+
 fn note_id_fallback(entity: &Value, card: &XhsNoteCard) -> String {
     let card_note_id = card.note_id.trim();
     if !card_note_id.is_empty() {

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -105,9 +105,9 @@ pub struct ReadNoteOptions {
     /// Transcribe downloaded video notes through the configured cloud ASR
     /// server. Implies `download_media` and `download_video_file` at the caller.
     pub transcribe_audio: bool,
-    /// Optional hydration settle after body content first appears. Direct
-    /// full-screen note routes use this because engagement counts can mount a
-    /// fraction later than the body; modal reads keep the zero default.
+    /// Optional additional hydration settle after body content first appears.
+    /// The page script always applies a small baseline settle because XHS can
+    /// mount engagement counts after the body.
     pub settle_ms: i64,
     pub max_images: usize,
     pub poster_url_fallback: String,
@@ -2028,13 +2028,9 @@ fn opened_note_id_from_url(url: &str) -> String {
 
 fn note_is_open(state: &Value) -> bool {
     state
-        .get("on_detail_route")
+        .get("detail_ready")
         .and_then(Value::as_bool)
         .unwrap_or(false)
-        || state
-            .get("has_modal")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
 }
 
 fn number(value: &Value, key: &str) -> f64 {

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -504,11 +504,22 @@ const SocaiXhsPageScripts = (() => {
 
   function noteOpen() {
     const url = location.href;
+    // 2026-07 `/search_result_ai` updates history to `/explore/<id>` before
+    // the detail tree mounts. Treating the URL alone as an open note lets the
+    // extractor run against the search feed and pick up the signed-in user or
+    // another card's engagement. The current detail UI exposes these stable
+    // structural roots once it is actually ready for scoped extraction.
+    const detailRoot = getNoteOverlay() || $('#noteContainer');
+    const detailReady = !!detailRoot && isVisible(detailRoot) && (
+      detailRoot.matches?.('#noteContainer, .note-scroller, .note-content')
+      || !!detailRoot.querySelector?.('#noteContainer, .note-scroller, .note-content, .author-container')
+    );
     return {
       ok: true,
       url,
       on_detail_route: /\/(?:explore|discovery|search_result)\/[^/?#]+/.test(url),
       has_modal: !!getNoteOverlay(),
+      detail_ready: detailReady,
       login_required: loginWallVisible(),
     };
   }
@@ -978,10 +989,10 @@ const SocaiXhsPageScripts = (() => {
       date,
       location: locationText,
       ip_location: ipLocation,
-      likes,
-      favorites,
-      comments_count: commentsCount,
-      shares,
+      likes: likes === '赞' ? '' : likes,
+      favorites: favorites === '收藏' ? '' : favorites,
+      comments_count: commentsCount === '评论' ? '' : commentsCount,
+      shares: shares === '分享' ? '' : shares,
       hashtags,
       image_count: imageUrls.length,
       image_urls: imageUrls,
@@ -1047,29 +1058,50 @@ const SocaiXhsPageScripts = (() => {
 
   function noteWithWait(opts = {}) {
     const timeoutMs = Math.max(500, Number(opts.timeout_ms) || 8000);
-    const shellSettleMs = Math.max(500, Number(opts.shell_settle_ms) || 3500);
-    const contentSettleMs = Math.max(0, Number(opts.settle_ms) || 0);
+    // Body text and engagement counters now hydrate in separate passes. Keep
+    // every note open for at least one second after body text appears, and
+    // allow up to three seconds when any of the three counters is still an
+    // empty/label placeholder. A caller may request a longer settle.
+    const contentSettleMs = Math.max(1000, Number(opts.settle_ms) || 0);
+    const incompleteEngagementSettleMs = Math.max(contentSettleMs, 3000);
     return new Promise((resolve) => {
       const startedAt = Date.now();
-      let shellSeenAt = 0;
       let contentSeenAt = 0;
       let best = null;
+      let bestScore = -1;
       let attempts = 0;
+      const meaningfulStat = (value) => {
+        const valueText = norm(value);
+        return !!valueText && !/^(?:赞|收藏|评论|分享)$/.test(valueText);
+      };
+      const hydrationScore = (value) => {
+        const bodyLength = norm(value.content).length;
+        return (bodyLength ? 1000 + Math.min(bodyLength, 4000) : 0)
+          + (norm(value.title) ? 100 : 0)
+          + (norm(value.author) ? 100 : 0)
+          + [value.likes, value.favorites, value.comments_count]
+            .filter(meaningfulStat).length * 200
+          + (Number(value.image_count) > 0 || value.type === 'video' ? 50 : 0);
+      };
       const tick = () => {
         attempts += 1;
-        const root = getNoteRoot();
         const value = note();
         const hasContent = !!norm(value.content);
         const hasShell = !!(value.note_id || value.title || value.author || value.likes || value.comments_count);
-        const pending = pendingHydration(root);
-        if (hasShell) { best = value; if (!shellSeenAt) shellSeenAt = Date.now(); }
-        if (hasContent && !contentSeenAt) contentSeenAt = Date.now();
-        if (hasContent && (contentSettleMs === 0 || Date.now() - contentSeenAt >= contentSettleMs)) {
-          resolve({ ready: true, reason: contentSettleMs > 0 ? 'content_settled' : 'content_ready', waited_ms: Date.now() - startedAt, attempts, note: value });
-          return;
+        const engagementReady = [value.likes, value.favorites, value.comments_count]
+          .every(meaningfulStat);
+        const score = hydrationScore(value);
+        if (hasShell && score >= bestScore) {
+          best = value;
+          bestScore = score;
         }
-        if (hasShell && !pending && Date.now() - shellSeenAt >= shellSettleMs) {
-          resolve({ ready: true, reason: 'shell_settled', waited_ms: Date.now() - startedAt, attempts, note: value });
+        if (hasContent && !contentSeenAt) contentSeenAt = Date.now();
+        const contentAge = contentSeenAt ? Date.now() - contentSeenAt : 0;
+        const requiredSettleMs = engagementReady
+          ? contentSettleMs
+          : incompleteEngagementSettleMs;
+        if (hasContent && contentAge >= requiredSettleMs) {
+          resolve({ ready: true, reason: engagementReady ? 'content_and_engagement_settled' : 'content_settled', waited_ms: Date.now() - startedAt, attempts, note: best || value });
           return;
         }
         if (Date.now() - startedAt >= timeoutMs) {

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -28,7 +28,8 @@ use crate::sites::runner::{
 };
 use crate::sites::xhs::entities::{parse_posted_at_ms, parse_stat_count};
 use crate::sites::xhs::media_manifest::{
-    ensure_entity_note_id, search_media_manifest, write_media_manifest_file,
+    ensure_entity_note_id, fill_entity_from_card, search_media_manifest,
+    write_media_manifest_file,
 };
 use crate::sites::xhs::page::{LoginGate, XHS_SEARCH_FILTERS};
 use crate::sites::xhs::{
@@ -1216,6 +1217,7 @@ async fn scan_card_note(
             let ok = payload.get("ok").and_then(Value::as_bool).unwrap_or(false);
             let mut entity = payload.get("entity").cloned().unwrap_or(Value::Null);
             ensure_entity_note_id(&mut entity, card);
+            fill_entity_from_card(&mut entity, card);
             // When the read failed (modal never opened, stale note, …), fall
             // back to the card so the entry still carries note_id/title, and
             // surface the failure reason for debugging.


### PR DESCRIPTION
## Summary
- require the visible XHS detail tree before treating a card click as open
- wait for body and engagement hydration and ignore label placeholders
- fall back to trustworthy search-card identity/count fields when detail fields remain empty

## Verification
- `node --check core/src/sites/xhs/page_scripts.js`
- `cargo check -p socai-core -p socai-cli`
- `cargo test -p socai-core sites::xhs --lib` (35 passed)
- live default-profile regressions: two XHS searches plus a three-note tokenized `get-notes` read; card/detail likes matched (`10/27/11`) and bodies/authors/counts were complete