### PR TITLE
fix: handle Feishu account token refresh

### DIFF
--- a/app/src-tauri/src/connectors/feishu.rs
+++ b/app/src-tauri/src/connectors/feishu.rs
@@ -626,7 +626,14 @@ async fn list_accounts(app: &AppHandle) -> Result<Vec<FeishuAccount>, String> {
                 .and_then(Value::as_str)
                 .filter(|name| !name.trim().is_empty())
                 .map(str::to_string);
-            let connected = item.get("tokenStatus").and_then(Value::as_str) == Some("valid");
+            // lark-cli reports `needs_refresh` when the short-lived access
+            // token is due for refresh but the refresh token is still usable.
+            // The next user API call refreshes it automatically, so this is
+            // still a connected account rather than a reason to re-authorize.
+            let connected = matches!(
+                item.get("tokenStatus").and_then(Value::as_str),
+                Some("valid" | "needs_refresh")
+            );
             let active = item.get("active").and_then(Value::as_bool).unwrap_or(false);
             Some(FeishuAccount {
                 profile,

--- a/app/src/connectors/feishu.ts
+++ b/app/src/connectors/feishu.ts
@@ -149,6 +149,9 @@ export function bindFeishuConnector(
     phase = "confirm_disconnect";
     shell.rerender();
   });
+  document.querySelector<HTMLButtonElement>("[data-feishu-reconnect]")?.addEventListener("click", () => {
+    void reconnectAccount(shell);
+  });
   document.querySelector<HTMLButtonElement>("[data-feishu-disconnect-cancel]")?.addEventListener("click", () => {
     phase = phaseBeforeDisconnect;
     shell.rerender();
@@ -235,11 +238,11 @@ function renderAccountPicker(): string {
           ${options || `<option value="" selected disabled>${esc(t("feishu.noAccount"))}</option>`}
           <option value="${CONNECT_ACCOUNT_VALUE}">${esc(t("feishu.connectCurrentAccount"))}</option>
         </select>
-        ${
-          selected
+        ${selected
+          ? selected.connected
             ? `<button type="button" class="btn-ghost btn-compact" data-feishu-disconnect>${esc(t("feishu.disconnect"))}</button>`
-            : ""
-        }
+            : `<button type="button" class="btn-ghost btn-compact" data-feishu-reconnect>${esc(t("feishu.reconnect"))}</button>`
+          : ""}
       </div>
     </div>
   `;
@@ -425,6 +428,38 @@ async function connectNewAccount(shell: ShellState): Promise<void> {
   }
 }
 
+async function reconnectAccount(shell: ShellState): Promise<void> {
+  if (!selectedProfile) return;
+  const currentOperation = ++operation;
+  phase = "connecting";
+  connectMessage = t("feishu.authorizing");
+  errorMessage = "";
+  shell.rerender();
+  try {
+    const status = await invoke<FeishuStatus>("feishu_connect", {
+      profile: selectedProfile,
+      newAccount: false,
+    });
+    if (currentOperation !== operation) return;
+    selectedProfile = status.profile;
+    localStorage.setItem(PROFILE_STORAGE_KEY, selectedProfile);
+    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    if (currentOperation !== operation) return;
+    destination = null;
+    documentResult = null;
+    chats = [];
+    phase = "choose";
+    shell.rerender();
+    await refreshChats(shell, currentOperation);
+  } catch (error) {
+    if (currentOperation !== operation) return;
+    errorMessage = `${error}`;
+    phase = "error";
+  } finally {
+    if (currentOperation === operation) shell.rerender();
+  }
+}
+
 async function disconnectAccount(shell: ShellState): Promise<void> {
   if (!selectedProfile) return;
   const currentOperation = ++operation;
@@ -460,6 +495,7 @@ async function disconnectAccount(shell: ShellState): Promise<void> {
 
 async function ensureConnected(currentOperation: number): Promise<string> {
   let profile = selectedProfile;
+  let reconnected = false;
   if (profile) {
     const status = await invoke<FeishuStatus>("feishu_status", { profile });
     if (currentOperation !== operation) throw new Error("cancelled");
@@ -469,6 +505,7 @@ async function ensureConnected(currentOperation: number): Promise<string> {
         newAccount: false,
       });
       profile = connected.profile;
+      reconnected = true;
     }
   } else {
     const connected = await invoke<FeishuStatus>("feishu_connect", {
@@ -476,10 +513,15 @@ async function ensureConnected(currentOperation: number): Promise<string> {
       newAccount: true,
     });
     profile = connected.profile;
+    reconnected = true;
   }
   if (currentOperation !== operation) throw new Error("cancelled");
   selectedProfile = profile;
   localStorage.setItem(PROFILE_STORAGE_KEY, profile);
+  if (reconnected) {
+    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    if (currentOperation !== operation) throw new Error("cancelled");
+  }
   return profile;
 }
 

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -228,6 +228,7 @@ const messages = {
   "feishu.sent": { en: "sent to group", zh: "已发送到群" },
   "feishu.disconnected": { en: "disconnected", zh: "已断开" },
   "feishu.disconnect": { en: "disconnect", zh: "断开" },
+  "feishu.reconnect": { en: "reconnect", zh: "重新连接" },
   "feishu.disconnecting": { en: "disconnecting…", zh: "正在断开账户…" },
   "feishu.disconnectConfirm": {
     en: "Disconnect “{name}”? This removes the local login but does not delete the Feishu app.",


### PR DESCRIPTION
## What changed

- Treat `needs_refresh` Feishu tokens as connected because lark-cli refreshes them automatically on the next user API call.
- Show “reconnect” for genuinely disconnected or expired profiles while keeping “disconnect” for connected accounts.
- Refresh account and chat state after reconnecting, including reconnects triggered during document export.

## Why

Socai mapped every lark-cli token state other than `valid` to disconnected. Normal short-lived access tokens therefore appeared disconnected after several days even though their refresh tokens were still usable. The UI also showed a disconnect action for those profiles and prevented group loading.

## User impact

Accounts awaiting automatic token refresh remain usable without unnecessary authorization. Truly expired accounts offer an explicit reconnect action, while an intentional disconnect continues to remove the local profile from the list.

## Validation

- `pnpm build` in `app/`
- `cargo check -p socai_app`
- `rustfmt --edition 2021 --check app/src-tauri/src/connectors/feishu.rs`
- `git diff --check HEAD^ HEAD`
