### PR TITLE
fix: decouple video downloads and preserve traces

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -452,6 +452,7 @@ pub async fn agent_task_start(
         )
         .await;
     let task_id = snapshot.task_id.clone();
+    let background_media_generation = socai_core::media::begin_background_media_generation();
     let runtime = runtime.inner().clone();
     let telemetry = telemetry.inner().clone();
     let task_id_for_spawn = task_id.clone();
@@ -471,6 +472,7 @@ pub async fn agent_task_start(
             provider,
             model,
             run_dir,
+            background_media_generation,
             telemetry,
         )
         .await;
@@ -558,6 +560,7 @@ pub async fn agent_task_reply(
         .await
         .ok_or_else(|| format!("unknown task: {task_id}"))?;
 
+    let background_media_generation = socai_core::media::begin_background_media_generation();
     let runtime = runtime.inner().clone();
     let telemetry = telemetry.inner().clone();
     let task_id_for_spawn = task_id.clone();
@@ -577,6 +580,7 @@ pub async fn agent_task_reply(
             provider,
             model,
             run_dir,
+            background_media_generation,
             telemetry,
         )
         .await;
@@ -710,6 +714,9 @@ pub async fn agent_task_cancel(
         .cancel(&task_id)
         .await
         .ok_or_else(|| format!("unknown task: {task_id}"))?;
+    if changed {
+        socai_core::media::begin_background_media_generation();
+    }
     if let Some(handle) = abort_handle {
         handle.abort();
     }
@@ -720,13 +727,11 @@ pub async fn agent_task_cancel(
         let usage = snapshot.run_dir.as_deref().and_then(read_run_usage);
         if let Some(run_dir) = snapshot.run_dir.as_deref() {
             let _ = mark_agent_run_status(run_dir, "cancelled", None);
-            // The aborted run future's drop guard wrote trace.json with
-            // status "interrupted" (usually before we get here — the
-            // close_target await above yields to the runtime); rewrite it to
-            // "cancelled" and ship it. Cancelled runs are the ones users gave
-            // up on, so their spans matter most.
-            let _ = mark_run_trace_status(run_dir, "cancelled");
-            telemetry.upload_run_trace(run_dir);
+            let run_dir = PathBuf::from(run_dir);
+            let telemetry = telemetry.inner().clone();
+            tauri::async_runtime::spawn(async move {
+                upload_terminal_run_trace(run_dir, "cancelled", &telemetry).await;
+            });
         }
         record_desktop_session(&snapshot, "[cancelled by user]", "cancelled");
         telemetry.capture(
@@ -770,6 +775,9 @@ pub async fn agent_task_delete(
     task_id: String,
 ) -> Result<(), String> {
     let snapshot = tasks.delete(&task_id).await?;
+    if let Some(run_dir) = snapshot.run_dir.as_deref() {
+        socai_core::media::cancel_background_media_for_run(run_dir);
+    }
     let mut dirs: Vec<String> = Vec::new();
     if let Some(session_dir) = &snapshot.session_dir {
         if let Ok(conversation) = Conversation::load(session_dir) {
@@ -782,29 +790,47 @@ pub async fn agent_task_delete(
     }
     dirs.sort();
     dirs.dedup();
-    for dir in &dirs {
-        if let Err(err) = std::fs::remove_dir_all(dir) {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                eprintln!("failed to delete task artifacts at {dir}: {err}");
-            }
-        }
-    }
-    // XHS history caches absolute media paths into these run dirs; scrub them
-    // so cross-run dedupe re-downloads instead of resurrecting dead paths.
-    let run_dirs: Vec<PathBuf> = dirs.iter().map(PathBuf::from).collect();
-    let scrubbed = XhsHistoryStore::open_default().scrub_media_under(&run_dirs);
-    if scrubbed > 0 {
-        eprintln!("forgot cached media for {scrubbed} notes under deleted task {task_id}");
-    }
+    let terminal_status = snapshot.status.clone();
+    let trace_run_dir = snapshot.run_dir.as_deref().map(PathBuf::from);
     telemetry.capture(
         "socai_agent_task_delete",
         json!({
-            "task_id": task_id,
-            "provider": snapshot.provider,
-            "model": snapshot.model,
-            "status": snapshot.status,
+            "task_id": task_id.clone(),
+            "provider": snapshot.provider.clone(),
+            "model": snapshot.model.clone(),
+            "status": terminal_status.clone(),
         }),
     );
+
+    // Removing a history row should feel immediate. The filesystem cleanup is
+    // background work, and cancelled/interrupted traces get a chance to finish
+    // durable staging before their source run directory disappears.
+    let telemetry = telemetry.inner().clone();
+    tauri::async_runtime::spawn(async move {
+        if matches!(terminal_status.as_str(), "cancelled" | "interrupted") {
+            if let Some(run_dir) = trace_run_dir.as_deref() {
+                wait_for_trace_staging(run_dir).await;
+                upload_terminal_run_trace(run_dir, &terminal_status, &telemetry).await;
+            }
+        }
+        let _ = tokio::task::spawn_blocking(move || {
+            for dir in &dirs {
+                if let Err(err) = std::fs::remove_dir_all(dir) {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        eprintln!("failed to delete task artifacts at {dir}: {err}");
+                    }
+                }
+            }
+            // XHS history caches absolute media paths into these run dirs; scrub
+            // them so cross-run dedupe re-downloads instead of resurrecting dead paths.
+            let run_dirs: Vec<PathBuf> = dirs.iter().map(PathBuf::from).collect();
+            let scrubbed = XhsHistoryStore::open_default().scrub_media_under(&run_dirs);
+            if scrubbed > 0 {
+                eprintln!("forgot cached media for {scrubbed} notes under deleted task {task_id}");
+            }
+        })
+        .await;
+    });
     Ok(())
 }
 
@@ -818,6 +844,7 @@ async fn run_agent_task_background(
     provider: Option<String>,
     model: Option<String>,
     run_dir: PathBuf,
+    background_media_generation: u64,
     telemetry: DesktopTelemetry,
 ) {
     let Some(_permit) = registry.acquire_run_permit().await else {
@@ -884,6 +911,7 @@ async fn run_agent_task_background(
         provider.as_deref(),
         model.as_deref(),
         Some(run_dir),
+        Some(background_media_generation),
         Some(registry.clone()),
         telemetry.clone(),
         format!("task · {}", title_safe(&task)),
@@ -989,6 +1017,58 @@ pub(crate) fn record_interrupted_run(snapshot: &AgentTaskSnapshot, message: &str
     );
 }
 
+/// Wait for an aborted agent future's trace drop guard, patch the precise
+/// terminal state, then stage the trace durably before the task can be deleted.
+/// AbortHandle::abort() only schedules cancellation; without this wait the
+/// telemetry worker can race `trace.json` creation and silently miss the run.
+pub(crate) async fn upload_terminal_run_trace(
+    run_dir: impl AsRef<std::path::Path>,
+    status: &str,
+    telemetry: &DesktopTelemetry,
+) -> bool {
+    const READY_RETRIES: usize = 40;
+    const READY_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
+
+    let run_dir = run_dir.as_ref();
+    let staged_marker = run_dir.join(".trace-staged");
+    if staged_marker.is_file() {
+        return true;
+    }
+    for attempt in 0..READY_RETRIES {
+        match mark_run_trace_status(run_dir, status) {
+            Ok(()) => {
+                if telemetry.upload_run_trace(run_dir) {
+                    let _ = std::fs::write(staged_marker, b"");
+                    return true;
+                }
+                return false;
+            }
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound && attempt + 1 < READY_RETRIES =>
+            {
+                tokio::time::sleep(READY_DELAY).await;
+            }
+            Err(_) => return false,
+        }
+    }
+    false
+}
+
+async fn wait_for_trace_staging(run_dir: &std::path::Path) {
+    const WAIT_RETRIES: usize = 50;
+    const WAIT_DELAY: std::time::Duration = std::time::Duration::from_millis(25);
+
+    let marker = run_dir.join(".trace-staged");
+    for attempt in 0..WAIT_RETRIES {
+        if marker.is_file() {
+            return;
+        }
+        if attempt + 1 < WAIT_RETRIES {
+            tokio::time::sleep(WAIT_DELAY).await;
+        }
+    }
+}
+
 fn record_desktop_session(snapshot: &AgentTaskSnapshot, assistant: &str, status: &str) {
     let Some(session_dir) = snapshot.session_dir.as_deref() else {
         return;
@@ -1015,6 +1095,7 @@ async fn run_agent_task_on_shared_page(
     provider: Option<&str>,
     model: Option<&str>,
     run_dir: Option<PathBuf>,
+    background_media_generation: Option<u64>,
     registry: Option<AgentTaskRegistry>,
     telemetry: DesktopTelemetry,
     title_label: String,
@@ -1101,6 +1182,7 @@ async fn run_agent_task_on_shared_page(
             seed_messages,
             run_dir,
             session_id,
+            background_media_generation,
             ..AgentRunConfig::default()
         };
         let outcome = run_agent_with_tools(task, llm_provider, tools, config, tx).await;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -79,7 +79,20 @@ pub fn run() {
             let tasks = app.state::<AgentTaskRegistry>().inner().clone();
             let telemetry = app.state::<DesktopTelemetry>().inner().clone();
             let handle = app.handle().clone();
+            let media_handle = handle.clone();
             tauri::async_runtime::spawn(async move {
+                // A graceful app shutdown marks active tasks interrupted in
+                // tasks.json before this process starts. If its trace drop
+                // guard finished during shutdown, recover and upload it now.
+                for snapshot in tasks.list().await {
+                    if snapshot.status == "interrupted" {
+                        if let Some(run_dir) = snapshot.run_dir.as_deref() {
+                            commands::upload_terminal_run_trace(run_dir, "interrupted", &telemetry)
+                                .await;
+                        }
+                    }
+                }
+
                 let mut rx = runtime.subscribe_browser_events();
                 while let Ok(event) = rx.recv().await {
                     match event {
@@ -100,6 +113,14 @@ pub fn run() {
                                     &snapshot,
                                     "chrome tab was closed",
                                 );
+                                if let Some(run_dir) = snapshot.run_dir.as_deref() {
+                                    commands::upload_terminal_run_trace(
+                                        run_dir,
+                                        "interrupted",
+                                        &telemetry,
+                                    )
+                                    .await;
+                                }
                                 telemetry.capture(
                                     "socai_agent_task_end",
                                     json!({
@@ -128,6 +149,18 @@ pub fn run() {
                                 .await;
                             }
                         }
+                    }
+                }
+            });
+            tauri::async_runtime::spawn(async move {
+                let mut media_events = socai_core::media::subscribe_background_media_events();
+                loop {
+                    match media_events.recv().await {
+                        Ok(event) => {
+                            let _ = media_handle.emit("agent_task:notes_updated", event);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }
                 }
             });

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -35,10 +35,11 @@ impl DesktopTelemetry {
 
     /// Upload a run's `trace.json` to the traces proxy. No-op when telemetry
     /// is off or the file is missing.
-    pub(crate) fn upload_run_trace(&self, run_dir: impl AsRef<Path>) {
+    pub(crate) fn upload_run_trace(&self, run_dir: impl AsRef<Path>) -> bool {
         if let Some(telemetry) = &self.0 {
-            telemetry.upload_run_trace(run_dir.as_ref());
+            return telemetry.upload_run_trace(run_dir.as_ref());
         }
+        false
     }
 }
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -75,6 +75,8 @@ export interface NoteMedia {
   src?: string; // downloaded file — absolute path, or media_dir-relative
   poster?: string; // video only — first-frame still (path)
   dur?: string; // video only — "0:48"
+  status?: "loading" | "failed"; // background video-file download state
+  error?: string; // local diagnostic; intentionally not rendered
   w?: number;
   h?: number;
 }
@@ -149,6 +151,11 @@ export interface AgentTaskEventPayload {
   model?: string;
   task?: string;
   target_id?: string | null;
+}
+
+interface BackgroundMediaEvent {
+  run_dir: string;
+  note_id: string;
 }
 
 export interface ShellState {
@@ -568,6 +575,9 @@ async function main(): Promise<void> {
       void agentPanel.loadTaskNotes(event.payload.task_id, shell());
       maybeRelaunchReadyUpdate();
     }
+  });
+  await listen<BackgroundMediaEvent>("agent_task:notes_updated", (event) => {
+    agentPanel.handleBackgroundMediaUpdate(event.payload.run_dir, shell());
   });
 
   let initialTasks: AgentTaskSnapshot[] = [];

--- a/app/src/panels/notes.ts
+++ b/app/src/panels/notes.ts
@@ -105,11 +105,19 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
   if (m.kind === "video") {
     const posterUrl = assetUrl(note, m.poster);
     const posterImg = posterUrl ? `<img class="note-media__img" src="${esc(posterUrl)}" alt="" loading="lazy" />` : "";
+    const loading = !m.src && m.status === "loading";
+    const loadingIndicator = loading
+      ? `<span class="note-media__loading" aria-hidden="true"></span>`
+      : "";
+    const failedIndicator = !m.src && m.status === "failed"
+      ? `<span class="note-media__failed" aria-hidden="true">!</span>`
+      : "";
+    const statusIndicator = loadingIndicator || failedIndicator;
     if (variant === "gallery") {
       const videoUrl = assetUrl(note, m.src);
       const inner = videoUrl
         ? `<video class="note-media__img" controls preload="metadata"${posterUrl ? ` poster="${esc(posterUrl)}"` : ""} src="${esc(videoUrl)}"></video>`
-        : `${posterImg}<span class="note-media__play">${IC.play()}</span>`;
+        : `${posterImg}${statusIndicator}`;
       return `<span class="note-media" data-kind="video">${inner}</span>`;
     }
     // With the file on disk the glyph is a real button and marks the whole
@@ -122,7 +130,7 @@ function mediaFrame(note: NoteData, m: NoteMedia, variant: MediaVariant, count =
       ? ""
       : videoUrl
         ? `<button type="button" class="note-media__play" data-note-play="${esc(videoUrl)}" aria-label="play video">${IC.play()}</button>`
-        : `<span class="note-media__play">${IC.play()}</span>`;
+        : statusIndicator;
     return `<span class="note-media note-media--pillarbox" data-kind="video"><span class="note-media__inner">${posterImg}${play}${m.dur && !decorative ? `<span class="note-media__dur">${esc(m.dur)}</span>` : ""}</span></span>`;
   }
   const url = assetUrl(note, m.src);

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -157,6 +157,23 @@ export namespace agentPanel {
     if (selected) void loadTaskNotes(selected.task_id, shell);
   }
 
+  const backgroundMediaRefreshTimers = new Map<string, number>();
+
+  /** A background video finished after its tool (or whole agent run) returned.
+   *  Coalesce concurrent completions, then reload the matching task so its
+   *  poster-only card upgrades to a playable video without user action. */
+  export function handleBackgroundMediaUpdate(runDir: string, shell: ShellState): void {
+    const task = tasks.find((item) => item.run_dir === runDir);
+    if (!task) return;
+    const existing = backgroundMediaRefreshTimers.get(runDir);
+    if (existing !== undefined) window.clearTimeout(existing);
+    const timer = window.setTimeout(() => {
+      backgroundMediaRefreshTimers.delete(runDir);
+      void loadTaskNotes(task.task_id, shell);
+    }, 350);
+    backgroundMediaRefreshTimers.set(runDir, timer);
+  }
+
   // ── live notes while a task runs ─────────────────────────────────────
   // notes.json is written incrementally (one rewrite per note read), but no
   // event fires mid-tool-call — a scan is silent for minutes. Poll the archive

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1436,6 +1436,25 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .note-media__play svg { width: 12px; height: 12px; margin-left: 1.5px; }
 button.note-media__play:hover { background: rgba(10, 10, 10, 0.78); transform: scale(1.05); }
+.note-media__loading,
+.note-media__failed {
+  position: absolute; width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-pill); background: rgba(10, 10, 10, 0.55);
+  color: var(--ink-9); pointer-events: none;
+}
+.note-media__failed {
+  font-family: var(--font-mono); font-size: 13px; font-weight: 600;
+}
+.note-media__loading::after {
+  content: ""; width: 11px; height: 11px;
+  border: 1.5px solid currentColor; border-right-color: transparent;
+  border-radius: 50%; animation: note-media-spin 0.75s linear infinite;
+}
+@keyframes note-media-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .note-media__loading::after { animation-duration: 1.5s; }
+}
 /* inline playback (cards): a video overlays the poster in the same pillarbox
    box, so the card doesn't reflow on click. Absolutely positioned: an in-flow
    video's intrinsic size would join the sizing of the box it's supposed to
@@ -1817,4 +1836,3 @@ code {
   color: var(--fg-soft);
   cursor: not-allowed;
 }
-

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -34,8 +34,7 @@ use crate::agent::llm::{
     ToolSchema,
 };
 use crate::agent::memory::{
-    compact_messages_for_context, DEFAULT_COMPACT_AFTER_MESSAGES,
-    DEFAULT_KEEP_RECENT_MESSAGES,
+    compact_messages_for_context, DEFAULT_COMPACT_AFTER_MESSAGES, DEFAULT_KEEP_RECENT_MESSAGES,
 };
 use crate::agent::report::report_with_artifacts;
 use crate::agent::run_logging::{make_run_dir, AgentRunRecorder};
@@ -112,6 +111,8 @@ pub struct AgentOptions {
     pub seed_messages: Vec<Message>,
     /// Optional parent conversation identifier.
     pub session_id: Option<String>,
+    /// Optional user-turn generation for cancelable background media work.
+    pub background_media_generation: Option<u64>,
 }
 
 impl Default for AgentOptions {
@@ -126,6 +127,7 @@ impl Default for AgentOptions {
             keep_recent_messages: DEFAULT_KEEP_RECENT_MESSAGES,
             seed_messages: Vec::new(),
             session_id: None,
+            background_media_generation: None,
         }
     }
 }
@@ -182,7 +184,9 @@ pub async fn run_agent_with_events(
         options.seed_messages.len(),
     );
 
-    let mut ctx = ToolContext::new(&run_id, &run_dir).with_run_state(Arc::clone(&run_state));
+    let mut ctx = ToolContext::new(&run_id, &run_dir)
+        .with_run_state(Arc::clone(&run_state))
+        .with_background_media_generation(options.background_media_generation);
     for site in &options.enabled_sites {
         ctx.enable_site(site.clone());
     }

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -144,6 +144,10 @@ pub struct ToolContext {
     pub run_dir: PathBuf,
     pub step: u32,
     pub active_tool_name: String,
+    /// Desktop user-turn generation used to cancel background media work when
+    /// the user submits another task or follow-up. `None` for hosts that do
+    /// not manage generations explicitly.
+    pub background_media_generation: Option<u64>,
     pub run_state: Option<Arc<RunState>>,
     tool_dir: Option<PathBuf>,
     pub enabled_sites: Arc<Mutex<BTreeSet<String>>>,
@@ -197,6 +201,7 @@ impl ToolContext {
             run_dir: run_dir.as_ref().to_path_buf(),
             step: 0,
             active_tool_name: String::new(),
+            background_media_generation: None,
             run_state: None,
             tool_dir: None,
             enabled_sites: Arc::new(Mutex::new(BTreeSet::new())),
@@ -210,6 +215,11 @@ impl ToolContext {
 
     pub fn with_progress_sender(mut self, progress: Option<ToolProgressSender>) -> Self {
         self.progress = progress;
+        self
+    }
+
+    pub fn with_background_media_generation(mut self, generation: Option<u64>) -> Self {
+        self.background_media_generation = generation;
         self
     }
 
@@ -326,6 +336,27 @@ impl ToolContext {
             // on-disk archive the desktop app reads is affected.
             tracing::warn!(error = %err, note_id, "failed to persist note archive");
         }
+    }
+
+    /// Atomically update an already-recorded note and persist the resulting
+    /// archive. Background media completion uses this instead of replacing a
+    /// stale whole-note snapshot while the agent may be recording other notes.
+    pub fn update_recorded_note(&self, note_id: &str, update: impl FnOnce(&mut Value)) -> bool {
+        if note_id.is_empty() {
+            return false;
+        }
+        let Ok(mut guard) = self.notes_seen.lock() else {
+            return false;
+        };
+        let Some((_, record)) = guard.iter_mut().find(|(id, _)| id == note_id) else {
+            return false;
+        };
+        update(record);
+        if let Err(err) = crate::agent::note_store::write_notes(&self.run_dir, &guard) {
+            tracing::warn!(error = %err, note_id, "failed to persist updated note archive");
+            return false;
+        }
+        true
     }
 
     pub fn with_run_state(mut self, run_state: Arc<RunState>) -> Self {

--- a/core/src/media/background.rs
+++ b/core/src/media/background.rs
@@ -1,0 +1,137 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde::Serialize;
+use tokio::sync::{broadcast, watch, Semaphore};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BackgroundMediaEvent {
+    pub run_dir: String,
+    pub note_id: String,
+}
+
+struct BackgroundMediaState {
+    generation: AtomicU64,
+    generation_tx: watch::Sender<u64>,
+    events_tx: broadcast::Sender<BackgroundMediaEvent>,
+    cancelled_runs: Mutex<HashSet<String>>,
+    in_flight_videos: Mutex<HashSet<String>>,
+}
+
+fn state() -> &'static BackgroundMediaState {
+    static STATE: OnceLock<BackgroundMediaState> = OnceLock::new();
+    STATE.get_or_init(|| {
+        let (generation_tx, _) = watch::channel(1);
+        let (events_tx, _) = broadcast::channel(128);
+        BackgroundMediaState {
+            generation: AtomicU64::new(1),
+            generation_tx,
+            events_tx,
+            cancelled_runs: Mutex::new(HashSet::new()),
+            in_flight_videos: Mutex::new(HashSet::new()),
+        }
+    })
+}
+
+/// Start a new user turn and cancel every unfinished background media fetch
+/// from older turns. The returned generation belongs on that turn's
+/// `ToolContext`, so a queued/older agent cannot enqueue work after the user
+/// has already moved on.
+pub fn begin_background_media_generation() -> u64 {
+    let generation = state().generation.fetch_add(1, Ordering::AcqRel) + 1;
+    if let Ok(mut cancelled) = state().cancelled_runs.lock() {
+        cancelled.clear();
+    }
+    state().generation_tx.send_replace(generation);
+    generation
+}
+
+pub fn current_background_media_generation() -> u64 {
+    state().generation.load(Ordering::Acquire)
+}
+
+pub fn background_media_generation_is_current(generation: u64) -> bool {
+    current_background_media_generation() == generation
+}
+
+pub fn cancel_background_media_for_run(run_dir: &str) {
+    let run_dir = run_dir.trim();
+    if run_dir.is_empty() {
+        return;
+    }
+    if let Ok(mut cancelled) = state().cancelled_runs.lock() {
+        cancelled.insert(run_dir.to_string());
+    }
+    // Wake generation watchers too; their cancellation predicate also checks
+    // the persistent run set, so subscribers cannot miss this targeted signal.
+    state()
+        .generation_tx
+        .send_replace(current_background_media_generation());
+}
+
+pub(crate) fn background_media_run_is_cancelled(run_dir: &str) -> bool {
+    state()
+        .cancelled_runs
+        .lock()
+        .is_ok_and(|cancelled| cancelled.contains(run_dir))
+}
+
+pub(crate) fn subscribe_background_media_cancellation() -> watch::Receiver<u64> {
+    state().generation_tx.subscribe()
+}
+
+pub(crate) fn background_video_download_semaphore() -> Arc<Semaphore> {
+    static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(3)))
+        .clone()
+}
+
+pub(crate) struct BackgroundVideoReservation {
+    key: String,
+}
+
+impl Drop for BackgroundVideoReservation {
+    fn drop(&mut self) {
+        if let Ok(mut in_flight) = state().in_flight_videos.lock() {
+            in_flight.remove(&self.key);
+        }
+    }
+}
+
+pub(crate) fn reserve_background_video_download(
+    generation: u64,
+    run_dir: &str,
+    note_id: &str,
+) -> Option<BackgroundVideoReservation> {
+    let key = format!("{generation}\0{run_dir}\0{note_id}");
+    let mut in_flight = state().in_flight_videos.lock().ok()?;
+    if !in_flight.insert(key.clone()) {
+        return None;
+    }
+    Some(BackgroundVideoReservation { key })
+}
+
+pub(crate) async fn wait_for_background_media_cancellation(
+    generation: u64,
+    run_dir: &str,
+    receiver: &mut watch::Receiver<u64>,
+) {
+    loop {
+        if *receiver.borrow() != generation || background_media_run_is_cancelled(run_dir) {
+            return;
+        }
+        if receiver.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+pub fn subscribe_background_media_events() -> broadcast::Receiver<BackgroundMediaEvent> {
+    state().events_tx.subscribe()
+}
+
+pub(crate) fn emit_background_media_event(event: BackgroundMediaEvent) {
+    let _ = state().events_tx.send(event);
+}

--- a/core/src/media/common.rs
+++ b/core/src/media/common.rs
@@ -77,12 +77,16 @@ pub(crate) fn save_named_bytes(
     label: &str,
     filename: &str,
 ) -> Result<PathBuf> {
+    let path = named_file_path(base_dir, label, filename)?;
+    std::fs::write(&path, payload)?;
+    Ok(path)
+}
+
+pub(crate) fn named_file_path(base_dir: &Path, label: &str, filename: &str) -> Result<PathBuf> {
     let safe_label = sanitize_label(label, "media");
     let safe_filename = sanitize_filename(filename, "asset.bin");
     let dir = ensure_dir(&base_dir.join(&safe_label))?;
-    let path = dir.join(safe_filename);
-    std::fs::write(&path, payload)?;
-    Ok(path)
+    Ok(dir.join(safe_filename))
 }
 
 pub(crate) fn url_suffix(url: &str, fallback: &str) -> String {

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -7,6 +7,7 @@
 //! fast and portable.
 
 mod audio;
+mod background;
 mod common;
 mod image;
 mod md5;
@@ -15,6 +16,16 @@ mod processor;
 mod timing;
 mod video;
 
+pub use self::background::{
+    background_media_generation_is_current, begin_background_media_generation,
+    cancel_background_media_for_run, current_background_media_generation,
+    subscribe_background_media_events, BackgroundMediaEvent,
+};
+pub(crate) use self::background::{
+    background_media_run_is_cancelled, background_video_download_semaphore,
+    emit_background_media_event, reserve_background_video_download,
+    subscribe_background_media_cancellation, wait_for_background_media_cancellation,
+};
 pub use self::common::{MediaConfig, MediaUnavailable};
 pub use self::ocr::diagnostics as ocr_diagnostics;
 pub use self::ocr::warm_up as ocr_warm_up;

--- a/core/src/media/processor.rs
+++ b/core/src/media/processor.rs
@@ -4,9 +4,13 @@ use std::time::{Duration, Instant};
 
 use crate::agent::Backend as LlmProvider;
 use anyhow::Result;
+use futures::StreamExt;
 use serde_json::Value;
+use tokio::io::AsyncWriteExt;
 
-use crate::media::common::{ensure_dir, save_bytes, save_named_bytes, MediaConfig, USER_AGENT};
+use crate::media::common::{
+    ensure_dir, named_file_path, save_bytes, save_named_bytes, MediaConfig, USER_AGENT,
+};
 use crate::media::timing::TimingRecord;
 
 #[derive(Clone)]
@@ -135,4 +139,74 @@ impl MediaProcessor {
         self.save_bytes(&payload, label, suffix)
     }
 
+    /// Stream a large download to a stable named file without buffering the
+    /// whole payload in memory. The `.part` file is removed on timeout,
+    /// cancellation (future drop), or failure; the final path only appears
+    /// after a complete atomic rename.
+    pub async fn download_named_file_streaming_with_timeout(
+        &self,
+        url: &str,
+        referer: &str,
+        label: &str,
+        filename: &str,
+        timeout: Duration,
+    ) -> Result<PathBuf> {
+        struct PartialFileGuard(Option<PathBuf>);
+        impl Drop for PartialFileGuard {
+            fn drop(&mut self) {
+                if let Some(path) = self.0.take() {
+                    let _ = std::fs::remove_file(path);
+                }
+            }
+        }
+
+        let target = url.trim();
+        if target.is_empty() {
+            anyhow::bail!("download URL is empty");
+        }
+        let path = named_file_path(&self.config.base_dir, label, filename)?;
+        if std::fs::metadata(&path).is_ok_and(|meta| meta.is_file() && meta.len() > 0) {
+            return Ok(path);
+        }
+        let part_path = path.with_extension(format!(
+            "{}.{}.part",
+            path.extension()
+                .and_then(|value| value.to_str())
+                .unwrap_or("bin"),
+            uuid::Uuid::new_v4()
+        ));
+        let mut partial = PartialFileGuard(Some(part_path.clone()));
+        let t0 = Instant::now();
+        let result = tokio::time::timeout(timeout, async {
+            let mut request = self.client.get(target).timeout(timeout);
+            if !referer.trim().is_empty() {
+                request = request.header("Referer", referer.trim());
+            }
+            let response = request.send().await?.error_for_status()?;
+            let mut stream = response.bytes_stream();
+            let mut file = tokio::fs::File::create(&part_path).await?;
+            while let Some(chunk) = stream.next().await {
+                file.write_all(&chunk?).await?;
+            }
+            file.flush().await?;
+            drop(file);
+            if let Err(err) = tokio::fs::rename(&part_path, &path).await {
+                // Another concurrent read of the same note may have completed
+                // first. Its non-empty stable file is equivalent; otherwise
+                // preserve the real rename error.
+                if !std::fs::metadata(&path).is_ok_and(|meta| meta.is_file() && meta.len() > 0) {
+                    return Err(err.into());
+                }
+                let _ = tokio::fs::remove_file(&part_path).await;
+            }
+            Ok::<PathBuf, anyhow::Error>(path.clone())
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("download timed out after {}s", timeout.as_secs()))?;
+        self.timing.record("download", t0.elapsed());
+        if result.is_ok() {
+            partial.0 = None;
+        }
+        result
+    }
 }

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -155,6 +155,68 @@ impl MediaProcessor {
         result
     }
 
+    /// Download only the playable file for a video whose poster has already
+    /// been fetched. This is the background companion to
+    /// `download_video_poster`: it streams into a stable note-local file and
+    /// preserves all poster/OCR fields on the input object.
+    pub async fn download_video_file(
+        &self,
+        video: &Value,
+        note_id: &str,
+        title: &str,
+        referer: &str,
+    ) -> Value {
+        let mut result = video.clone();
+        if !result.is_object() {
+            result = crate::media::common::empty_object();
+        }
+        let label = if !note_id.trim().is_empty() {
+            note_id
+        } else if !title.trim().is_empty() {
+            title
+        } else {
+            "video"
+        };
+        let source = downloadable_video_url(&result);
+        if source.is_empty() {
+            insert_string(
+                &mut result,
+                "download_error",
+                "downloadable video URL not found (blob: URLs cannot be downloaded)",
+            );
+            return result;
+        }
+
+        let suffix = url_suffix(&source, ".mp4");
+        let filename = format!("video{suffix}");
+        let t_file = Instant::now();
+        match self
+            .download_named_file_streaming_with_timeout(
+                &source,
+                referer,
+                label,
+                &filename,
+                Duration::from_secs(VIDEO_DOWNLOAD_TIMEOUT_S.max(self.config.request_timeout_s)),
+            )
+            .await
+        {
+            Ok(path) => {
+                if let Some(map) = result.as_object_mut() {
+                    map.remove("download_error");
+                }
+                insert_string(&mut result, "local_path", path.to_string_lossy());
+            }
+            Err(err) => insert_string(&mut result, "download_error", format!("{err:#}")),
+        }
+        if let Some(map) = result.as_object_mut() {
+            map.insert(
+                "download_ms".into(),
+                serde_json::json!(t_file.elapsed().as_millis() as u64),
+            );
+        }
+        result
+    }
+
     /// Transcribe an already-downloaded video file in place. The caller must
     /// have downloaded the video first and stored `local_path` on the object.
     pub async fn transcribe_downloaded_video(&self, video: &mut Value) {

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -308,6 +308,7 @@ pub struct AgentRunConfig {
     /// Prior chat-level messages to continue an ongoing conversation from.
     pub seed_messages: Vec<Message>,
     pub session_id: Option<String>,
+    pub background_media_generation: Option<u64>,
 }
 
 impl Default for AgentRunConfig {
@@ -325,6 +326,7 @@ impl Default for AgentRunConfig {
             run_dir: None,
             seed_messages: Vec::new(),
             session_id: None,
+            background_media_generation: None,
         }
     }
 }
@@ -350,6 +352,7 @@ pub async fn run_agent_task(
         keep_recent_messages: config.keep_recent_messages,
         seed_messages: config.seed_messages,
         session_id: config.session_id,
+        background_media_generation: config.background_media_generation,
     };
     run_agent_with_events(task, llm_provider, tools, options, events_tx).await
 }

--- a/core/src/sites/xhs/media_manifest.rs
+++ b/core/src/sites/xhs/media_manifest.rs
@@ -189,12 +189,20 @@ fn video_manifest_entry(note_id: &str, video: &Value, run_dir: &Path) -> Value {
     let local_path = string_field_value(video, "local_path");
     let download_error = first_string_field(video, &["download_error", "save_error"]);
     let local_file = local_path_buf(run_dir, &local_path);
-    let (status, error) = download_status_and_error(
-        &local_path,
-        local_file.as_deref(),
-        &source_url,
-        download_error,
-    );
+    let pending = video
+        .get("background_download_pending")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let (status, error) = if pending {
+        ("pending", None)
+    } else {
+        download_status_and_error(
+            &local_path,
+            local_file.as_deref(),
+            &source_url,
+            download_error,
+        )
+    };
     let size_bytes = file_size(local_file.as_deref());
 
     json!({

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -15,7 +15,13 @@ use crate::agent::tool::{
 };
 use crate::agent::{Backend as LlmProvider, Tool, ToolContext, ToolResult};
 use crate::cdp::PageSession;
-use crate::media::{ocr_diagnostics, ocr_warm_up, timing_delta, MediaProcessor, TimingSnapshot};
+use crate::media::{
+    background_media_generation_is_current, background_media_run_is_cancelled,
+    background_video_download_semaphore, current_background_media_generation,
+    emit_background_media_event, ocr_diagnostics, ocr_warm_up, reserve_background_video_download,
+    subscribe_background_media_cancellation, timing_delta, wait_for_background_media_cancellation,
+    BackgroundMediaEvent, MediaProcessor, TimingSnapshot,
+};
 use async_trait::async_trait;
 use serde_json::{json, Map, Value};
 
@@ -28,8 +34,7 @@ use crate::sites::runner::{
 };
 use crate::sites::xhs::entities::{parse_posted_at_ms, parse_stat_count};
 use crate::sites::xhs::media_manifest::{
-    ensure_entity_note_id, fill_entity_from_card, search_media_manifest,
-    write_media_manifest_file,
+    ensure_entity_note_id, fill_entity_from_card, search_media_manifest, write_media_manifest_file,
 };
 use crate::sites::xhs::page::{LoginGate, XHS_SEARCH_FILTERS};
 use crate::sites::xhs::{
@@ -1129,6 +1134,11 @@ async fn scan_card_note(
     // video note's video file — an OCR-only run downloads just the poster —
     // and is the download requirement checked against cross-run history.
     download_media_requested: bool,
+    // Desktop macro scans return after downloading the poster and enqueue the
+    // full video separately. TUI/CLI downloads and transcription requests keep
+    // the file inline.
+    download_video_file_inline: bool,
+    background_video_downloads: bool,
     ocr: bool,
     transcribe_audio: bool,
     // When true, images are downloaded inline but OCR is left to the caller (run
@@ -1187,7 +1197,7 @@ async fn scan_card_note(
                 level: level.to_string(),
                 include_media,
                 download_media,
-                download_video_file: download_media_requested,
+                download_video_file: download_video_file_inline,
                 // Scans never transcribe inline: the caller runs cloud ASR in a
                 // background task (spawn_note_transcribe) so it overlaps the
                 // next note's read + download. The dedup check above still uses
@@ -1299,7 +1309,10 @@ async fn scan_card_note(
         // the desktop app can render it as a rich, locally-served card without
         // re-fetching. Recorded here — before the lean trim strips images/video
         // from the agent-facing payload — so the archive keeps the full note.
-        if let Some((note_id, record)) = build_note_record(&entry, ctx, level) {
+        if let Some((note_id, mut record)) = build_note_record(&entry, ctx, level) {
+            if background_video_downloads {
+                set_note_record_video_status(&mut record, Some("loading"), None);
+            }
             ctx.record_note(&note_id, record);
         }
     }
@@ -1910,6 +1923,268 @@ fn run_relative_path(path: &str, run_dir: &Path) -> String {
         .strip_prefix(run_dir)
         .map(|relative| relative.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|_| path.to_string())
+}
+
+fn set_note_record_video_status(record: &mut Value, status: Option<&str>, error: Option<&str>) {
+    let Some(items) = record.get_mut("media").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if let Some(video) = items
+        .iter_mut()
+        .find(|item| item.get("kind").and_then(Value::as_str) == Some("video"))
+        .and_then(Value::as_object_mut)
+    {
+        match status {
+            Some(status) => {
+                video.insert("status".into(), Value::String(status.into()));
+            }
+            None => {
+                video.remove("status");
+            }
+        }
+        match error {
+            Some(error) => {
+                video.insert("error".into(), Value::String(error.into()));
+            }
+            None => {
+                video.remove("error");
+            }
+        }
+    }
+}
+
+fn set_recorded_video_status(
+    ctx: &ToolContext,
+    note_id: &str,
+    status: Option<&str>,
+    error: Option<&str>,
+) -> bool {
+    ctx.update_recorded_note(note_id, |record| {
+        set_note_record_video_status(record, status, error);
+    })
+}
+
+fn emit_background_note_update(ctx: &ToolContext, note_id: &str) {
+    emit_background_media_event(BackgroundMediaEvent {
+        run_dir: ctx.run_dir.to_string_lossy().into_owned(),
+        note_id: note_id.to_string(),
+    });
+}
+
+/// Complete video files after a desktop macro has returned its poster-only note
+/// bundle. Downloads are process-wide bounded, survive the agent's final answer,
+/// and are canceled by the next desktop user-turn generation.
+fn spawn_background_video_downloads(
+    notes: &mut [Value],
+    media: &Option<MediaProcessor>,
+    history: &Arc<XhsHistoryStore>,
+    ctx: &ToolContext,
+    level: &str,
+    include_media: bool,
+) {
+    let Some(media) = media.clone() else {
+        return;
+    };
+    let generation = ctx
+        .background_media_generation
+        .unwrap_or_else(current_background_media_generation);
+    let run_dir = ctx.run_dir.to_string_lossy().into_owned();
+    if !background_media_generation_is_current(generation)
+        || background_media_run_is_cancelled(&run_dir)
+    {
+        return;
+    }
+
+    for entry in notes {
+        if entry.get("ok").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        let Some(entity) = entry.get_mut("entity").filter(|value| value.is_object()) else {
+            continue;
+        };
+        if entity.get("type").and_then(Value::as_str) != Some("video") {
+            continue;
+        }
+        let note_id = entity
+            .get("note_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if note_id.is_empty() {
+            continue;
+        }
+        let title = entity
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let referer = entity
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let Some(video) = entity.get_mut("video").filter(|value| value.is_object()) else {
+            continue;
+        };
+        if video
+            .get("local_path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| !path.trim().is_empty())
+        {
+            continue;
+        }
+        // A prior search in the same agent step may have completed this note's
+        // background download while the current search was still reading it.
+        // Re-check history at enqueue time (later than scan_card_note's cache
+        // check) and reuse that file instead of fetching the same video twice.
+        let completed_elsewhere = history
+            .get(&note_id)
+            .and_then(|entry| entry.entity)
+            .and_then(|entity| entity.get("video").cloned())
+            .and_then(|video| {
+                let path = video
+                    .get("local_path")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|path| !path.is_empty())?;
+                std::fs::metadata(path)
+                    .is_ok_and(|meta| meta.is_file() && meta.len() > 0)
+                    .then(|| path.to_string())
+            });
+        if let Some(local_path) = completed_elsewhere {
+            if let Some(map) = video.as_object_mut() {
+                map.insert("local_path".into(), Value::String(local_path.clone()));
+            }
+            let src = run_relative_path(&local_path, &ctx.run_dir);
+            ctx.update_recorded_note(&note_id, |record| {
+                let Some(items) = record.get_mut("media").and_then(Value::as_array_mut) else {
+                    return;
+                };
+                if let Some(video) = items
+                    .iter_mut()
+                    .find(|item| item.get("kind").and_then(Value::as_str) == Some("video"))
+                    .and_then(Value::as_object_mut)
+                {
+                    video.insert("src".into(), Value::String(src));
+                    video.remove("status");
+                    video.remove("error");
+                }
+            });
+            continue;
+        }
+        if let Some(map) = video.as_object_mut() {
+            map.insert("background_download_pending".into(), Value::Bool(true));
+        }
+        set_recorded_video_status(ctx, &note_id, Some("loading"), None);
+        let Some(reservation) = reserve_background_video_download(generation, &run_dir, &note_id)
+        else {
+            continue;
+        };
+        let video = video.clone();
+        let mut entity = entity.clone();
+        let media = media.clone();
+        let history = history.clone();
+        let ctx = ctx.clone();
+        let level = level.to_string();
+        let run_dir = run_dir.clone();
+
+        tokio::spawn(async move {
+            let _reservation = reservation;
+            let mut cancellation = subscribe_background_media_cancellation();
+            let semaphore = background_video_download_semaphore();
+            let permit = tokio::select! {
+                permit = semaphore.acquire_owned() => match permit {
+                    Ok(permit) => permit,
+                    Err(_) => return,
+                },
+                _ = wait_for_background_media_cancellation(generation, &run_dir, &mut cancellation) => {
+                    if set_recorded_video_status(&ctx, &note_id, None, None) {
+                        emit_background_note_update(&ctx, &note_id);
+                    }
+                    return;
+                },
+            };
+            let download = media.download_video_file(&video, &note_id, &title, &referer);
+            let completed_video = tokio::select! {
+                video = download => video,
+                _ = wait_for_background_media_cancellation(generation, &run_dir, &mut cancellation) => {
+                    if set_recorded_video_status(&ctx, &note_id, None, None) {
+                        emit_background_note_update(&ctx, &note_id);
+                    }
+                    return;
+                },
+            };
+            drop(permit);
+            if !background_media_generation_is_current(generation)
+                || background_media_run_is_cancelled(&run_dir)
+            {
+                if set_recorded_video_status(&ctx, &note_id, None, None) {
+                    emit_background_note_update(&ctx, &note_id);
+                }
+                return;
+            }
+            let Some(local_path) = completed_video
+                .get("local_path")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_string)
+            else {
+                let error = completed_video
+                    .get("download_error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("video download did not produce a local file");
+                if set_recorded_video_status(&ctx, &note_id, Some("failed"), Some(error)) {
+                    emit_background_note_update(&ctx, &note_id);
+                }
+                tracing::warn!(
+                    note_id,
+                    error,
+                    "background video download did not produce a local file"
+                );
+                return;
+            };
+
+            let mut completed_video = completed_video;
+            if let Some(map) = completed_video.as_object_mut() {
+                map.remove("background_download_pending");
+            }
+            if let Some(map) = entity.as_object_mut() {
+                map.insert("video".into(), completed_video);
+            }
+            history.record(&entity, &level, include_media);
+
+            let src = run_relative_path(&local_path, &ctx.run_dir);
+            let updated = ctx.update_recorded_note(&note_id, |record| {
+                let Some(map) = record.as_object_mut() else {
+                    return;
+                };
+                let media = map
+                    .entry("media")
+                    .or_insert_with(|| Value::Array(Vec::new()));
+                let Some(items) = media.as_array_mut() else {
+                    return;
+                };
+                if let Some(video) = items
+                    .iter_mut()
+                    .find(|item| item.get("kind").and_then(Value::as_str) == Some("video"))
+                {
+                    if let Some(video) = video.as_object_mut() {
+                        video.insert("src".into(), Value::String(src.clone()));
+                        video.remove("status");
+                        video.remove("error");
+                    }
+                } else {
+                    items.insert(0, json!({ "kind": "video", "ratio": "9:16", "src": src }));
+                }
+                map.insert("saved".into(), Value::Bool(true));
+            });
+            if updated {
+                emit_background_note_update(&ctx, &note_id);
+            }
+        });
+    }
 }
 
 /// Seconds → the app's display duration, "M:SS".
@@ -2573,7 +2848,8 @@ async fn scan_direct_note(
     position: usize,
     comment_count: i64,
     download_media: bool,
-    download_media_requested: bool,
+    download_video_file_inline: bool,
+    background_video_downloads: bool,
     ocr: bool,
     defer_ocr: bool,
 ) -> Value {
@@ -2617,7 +2893,7 @@ async fn scan_direct_note(
                 level: "deep".to_string(),
                 include_media: false,
                 download_media,
-                download_video_file: download_media_requested,
+                download_video_file: download_video_file_inline,
                 ocr: ocr && !defer_ocr,
                 transcribe_audio: false,
                 settle_ms: 800,
@@ -2719,7 +2995,10 @@ async fn scan_direct_note(
         "ok": true,
         "entity": entity,
     });
-    if let Some((note_id, record)) = build_note_record(&entry, ctx, "deep") {
+    if let Some((note_id, mut record)) = build_note_record(&entry, ctx, "deep") {
+        if background_video_downloads {
+            set_note_record_video_status(&mut record, Some("loading"), None);
+        }
         ctx.record_note(&note_id, record);
     }
     if let Some(map) = entry.as_object_mut() {
@@ -2825,6 +3104,10 @@ impl Tool for GetNotesTool {
             || get_bool(&input, "download_media", false)
             || transcribe_audio;
         let download_media = ocr || download_media_requested;
+        let background_video_downloads = self.always_download_media
+            && ctx.background_media_generation.is_some()
+            && download_media_requested
+            && !transcribe_audio;
         if ocr {
             tokio::task::spawn_blocking(ocr_warm_up);
         }
@@ -2861,7 +3144,8 @@ impl Tool for GetNotesTool {
                 position,
                 comment_count,
                 download_media,
-                download_media_requested,
+                download_media_requested && !background_video_downloads,
+                background_video_downloads,
                 ocr,
                 ocr,
             )
@@ -2923,6 +3207,9 @@ impl Tool for GetNotesTool {
             false,
         )
         .await;
+        if background_video_downloads {
+            spawn_background_video_downloads(&mut notes, &media, &self.history, ctx, "deep", false);
+        }
         write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
         if ocr {
             scan_progress.finish_ocr(notes.len());
@@ -3811,6 +4098,10 @@ impl Tool for SearchTool {
         // OCR still implies downloading what it reads (carousel images, video
         // posters) — but only an explicit request fetches video files.
         let download_media = ocr || download_media_requested;
+        let background_video_downloads = self.always_download_media
+            && ctx.background_media_generation.is_some()
+            && download_media_requested
+            && !transcribe_audio;
         // Warm the OCR engine off the critical path (model load + session init +
         // graph compile) so the first note's OCR doesn't pay it; overlaps the
         // search submit + first note open below.
@@ -3950,6 +4241,8 @@ impl Tool for SearchTool {
                 include_media,
                 download_media,
                 download_media_requested,
+                download_media_requested && !background_video_downloads,
+                background_video_downloads,
                 ocr,
                 transcribe_audio,
                 // Defer OCR to a background task when OCR is on, so the loop can
@@ -4013,6 +4306,16 @@ impl Tool for SearchTool {
             include_media,
         )
         .await;
+        if background_video_downloads {
+            spawn_background_video_downloads(
+                &mut notes,
+                &media,
+                &self.history,
+                ctx,
+                level,
+                include_media,
+            );
+        }
         // Write the scan perf record (per-note phase timing + OCR pipeline) to a
         // separate debug file; the JSON artifact stays LLM-facing.
         write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
@@ -4239,8 +4542,7 @@ impl Tool for AuthorScanTool {
         // `preview=true, download_media=true` call would still spin up the media
         // pipeline and emit media metadata even though no note is opened.
         let ocr = self.always_ocr || get_bool(&input, "ocr", false);
-        let transcribe_audio = !preview
-            && get_bool(&input, "transcribe_audio", false);
+        let transcribe_audio = !preview && get_bool(&input, "transcribe_audio", false);
         // Explicit request: download everything, video files included. OCR
         // still implies downloading what it reads (carousel images, video
         // posters) — but only an explicit request fetches video files.
@@ -4249,6 +4551,10 @@ impl Tool for AuthorScanTool {
                 || get_bool(&input, "download_media", false)
                 || transcribe_audio);
         let download_media = !preview && (ocr || download_media_requested);
+        let background_video_downloads = self.always_download_media
+            && ctx.background_media_generation.is_some()
+            && download_media_requested
+            && !transcribe_audio;
         // Warm the OCR engine off the critical path; overlaps opening the profile
         // and collecting note cards below.
         if ocr {
@@ -4356,6 +4662,8 @@ impl Tool for AuthorScanTool {
                     false,
                     download_media,
                     download_media_requested,
+                    download_media_requested && !background_video_downloads,
+                    background_video_downloads,
                     ocr,
                     transcribe_audio,
                     ocr,
@@ -4413,6 +4721,16 @@ impl Tool for AuthorScanTool {
                 false,
             )
             .await;
+            if background_video_downloads {
+                spawn_background_video_downloads(
+                    &mut notes,
+                    &media,
+                    &self.history,
+                    ctx,
+                    "deep",
+                    false,
+                );
+            }
             write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
             if ocr {
                 scan_progress.finish_ocr(notes.len());

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -18,6 +18,11 @@ const TRACES_ENDPOINT: &str = "https://socai.io/v1/traces";
 const CHANNEL_CAPACITY: usize = 512;
 const REMOTE_BATCH_SIZE: usize = 25;
 const REMOTE_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const TRACE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+const TRACE_UPLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+const TRACE_RETRY_BATCH_SIZE: usize = 5;
+const TRACE_FILE_READY_RETRIES: usize = 20;
+const TRACE_FILE_READY_DELAY: Duration = Duration::from_millis(50);
 
 /// Which socai surface is emitting telemetry. Carried verbatim into the `source`
 /// field of every event and used to decide which device context is meaningful
@@ -46,13 +51,16 @@ impl TelemetrySource {
 #[derive(Clone)]
 pub struct Telemetry {
     sender: mpsc::Sender<QueuedItem>,
+    pending_trace_dir: PathBuf,
 }
 
 #[derive(Debug)]
 enum QueuedItem {
     Event(QueuedEvent),
-    /// Path to a run's `trace.json`; the worker reads, enriches, and uploads it.
+    /// Path to a run's `trace.json` that was not ready when it was queued.
     TraceFile(PathBuf),
+    /// Durable, identity-free copy under telemetry/pending-traces.
+    PendingTrace(PathBuf),
 }
 
 #[derive(Debug)]
@@ -67,6 +75,7 @@ struct WorkerConfig {
     session_id: String,
     source: TelemetrySource,
     local_path: PathBuf,
+    pending_trace_dir: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +94,7 @@ impl Telemetry {
         let install_id = crate::identity::load_or_create_install_id(home);
         let session_id = new_session_id();
         let local_path = home.join("telemetry/events.jsonl");
+        let pending_trace_dir = home.join("telemetry/pending-traces");
 
         let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
         let config = WorkerConfig {
@@ -92,10 +102,14 @@ impl Telemetry {
             session_id,
             source,
             local_path,
+            pending_trace_dir: pending_trace_dir.clone(),
         };
         spawn_worker(receiver, config);
 
-        Self { sender }
+        Self {
+            sender,
+            pending_trace_dir,
+        }
     }
 
     pub fn capture(&self, name: impl Into<String>, properties: Value) {
@@ -105,13 +119,20 @@ impl Telemetry {
         }));
     }
 
-    /// Fire-and-forget upload of a run's `trace.json` (written by the run's
-    /// trace builder on finish or abort). Missing file — e.g. a run that
-    /// failed before the loop started — is a silent no-op.
-    pub fn upload_run_trace(&self, run_dir: &Path) {
-        let _ = self
-            .sender
-            .try_send(QueuedItem::TraceFile(run_dir.join("trace.json")));
+    /// Durably stage and asynchronously upload a run's `trace.json`.
+    ///
+    /// Staging happens before this method returns so deleting a completed or
+    /// cancelled task cannot race the telemetry worker's first file read. A
+    /// cancellation can call this just before the trace drop guard finishes;
+    /// that source path is retried briefly by the worker.
+    pub fn upload_run_trace(&self, run_dir: &Path) -> bool {
+        let source = run_dir.join("trace.json");
+        let (item, staged) = match stage_trace_file(&source, &self.pending_trace_dir) {
+            Ok(path) => (QueuedItem::PendingTrace(path), true),
+            Err(_) => (QueuedItem::TraceFile(source), false),
+        };
+        let _ = self.sender.try_send(item);
+        staged
     }
 }
 
@@ -142,10 +163,18 @@ fn spawn_worker(receiver: mpsc::Receiver<QueuedItem>, config: WorkerConfig) {
 }
 
 async fn worker_loop(mut receiver: mpsc::Receiver<QueuedItem>, config: WorkerConfig) {
-    let client = reqwest::Client::new();
+    let client = match reqwest::Client::builder()
+        .timeout(TRACE_UPLOAD_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return,
+    };
     let mut remote_batch: Vec<Value> = Vec::new();
     let mut flush_tick = tokio::time::interval(REMOTE_FLUSH_INTERVAL);
     flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut trace_retry_tick = tokio::time::interval(TRACE_RETRY_INTERVAL);
+    trace_retry_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     loop {
         tokio::select! {
@@ -165,13 +194,21 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedItem>, config: WorkerCon
                             flush_remote(&client, &mut remote_batch).await;
                         }
                     }
-                    QueuedItem::TraceFile(path) => {
-                        upload_trace_file(&client, &config, &path).await;
+                    QueuedItem::TraceFile(source) => {
+                        if let Some(path) = stage_trace_file_when_ready(&source, &config.pending_trace_dir).await {
+                            upload_pending_trace(&client, &config, &path).await;
+                        }
+                    }
+                    QueuedItem::PendingTrace(path) => {
+                        upload_pending_trace(&client, &config, &path).await;
                     }
                 }
             }
             _ = flush_tick.tick() => {
                 flush_remote(&client, &mut remote_batch).await;
+            }
+            _ = trace_retry_tick.tick() => {
+                retry_pending_traces(&client, &config).await;
             }
         }
     }
@@ -179,10 +216,71 @@ async fn worker_loop(mut receiver: mpsc::Receiver<QueuedItem>, config: WorkerCon
     flush_remote(&client, &mut remote_batch).await;
 }
 
-/// Read a run's `trace.json`, append identity resource attributes, and POST it
-/// to the traces proxy. Best-effort at every step: a missing/invalid file or a
-/// failed upload is dropped silently, matching the events contract.
-async fn upload_trace_file(client: &reqwest::Client, config: &WorkerConfig, path: &Path) {
+fn stage_trace_file(source: &Path, pending_dir: &Path) -> std::io::Result<PathBuf> {
+    let bytes = std::fs::read(source)?;
+    let payload: Value = serde_json::from_slice(&bytes).map_err(std::io::Error::other)?;
+    let key = trace_spool_key(&payload)
+        .ok_or_else(|| std::io::Error::other("trace.json has no root trace/span id"))?;
+    std::fs::create_dir_all(pending_dir)?;
+    let destination = pending_dir.join(format!("{key}.json"));
+    let temporary = pending_dir.join(format!("{key}.{}.tmp", uuid::Uuid::new_v4()));
+    std::fs::write(&temporary, bytes)?;
+    if destination.exists() {
+        let _ = std::fs::remove_file(&destination);
+    }
+    std::fs::rename(&temporary, &destination)?;
+    Ok(destination)
+}
+
+fn trace_spool_key(payload: &Value) -> Option<String> {
+    let root = payload
+        .pointer("/resourceSpans/0/scopeSpans/0/spans")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|span| span.get("parentSpanId").is_none())?;
+    let trace_id = root.get("traceId")?.as_str()?;
+    let span_id = root.get("spanId")?.as_str()?;
+    if trace_id.is_empty() || span_id.is_empty() {
+        return None;
+    }
+    Some(format!("{trace_id}-{span_id}"))
+}
+
+async fn stage_trace_file_when_ready(source: &Path, pending_dir: &Path) -> Option<PathBuf> {
+    for attempt in 0..TRACE_FILE_READY_RETRIES {
+        match stage_trace_file(source, pending_dir) {
+            Ok(path) => return Some(path),
+            Err(_) if attempt + 1 < TRACE_FILE_READY_RETRIES => {
+                tokio::time::sleep(TRACE_FILE_READY_DELAY).await;
+            }
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+async fn retry_pending_traces(client: &reqwest::Client, config: &WorkerConfig) {
+    let Ok(mut entries) = tokio::fs::read_dir(&config.pending_trace_dir).await else {
+        return;
+    };
+    let mut paths = Vec::new();
+    while paths.len() < TRACE_RETRY_BATCH_SIZE {
+        let Ok(Some(entry)) = entries.next_entry().await else {
+            break;
+        };
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            paths.push(path);
+        }
+    }
+    for path in paths {
+        upload_pending_trace(client, config, &path).await;
+    }
+}
+
+/// Append identity resource attributes and POST one durable pending trace.
+/// The spool file is removed only after the proxy acknowledges the handoff.
+async fn upload_pending_trace(client: &reqwest::Client, config: &WorkerConfig, path: &Path) {
     let Ok(bytes) = tokio::fs::read(path).await else {
         return;
     };
@@ -190,7 +288,12 @@ async fn upload_trace_file(client: &reqwest::Client, config: &WorkerConfig, path
         return;
     };
     enrich_trace_resource(&mut payload, config);
-    let _ = client.post(traces_endpoint()).json(&payload).send().await;
+    let Ok(response) = client.post(traces_endpoint()).json(&payload).send().await else {
+        return;
+    };
+    if response.status().is_success() {
+        let _ = tokio::fs::remove_file(path).await;
+    }
 }
 
 /// The on-disk trace stays identity-free so run dirs can be shared; the

--- a/docs/development/telemetry-runbook.md
+++ b/docs/development/telemetry-runbook.md
@@ -142,6 +142,19 @@ The desktop app writes its own buffer under the app data dir:
 ~/.socai/app/telemetry/events.jsonl
 ```
 
+Desktop run traces are staged separately before upload:
+
+```text
+~/.socai/app/telemetry/pending-traces/*.json
+```
+
+A pending trace is removed only after `/v1/traces` acknowledges it. Proxy,
+network, or Axiom failures leave the file in place and the worker retries it
+periodically and after the next app start. This staging also prevents deleting
+a cancelled task from racing the trace worker's first read. Cancellation and
+history deletion return to the UI immediately; trace finalization, staging,
+upload, and artifact cleanup continue as invisible background work.
+
 Example inspection:
 
 ```bash

--- a/site/api/traces.js
+++ b/site/api/traces.js
@@ -58,13 +58,13 @@ export default async function handler(req, res) {
 
   try {
     await forwardToAxiom({ resourceSpans });
+    res.status(202).json({ ok: true });
   } catch (error) {
-    // Best-effort, same as events: the client has handed the trace off; proxy
-    // or Axiom outages must not create retry storms or leak backend details.
+    // Return a retryable failure to clients. They persist trace payloads
+    // locally, so an Axiom/proxy outage no longer turns a 202 into silent loss.
     console.error('trace forward failed', error);
+    res.status(502).json({ ok: false, error: 'trace_forward_failed' });
   }
-
-  res.status(202).json({ ok: true });
 }
 
 async function readJsonBody(req) {
@@ -139,8 +139,7 @@ function consumeRateLimit(key) {
 async function forwardToAxiom(payload) {
   const token = process.env.AXIOM_TRACES_TOKEN || process.env.AXIOM_TOKEN;
   if (!token) {
-    console.warn('AXIOM_TRACES_TOKEN is not configured; dropping trace');
-    return;
+    throw new Error('AXIOM_TRACES_TOKEN is not configured');
   }
 
   const dataset = process.env.AXIOM_TRACES_DATASET || DEFAULT_DATASET;


### PR DESCRIPTION
## Summary

- keep XHS searches responsive by downloading posters inline and full videos concurrently in cancellable background tasks
- update desktop note previews from loading to playable or failed without blocking the agent response
- durably stage and retry telemetry trace uploads so cancellation and task deletion cannot lose traces or delay the UI

## Root cause

Desktop searches downloaded full video files on the critical path, while background media state was only recorded after the entire scan. Cancellation also raced trace finalization and task cleanup, which could drop the trace before the telemetry worker read it.

## User impact

Searches can return after poster/OCR enrichment while videos continue in the background. Preview overlays now reflect loading, success, and failure immediately. Cancelling remains immediate and trace upload stays invisible in the background.

## Validation

- `cargo check -p socai_app`
- `cargo test -p socai-core sites::xhs::media_manifest:: --lib` (9 passed)
- `cargo test -p socai-core telemetry:: --lib` (14 passed)
- `pnpm --dir app build`
- `pnpm --dir site build`
- `node --check site/api/traces.js`
- `git diff --check`