### PR TITLE
feat: remote hosted browser mode (chrome.profile remote, socai pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Config lives in `~/.socai/config.json`. 常用配置项：
   paths from the current directory. `SOCAI_RUNS_DIR` still takes precedence when
   set.
 - `chrome.profile` — browser profile mode: `existing`, `managed`, `auto`, or
-  `remote`. Default is `existing`, which attaches to your existing
+  `remote` (beta). Default is `existing`, which attaches to your existing
   browser/profile with CDP enabled. To opt into socai's isolated profile
   persistently:
 
@@ -118,10 +118,11 @@ Config lives in `~/.socai/config.json`. 常用配置项：
   socai config set chrome.profile_dir ~/.socai/profiles/xhs-test
   ```
 
-- `chrome.profile remote` — run on socai's hosted cloud browser instead of any
-  local chrome: no local chrome install and no xiaohongshu login needed. This
-  is a socai pro feature; activate an invite first with
-  `socai pro activate <invite_code>`.
+- `chrome.profile remote` — **beta** — run on socai's hosted cloud browser
+  instead of any local chrome: no local chrome install and no xiaohongshu login
+  needed. This is a socai pro feature; activate an invite first with
+  `socai pro activate <invite_code>`. Being beta, it is off by default, has
+  daily session limits, and its behaviour may change between releases.
 
 To switch back to your existing browser profile:
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ Config lives in `~/.socai/config.json`. 常用配置项：
   Relative paths passed to `socai config set runs.dir` are stored as absolute
   paths from the current directory. `SOCAI_RUNS_DIR` still takes precedence when
   set.
-- `chrome.profile` — browser profile mode: `existing`, `managed`, or `auto`.
-  Default is `existing`, which attaches to your existing browser/profile with
-  CDP enabled. To opt into socai's isolated profile persistently:
+- `chrome.profile` — browser profile mode: `existing`, `managed`, `auto`, or
+  `remote`. Default is `existing`, which attaches to your existing
+  browser/profile with CDP enabled. To opt into socai's isolated profile
+  persistently:
 
   ```bash
   socai config set chrome.profile managed # 以后默认使用 socai 独立 chrome 资料目录
@@ -116,6 +117,11 @@ Config lives in `~/.socai/config.json`. 常用配置项：
   ```bash
   socai config set chrome.profile_dir ~/.socai/profiles/xhs-test
   ```
+
+- `chrome.profile remote` — run on socai's hosted cloud browser instead of any
+  local chrome: no local chrome install and no xiaohongshu login needed. This
+  is a socai pro feature; activate an invite first with
+  `socai pro activate <invite_code>`.
 
 To switch back to your existing browser profile:
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1327,8 +1327,8 @@ async fn emit_timeline_payload(
 
 #[derive(serde::Serialize)]
 pub struct DesktopConfig {
-    /// Chrome profile mode: "managed" | "existing" | "auto". Falls back to the
-    /// product default ("existing") when the config key is unset.
+    /// Chrome profile mode: "managed" | "existing" | "auto" | "remote". Falls
+    /// back to the product default ("existing") when the config key is unset.
     chrome_source: String,
     /// Configured managed-profile directory, or "" when unset.
     chrome_profile_dir: String,

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -11,8 +11,8 @@ use socai_core::agent::{
 };
 use socai_core::runtime::{
     create_llm_provider_for, ensure_llm_provider_configured_for,
-    run_agent_task as run_agent_with_tools, AgentRunConfig, BrowserStatus, RuntimePageSession,
-    SocaiRuntime,
+    run_agent_task as run_agent_with_tools, wait_browser_connected, AgentRunConfig, BrowserStatus,
+    RuntimePageSession, SocaiRuntime,
 };
 use socai_core::sites::xhs::XhsHistoryStore;
 use socai_core::sites::{find_site, SiteSpec};
@@ -102,11 +102,16 @@ pub async fn app_relaunch(app: AppHandle) {
     tauri::process::restart(&app.env());
 }
 
-async fn require_connected(runtime: &SocaiRuntime) -> Result<(), String> {
-    match runtime.browser_status().await {
-        BrowserStatus::Connected { .. } => Ok(()),
-        _ => Err("chrome not connected — click connect first".into()),
-    }
+/// Ensure the browser is connected before an agent run, connecting when it is
+/// not. Starting a run expresses the user's intent to resume, so a dropped
+/// connection reconnects here instead of bouncing them to the connect button.
+/// Routine for remote profiles — hosted sessions expire on a server-side
+/// timeout between runs, and reconnecting mints a fresh one — and it also
+/// revives a killed managed chrome. Bounded by the runtime's connect budget.
+async fn ensure_browser_connected(runtime: &SocaiRuntime) -> Result<(), String> {
+    wait_browser_connected(runtime)
+        .await
+        .map_err(|err| format!("{err:#}"))
 }
 
 async fn label_controlled_page(page: &RuntimePageSession, label: &str) {
@@ -424,7 +429,7 @@ pub async fn agent_task_start(
     provider: Option<String>,
     model: Option<String>,
 ) -> Result<AgentTaskSnapshot, String> {
-    require_connected(&runtime).await?;
+    ensure_browser_connected(&runtime).await?;
     let task_text = task.trim().to_string();
     if task_text.is_empty() {
         return Err("task is empty".into());
@@ -508,7 +513,7 @@ pub async fn agent_task_reply(
     task_id: String,
     message: String,
 ) -> Result<AgentTaskSnapshot, String> {
-    require_connected(&runtime).await?;
+    ensure_browser_connected(&runtime).await?;
     let message_text = message.trim().to_string();
     if message_text.is_empty() {
         return Err("message is empty".into());

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -54,6 +54,10 @@ const messages = {
   },
   "chrome.connectCta": { en: "connect chrome →", zh: "连接 chrome →" },
   "chrome.connectingCta": { en: "connecting…", zh: "连接中…" },
+  "chrome.remoteAutoReconnect": {
+    en: "hosted browser not connected — it reconnects when you send.",
+    zh: "云端浏览器未连接 — 发送时会自动重连。",
+  },
   "chrome.remoteDebuggingHelp": {
     en: "how do i enable remote debugging? ↗",
     zh: "如何启用远程调试？↗",

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -41,7 +41,7 @@ const messages = {
   "chrome.source": { en: "source", zh: "来源" },
   "chrome.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
   "chrome.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
-  "chrome.sourceRemote": { en: "remote browser", zh: "远程浏览器" },
+  "chrome.sourceRemote": { en: "remote (beta)", zh: "远程（beta）" },
   "chrome.profile": { en: "profile", zh: "资料目录" },
   "chrome.disconnect": { en: "disconnect", zh: "断开连接" },
   "chrome.lookingForChrome": {
@@ -103,15 +103,15 @@ const messages = {
   "settings.source": { en: "source", zh: "来源" },
   "settings.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
   "settings.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
-  "settings.sourceRemote": { en: "remote browser", zh: "远程浏览器" },
+  "settings.sourceRemote": { en: "remote (beta)", zh: "远程（beta）" },
   "settings.profileDir": { en: "profile directory", zh: "资料目录" },
   "settings.profileHint": {
     en: "socai launches a throwaway chrome with this profile.",
     zh: "socai 会用此资料目录启动临时 chrome。",
   },
   "settings.remoteHint": {
-    en: "runs on socai's hosted browser — no local chrome, no xiaohongshu login needed.",
-    zh: "使用 socai 云端托管浏览器 — 无需本地 chrome，也无需登录小红书。",
+    en: "beta — runs on socai's hosted browser; no local chrome, no xiaohongshu login needed. daily session limits apply.",
+    zh: "beta — 使用 socai 云端托管浏览器；无需本地 chrome，也无需登录小红书。每天有会话次数限制。",
   },
   "settings.endpoint": { en: "debugging endpoint", zh: "调试端点" },
   "settings.endpointHint": {

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -41,6 +41,7 @@ const messages = {
   "chrome.source": { en: "source", zh: "来源" },
   "chrome.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
   "chrome.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
+  "chrome.sourceRemote": { en: "remote browser", zh: "远程浏览器" },
   "chrome.profile": { en: "profile", zh: "资料目录" },
   "chrome.disconnect": { en: "disconnect", zh: "断开连接" },
   "chrome.lookingForChrome": {
@@ -102,10 +103,15 @@ const messages = {
   "settings.source": { en: "source", zh: "来源" },
   "settings.sourceManaged": { en: "isolated profile", zh: "独立配置文件" },
   "settings.sourceExisting": { en: "existing browser", zh: "现有浏览器" },
+  "settings.sourceRemote": { en: "remote browser", zh: "远程浏览器" },
   "settings.profileDir": { en: "profile directory", zh: "资料目录" },
   "settings.profileHint": {
     en: "socai launches a throwaway chrome with this profile.",
     zh: "socai 会用此资料目录启动临时 chrome。",
+  },
+  "settings.remoteHint": {
+    en: "runs on socai's hosted browser — no local chrome, no xiaohongshu login needed.",
+    zh: "使用 socai 云端托管浏览器 — 无需本地 chrome，也无需登录小红书。",
   },
   "settings.endpoint": { en: "debugging endpoint", zh: "调试端点" },
   "settings.endpointHint": {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -20,6 +20,7 @@ export type Status =
       page_count: number;
       source?: string;
       managed?: boolean;
+      remote?: boolean;
       user_data_dir?: string | null;
     };
 
@@ -267,17 +268,18 @@ function renderConnectionDialog(connected: Extract<Status, { state: "connected" 
         </div>
         <div>
           <p class="t-eyebrow">${htmlEsc(t("chrome.source"))}</p>
-          <p class="t-mono">${htmlEsc(connected.managed ? t("chrome.sourceManaged") : t("chrome.sourceExisting"))}</p>
+          <p class="t-mono">${htmlEsc(connected.remote ? t("chrome.sourceRemote") : connected.managed ? t("chrome.sourceManaged") : t("chrome.sourceExisting"))}</p>
         </div>
         ${connected.user_data_dir ? `
         <div class="connection-meta-wide">
           <p class="t-eyebrow">${htmlEsc(t("chrome.profile"))}</p>
           <p class="t-mono connection-endpoint">${htmlEsc(connected.user_data_dir)}</p>
         </div>` : ""}
+        ${connected.remote ? "" : `
         <div class="connection-meta-wide">
           <p class="t-eyebrow">${htmlEsc(t("chrome.endpoint"))}</p>
           <p class="t-mono connection-endpoint">${htmlEsc(connected.endpoint)}</p>
-        </div>
+        </div>`}
       </div>
       <button id="chrome-disconnect" type="button" class="btn-ghost">${htmlEsc(t("chrome.disconnect"))}</button>
     </div>

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -34,6 +34,12 @@ export interface ComposerProps {
   modelReady: boolean;
   /** True while the shown task runs — the composer waits for the slot. */
   running: boolean;
+  /**
+   * Configured browser source is the remote hosted browser. Disconnected is
+   * routine there (hosted sessions expire between runs) and submitting a run
+   * reconnects on demand, so the connect overlay and send gating don't apply.
+   */
+  remoteProfile: boolean;
 }
 
 export interface ConversationProps {
@@ -65,7 +71,7 @@ export function renderConversation(props: ConversationProps): string {
 // A centered hero + the same chat composer. When chrome isn't connected the
 // form is masked behind the connect overlay.
 export function renderComposePane(composer: ComposerProps): string {
-  const gated = composer.status.state !== "connected";
+  const gated = !composer.remoteProfile && composer.status.state !== "connected";
   return `
     <div class="compose-pane">
       <div class="new-task-compose">
@@ -427,7 +433,10 @@ function renderComposer(c: ComposerProps): string {
   const connected = c.status.state === "connected";
   const connecting = c.status.state === "connecting";
   const disabled = c.submitting || c.running;
-  const sendDisabled = disabled || !c.value.trim() || !connected || !c.modelReady;
+  // A remote profile submits while disconnected: the run reconnects (minting
+  // a fresh hosted session) on demand.
+  const needsConnection = !connected && !c.remoteProfile;
+  const sendDisabled = disabled || !c.value.trim() || needsConnection || !c.modelReady;
   const placeholder = c.running
     ? t("task.working")
     : c.mode === "new"
@@ -438,7 +447,9 @@ function renderComposer(c: ComposerProps): string {
     : `<svg class="composer__send-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 7 16 13 8 13"></polyline><polyline points="11 10 8 13 11 16"></polyline></svg>`;
   const connectHint = connected
     ? ""
-    : `
+    : c.remoteProfile
+      ? `<p class="composer__hint">${esc(t("chrome.remoteAutoReconnect"))}</p>`
+      : `
       <p class="composer__hint">
         ${esc(t(c.mode === "new" ? "chrome.connectToStart" : "task.replyConnectHint"))}
         <button id="composer-connect" type="button" class="btn-ghost btn-compact" ${connecting ? "disabled" : ""}>

--- a/app/src/panels/settings.ts
+++ b/app/src/panels/settings.ts
@@ -85,6 +85,13 @@ export namespace settingsMenu {
     }
   }
 
+  /// Whether the configured browser source is socai's remote hosted browser.
+  /// The composer consults this: remote sessions are minted on demand at run
+  /// start, so a disconnected status is routine there, not a setup problem.
+  export function isRemoteProfile(): boolean {
+    return (draft?.chrome_source ?? config?.chrome_source) === "remote";
+  }
+
   export function isOpen(): boolean {
     return open;
   }

--- a/app/src/panels/settings.ts
+++ b/app/src/panels/settings.ts
@@ -220,6 +220,7 @@ export namespace settingsMenu {
 
   function renderChromeGroup(shell: ShellState, c: DesktopConfig, d: SettingsDraft): string {
     const managed = d.chrome_source === "managed";
+    const remote = d.chrome_source === "remote";
     const detail = managed
       ? `
         <div class="settings-field">
@@ -238,16 +239,27 @@ export namespace settingsMenu {
           <p class="t-small subtle settings-field-hint">${esc(t("settings.profileHint"))}</p>
         </div>
       `
-      : renderEndpointField(shell);
-    // "existing browser" is the product default, so it leads the toggle.
+      : remote
+        ? `
+        <div class="settings-field">
+          <p class="t-small subtle settings-field-hint">${esc(t("settings.remoteHint"))}</p>
+        </div>
+      `
+        : renderEndpointField(shell);
+    // "existing browser" is the product default, so it leads the toggle. The
+    // remote option is pro-gated; keep it visible if it is already the
+    // configured source so the state stays legible (and escapable) even after
+    // a deactivation.
+    const showRemote = c.pro_activated || remote;
     return `
       <section class="settings-group">
         <p class="settings-group-label">${esc(t("settings.chrome"))}</p>
         <div class="settings-field">
           <span class="t-small settings-field-label">${esc(t("settings.source"))}</span>
           <div class="seg-toggle" role="group" aria-label="${esc(t("settings.source"))}">
-            <button type="button" class="seg-toggle__button" data-settings-source="existing" aria-pressed="${managed ? "false" : "true"}">${esc(t("settings.sourceExisting"))}</button>
+            <button type="button" class="seg-toggle__button" data-settings-source="existing" aria-pressed="${!managed && !remote ? "true" : "false"}">${esc(t("settings.sourceExisting"))}</button>
             <button type="button" class="seg-toggle__button" data-settings-source="managed" aria-pressed="${managed ? "true" : "false"}">${esc(t("settings.sourceManaged"))}</button>
+            ${showRemote ? `<button type="button" class="seg-toggle__button" data-settings-source="remote" aria-pressed="${remote ? "true" : "false"}">${esc(t("settings.sourceRemote"))}</button>` : ""}
           </div>
         </div>
         ${detail}

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -14,6 +14,7 @@ import type {
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
 import { isSendShortcut } from "../lib/shortcuts";
+import { settingsMenu } from "./settings";
 import { renderConfirmDeleteDialog, renderSidebar as renderSidebarMarkup } from "./task_history";
 import {
   noteRefsFromEvent,
@@ -709,6 +710,7 @@ export namespace agentPanel {
       status: shell.status,
       modelReady: !!selected && selected.has_key,
       running: false,
+      remoteProfile: settingsMenu.isRemoteProfile(),
     };
   }
 
@@ -721,6 +723,7 @@ export namespace agentPanel {
       status: shell.status,
       modelReady: true,
       running,
+      remoteProfile: settingsMenu.isRemoteProfile(),
     };
   }
 
@@ -900,10 +903,12 @@ export namespace agentPanel {
     const value = task ? replyDraft : draft;
     const submitting = task ? submittingReply : submittingTask;
     const running = !!task && (task.status === "running" || task.status === "queued");
-    const connected = shell.status.state === "connected";
+    // Remote profiles submit while disconnected; the run reconnects on demand.
+    const needsConnection =
+      shell.status.state !== "connected" && !settingsMenu.isRemoteProfile();
     const selected = selectedModel();
     const modelReady = task ? true : !!selected && selected.has_key;
-    button.disabled = submitting || running || !value.trim() || !connected || !modelReady;
+    button.disabled = submitting || running || !value.trim() || needsConnection || !modelReady;
   }
 
   // Grows the composer textarea with its content instead of leaving multi-line

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -349,6 +349,11 @@ fn run_config_command(matches: &ArgMatches) -> Result<()> {
             let canonical = socai_config::canonical_config_key(key)?;
             let path = socai_config::set_config_key(key, value)?;
             println!("set {canonical} in {}", path.display());
+            if canonical == "chrome.profile" && value.trim().eq_ignore_ascii_case("remote") {
+                eprintln!(
+                    "Note: the remote hosted browser is beta — it needs socai pro, applies daily session limits, and its behaviour may change between releases."
+                );
+            }
             if canonical.starts_with("chrome.") {
                 eprintln!(
                     "If the socai daemon is already running, run `socai stop` once so the next session uses the new chrome preference."

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -20,7 +20,8 @@ pub enum ChromeProfile {
     Managed,
     /// Try managed first, then fall back to existing-browser discovery.
     Auto,
-    /// Drive a remote hosted browser minted via socai-server (socai pro).
+    /// Drive a remote hosted browser minted via socai-server (socai pro,
+    /// beta).
     Remote,
 }
 

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -205,15 +205,26 @@ impl From<&CdpState> for StatusPayload {
                 targets,
                 owner,
                 ..
-            } => Self::Connected {
-                endpoint: endpoint.browser_ws_url.clone(),
-                browser_version: browser_version.clone(),
-                page_count: targets.values().filter(|t| t.r#type == "page").count(),
-                source: endpoint.source.clone(),
-                managed: endpoint.managed,
-                remote: matches!(owner, BrowserOwner::Remote(_)),
-                user_data_dir: endpoint.user_data_dir.clone(),
-            },
+            } => {
+                let remote = matches!(owner, BrowserOwner::Remote(_));
+                Self::Connected {
+                    // A hosted connect URL is a browser-control credential and
+                    // this payload crosses the Tauri IPC boundary on every
+                    // status change, so remote endpoints are redacted at the
+                    // source rather than merely hidden by the UI.
+                    endpoint: if remote {
+                        crate::cdp::endpoint::redact_remote_ws_url(&endpoint.browser_ws_url)
+                    } else {
+                        endpoint.browser_ws_url.clone()
+                    },
+                    browser_version: browser_version.clone(),
+                    page_count: targets.values().filter(|t| t.r#type == "page").count(),
+                    source: endpoint.source.clone(),
+                    managed: endpoint.managed,
+                    remote,
+                    user_data_dir: endpoint.user_data_dir.clone(),
+                }
+            }
         }
     }
 }
@@ -266,16 +277,22 @@ impl Cdp {
         }
     }
 
-    /// True when the current connection drives a remote hosted browser socai
-    /// minted via socai-server (as opposed to any local chrome).
-    pub async fn is_remote(&self) -> bool {
-        matches!(
-            &*self.state.lock().await,
+    /// The browser websocket plus whether it belongs to a remote hosted
+    /// browser, read under one lock. Page creation must learn both together:
+    /// deriving remote-ness in a second lookup could observe a different
+    /// connection if a disconnect/reconnect lands in between.
+    pub(crate) async fn browser_client_with_mode(&self) -> Option<(RawCdpClient, bool)> {
+        match &*self.state.lock().await {
             CdpState::Connected {
-                owner: BrowserOwner::Remote(_),
+                browser_client,
+                owner,
                 ..
-            }
-        )
+            } => Some((
+                browser_client.clone(),
+                matches!(owner, BrowserOwner::Remote(_)),
+            )),
+            _ => None,
+        }
     }
 
     pub(crate) async fn register_owned_target(&self, target_id: impl Into<String>) {

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -239,6 +239,11 @@ pub struct Cdp {
     state: Arc<Mutex<CdpState>>,
     events: broadcast::Sender<BrowserEvent>,
     owned_targets: Arc<Mutex<HashSet<String>>>,
+    /// Held for the lifetime of a connect loop so only one runs at a time.
+    /// Reading the state cannot provide that on its own: two callers can both
+    /// observe `Disconnected` before either transitions, and each would then
+    /// acquire its own browser — for a hosted profile, its own billed session.
+    connect_lock: Arc<Mutex<()>>,
 }
 
 impl Cdp {
@@ -248,6 +253,7 @@ impl Cdp {
             state: Arc::new(Mutex::new(CdpState::initial())),
             events,
             owned_targets: Arc::new(Mutex::new(HashSet::new())),
+            connect_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -328,6 +334,10 @@ impl Cdp {
 
     pub(crate) fn state(&self) -> Arc<Mutex<CdpState>> {
         Arc::clone(&self.state)
+    }
+
+    pub(crate) fn connect_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.connect_lock)
     }
 
     pub(crate) fn emit(&self, event: BrowserEvent) {

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -20,6 +20,8 @@ pub enum ChromeProfile {
     Managed,
     /// Try managed first, then fall back to existing-browser discovery.
     Auto,
+    /// Drive a remote hosted browser minted via socai-server (socai pro).
+    Remote,
 }
 
 impl ChromeProfile {
@@ -28,8 +30,9 @@ impl ChromeProfile {
             "existing" => Ok(Self::Existing),
             "managed" => Ok(Self::Managed),
             "auto" => Ok(Self::Auto),
+            "remote" => Ok(Self::Remote),
             other => Err(anyhow::anyhow!(
-                "invalid chrome profile {other:?}; expected existing, managed, or auto"
+                "invalid chrome profile {other:?}; expected existing, managed, auto, or remote"
             )),
         }
     }
@@ -39,6 +42,7 @@ impl ChromeProfile {
             Self::Existing => "existing",
             Self::Managed => "managed",
             Self::Auto => "auto",
+            Self::Remote => "remote",
         }
     }
 }
@@ -107,14 +111,47 @@ pub enum CdpState {
         browser_version: String,
         targets: HashMap<String, TargetInfo>,
         monitor_task: tokio::task::AbortHandle,
-        /// Managed chrome process socai launched, if any. Held here so it is
-        /// killed on drop — disconnect, reconnect, or daemon shutdown all
-        /// replace this state and tear the browser down, mirroring the old
-        /// chromiumoxide `Browser` drop semantics. `None` when we attached to an
-        /// already-running browser (the user's existing profile, or a managed
-        /// profile a prior socai entrypoint launched and we merely reused).
-        chrome_process: Option<ChromeProcess>,
+        /// Browser resource socai owns for this connection. Held here so it is
+        /// torn down on drop — disconnect, reconnect, or daemon shutdown all
+        /// replace this state and release the browser, mirroring the old
+        /// chromiumoxide `Browser` drop semantics.
+        owner: BrowserOwner,
     },
+}
+
+/// What socai owns behind the current connection, torn down when the
+/// `Connected` state is replaced. The variant payloads exist for their `Drop`
+/// side effects (kill the launched chrome / release the minted session).
+pub enum BrowserOwner {
+    /// Attached to a browser socai does not own (the user's existing profile,
+    /// a reused managed chrome, or an explicit endpoint) — nothing to release.
+    None,
+    /// Managed chrome process socai launched; killed on drop.
+    Local(ChromeProcess),
+    /// Remote hosted browser session socai minted via socai-server; a
+    /// best-effort release fires on drop, with the server-side session
+    /// timeout as the backstop.
+    Remote(RemoteSession),
+}
+
+pub struct RemoteSession {
+    pub session_id: String,
+}
+
+impl Drop for RemoteSession {
+    fn drop(&mut self) {
+        let session_id = std::mem::take(&mut self.session_id);
+        if session_id.is_empty() {
+            return;
+        }
+        // Outside a tokio runtime (process teardown) the release is skipped;
+        // the server-side session timeout reaps it instead.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = crate::cloud::release_browser_session(&session_id).await;
+            });
+        }
+    }
 }
 
 impl CdpState {
@@ -148,6 +185,9 @@ pub enum StatusPayload {
         page_count: usize,
         source: String,
         managed: bool,
+        /// True when socai minted this connection's browser remotely via
+        /// socai-server (chrome.profile `remote`).
+        remote: bool,
         user_data_dir: Option<String>,
     },
 }
@@ -163,6 +203,7 @@ impl From<&CdpState> for StatusPayload {
                 endpoint,
                 browser_version,
                 targets,
+                owner,
                 ..
             } => Self::Connected {
                 endpoint: endpoint.browser_ws_url.clone(),
@@ -170,6 +211,7 @@ impl From<&CdpState> for StatusPayload {
                 page_count: targets.values().filter(|t| t.r#type == "page").count(),
                 source: endpoint.source.clone(),
                 managed: endpoint.managed,
+                remote: matches!(owner, BrowserOwner::Remote(_)),
                 user_data_dir: endpoint.user_data_dir.clone(),
             },
         }
@@ -222,6 +264,18 @@ impl Cdp {
             CdpState::Connected { browser_client, .. } => Some(browser_client.clone()),
             _ => None,
         }
+    }
+
+    /// True when the current connection drives a remote hosted browser socai
+    /// minted via socai-server (as opposed to any local chrome).
+    pub async fn is_remote(&self) -> bool {
+        matches!(
+            &*self.state.lock().await,
+            CdpState::Connected {
+                owner: BrowserOwner::Remote(_),
+                ..
+            }
+        )
     }
 
     pub(crate) async fn register_owned_target(&self, target_id: impl Into<String>) {

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -205,26 +205,21 @@ impl From<&CdpState> for StatusPayload {
                 targets,
                 owner,
                 ..
-            } => {
-                let remote = matches!(owner, BrowserOwner::Remote(_));
-                Self::Connected {
-                    // A hosted connect URL is a browser-control credential and
-                    // this payload crosses the Tauri IPC boundary on every
-                    // status change, so remote endpoints are redacted at the
-                    // source rather than merely hidden by the UI.
-                    endpoint: if remote {
-                        crate::cdp::endpoint::redact_remote_ws_url(&endpoint.browser_ws_url)
-                    } else {
-                        endpoint.browser_ws_url.clone()
-                    },
-                    browser_version: browser_version.clone(),
-                    page_count: targets.values().filter(|t| t.r#type == "page").count(),
-                    source: endpoint.source.clone(),
-                    managed: endpoint.managed,
-                    remote,
-                    user_data_dir: endpoint.user_data_dir.clone(),
-                }
-            }
+            } => Self::Connected {
+                // This payload crosses the Tauri IPC boundary on every status
+                // change, so a credential-bearing endpoint is redacted at the
+                // source rather than merely hidden by the UI. `display_ws_url`
+                // covers both minted sessions and credential-shaped overrides.
+                endpoint: endpoint.display_ws_url(),
+                browser_version: browser_version.clone(),
+                page_count: targets.values().filter(|t| t.r#type == "page").count(),
+                source: endpoint.source.clone(),
+                managed: endpoint.managed,
+                // Ownership, not URL shape: `remote` drives teardown/release
+                // and profile matching, so it means "socai minted this".
+                remote: matches!(owner, BrowserOwner::Remote(_)),
+                user_data_dir: endpoint.user_data_dir.clone(),
+            },
         }
     }
 }

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -201,13 +201,46 @@ pub fn managed_chrome_user_data_dir() -> anyhow::Result<PathBuf> {
     Ok(PathBuf::from(".socai/chrome-profile"))
 }
 
-/// Strip the credential-bearing parts of a hosted browser's connect URL,
-/// leaving only scheme + host. A remote `connect_url` is a live
-/// browser-control credential (the session token rides in it), so it must be
-/// redacted before reaching logs, status payloads, or error strings. Local
-/// endpoints are not passed through this — a `ws://127.0.0.1` devtools URL is
-/// useful in bug reports and reachable only from this machine.
-pub(crate) fn redact_remote_ws_url(url: &str) -> String {
+/// `Endpoint::source` for a hosted session socai minted via socai-server.
+pub(crate) const REMOTE_SOURCE: &str = "remote";
+
+impl Endpoint {
+    /// True when socai minted this endpoint as a hosted browser session.
+    pub(crate) fn is_remote_session(&self) -> bool {
+        self.source == REMOTE_SOURCE
+    }
+
+    /// The websocket URL in the form it is safe to display, log, or ship over
+    /// IPC. A hosted connect URL is a live browser-control credential (the
+    /// session token rides in it), so both minted sessions and any
+    /// credential-shaped override are reduced to scheme + host. Loopback
+    /// devtools URLs hold no secret and pass through unchanged — they are
+    /// useful in bug reports and reachable only from this machine.
+    pub(crate) fn display_ws_url(&self) -> String {
+        if self.is_remote_session() || url_carries_credential(&self.browser_ws_url) {
+            redact_ws_url(&self.browser_ws_url)
+        } else {
+            self.browser_ws_url.clone()
+        }
+    }
+}
+
+/// Whether a URL has somewhere a secret could be hiding. A query string is
+/// how hosted CDP endpoints carry their session token, and userinfo
+/// (`user:pass@host`) is a credential by definition. This catches a
+/// `SOCAI_CDP_WS` override pointing at a hosted browser, which socai does not
+/// own and therefore cannot recognize by ownership.
+fn url_carries_credential(url: &str) -> bool {
+    let rest = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let before_fragment = rest.split('#').next().unwrap_or(rest);
+    before_fragment.contains('?')
+        || before_fragment
+            .split('/')
+            .next()
+            .is_some_and(|authority| authority.contains('@'))
+}
+
+fn redact_ws_url(url: &str) -> String {
     let (scheme, rest) = match url.split_once("://") {
         Some((scheme, rest)) => (scheme, rest),
         None => return "<redacted>".into(),

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -201,6 +201,31 @@ pub fn managed_chrome_user_data_dir() -> anyhow::Result<PathBuf> {
     Ok(PathBuf::from(".socai/chrome-profile"))
 }
 
+/// Strip the credential-bearing parts of a hosted browser's connect URL,
+/// leaving only scheme + host. A remote `connect_url` is a live
+/// browser-control credential (the session token rides in it), so it must be
+/// redacted before reaching logs, status payloads, or error strings. Local
+/// endpoints are not passed through this — a `ws://127.0.0.1` devtools URL is
+/// useful in bug reports and reachable only from this machine.
+pub(crate) fn redact_remote_ws_url(url: &str) -> String {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((scheme, rest)) => (scheme, rest),
+        None => return "<redacted>".into(),
+    };
+    let host = rest
+        .split(['/', '?', '#'])
+        .next()
+        .filter(|host| !host.is_empty());
+    match host {
+        // Userinfo (user:pass@host) would itself be a credential; drop it.
+        Some(host) => match host.rsplit_once('@') {
+            Some((_, bare)) => format!("{scheme}://{bare}/<redacted>"),
+            None => format!("{scheme}://{host}/<redacted>"),
+        },
+        None => "<redacted>".into(),
+    }
+}
+
 pub(crate) fn mark_managed_endpoint(mut endpoint: Endpoint, user_data_dir: &Path) -> Endpoint {
     endpoint.source = format!("managed_profile:{}", user_data_dir.display());
     endpoint.managed = true;

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -14,11 +14,17 @@ use crate::cdp::raw_client::RawCdpClient;
 
 const MAX_ATTEMPTS: u8 = 3;
 const ATTEMPT_DELAY: Duration = Duration::from_millis(500);
+/// Wall-clock ceiling for a whole connect (every attempt, plus the delays
+/// between them). Must stay below `runtime::engine::CONNECT_TIMEOUT` so this
+/// task reaches a terminal state — releasing anything it acquired — before the
+/// waiter there stops polling. Nothing cancels this task when the waiter
+/// returns, so without the ceiling a late attempt could mint a hosted session
+/// for a caller that already reported a timeout.
+const CONNECT_BUDGET: Duration = Duration::from_secs(85);
 /// Ceiling for the browser-websocket handshake plus the two inventory
 /// commands. The handshake has no timeout of its own and each command can wait
-/// `raw_client::COMMAND_TIMEOUT`, so without this an endpoint that accepts a
-/// connection but never answers keeps the state in `Connecting` — blocking
-/// every later connect — and holds a minted hosted session that nobody uses.
+/// `raw_client::COMMAND_TIMEOUT`, so without this one unresponsive endpoint
+/// would swallow the whole `CONNECT_BUDGET` and leave no room to retry.
 const INVENTORY_TIMEOUT: Duration = Duration::from_secs(20);
 const TARGET_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const TARGET_POLL_FAILURES: u8 = 3;
@@ -98,20 +104,27 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
         }
     }
 
+    // One budget for all attempts, so this task always settles into a terminal
+    // state before the runtime's waiter stops polling. Per-phase timeouts alone
+    // could not promise that: their worst case multiplies by MAX_ATTEMPTS, and
+    // nothing cancels this task when the waiter returns — a late attempt would
+    // then mint a hosted session for a caller that already gave up.
+    let deadline = tokio::time::Instant::now() + CONNECT_BUDGET;
     for attempt in 1..=MAX_ATTEMPTS {
         if !begin_connect_attempt(&cdp, attempt, attempt == 1).await {
             return;
         }
-        match try_connect_once(&cdp, options.clone()).await {
-            Ok(ConnectAttempt::Connected) => return,
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, try_connect_once(&cdp, options.clone())).await {
+            Ok(Ok(ConnectAttempt::Connected)) => return,
             // Someone replaced the state while we were connecting (an explicit
             // disconnect). Leave their state alone and stop: another attempt
             // would undo the disconnect and re-mint a hosted session.
-            Ok(ConnectAttempt::Cancelled) => {
+            Ok(Ok(ConnectAttempt::Cancelled)) => {
                 debug!("connect attempt cancelled by an external state change");
                 return;
             }
-            Err(err) => {
+            Ok(Err(err)) => {
                 warn!(attempt, error = %err, "cdp connect attempt failed");
                 if attempt == MAX_ATTEMPTS {
                     transition_unconditional(
@@ -125,8 +138,30 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
                 }
                 tokio::time::sleep(ATTEMPT_DELAY).await;
             }
+            // Budget gone. Dropping the attempt future released whatever it had
+            // acquired, including a just-minted hosted session.
+            Err(_) => {
+                warn!(attempt, "cdp connect budget exhausted");
+                if !is_connected(&cdp).await {
+                    transition_unconditional(
+                        &cdp,
+                        CdpState::Disconnected {
+                            reason: format!(
+                                "browser did not connect within {}s",
+                                CONNECT_BUDGET.as_secs()
+                            ),
+                        },
+                    )
+                    .await;
+                }
+                return;
+            }
         }
     }
+}
+
+async fn is_connected(cdp: &Cdp) -> bool {
+    matches!(&*cdp.state().lock().await, CdpState::Connected { .. })
 }
 
 async fn try_connect_once(

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -109,7 +109,9 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
 async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> anyhow::Result<()> {
     let OpenEndpoint { endpoint, owner } = open_endpoint(options).await?;
 
-    let inventory = connect_inventory(&endpoint).await?;
+    let inventory = connect_inventory(&endpoint)
+        .await
+        .map_err(|err| redact_endpoint_in_error(&endpoint, &owner, err))?;
     let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.browser_client.clone());
 
     {
@@ -205,6 +207,24 @@ async fn open_remote_endpoint() -> anyhow::Result<OpenEndpoint> {
             session_id: session.session_id,
         }),
     })
+}
+
+/// Rewrite a hosted browser's connect URL out of a connect failure. The
+/// websocket layer puts the URL it dialed into its error context, and
+/// `run_connect` sends that text to both tracing and the `Disconnected`
+/// reason — for a remote session that URL is a live browser-control
+/// credential. The chain is flattened so the sanitized text survives the
+/// outermost-message-only handling downstream.
+fn redact_endpoint_in_error(
+    endpoint: &Endpoint,
+    owner: &BrowserOwner,
+    err: anyhow::Error,
+) -> anyhow::Error {
+    if !matches!(owner, BrowserOwner::Remote(_)) {
+        return err;
+    }
+    let redacted = endpoint::redact_remote_ws_url(&endpoint.browser_ws_url);
+    anyhow::anyhow!(format!("{err:#}").replace(&endpoint.browser_ws_url, &redacted))
 }
 
 async fn open_existing_endpoint() -> anyhow::Result<OpenEndpoint> {

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -111,7 +111,7 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
 
     let inventory = connect_inventory(&endpoint)
         .await
-        .map_err(|err| redact_endpoint_in_error(&endpoint, &owner, err))?;
+        .map_err(|err| redact_endpoint_in_error(&endpoint, err))?;
     let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.browser_client.clone());
 
     {
@@ -157,6 +157,12 @@ async fn open_endpoint(options: Option<ChromeConnectOptions>) -> anyhow::Result<
 
     if !matches!(options.profile, ChromeProfile::Managed) {
         if let Some(endpoint) = endpoint::resolve_explicit_endpoint(None, None).await? {
+            // An explicit override may well point at a hosted browser, but
+            // socai neither minted nor owns it: no release on drop, and it is
+            // not tagged `remote` (the user set that endpoint up and can reach
+            // its own live view, so the normal login protocol applies).
+            // Credential redaction is keyed on URL shape, so it still covers
+            // this case — see `Endpoint::display_ws_url`.
             return Ok(OpenEndpoint {
                 endpoint,
                 owner: BrowserOwner::None,
@@ -196,7 +202,7 @@ async fn open_remote_endpoint() -> anyhow::Result<OpenEndpoint> {
     let session = crate::cloud::create_browser_session().await?;
     Ok(OpenEndpoint {
         endpoint: Endpoint {
-            source: "remote".into(),
+            source: endpoint::REMOTE_SOURCE.into(),
             browser_ws_url: session.connect_url,
             http_version_url: None,
             version: None,
@@ -209,22 +215,18 @@ async fn open_remote_endpoint() -> anyhow::Result<OpenEndpoint> {
     })
 }
 
-/// Rewrite a hosted browser's connect URL out of a connect failure. The
+/// Rewrite a credential-bearing connect URL out of a connect failure. The
 /// websocket layer puts the URL it dialed into its error context, and
 /// `run_connect` sends that text to both tracing and the `Disconnected`
-/// reason — for a remote session that URL is a live browser-control
+/// reason — for a hosted endpoint that URL is a live browser-control
 /// credential. The chain is flattened so the sanitized text survives the
 /// outermost-message-only handling downstream.
-fn redact_endpoint_in_error(
-    endpoint: &Endpoint,
-    owner: &BrowserOwner,
-    err: anyhow::Error,
-) -> anyhow::Error {
-    if !matches!(owner, BrowserOwner::Remote(_)) {
+fn redact_endpoint_in_error(endpoint: &Endpoint, err: anyhow::Error) -> anyhow::Error {
+    let display = endpoint.display_ws_url();
+    if display == endpoint.browser_ws_url {
         return err;
     }
-    let redacted = endpoint::redact_remote_ws_url(&endpoint.browser_ws_url);
-    anyhow::anyhow!(format!("{err:#}").replace(&endpoint.browser_ws_url, &redacted))
+    anyhow::anyhow!(format!("{err:#}").replace(&endpoint.browser_ws_url, &display))
 }
 
 async fn open_existing_endpoint() -> anyhow::Result<OpenEndpoint> {

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -96,6 +96,15 @@ impl Cdp {
 }
 
 async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
+    // Exactly one connect loop at a time. The state check below is a filter,
+    // not a claim: two callers (a UI connect button pressed twice, say) can
+    // both observe `Disconnected` before either transitions, and both would
+    // then open their own browser — two hosted sessions on a remote profile.
+    let connect_lock = cdp.connect_lock();
+    let Ok(_connect_guard) = connect_lock.try_lock() else {
+        debug!("connect already in progress; ignoring duplicate request");
+        return;
+    };
     {
         let state = cdp.state();
         let guard = state.lock().await;
@@ -393,6 +402,10 @@ async fn on_connection_lost(cdp: Cdp, reason: String) {
 /// asymmetry is what keeps an explicit `disconnect()` during the retry delay
 /// from being resurrected into a fresh connection (and, for a hosted profile,
 /// a fresh billed session).
+///
+/// `Connecting` can be trusted to be *our own* attempt because `run_connect`
+/// holds `Cdp::connect_lock` for the whole loop, so no second loop exists to
+/// have left it there.
 async fn begin_connect_attempt(cdp: &Cdp, attempt: u8, first: bool) -> bool {
     let state = cdp.state();
     let mut guard = state.lock().await;

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -5,11 +5,11 @@ use serde_json::{json, Value};
 use tracing::{debug, warn};
 
 use crate::cdp::connection::{
-    page_list_from, BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile,
-    StatusPayload, TargetInfo,
+    page_list_from, BrowserEvent, BrowserOwner, Cdp, CdpState, ChromeConnectOptions, ChromeProfile,
+    RemoteSession, StatusPayload, TargetInfo,
 };
 use crate::cdp::endpoint::{self, Endpoint};
-use crate::cdp::launch::{self, ChromeProcess};
+use crate::cdp::launch;
 use crate::cdp::raw_client::RawCdpClient;
 
 const MAX_ATTEMPTS: u8 = 3;
@@ -23,12 +23,13 @@ struct ConnectInventory {
     browser_client: RawCdpClient,
 }
 
-/// A resolved remote-debugging endpoint plus, for managed mode, the chrome
-/// process socai launched. The process guard is threaded into the `Connected`
-/// state so it lives exactly as long as the connection.
+/// A resolved remote-debugging endpoint plus whatever browser resource socai
+/// owns behind it (a launched chrome process, a minted remote session, or
+/// nothing for plain attaches). The owner guard is threaded into the
+/// `Connected` state so it lives exactly as long as the connection.
 struct OpenEndpoint {
     endpoint: Endpoint,
-    chrome_process: Option<ChromeProcess>,
+    owner: BrowserOwner,
 }
 
 impl Cdp {
@@ -106,10 +107,7 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
 }
 
 async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> anyhow::Result<()> {
-    let OpenEndpoint {
-        endpoint,
-        chrome_process,
-    } = open_endpoint(options).await?;
+    let OpenEndpoint { endpoint, owner } = open_endpoint(options).await?;
 
     let inventory = connect_inventory(&endpoint).await?;
     let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.browser_client.clone());
@@ -119,8 +117,9 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
         let mut guard = state.lock().await;
         if !guard.is_connecting() {
             monitor_task.abort();
-            // Dropping `chrome_process` here kills a just-launched managed chrome
-            // if the connect was cancelled mid-flight.
+            // Dropping `owner` here kills a just-launched managed chrome (or
+            // releases a just-minted remote session) if the connect was
+            // cancelled mid-flight.
             return Err(anyhow::anyhow!("connect cancelled"));
         }
         *guard = CdpState::Connected {
@@ -129,7 +128,7 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
             browser_version: inventory.browser_version,
             targets: inventory.targets,
             monitor_task,
-            chrome_process,
+            owner,
         };
         let payload: StatusPayload = (&*guard).into();
         cdp.emit(BrowserEvent::StatusChanged(payload));
@@ -158,7 +157,7 @@ async fn open_endpoint(options: Option<ChromeConnectOptions>) -> anyhow::Result<
         if let Some(endpoint) = endpoint::resolve_explicit_endpoint(None, None).await? {
             return Ok(OpenEndpoint {
                 endpoint,
-                chrome_process: None,
+                owner: BrowserOwner::None,
             });
         }
     }
@@ -166,6 +165,7 @@ async fn open_endpoint(options: Option<ChromeConnectOptions>) -> anyhow::Result<
     match options.profile {
         ChromeProfile::Managed => open_managed_endpoint(&options).await,
         ChromeProfile::Existing => open_existing_endpoint().await,
+        ChromeProfile::Remote => open_remote_endpoint().await,
         ChromeProfile::Auto => match open_managed_endpoint(&options).await {
             Ok(open) => Ok(open),
             Err(managed_err) => {
@@ -180,6 +180,33 @@ async fn open_endpoint(options: Option<ChromeConnectOptions>) -> anyhow::Result<
     }
 }
 
+/// Mint a remote hosted browser session via socai-server and treat its
+/// connect URL as the endpoint. Gated on socai pro activation up front: the
+/// error becomes the `Disconnected` reason verbatim, and gating pre-mint
+/// avoids burning the connect retries on doomed server calls.
+async fn open_remote_endpoint() -> anyhow::Result<OpenEndpoint> {
+    if !crate::cloud::pro_activated() {
+        anyhow::bail!(
+            "socai remote browser requires socai pro — run `socai pro activate <invite_code>`, \
+             or switch back with `socai config set chrome.profile existing`."
+        );
+    }
+    let session = crate::cloud::create_browser_session().await?;
+    Ok(OpenEndpoint {
+        endpoint: Endpoint {
+            source: "remote".into(),
+            browser_ws_url: session.connect_url,
+            http_version_url: None,
+            version: None,
+            managed: false,
+            user_data_dir: None,
+        },
+        owner: BrowserOwner::Remote(RemoteSession {
+            session_id: session.session_id,
+        }),
+    })
+}
+
 async fn open_existing_endpoint() -> anyhow::Result<OpenEndpoint> {
     let endpoint = endpoint::discover_running_chrome_endpoint()
         .await?
@@ -192,7 +219,7 @@ async fn open_existing_endpoint() -> anyhow::Result<OpenEndpoint> {
         })?;
     Ok(OpenEndpoint {
         endpoint,
-        chrome_process: None,
+        owner: BrowserOwner::None,
     })
 }
 
@@ -212,7 +239,7 @@ async fn open_managed_endpoint(options: &ChromeConnectOptions) -> anyhow::Result
         if reachable(&endpoint).await {
             return Ok(OpenEndpoint {
                 endpoint,
-                chrome_process: None,
+                owner: BrowserOwner::None,
             });
         }
         warn!(
@@ -224,7 +251,7 @@ async fn open_managed_endpoint(options: &ChromeConnectOptions) -> anyhow::Result
     let (endpoint, chrome_process) = launch::launch_managed_chrome(&user_data_dir).await?;
     Ok(OpenEndpoint {
         endpoint,
-        chrome_process: Some(chrome_process),
+        owner: BrowserOwner::Local(chrome_process),
     })
 }
 

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -14,6 +14,12 @@ use crate::cdp::raw_client::RawCdpClient;
 
 const MAX_ATTEMPTS: u8 = 3;
 const ATTEMPT_DELAY: Duration = Duration::from_millis(500);
+/// Ceiling for the browser-websocket handshake plus the two inventory
+/// commands. The handshake has no timeout of its own and each command can wait
+/// `raw_client::COMMAND_TIMEOUT`, so without this an endpoint that accepts a
+/// connection but never answers keeps the state in `Connecting` — blocking
+/// every later connect — and holds a minted hosted session that nobody uses.
+const INVENTORY_TIMEOUT: Duration = Duration::from_secs(20);
 const TARGET_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const TARGET_POLL_FAILURES: u8 = 3;
 
@@ -30,6 +36,16 @@ struct ConnectInventory {
 struct OpenEndpoint {
     endpoint: Endpoint,
     owner: BrowserOwner,
+}
+
+/// How one connect attempt ended. `Cancelled` means the connection state was
+/// replaced from outside while the attempt was in flight — an explicit
+/// `disconnect()` — which must never be retried: retrying would resurrect a
+/// browser the user asked to release, and for a hosted profile it would mint
+/// (and bill for) a fresh session.
+enum ConnectAttempt {
+    Connected,
+    Cancelled,
 }
 
 impl Cdp {
@@ -83,11 +99,18 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
     }
 
     for attempt in 1..=MAX_ATTEMPTS {
-        if !transition_if_eligible(&cdp, CdpState::Connecting { attempt }).await {
+        if !begin_connect_attempt(&cdp, attempt, attempt == 1).await {
             return;
         }
         match try_connect_once(&cdp, options.clone()).await {
-            Ok(()) => return,
+            Ok(ConnectAttempt::Connected) => return,
+            // Someone replaced the state while we were connecting (an explicit
+            // disconnect). Leave their state alone and stop: another attempt
+            // would undo the disconnect and re-mint a hosted session.
+            Ok(ConnectAttempt::Cancelled) => {
+                debug!("connect attempt cancelled by an external state change");
+                return;
+            }
             Err(err) => {
                 warn!(attempt, error = %err, "cdp connect attempt failed");
                 if attempt == MAX_ATTEMPTS {
@@ -106,12 +129,25 @@ async fn run_connect(cdp: Cdp, options: Option<ChromeConnectOptions>) {
     }
 }
 
-async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> anyhow::Result<()> {
+async fn try_connect_once(
+    cdp: &Cdp,
+    options: Option<ChromeConnectOptions>,
+) -> anyhow::Result<ConnectAttempt> {
     let OpenEndpoint { endpoint, owner } = open_endpoint(options).await?;
 
-    let inventory = connect_inventory(&endpoint)
-        .await
-        .map_err(|err| redact_endpoint_in_error(&endpoint, err))?;
+    let inventory =
+        match tokio::time::timeout(INVENTORY_TIMEOUT, connect_inventory(&endpoint)).await {
+            Ok(result) => result.map_err(|err| redact_endpoint_in_error(&endpoint, err))?,
+            // Dropping `owner` on the way out releases a hosted session that was
+            // minted for a browser websocket which never answered.
+            Err(_) => {
+                anyhow::bail!(
+                    "browser websocket {} did not respond within {}s",
+                    endpoint.display_ws_url(),
+                    INVENTORY_TIMEOUT.as_secs()
+                )
+            }
+        };
     let monitor_task = spawn_target_poll_loop(cdp.clone(), inventory.browser_client.clone());
 
     {
@@ -121,8 +157,9 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
             monitor_task.abort();
             // Dropping `owner` here kills a just-launched managed chrome (or
             // releases a just-minted remote session) if the connect was
-            // cancelled mid-flight.
-            return Err(anyhow::anyhow!("connect cancelled"));
+            // cancelled mid-flight. Reported as an outcome, not an error, so
+            // the caller stops instead of retrying over the new state.
+            return Ok(ConnectAttempt::Cancelled);
         }
         *guard = CdpState::Connected {
             endpoint,
@@ -143,7 +180,7 @@ async fn try_connect_once(cdp: &Cdp, options: Option<ChromeConnectOptions>) -> a
     let initial_pages = cdp.pages().await;
     cdp.emit(BrowserEvent::TargetsChanged(initial_pages));
 
-    Ok(())
+    Ok(ConnectAttempt::Connected)
 }
 
 /// Resolve the remote-debugging endpoint for this connect attempt, honoring the
@@ -315,17 +352,24 @@ async fn on_connection_lost(cdp: Cdp, reason: String) {
     }
 }
 
-async fn transition_if_eligible(cdp: &Cdp, new: CdpState) -> bool {
+/// Move into `Connecting` for one attempt, returning whether the attempt may
+/// proceed. The first attempt starts from `Disconnected`; a retry may only
+/// continue from the `Connecting` state the previous attempt left behind. That
+/// asymmetry is what keeps an explicit `disconnect()` during the retry delay
+/// from being resurrected into a fresh connection (and, for a hosted profile,
+/// a fresh billed session).
+async fn begin_connect_attempt(cdp: &Cdp, attempt: u8, first: bool) -> bool {
     let state = cdp.state();
     let mut guard = state.lock().await;
-    let eligible = matches!(
-        *guard,
-        CdpState::Disconnected { .. } | CdpState::Connecting { .. }
-    );
+    let eligible = match *guard {
+        CdpState::Connecting { .. } => true,
+        CdpState::Disconnected { .. } => first,
+        CdpState::Connected { .. } => false,
+    };
     if !eligible {
         return false;
     }
-    *guard = new;
+    *guard = CdpState::Connecting { attempt };
     let payload: StatusPayload = (&*guard).into();
     cdp.emit(BrowserEvent::StatusChanged(payload));
     true

--- a/core/src/cdp/pages.rs
+++ b/core/src/cdp/pages.rs
@@ -69,11 +69,15 @@ impl PageSessionManager {
             .to_string();
 
         self.cdp.register_owned_target(target_id.clone()).await;
+        // Snapshot the browser mode now: the page outlives connection state
+        // changes, so it must not consult the shared `Cdp` later.
+        let remote_browser = self.cdp.is_remote().await;
         Ok(PageSession::attached(
             target_id,
             browser_client,
             session_id,
             self.cdp.clone(),
+            remote_browser,
         ))
     }
 

--- a/core/src/cdp/pages.rs
+++ b/core/src/cdp/pages.rs
@@ -21,18 +21,22 @@ impl PageSessionManager {
     /// avoids browser-wide CDP target discovery/auto-attach, so unrelated user
     /// tabs are not instrumented.
     pub async fn create_page(&self, start_url: &str) -> anyhow::Result<PageSession> {
-        let browser_client = self
+        // Client and browser mode come from one locked read: the page is
+        // labelled with the browser it is actually created in, even if the
+        // connection is replaced while the target commands below are in flight.
+        let (browser_client, remote_browser) = self
             .cdp
-            .browser_client()
+            .browser_client_with_mode()
             .await
             .ok_or_else(|| anyhow::anyhow!("CDP browser websocket is not connected"))?;
-        self.create_page_via_browser_ws(browser_client, start_url)
+        self.create_page_via_browser_ws(browser_client, remote_browser, start_url)
             .await
     }
 
     async fn create_page_via_browser_ws(
         &self,
         browser_client: crate::cdp::raw_client::RawCdpClient,
+        remote_browser: bool,
         start_url: &str,
     ) -> anyhow::Result<PageSession> {
         let created = browser_client
@@ -69,9 +73,6 @@ impl PageSessionManager {
             .to_string();
 
         self.cdp.register_owned_target(target_id.clone()).await;
-        // Snapshot the browser mode now: the page outlives connection state
-        // changes, so it must not consult the shared `Cdp` later.
-        let remote_browser = self.cdp.is_remote().await;
         Ok(PageSession::attached(
             target_id,
             browser_client,

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -25,6 +25,11 @@ pub struct PageSession {
     owner: Cdp,
     client: RawCdpClient,
     session_id: Option<String>,
+    /// Whether the browser this page was created in was a remote hosted one.
+    /// Captured at attach time: the page keeps its own websocket and can
+    /// outlive `owner`'s current connection, so asking the shared `Cdp` later
+    /// could report a different browser's mode.
+    remote_browser: bool,
     recorder: StdMutex<Option<Arc<SnapshotRecorder>>>,
 }
 
@@ -48,12 +53,14 @@ impl PageSession {
         client: RawCdpClient,
         session_id: String,
         owner: Cdp,
+        remote_browser: bool,
     ) -> Self {
         Self {
             target_id,
             owner,
             client,
             session_id: Some(session_id),
+            remote_browser,
             recorder: StdMutex::new(None),
         }
     }
@@ -62,10 +69,10 @@ impl PageSession {
         &self.target_id
     }
 
-    /// True when this page lives in a remote hosted browser (socai pro
+    /// True when this page was created in a remote hosted browser (socai pro
     /// `chrome.profile remote`) rather than any local chrome.
-    pub async fn is_remote_browser(&self) -> bool {
-        self.owner.is_remote().await
+    pub fn is_remote_browser(&self) -> bool {
+        self.remote_browser
     }
 
     /// Attach a debug snapshot recorder. Captures begin on the next

--- a/core/src/cdp/session.rs
+++ b/core/src/cdp/session.rs
@@ -62,6 +62,12 @@ impl PageSession {
         &self.target_id
     }
 
+    /// True when this page lives in a remote hosted browser (socai pro
+    /// `chrome.profile remote`) rather than any local chrome.
+    pub async fn is_remote_browser(&self) -> bool {
+        self.owner.is_remote().await
+    }
+
     /// Attach a debug snapshot recorder. Captures begin on the next
     /// `evaluate_json`. Replacing or clearing it is cheap and lock-guarded.
     pub fn set_recorder(&self, recorder: Arc<SnapshotRecorder>) {

--- a/core/src/cloud.rs
+++ b/core/src/cloud.rs
@@ -220,6 +220,65 @@ pub async fn transcribe_audio_file(
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct BrowserSessionInfo {
+    pub session_id: String,
+    pub connect_url: String,
+}
+
+/// Mint a remote hosted browser session via socai-server. The server holds
+/// all Browserbase credentials and authorizes the device token; the returned
+/// connect URL carries only a session-scoped token.
+///
+/// Errors are single-level messages (no `context` chains): the CDP connect
+/// loop surfaces only the outermost message as the disconnect reason.
+pub async fn create_browser_session() -> Result<BrowserSessionInfo> {
+    let base_url = configured_base_url()
+        .ok_or_else(|| anyhow::anyhow!("socai pro server URL is not configured"))?;
+    let creds = load_credentials().ok_or_else(|| {
+        anyhow::anyhow!("socai pro is not activated; run `socai pro activate <invite_code>`")
+    })?;
+    let client = http_client()?;
+    let response = bearer(
+        client.post(format!("{base_url}/v1/browser/sessions")),
+        &creds.device_token,
+    )
+    .send()
+    .await
+    .map_err(|err| anyhow::anyhow!("remote browser session request failed: {err}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "remote browser session request failed ({status}): {}",
+            short_error(&body)
+        );
+    }
+    response
+        .json()
+        .await
+        .map_err(|err| anyhow::anyhow!("remote browser session response was malformed: {err}"))
+}
+
+/// Best-effort early release of a remote browser session. The server-side
+/// session timeout is the backstop, so callers may ignore failures.
+pub async fn release_browser_session(session_id: &str) -> Result<()> {
+    let base_url = configured_base_url()
+        .ok_or_else(|| anyhow::anyhow!("socai pro server URL is not configured"))?;
+    let creds = load_credentials().ok_or_else(|| anyhow::anyhow!("socai pro is not activated"))?;
+    let client = http_client()?;
+    bearer(
+        client.post(format!(
+            "{base_url}/v1/browser/sessions/{session_id}/release"
+        )),
+        &creds.device_token,
+    )
+    .send()
+    .await?
+    .error_for_status()?;
+    Ok(())
+}
+
 /// Trim a provider error to something an agent can read. Raw DashScope task
 /// dumps run to kilobytes of nested JSON with signed URLs; the leading part
 /// carries the task id + failure code, which is all a transcript_error needs.

--- a/core/src/cloud.rs
+++ b/core/src/cloud.rs
@@ -227,11 +227,10 @@ pub struct BrowserSessionInfo {
 }
 
 /// Browser-session requests get tighter budgets than the shared client's 120s
-/// cap. The CDP connect waiter gives up after 90s
-/// (`runtime::engine::CONNECT_TIMEOUT`) and the connect loop makes up to three
-/// attempts, so a stalled mint must fail fast enough that every attempt fits
-/// inside that window — otherwise the caller reports a timeout while detached
-/// attempts keep minting sessions nobody connects to.
+/// cap: a stalled mint should leave room for another attempt rather than
+/// swallowing the connect loop's whole budget. The guarantee that no session is
+/// minted after the caller gave up comes from `cdp::lifecycle::CONNECT_BUDGET`,
+/// which bounds the entire connect regardless of these per-phase values.
 const BROWSER_SESSION_CREATE_TIMEOUT: Duration = Duration::from_secs(25);
 /// Release is best-effort and runs detached from a drop; the server-side
 /// session timeout is the backstop, so it should never linger.

--- a/core/src/cloud.rs
+++ b/core/src/cloud.rs
@@ -226,6 +226,17 @@ pub struct BrowserSessionInfo {
     pub connect_url: String,
 }
 
+/// Browser-session requests get tighter budgets than the shared client's 120s
+/// cap. The CDP connect waiter gives up after 90s
+/// (`runtime::engine::CONNECT_TIMEOUT`) and the connect loop makes up to three
+/// attempts, so a stalled mint must fail fast enough that every attempt fits
+/// inside that window — otherwise the caller reports a timeout while detached
+/// attempts keep minting sessions nobody connects to.
+const BROWSER_SESSION_CREATE_TIMEOUT: Duration = Duration::from_secs(25);
+/// Release is best-effort and runs detached from a drop; the server-side
+/// session timeout is the backstop, so it should never linger.
+const BROWSER_SESSION_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Mint a remote hosted browser session via socai-server. The server holds
 /// all Browserbase credentials and authorizes the device token; the returned
 /// connect URL carries only a session-scoped token.
@@ -240,7 +251,9 @@ pub async fn create_browser_session() -> Result<BrowserSessionInfo> {
     })?;
     let client = http_client()?;
     let response = bearer(
-        client.post(format!("{base_url}/v1/browser/sessions")),
+        client
+            .post(format!("{base_url}/v1/browser/sessions"))
+            .timeout(BROWSER_SESSION_CREATE_TIMEOUT),
         &creds.device_token,
     )
     .send()
@@ -268,9 +281,11 @@ pub async fn release_browser_session(session_id: &str) -> Result<()> {
     let creds = load_credentials().ok_or_else(|| anyhow::anyhow!("socai pro is not activated"))?;
     let client = http_client()?;
     bearer(
-        client.post(format!(
-            "{base_url}/v1/browser/sessions/{session_id}/release"
-        )),
+        client
+            .post(format!(
+                "{base_url}/v1/browser/sessions/{session_id}/release"
+            ))
+            .timeout(BROWSER_SESSION_RELEASE_TIMEOUT),
         &creds.device_token,
     )
     .send()

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -57,7 +57,7 @@ impl SocaiConfig {
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(expand_tilde_path),
-            ChromeProfile::Existing => None,
+            ChromeProfile::Existing | ChromeProfile::Remote => None,
         };
         ChromeConnectOptions {
             profile,

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -201,7 +201,9 @@ fn browser_status_matches_options(status: &StatusPayload, options: &ChromeConnec
         // `remote: false` (socai didn't mint it); that combination is a debug
         // facility and this options-matching path currently has no callers.
         ChromeProfile::Remote => *remote,
-        ChromeProfile::Auto => true,
+        // Auto resolves to managed or existing — never a hosted browser — so
+        // a remote connection satisfies neither and must be torn down.
+        ChromeProfile::Auto => !remote,
     }
 }
 

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -18,6 +18,10 @@ use tokio::time::{sleep, Instant};
 
 use super::BrowserStatus;
 
+/// How long a caller waits for a connect. Keep this above
+/// `cdp::lifecycle::CONNECT_BUDGET` so the connect task always settles first:
+/// the waiter cannot cancel it, and a task still running past this point could
+/// acquire a browser (or mint a hosted session) nobody is waiting for.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Shared in-process runtime handle for one entrypoint. Tauri, TUI, and the

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -171,6 +171,7 @@ impl Default for SocaiRuntime {
 fn browser_status_matches_options(status: &StatusPayload, options: &ChromeConnectOptions) -> bool {
     let StatusPayload::Connected {
         managed,
+        remote,
         user_data_dir,
         ..
     } = status
@@ -179,7 +180,7 @@ fn browser_status_matches_options(status: &StatusPayload, options: &ChromeConnec
     };
 
     match options.profile {
-        ChromeProfile::Existing => !managed,
+        ChromeProfile::Existing => !managed && !remote,
         ChromeProfile::Managed => {
             if !managed {
                 return false;
@@ -192,6 +193,10 @@ fn browser_status_matches_options(status: &StatusPayload, options: &ChromeConnec
                 None => true,
             }
         }
+        // An explicit SOCAI_CDP_* override connected under `remote` reports
+        // `remote: false` (socai didn't mint it); that combination is a debug
+        // facility and this options-matching path currently has no callers.
+        ChromeProfile::Remote => *remote,
         ChromeProfile::Auto => true,
     }
 }

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -54,6 +54,11 @@ they're in). When it returns `logged_in:true`, re-run the original tool once and
 continue. If it returns `logged_in:false`, remind the user and call
 `wait_for_login` again.
 
+**Exception — `remote_browser:true` on the result:** the session runs in socai's
+remote hosted browser and its login is operated by socai, not the user. Tell the
+user remote browsing is temporarily unavailable on socai's side and to try again
+later. Do NOT ask them to scan a QR and do NOT call `wait_for_login`.
+
 ## Tool Use
 
 ### `search` and `author_scan`

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -904,6 +904,29 @@ fn attach_pro_skip_note(payload: &mut Value, skipped: bool) {
     }
 }
 
+/// Attached to a `login_required` result when the page lives in a remote
+/// hosted browser: the shared login there is socai-operated, so the local
+/// scan-the-QR protocol does not apply and the user cannot fix it.
+const REMOTE_LOGIN_NOTE: &str = "the hosted browser's shared login is unavailable — a \
+     socai-side issue, not something the user can fix. Tell the user remote browsing \
+     is temporarily unavailable and to try again later; do NOT ask them to scan a QR \
+     and do NOT call wait_for_login.";
+
+/// Mark a `reason: login_required` result as coming from a remote hosted
+/// browser so the agent reports a socai-side outage instead of starting the
+/// local login protocol. No-op for local browsers or other failure reasons.
+async fn annotate_remote_login_gate(page: &PageSession, value: &mut Value) {
+    if value.get("reason").and_then(Value::as_str) != Some("login_required")
+        || !page.is_remote_browser().await
+    {
+        return;
+    }
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("remote_browser".into(), Value::Bool(true));
+        obj.insert("note".into(), json!(REMOTE_LOGIN_NOTE));
+    }
+}
+
 fn media_for(
     ctx: &ToolContext,
     llm_provider: Option<Arc<dyn LlmProvider>>,
@@ -3090,11 +3113,13 @@ impl Tool for GetNotesTool {
         let targets = direct_note_refs(&input)?;
         let login = XhsPageRuntime::new(&self.page).login_gate(true).await?;
         if login == LoginGate::Required {
-            return Ok(json_result(&json!({
+            let mut payload = json!({
                 "ok": false,
                 "notes": [],
                 "reason": "login_required",
-            })));
+            });
+            annotate_remote_login_gate(&self.page, &mut payload).await;
+            return Ok(json_result(&payload));
         }
 
         let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
@@ -3586,6 +3611,15 @@ impl Tool for WaitForLoginTool {
             return Ok(json_result(&json!({
                 "logged_in": true,
                 "message": "Already logged in. Re-run the original tool.",
+            })));
+        }
+        // A remote hosted browser has no window the user could scan a QR in;
+        // its shared login is socai-operated. Fail fast instead of polling.
+        if self.page.is_remote_browser().await {
+            return Ok(json_result(&json!({
+                "logged_in": false,
+                "remote_browser": true,
+                "message": REMOTE_LOGIN_NOTE,
             })));
         }
         // Bring the XHS login wall on screen so the user has a QR to scan.
@@ -4081,6 +4115,7 @@ impl Tool for SearchTool {
                     ARTIFACT_EXTRA_PREVIEW_CARD_PROPERTIES,
                 );
             }
+            annotate_remote_login_gate(&self.page, &mut value).await;
             return Ok(json_result(&value));
         }
 
@@ -4160,6 +4195,7 @@ impl Tool for SearchTool {
             // `reason` already summarizes the failure; keep the failed scan
             // compact too.
             lean_scan_payload(&mut payload);
+            annotate_remote_login_gate(&self.page, &mut payload).await;
             return Ok(json_result(&payload));
         }
 
@@ -4584,12 +4620,14 @@ impl Tool for AuthorScanTool {
                 .filter(|reason| !reason.is_empty())
                 .unwrap_or("open_profile_failed")
                 .to_string();
-            return Ok(json_result(&json!({
+            let mut payload = json!({
                 "ok": false,
                 "author_id": author_id,
                 "notes": [],
                 "reason": reason,
-            })));
+            });
+            annotate_remote_login_gate(&self.page, &mut payload).await;
+            return Ok(json_result(&payload));
         }
 
         let info = xhs.profile_info().await?;

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -915,9 +915,9 @@ const REMOTE_LOGIN_NOTE: &str = "the hosted browser's shared login is unavailabl
 /// Mark a `reason: login_required` result as coming from a remote hosted
 /// browser so the agent reports a socai-side outage instead of starting the
 /// local login protocol. No-op for local browsers or other failure reasons.
-async fn annotate_remote_login_gate(page: &PageSession, value: &mut Value) {
+fn annotate_remote_login_gate(page: &PageSession, value: &mut Value) {
     if value.get("reason").and_then(Value::as_str) != Some("login_required")
-        || !page.is_remote_browser().await
+        || !page.is_remote_browser()
     {
         return;
     }
@@ -3118,7 +3118,7 @@ impl Tool for GetNotesTool {
                 "notes": [],
                 "reason": "login_required",
             });
-            annotate_remote_login_gate(&self.page, &mut payload).await;
+            annotate_remote_login_gate(&self.page, &mut payload);
             return Ok(json_result(&payload));
         }
 
@@ -3278,6 +3278,9 @@ impl Tool for GetNotesTool {
         if !stop_reason.is_empty() {
             payload["reason"] = json!(stop_reason);
         }
+        // Mid-scan login loss surfaces as a top-level `reason` too; mark it
+        // for remote browsers the same way the pre-flight gate is marked.
+        annotate_remote_login_gate(&self.page, &mut payload);
         if let Some((count, path, error)) = media_manifest_metadata {
             payload["media_manifest_count"] = json!(count);
             if let Some(path) = path {
@@ -3615,7 +3618,7 @@ impl Tool for WaitForLoginTool {
         }
         // A remote hosted browser has no window the user could scan a QR in;
         // its shared login is socai-operated. Fail fast instead of polling.
-        if self.page.is_remote_browser().await {
+        if self.page.is_remote_browser() {
             return Ok(json_result(&json!({
                 "logged_in": false,
                 "remote_browser": true,
@@ -4115,7 +4118,7 @@ impl Tool for SearchTool {
                     ARTIFACT_EXTRA_PREVIEW_CARD_PROPERTIES,
                 );
             }
-            annotate_remote_login_gate(&self.page, &mut value).await;
+            annotate_remote_login_gate(&self.page, &mut value);
             return Ok(json_result(&value));
         }
 
@@ -4195,7 +4198,7 @@ impl Tool for SearchTool {
             // `reason` already summarizes the failure; keep the failed scan
             // compact too.
             lean_scan_payload(&mut payload);
-            annotate_remote_login_gate(&self.page, &mut payload).await;
+            annotate_remote_login_gate(&self.page, &mut payload);
             return Ok(json_result(&payload));
         }
 
@@ -4626,7 +4629,7 @@ impl Tool for AuthorScanTool {
                 "notes": [],
                 "reason": reason,
             });
-            annotate_remote_login_gate(&self.page, &mut payload).await;
+            annotate_remote_login_gate(&self.page, &mut payload);
             return Ok(json_result(&payload));
         }
 


### PR DESCRIPTION
## What

Adds a fourth `chrome.profile` value, **`remote`**: socai asks socai-server to mint a hosted (Browserbase) cloud-browser session and drives it over the returned wss CDP endpoint — no local chrome, and **no xiaohongshu login step for users** (sessions restore a socai-operated shared login read-only). Default stays `existing`; the mode is default-off and invite-gated by the same socai pro activation as video transcription.

Server counterpart: socai-io/socai-server#17.

## How it works

- `open_endpoint()` gains a `Remote` arm → `cloud::create_browser_session()` (bearer device token) → connects to the returned `connect_url`. `SOCAI_CDP_WS` still wins as a dev override, preserving the prototype workflow.
- **Ownership guard**: `BrowserOwner` enum replaces the `chrome_process` slot in `CdpState::Connected` — `Local(ChromeProcess)` kills chrome on drop, `Remote(RemoteSession)` fires a best-effort release on drop (server timeout is the backstop). Release-on-drop matters: mint-then-fail connect attempts would otherwise strand sessions against the concurrency quota, and stale `PageSession` clones pin the websocket after `disconnect()` so socket-close auto-end isn't prompt.
- **Gating**, two layers: connect-time `pro_activated()` check with a flat, actionable error (the connect loop surfaces only the outermost message as the disconnect reason), plus server-side bearer auth on every mint.
- **Session death** (hosted sessions have a server-side timeout): the existing target-poll loop detects the drop; the next tool call re-mints automatically and the shared context restores the login.
- **`login_required` in remote mode is a socai-side outage, not a user action**: results are annotated `remote_browser: true` with agent guidance to say remote browsing is temporarily unavailable (never QR instructions); `wait_for_login` fails fast instead of polling 180s. Knowledge doc updated accordingly.
- `StatusPayload` gains `remote: bool` (profile matching now distinguishes remote from existing); the app's connection dialog labels the source "remote browser" and hides the endpoint row (the connect URL embeds a session-scoped token).
- App settings: third browser-source toggle option, visible when pro is activated (or when already configured, so the state stays escapable), en/zh strings.

## Verified

- `cargo test -p socai-core` 91/91; workspace clippy count unchanged vs main (21 pre-existing); my files fmt-clean; app `tsc --noEmit` clean.
- Live smoke against a local socai-server (fresh sqlite + fake `$HOME`):
  - unactivated + remote → `CDP disconnected: socai remote browser requires socai pro — run 'socai pro activate <invite_code>' …`
  - activated + remote (no Browserbase key on server) → `CDP disconnected: remote browser session request failed (503 Service Unavailable): {"detail":"remote browser is not enabled on this server"}`
- Real Browserbase mint/connect requires the API key on the server — follow-up manual step (ops runbook in the server PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
