### PR TITLE
release: mirror downloads to Alibaba OSS

### DIFF
--- a/.github/scripts/publish-oss-release.py
+++ b/.github/scripts/publish-oss-release.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Publish signed release artifacts to Alibaba Cloud OSS.
+
+The release is staged under an immutable version prefix before GitHub is
+published. The mutable latest prefix is promoted only after GitHub succeeds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+import oss2
+
+
+IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+LATEST_CACHE_CONTROL = "no-cache, no-store, must-revalidate"
+PLATFORMS = ("darwin-aarch64", "darwin-x86_64", "windows-x86_64")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase", choices=("stage", "promote"))
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--prefix", default="releases")
+    parser.add_argument("--public-base-url", required=True)
+    return parser.parse_args()
+
+
+def content_type(name: str) -> str:
+    explicit = {
+        ".dmg": "application/x-apple-diskimage",
+        ".exe": "application/vnd.microsoft.portable-executable",
+        ".json": "application/json",
+        ".ps1": "text/plain; charset=utf-8",
+        ".sh": "text/plain; charset=utf-8",
+        ".sig": "text/plain; charset=utf-8",
+    }
+    for suffix, value in explicit.items():
+        if name.endswith(suffix):
+            return value
+    guessed, _ = mimetypes.guess_type(name)
+    return guessed or "application/octet-stream"
+
+
+def headers_for(name: str, cache_control: str) -> dict[str, str]:
+    headers = {
+        "Cache-Control": cache_control,
+        "Content-Type": content_type(name),
+    }
+    if name.endswith((".dmg", ".exe", ".tar.gz", ".zip")):
+        headers["Content-Disposition"] = f'attachment; filename="{name}"'
+    return headers
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def public_url(base_url: str, *parts: str) -> str:
+    encoded = "/".join(quote(part, safe="") for part in parts)
+    return f"{base_url.rstrip('/')}/{encoded}"
+
+
+def build_oss_manifest(source_dir: Path, tag: str, base_url: str) -> bytes:
+    source = json.loads((source_dir / "latest.json").read_text())
+    platforms = source.get("platforms", {})
+    for platform in PLATFORMS:
+        entry = platforms.get(platform)
+        if not isinstance(entry, dict):
+            raise SystemExit(f"latest.json missing platform {platform}")
+        asset_name = Path(urlparse(entry.get("url", "")).path).name
+        if not asset_name or not (source_dir / asset_name).is_file():
+            raise SystemExit(
+                f"latest.json {platform} references missing asset {asset_name!r}"
+            )
+        entry["url"] = public_url(base_url, tag, asset_name)
+    return (json.dumps(source, indent=2) + "\n").encode()
+
+
+def source_payloads(source_dir: Path, oss_manifest: bytes) -> dict[str, bytes | Path]:
+    payloads: dict[str, bytes | Path] = {}
+    for path in sorted(source_dir.iterdir()):
+        if not path.is_file():
+            continue
+        payloads[path.name] = oss_manifest if path.name == "latest.json" else path
+    if "latest.json" not in payloads:
+        raise SystemExit(f"missing {source_dir / 'latest.json'}")
+    return payloads
+
+
+def payload_size(payload: bytes | Path) -> int:
+    return len(payload) if isinstance(payload, bytes) else payload.stat().st_size
+
+
+def payload_sha256(payload: bytes | Path) -> str:
+    if isinstance(payload, bytes):
+        return sha256_bytes(payload)
+    digest = hashlib.sha256()
+    with payload.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def upload(
+    bucket: oss2.Bucket,
+    key: str,
+    name: str,
+    payload: bytes | Path,
+    cache_control: str,
+) -> None:
+    headers = headers_for(name, cache_control)
+    if isinstance(payload, bytes):
+        bucket.put_object(key, payload, headers=headers)
+    else:
+        oss2.resumable_upload(bucket, key, str(payload), headers=headers)
+    result = bucket.head_object(key)
+    expected_size = payload_size(payload)
+    if result.content_length != expected_size:
+        raise SystemExit(
+            f"OSS size mismatch for {key}: {result.content_length} != {expected_size}"
+        )
+    print(
+        f"uploaded {key} size={expected_size} sha256={payload_sha256(payload)}",
+        flush=True,
+    )
+
+
+def verify_public_object(url: str, expected_size: int | None = None) -> None:
+    request = Request(url, method="HEAD", headers={"Cache-Control": "no-cache"})
+    with urlopen(request, timeout=60) as response:
+        if response.status != 200:
+            raise SystemExit(f"public verification failed for {url}: {response.status}")
+        length = response.headers.get("Content-Length")
+        if expected_size is not None and length and int(length) != expected_size:
+            raise SystemExit(
+                f"public size mismatch for {url}: {length} != {expected_size}"
+            )
+    print(f"verified public {url}", flush=True)
+
+
+def verify_public_manifest(url: str, tag: str, base_url: str) -> None:
+    request = Request(url, headers={"Cache-Control": "no-cache"})
+    with urlopen(request, timeout=60) as response:
+        manifest = json.load(response)
+    expected_version = tag.removeprefix("v")
+    if manifest.get("version") != expected_version:
+        raise SystemExit(
+            f"public manifest version {manifest.get('version')} != {expected_version}"
+        )
+    for platform in PLATFORMS:
+        entry = manifest.get("platforms", {}).get(platform, {})
+        asset_url = entry.get("url", "")
+        signature = entry.get("signature", "")
+        if not signature:
+            raise SystemExit(f"public manifest {platform} signature is empty")
+        if not asset_url.startswith(f"{base_url.rstrip('/')}/{tag}/"):
+            raise SystemExit(f"public manifest {platform} has unexpected URL {asset_url}")
+        verify_public_object(asset_url)
+    print(f"verified public manifest {url}", flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    source_dir = args.source_dir.resolve()
+    if not source_dir.is_dir():
+        raise SystemExit(f"source directory does not exist: {source_dir}")
+
+    access_key_id = os.environ.get("ALIYUN_ACCESS_KEY_ID", "")
+    access_key_secret = os.environ.get("ALIYUN_ACCESS_KEY_SECRET", "")
+    security_token = os.environ.get("ALIYUN_SECURITY_TOKEN", "")
+    if not access_key_id or not access_key_secret:
+        raise SystemExit("missing ALIYUN_ACCESS_KEY_ID or ALIYUN_ACCESS_KEY_SECRET")
+
+    auth: oss2.Auth | oss2.StsAuth
+    if security_token:
+        auth = oss2.StsAuth(access_key_id, access_key_secret, security_token)
+    else:
+        auth = oss2.Auth(access_key_id, access_key_secret)
+
+    bucket = oss2.Bucket(auth, args.endpoint, args.bucket)
+    prefix = args.prefix.strip("/")
+    base_url = args.public_base_url.rstrip("/")
+    oss_manifest = build_oss_manifest(source_dir, args.tag, base_url)
+    payloads = source_payloads(source_dir, oss_manifest)
+
+    if args.phase == "stage":
+        for name, payload in payloads.items():
+            key = f"{prefix}/{args.tag}/{name}"
+            upload(bucket, key, name, payload, IMMUTABLE_CACHE_CONTROL)
+        for name, payload in payloads.items():
+            verify_public_object(
+                public_url(base_url, args.tag, name),
+                payload_size(payload),
+            )
+        verify_public_manifest(
+            public_url(base_url, args.tag, "latest.json"),
+            args.tag,
+            base_url,
+        )
+        return
+
+    # Update mutable assets first and latest.json last. Existing updater
+    # manifests always reference immutable versioned assets, so this promotion
+    # cannot invalidate an older updater response.
+    for name, payload in payloads.items():
+        if name == "latest.json":
+            continue
+        versioned_key = f"{prefix}/{args.tag}/{name}"
+        versioned = bucket.head_object(versioned_key)
+        if versioned.content_length != payload_size(payload):
+            raise SystemExit(f"staged OSS object is missing or incomplete: {versioned_key}")
+        upload(
+            bucket,
+            f"{prefix}/latest/{name}",
+            name,
+            payload,
+            LATEST_CACHE_CONTROL,
+        )
+
+    upload(
+        bucket,
+        f"{prefix}/latest/latest.json",
+        "latest.json",
+        oss_manifest,
+        LATEST_CACHE_CONTROL,
+    )
+    verify_public_manifest(
+        public_url(base_url, "latest", "latest.json"),
+        args.tag,
+        base_url,
+    )
+    for name, payload in payloads.items():
+        verify_public_object(
+            public_url(base_url, "latest", name),
+            payload_size(payload),
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except oss2.exceptions.OssError as exc:
+        print(
+            f"OSS request failed: status={exc.status} code={exc.code} "
+            f"request_id={exc.request_id}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -949,6 +949,11 @@ jobs:
       - build-windows-cli
       - build-windows-app
     runs-on: ubuntu-latest
+    env:
+      SOCAI_OSS_BUCKET: ${{ vars.SOCAI_OSS_BUCKET }}
+      SOCAI_OSS_ENDPOINT: ${{ vars.SOCAI_OSS_ENDPOINT }}
+      SOCAI_OSS_PREFIX: ${{ vars.SOCAI_OSS_PREFIX }}
+      SOCAI_OSS_PUBLIC_BASE_URL: ${{ vars.SOCAI_OSS_PUBLIC_BASE_URL }}
 
     steps:
       - name: checkout main
@@ -1002,6 +1007,24 @@ jobs:
 
           echo "merged latest.json:"
           cat "${manifest}"
+
+      - name: install OSS release publisher dependencies
+        run: python3 -m pip install --disable-pip-version-check --quiet oss2==2.19.1
+
+      - name: stage versioned release on Alibaba Cloud OSS
+        env:
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/publish-oss-release.py stage \
+            --source-dir dist-artifacts \
+            --bucket "${SOCAI_OSS_BUCKET}" \
+            --endpoint "${SOCAI_OSS_ENDPOINT}" \
+            --tag "${TAG}" \
+            --prefix "${SOCAI_OSS_PREFIX}" \
+            --public-base-url "${SOCAI_OSS_PUBLIC_BASE_URL}"
 
       - name: publish release
         shell: bash
@@ -1084,6 +1107,15 @@ jobs:
           cat > release-notes.md <<EOF
           ## downloads
 
+          China mirror:
+
+          - [universal mac dmg](${SOCAI_OSS_PUBLIC_BASE_URL}/${TAG}/socai-macos-universal.dmg)
+          - [windows app installer (.exe)](${SOCAI_OSS_PUBLIC_BASE_URL}/${TAG}/socai-windows-x86_64-setup.exe)
+          - [macOS CLI installer](${SOCAI_OSS_PUBLIC_BASE_URL}/${TAG}/install.sh)
+          - [Windows CLI installer](${SOCAI_OSS_PUBLIC_BASE_URL}/${TAG}/install.ps1)
+
+          GitHub archive:
+
           - [universal mac dmg](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-macos-universal.dmg) — supports Apple Silicon and Intel Macs.
           - [windows app installer (.exe)](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/socai-windows-x86_64-setup.exe) — desktop app for Windows 10/11 (x64).
           - [macOS CLI installer](https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/install.sh) — one-command macOS CLI install.
@@ -1119,6 +1151,21 @@ jobs:
 
           trap - ERR
           cat release-notes.md
+
+      - name: promote OSS latest release
+        env:
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/publish-oss-release.py promote \
+            --source-dir dist-artifacts \
+            --bucket "${SOCAI_OSS_BUCKET}" \
+            --endpoint "${SOCAI_OSS_ENDPOINT}" \
+            --tag "${TAG}" \
+            --prefix "${SOCAI_OSS_PREFIX}" \
+            --public-base-url "${SOCAI_OSS_PUBLIC_BASE_URL}"
 
   verify-cli-installer:
     name: verify latest CLI installer
@@ -1294,41 +1341,42 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          OSS_MANIFEST_URL: ${{ vars.SOCAI_OSS_PUBLIC_BASE_URL }}/latest/latest.json
         run: |
           set -euo pipefail
 
-          manifest_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/latest.json"
-
-          manifest=""
-          for attempt in {1..12}; do
-            echo "fetch attempt ${attempt}: ${manifest_url}"
-            if manifest="$(curl -fsSL "${manifest_url}")"; then
-              break
-            fi
+          github_manifest_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/latest.json"
+          for manifest_url in "${OSS_MANIFEST_URL}" "${github_manifest_url}"; do
             manifest=""
-            sleep 10
-          done
+            for attempt in {1..12}; do
+              echo "fetch attempt ${attempt}: ${manifest_url}"
+              if manifest="$(curl -fsSL -H 'Cache-Control: no-cache' "${manifest_url}")"; then
+                break
+              fi
+              manifest=""
+              sleep 10
+            done
 
-          if [ -z "${manifest}" ]; then
-            echo "failed to fetch latest.json from latest release" >&2
-            exit 1
-          fi
-
-          echo "${manifest}"
-
-          manifest_version="$(printf '%s' "${manifest}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
-          if [ "${manifest_version}" != "${VERSION}" ]; then
-            echo "latest.json version ${manifest_version} does not match release ${VERSION}" >&2
-            exit 1
-          fi
-
-          for arch in darwin-aarch64 darwin-x86_64 windows-x86_64; do
-            asset_url="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['url'])")"
-            signature="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['signature'])")"
-            if [ -z "${signature}" ]; then
-              echo "latest.json ${arch} signature is empty" >&2
+            if [ -z "${manifest}" ]; then
+              echo "failed to fetch updater manifest ${manifest_url}" >&2
               exit 1
             fi
-            echo "checking ${arch} updater asset: ${asset_url}"
-            curl -fsSL -I "${asset_url}" > /dev/null
+
+            echo "${manifest}"
+            manifest_version="$(printf '%s' "${manifest}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+            if [ "${manifest_version}" != "${VERSION}" ]; then
+              echo "latest.json version ${manifest_version} does not match release ${VERSION}" >&2
+              exit 1
+            fi
+
+            for arch in darwin-aarch64 darwin-x86_64 windows-x86_64; do
+              asset_url="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['url'])")"
+              signature="$(printf '%s' "${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin)['platforms']['${arch}']['signature'])")"
+              if [ -z "${signature}" ]; then
+                echo "latest.json ${arch} signature is empty" >&2
+                exit 1
+              fi
+              echo "checking ${arch} updater asset: ${asset_url}"
+              curl -fsSL -I "${asset_url}" > /dev/null
+            done
           done

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -63,6 +63,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkzQ0JFNTY3QTZFRjUzMUQKUldRZFUrK21aK1hMazFSSExtMTl4QWpCZzZ5OVFjcXpicGkrTWJ6VGZlYVplYjJiZEdrajVmdE0K",
       "endpoints": [
+        "https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest/latest.json",
         "https://github.com/socai-io/socai/releases/latest/download/latest.json"
       ]
     }

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -25,14 +25,41 @@ prepare
   └─ build-windows-cli      # Windows x86_64 CLI
 
 release                    # waits for all platform build jobs
+  ├─ stage versioned assets on Alibaba Cloud OSS
+  ├─ publish GitHub Release
+  ├─ promote OSS releases/latest
   ├─ verify-cli-installer          # macOS latest-release installer smoke
   ├─ verify-windows-cli-installer  # Windows latest-release installer smoke
-  └─ verify-desktop-updater        # desktop latest.json manifest check
+  └─ verify-desktop-updater        # OSS + GitHub latest.json checks
 ```
 
 The macOS app/DMG, macOS CLI, and Windows CLI build jobs run in parallel. The
-`release` job stays centralized so all platform artifacts are collected into one
-GitHub Release atomically.
+`release` job stays centralized so the same signed artifacts are published to
+Alibaba Cloud OSS and GitHub Releases.
+
+## Distribution hosts
+
+Alibaba Cloud OSS is the primary download host for the website, CLI installers,
+and desktop updater. GitHub Releases remains the public archive and updater
+fallback.
+
+The production repository defines these GitHub Actions variables:
+
+- `SOCAI_OSS_BUCKET`
+- `SOCAI_OSS_ENDPOINT`
+- `SOCAI_OSS_PREFIX`
+- `SOCAI_OSS_PUBLIC_BASE_URL`
+
+The release job reads `ALIYUN_ACCESS_KEY_ID` and
+`ALIYUN_ACCESS_KEY_SECRET` from GitHub Actions secrets. The RAM identity should
+be restricted to uploading objects under the configured bucket/prefix. Do not
+put credentials in the repository.
+
+The publisher first uploads immutable objects to
+`releases/vMAJOR.MINOR.PATCH/` and verifies their public URLs. After GitHub
+publishes successfully, it updates the mutable `releases/latest/` objects,
+writing `latest.json` last. Versioned objects use a one-year immutable cache;
+the latest alias uses `no-cache`.
 
 ## Versioning
 
@@ -144,15 +171,17 @@ socai-macos-universal.app.tar.gz.sig
 latest.json
 ```
 
-The release notes link to the app DMG, macOS CLI installer/archive/checksum, and
-Windows CLI installer/archive/checksum. `latest.json`,
-`socai-macos-universal.app.tar.gz`, and its `.sig` back the in-app auto-updater
-and are served via the same `releases/latest/download/...` alias.
+The release notes link to both the OSS mirror and GitHub archive. The GitHub
+`latest.json` continues to reference GitHub assets. The OSS copy is generated
+separately and references immutable OSS version URLs. This keeps the desktop
+updater's second GitHub endpoint a real fallback instead of returning a GitHub
+manifest that still depends on OSS.
 
 ## Installer smoke tests
 
-Installer smoke tests run **after** the GitHub Release is published because they
-use GitHub's real `releases/latest/download/...` URLs.
+Installer smoke tests run after both destinations publish. The scripts are
+fetched from GitHub, then download the CLI archive from OSS by default and retry
+GitHub if the OSS download or checksum verification fails.
 
 ### macOS installer verification
 
@@ -184,12 +213,12 @@ with a temporary `SOCAI_INSTALL_DIR`. It verifies:
 
 ### Desktop updater verification
 
-`verify-desktop-updater` runs on `ubuntu-latest` and fetches
-`releases/latest/download/latest.json`. It verifies:
+`verify-desktop-updater` runs on `ubuntu-latest` and fetches both the OSS and
+GitHub `latest.json` URLs. It verifies:
 
 - the manifest `version` matches the release version
 - each `darwin-*` platform has a non-empty signature
-- each platform's updater tarball URL resolves (HTTP `HEAD`)
+- each platform's updater artifact URL resolves (HTTP `HEAD`)
 
 ## Update behavior
 

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -3,7 +3,9 @@ $ErrorActionPreference = 'Stop'
 $Repo = 'socai-io/socai'
 $Asset = 'socai-cli-windows-x86_64.zip'
 $Checksum = "$Asset.sha256"
-$BaseUrl = if ($env:SOCAI_DOWNLOAD_BASE_URL) { $env:SOCAI_DOWNLOAD_BASE_URL } else { "https://github.com/$Repo/releases/latest/download" }
+$DefaultBaseUrl = 'https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest'
+$GitHubBaseUrl = "https://github.com/$Repo/releases/latest/download"
+$BaseUrl = if ($env:SOCAI_DOWNLOAD_BASE_URL) { $env:SOCAI_DOWNLOAD_BASE_URL } else { $DefaultBaseUrl }
 $InstallDir = if ($env:SOCAI_INSTALL_DIR) { $env:SOCAI_INSTALL_DIR } else { Join-Path $HOME '.socai\bin' }
 
 if ($env:OS -ne 'Windows_NT') {
@@ -18,14 +20,27 @@ try {
     $ChecksumPath = Join-Path $TempDir $Checksum
     $UnpackDir = Join-Path $TempDir 'unpack'
 
-    Write-Host "downloading socai CLI from $BaseUrl"
-    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Asset" -OutFile $ArchivePath
-    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Checksum" -OutFile $ChecksumPath
-
-    $ExpectedHash = ((Get-Content -Raw $ChecksumPath).Trim() -split '\s+')[0].ToLowerInvariant()
-    $ActualHash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
-    if ($ActualHash -ne $ExpectedHash) {
-        throw "checksum mismatch for $Asset`: expected $ExpectedHash, got $ActualHash"
+    $Downloaded = $false
+    foreach ($CandidateBaseUrl in (@($BaseUrl, $GitHubBaseUrl) | Select-Object -Unique)) {
+        Write-Host "downloading socai CLI from $CandidateBaseUrl"
+        Remove-Item -Force -LiteralPath $ArchivePath, $ChecksumPath -ErrorAction SilentlyContinue
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri "$CandidateBaseUrl/$Asset" -OutFile $ArchivePath
+            Invoke-WebRequest -UseBasicParsing -Uri "$CandidateBaseUrl/$Checksum" -OutFile $ChecksumPath
+            $ExpectedHash = ((Get-Content -Raw $ChecksumPath).Trim() -split '\s+')[0].ToLowerInvariant()
+            $ActualHash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
+            if ($ActualHash -ne $ExpectedHash) {
+                throw "checksum mismatch for $Asset`: expected $ExpectedHash, got $ActualHash"
+            }
+            $BaseUrl = $CandidateBaseUrl
+            $Downloaded = $true
+            break
+        } catch {
+            Write-Warning "download or checksum verification failed from $CandidateBaseUrl`: $_"
+        }
+    }
+    if (-not $Downloaded) {
+        throw 'failed to download a verified socai CLI release'
     }
     Write-Host "$Asset`: OK"
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -4,7 +4,9 @@ set -eu
 repo="socai-io/socai"
 asset="socai-cli-macos-universal.tar.gz"
 checksum="${asset}.sha256"
-base_url="${SOCAI_DOWNLOAD_BASE_URL:-https://github.com/${repo}/releases/latest/download}"
+default_base_url="https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest"
+github_base_url="https://github.com/${repo}/releases/latest/download"
+base_url="${SOCAI_DOWNLOAD_BASE_URL:-$default_base_url}"
 install_dir="${SOCAI_INSTALL_DIR:-$HOME/.socai/bin}"
 
 case "$(uname -s 2>/dev/null || echo unknown)" in
@@ -39,10 +41,30 @@ archive="$tmp_dir/$asset"
 checksum_file="$tmp_dir/$checksum"
 unpack_dir="$tmp_dir/unpack"
 
-printf 'downloading socai CLI from %s\n' "$base_url"
-curl -fL "$base_url/$asset" -o "$archive"
-curl -fL "$base_url/$checksum" -o "$checksum_file"
-(cd "$tmp_dir" && shasum -a 256 -c "$checksum")
+downloaded=false
+attempted_base_url=""
+for candidate_base_url in "$base_url" "$github_base_url"; do
+  if [ "$candidate_base_url" = "$attempted_base_url" ]; then
+    continue
+  fi
+  attempted_base_url="$candidate_base_url"
+
+  printf 'downloading socai CLI from %s\n' "$candidate_base_url"
+  rm -f "$archive" "$checksum_file"
+  if curl -fL "$candidate_base_url/$asset" -o "$archive" &&
+    curl -fL "$candidate_base_url/$checksum" -o "$checksum_file" &&
+    (cd "$tmp_dir" && shasum -a 256 -c "$checksum"); then
+    base_url="$candidate_base_url"
+    downloaded=true
+    break
+  fi
+  printf 'download or checksum verification failed from %s\n' "$candidate_base_url" >&2
+done
+
+if [ "$downloaded" != "true" ]; then
+  echo "failed to download a verified socai CLI release" >&2
+  exit 1
+fi
 
 mkdir -p "$unpack_dir" "$install_dir"
 tar -xzf "$archive" -C "$unpack_dir"

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -43,17 +43,17 @@
     },
     {
       "source": "/download",
-      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg",
+      "destination": "https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest/socai-macos-universal.dmg",
       "permanent": false
     },
     {
       "source": "/download/macos",
-      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg",
+      "destination": "https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest/socai-macos-universal.dmg",
       "permanent": false
     },
     {
       "source": "/download/windows",
-      "destination": "https://github.com/socai-io/socai/releases/latest/download/socai-windows-x86_64-setup.exe",
+      "destination": "https://socai-download.oss-cn-beijing.aliyuncs.com/releases/latest/socai-windows-x86_64-setup.exe",
       "permanent": false
     },
     {


### PR DESCRIPTION
## What changed

- mirror every GitHub Release artifact to the socai-download Alibaba Cloud OSS bucket
- publish immutable versioned objects before the GitHub Release and promote releases/latest only after GitHub succeeds
- use OSS first for socai.io downloads, desktop updater, and CLI archives, with GitHub fallback where supported
- keep README and GitHub Release assets available on GitHub
- document the dual-host release flow and validation

## Why

Mainland users can have unreliable GitHub asset downloads. The OSS mirror provides a public mainland download path without removing GitHub as the canonical archive and fallback.

## Validation

- pnpm --dir site build
- pnpm --dir app build
- actionlint release workflow
- shellcheck macOS installer
- Python/JSON syntax checks
- git diff --check
- anonymous OSS downloads and checksums verified against GitHub v0.4.13 assets