### PR TITLE
site: track download clicks

### DIFF
--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -55,6 +55,24 @@ The release job reads `ALIYUN_ACCESS_KEY_ID` and
 be restricted to uploading objects under the configured bucket/prefix. Do not
 put credentials in the repository.
 
+### Local Alibaba Cloud credentials
+
+The operator machine keeps local credentials under
+`~/.config/socai/aliyun/`. The CSV contents are local secrets and must never be
+committed, pasted into logs, or included in a PR:
+
+- `oss-release-publisher.csv` is RAM user `socai-oss`. Use it for release-object
+  publishing and OSS inspection. It is the local counterpart of the two
+  `ALIYUN_ACCESS_KEY_*` GitHub Actions secrets and does not have SLS query
+  access.
+- `sls-operator.csv` is RAM user `cym`. Reserve it for read-only OSS/SLS
+  diagnostics, including download-log queries; do not use it as a CI publisher
+  credential.
+
+The local directory must be mode `0700` and both credential files mode `0600`.
+The local `README.md` in that directory records the current service endpoints
+and verified permission boundary without storing either key value in docs.
+
 The publisher first uploads immutable objects to
 `releases/vMAJOR.MINOR.PATCH/` and verifies their public URLs. After GitHub
 publishes successfully, it updates the mutable `releases/latest/` objects,

--- a/docs/website-deployment.md
+++ b/docs/website-deployment.md
@@ -18,3 +18,31 @@ Use the skill for:
 - troubleshooting deployment failures
 
 Keeping the runbook in one place avoids drift between docs and agent instructions.
+
+## Download analytics
+
+The home-page macOS and Windows buttons send a Vercel Web Analytics custom event
+named `download_click` before following the `/download` redirect. Its dimensions
+are:
+
+- `platform`: `macos` or `windows`
+- `language`: `zh` or `en`
+
+This event measures download intent. Actual binary delivery is measured
+separately from Alibaba Cloud OSS real-time access logs:
+
+- SLS endpoint: `cn-beijing.log.aliyuncs.com`
+- Project: `oss-log-1006144703132379-cn-beijing`
+- Logstore: `oss-log-store`
+- Filters: topic `oss_access_log`, bucket `socai-download`
+
+On the operator machine, use
+`~/.config/socai/aliyun/sls-operator.csv` (RAM user `cym`) only for read-only
+OSS/SLS analytics queries. The release publisher credential is
+`~/.config/socai/aliyun/oss-release-publisher.csv` (RAM user `socai-oss`);
+it can inspect and publish OSS release objects but cannot query SLS. Never
+commit either credential or print its values.
+
+OSS logging was enabled on 2026-07-25, so object-level results start from that
+point. Exclude the `socai-analytics-probe/1.0` User-Agent used for ingestion
+checks when reporting real traffic.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -234,7 +234,11 @@ const socialImageAlt = message("meta.socialImageAlt");
                         aria-label={message("hero.actionsAria")}
                         data-i18n-aria-label="hero.actionsAria"
                     >
-                        <a class="button button--primary" href={downloadPath}>
+                        <a
+                            class="button button--primary"
+                            href={downloadPath}
+                            data-download-platform="macos"
+                        >
                             <span data-i18n="hero.download"
                                 >{message("hero.download")}</span
                             >
@@ -245,6 +249,7 @@ const socialImageAlt = message("meta.socialImageAlt");
                         <a
                             class="button button--primary"
                             href={downloadWindowsPath}
+                            data-download-platform="windows"
                         >
                             <span data-i18n="hero.downloadWindows"
                                 >{message("hero.downloadWindows")}</span

--- a/site/src/scripts/site.ts
+++ b/site/src/scripts/site.ts
@@ -4,6 +4,8 @@
 // clipboard copy buttons, and the hero typewriter. Each feature no-ops when its
 // markup is absent, so one script serves the home, connect, and contact pages.
 
+import { track } from "@vercel/analytics";
+
 const i18nElement = document.getElementById("site-i18n");
 const dictionary = JSON.parse(i18nElement?.textContent || "{}");
 const languageKey = "socai-language";
@@ -192,6 +194,16 @@ const applyLanguage = (language, shouldPersist = false) => {
 languageOptions.forEach((option) => {
     option.addEventListener("click", () => {
         applyLanguage(option.getAttribute("data-lang-option") || "zh", true);
+    });
+});
+
+document.querySelectorAll("[data-download-platform]").forEach((link) => {
+    link.addEventListener("click", () => {
+        track("download_click", {
+            platform:
+                link.getAttribute("data-download-platform") || "unknown",
+            language: document.documentElement.dataset.language || "zh",
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

- track macOS and Windows download-button clicks in Vercel Web Analytics
- document the OSS release publisher and SLS analytics credential roles without exposing key values
- document the OSS/SLS download-log location and probe exclusion

## Validation

- `pnpm --dir site build`
- `git diff --check`
- verified no local AccessKey ID or secret value appears in the diff
- verified the local SLS operator can read `oss-log-store`
- verified the local release publisher can inspect `socai-download` release objects