### PR TITLE
fix(agent): never split tool_use/tool_result pairs at the compaction boundary

### DIFF
--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -20,10 +20,12 @@ const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 
 /// Rewrite the transcript only when it has grown beyond `compact_after` full
 /// messages. The original first message remains, the last `keep_recent`
-/// messages remain verbatim, and the older tool outputs become artifact
-/// locators. Mutating the transcript, rather than rebuilding a summary for
-/// every request, leaves the request prefix stable until the next sawtooth
-/// compaction point and therefore friendly to provider prompt caches.
+/// messages remain verbatim (widened backward when the window would open on
+/// a tool_result message, so tool_use/tool_result pairs never split), and
+/// the older tool outputs become artifact locators. Mutating the transcript,
+/// rather than rebuilding a summary for every request, leaves the request
+/// prefix stable until the next sawtooth compaction point and therefore
+/// friendly to provider prompt caches.
 pub fn compact_messages_for_context(
     messages: &mut Vec<Message>,
     compact_after: usize,
@@ -37,7 +39,18 @@ pub fn compact_messages_for_context(
         return false;
     }
 
-    let recent_start = messages.len() - keep_recent;
+    let mut recent_start = messages.len() - keep_recent;
+    // Tool results live in a user message appended immediately after the
+    // assistant message carrying the matching tool_use blocks, and providers
+    // reject a request that keeps one side of that pair without the other
+    // (OpenAI-compat: tool message without tool_calls; Anthropic: tool_result
+    // without its tool_use). A count-based boundary can land between the two —
+    // an extra lone user message (max-tokens discard note, forced-summary
+    // prompt) shifts the window onto the tool_result — so widen the window
+    // until it no longer starts mid-pair.
+    while recent_start > 1 && contains_tool_result(&messages[recent_start]) {
+        recent_start -= 1;
+    }
     let original = messages[0].clone();
     let older = &messages[1..recent_start];
     let recent = messages[recent_start..].to_vec();
@@ -51,6 +64,15 @@ pub fn compact_messages_for_context(
     compacted.extend(recent);
     *messages = compacted;
     true
+}
+
+fn contains_tool_result(message: &Message) -> bool {
+    match &message.content {
+        MessageContent::Blocks(blocks) => blocks
+            .iter()
+            .any(|block| matches!(block, Block::ToolResult { .. })),
+        MessageContent::Text(_) => false,
+    }
 }
 
 fn compact_older_messages(messages: &[Message]) -> String {


### PR DESCRIPTION
## What

`compact_messages_for_context` (core/src/agent/memory.rs) slices the keep-recent window by raw message count. The agent loop's history has an atomic unit that must never split: an assistant message carrying `tool_use` blocks followed immediately by the user message carrying the matching `tool_result` blocks. When the count-based boundary landed on the tool-results message, its paired assistant was folded into the compacted-context summary, and the OpenAI-compat serializer then emitted `role:"tool"` messages with no preceding `tool_calls`:

```
deepseek API error | status=400 | message=Messages with role 'tool' must be a response to a preceding message with 'tool_calls'
```

The fix widens the window backward until it no longer opens on a tool-result message, so the pair stays intact (cost: at most one extra kept message per compaction).

## Why

Production telemetry (socai-cli-prod, `socai_agent_task_end`) shows 4 failed desktop tasks across 3 installs on 0.4.12/0.4.13, all `deepseek-v4-pro`, all with this 400.

In the steady state the transcript tail alternates `[assistant(tool_use), user(tool_results)]`, so a fixed-size window counted back from the end happens to start on an assistant — safe only by parity accident. Two loop paths push a lone user message that shifts the boundary onto the tool-results message:

1. **Forced-summary prompt at max_steps** (loop.rs) — deterministic with the default limits (`max_steps=30, compact_after=20, keep_recent=10`): a model still calling tools at step 30 exits with 22 messages, the prompt makes 23, compaction fires, and the window opens on an orphaned tool-result. Every chat-completions run that ground to the step ceiling lost its final answer (the failed runs lasted ~10 min with ~1.2M cumulative input tokens). `deepseek-v4-pro` being the weakest tool-caller is why only it shows up in telemetry.
2. **Max-tokens discard note** (loop.rs) — the same split at mid-run compactions.

Ruled out: run resume/replay (follow-up turns reseed text-only report pairs via `Conversation::chat_messages`; only the loop builds `ToolResult` history) and retry-after-error (`send_with_retry` resends the identical slice).

The same latent bug affected Anthropic (`unexpected tool_use_id`) and OpenAI Responses (`function_call_output` without its call) — the compacted history feeds all serializers, so this fix covers them too.

## Verification

- A scratch harness drove the real `compact_messages_for_context` through both scenarios: the old count-only slicing reproduces the orphan exactly (window shape `UU T ATATAT…`); the fixed version yields `UU ATATATAT…` and passes DeepSeek's pairing rule in the clean 30-step run and all 30 note-position variants.
- `cargo clippy -p socai-core` clean (no new warnings); all 91 existing tests pass. No new tests per repo convention.

## Reviewer note

Not addressed here, worth a follow-up: with these defaults the forced-summary request compacts almost every time, so the model writes its final answer having just lost the five oldest tool rounds from verbatim context — consider letting that final request skip compaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)