### PR TITLE
docs: sync socai-release skill with the OSS mirror release pipeline

### DIFF
--- a/.claude/skills/socai-release/SKILL.md
+++ b/.claude/skills/socai-release/SKILL.md
@@ -28,15 +28,19 @@ A helper script wraps this command, finds the created run, watches it, and print
 - Test ref: `fix/release-*` branches only; build runs but publish job is skipped
 - Version source: latest strict semver tag matching `vMAJOR.MINOR.PATCH`; if no tag exists, app version from `app/src-tauri/tauri.conf.json`
 - Desktop artifacts: `socai-macos-universal.dmg` and `socai-windows-x86_64-setup.exe`, plus the auto-updater set `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json` (darwin + windows platforms)
+- CLI artifacts: `install.sh`, `socai-cli-macos-universal.tar.gz` + `.sha256`, `install.ps1`, and `socai-cli-windows-x86_64.zip` + `.sha256`
+- Alibaba Cloud OSS mirror: every asset is also published to `https://socai-download.oss-cn-beijing.aliyuncs.com/releases/` (`vars.SOCAI_OSS_PUBLIC_BASE_URL` in the workflow) — an immutable `releases/vX.Y.Z/` copy staged before the GitHub release, and a mutable `releases/latest/` copy promoted after it. The OSS copy of `latest.json` is rewritten so its platform URLs point at the OSS `releases/vX.Y.Z/` assets instead of GitHub.
 - Production publish steps on `main`:
-  1. Build universal macOS app + DMG on GitHub Actions.
+  1. Build on GitHub Actions, in parallel: universal macOS app + DMG, universal macOS CLI, Windows CLI, and the Windows NSIS installer.
   2. Require Developer ID signing + notarization secrets, and the updater minisign keypair (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`).
-  3. Update app version files with `.github/scripts/set-app-version.py`.
-  4. Commit `chore: release socai vX.Y.Z` to `main` if needed.
+  3. Merge the Windows updater fragment into `latest.json`, then stage the versioned release on OSS (`.github/scripts/publish-oss-release.py stage` → `releases/vX.Y.Z/`) before anything is pushed to GitHub.
+  4. Update app version files with `.github/scripts/set-app-version.py` and commit `chore: release socai vX.Y.Z` to `main` if needed.
   5. Tag the release commit as `vX.Y.Z`.
-  6. Create a draft GitHub Release with generated notes and the DMG.
+  6. Create a draft GitHub Release with generated notes (China-mirror OSS links + GitHub links) and all desktop + CLI assets.
   7. Push updated `main`.
   8. Publish the release by clearing draft status.
+  9. Promote the OSS latest release (`publish-oss-release.py promote` → overwrite `releases/latest/`, `latest.json` last).
+  10. Run the post-publish verify jobs: verify latest CLI installer (macOS + Windows), verify latest windows desktop installer, and verify desktop updater manifest (`latest.json` from both the OSS mirror and GitHub).
 
 ## Safety rules
 
@@ -48,7 +52,7 @@ A helper script wraps this command, finds the created run, watches it, and print
 - Do not delete tags/releases unless the workflow failed and the user explicitly approves cleanup.
 - If local files are dirty, do not include unrelated changes in release work. The workflow publishes from the remote ref, not local uncommitted files.
 - The website redeploys automatically: Vercel Git integration is connected to `socai-io/socai` with production branch `main`, so the `chore: release socai vX.Y.Z` push triggers a production `socai-site` build with no manual step. Do not alter or rerun the release workflow to update `socai.io`.
-- Verifying `socai.io` (the `/download`, `/download/windows`, and `/github` redirects) is a **mandatory** part of every production release — the release is not done until the redirects are confirmed resolving to the new tag's assets. Fall back to a manual `socai-site-deployment` redeploy only if that verification fails.
+- Verifying `socai.io` (the `/download`, `/download/macos`, `/download/windows`, and `/github` redirects) is a **mandatory** part of every production release — the release is not done until the redirects are confirmed resolving to the new tag's assets. Fall back to a manual `socai-site-deployment` redeploy only if that verification fails.
 
 ## Preflight checks
 
@@ -128,21 +132,22 @@ Use `minor` or `major` instead of `patch` only when requested.
 
 The website is **not** an optional follow-up — verifying it is a required release gate.
 
-Vercel Git integration is connected to `socai-io/socai` with production branch `main` (project `socai-site`, scope `socai-d83824c8`). The release workflow's push of `chore: release socai vX.Y.Z` to `main` therefore triggers a production `socai-site` build automatically, so no manual deploy is normally needed. The site does not display a version number (the hero release-meta line was removed); the `/download*` redirects always point at the GitHub **latest** release, so the site serves the new version as soon as the GitHub release is published.
+Vercel Git integration is connected to `socai-io/socai` with production branch `main` (project `socai-site`, scope `socai-d83824c8`). The release workflow's push of `chore: release socai vX.Y.Z` to `main` therefore triggers a production `socai-site` build automatically, so no manual deploy is normally needed. The site does not display a version number (the hero release-meta line was removed); the `/download*` redirects point at the Alibaba Cloud OSS mirror's mutable `releases/latest/` objects, which the release workflow's `promote OSS latest release` step overwrites right after the GitHub release is published — the downloads serve the new version as soon as that promotion completes, with no site change involved.
 
 After the GitHub release verification, confirm the live site responds and every redirect resolves. The auto-deploy usually finishes within ~1 minute of the `main` push; allow for that and re-check if it is still mid-build.
 
 ```bash
 curl -sI https://socai.io/                  | grep -iE '^HTTP'             # 200
 curl -sI https://www.socai.io/              | grep -iE '^HTTP|^location'   # 308 -> https://socai.io/
-curl -sI https://socai.io/download          | grep -iE '^HTTP|^location'   # 307 -> GitHub latest DMG
-curl -sI https://socai.io/download/windows  | grep -iE '^HTTP|^location'   # 307 -> GitHub latest windows setup.exe
+curl -sI https://socai.io/download          | grep -iE '^HTTP|^location'   # 307 -> OSS releases/latest/socai-macos-universal.dmg
+curl -sI https://socai.io/download/macos    | grep -iE '^HTTP|^location'   # 307 -> OSS releases/latest/socai-macos-universal.dmg
+curl -sI https://socai.io/download/windows  | grep -iE '^HTTP|^location'   # 307 -> OSS releases/latest/socai-windows-x86_64-setup.exe
 curl -sI https://socai.io/github            | grep -iE '^HTTP|^location'   # 307 -> github.com/socai-io/socai
 ```
 
-The release is complete only when all five checks above pass **and** the `/download` + `/download/windows` targets resolve to assets of the just-published tag (see the redirect-resolution check in [Verify the published release](#verify-the-published-release)).
+The release is complete only when all six checks above pass **and** the `/download*` targets serve the just-published tag's build (see the redirect-resolution check in [Verify the published release](#verify-the-published-release)). The OSS `latest/` URLs are stable and do not embed the tag, so that tag check is a content-identity comparison, not a URL match.
 
-If the site has **not** updated after the auto-deploy should have finished, fall back to a manual redeploy: switch to the `socai-site-deployment` skill and deploy the production `socai-site` project with `SOCAI_RELEASE_VERSION=X.Y.Z`. Do not rerun the GitHub release workflow to fix a site-only lag, and do not add website-deploy steps to the release workflow — the Git integration already performs the deploy.
+If the site has **not** updated after the auto-deploy should have finished, fall back to a manual redeploy: switch to the `socai-site-deployment` skill and deploy the production `socai-site` project with `SOCAI_RELEASE_VERSION=X.Y.Z`. Do not rerun the GitHub release workflow to fix a site-only lag, and do not add website-deploy steps to the release workflow — the Git integration already performs the deploy. Note the redirect destinations are static OSS URLs in `site/vercel.json`: if the redirects respond correctly but `/download*` serves a stale build, the problem is the OSS `releases/latest/` objects (the workflow's `promote OSS latest release` step), and a site redeploy will not fix it.
 
 ## Test the release workflow without publishing
 
@@ -188,7 +193,10 @@ Common failure notes:
 - Missing Apple secrets on `main`: production release cannot proceed until signing/notarization secrets are configured.
 - Build/notarization failure after no `main` push: inspect logs; the workflow attempts to clean up draft release/tag state.
 - Failure after `main was already updated`: leave state for manual inspection; do not delete the release/tag without explicit approval.
-- If `socai.io` still shows the previous version after a release, do not rerun the release. Use the `socai-site-deployment` skill to redeploy the site with `SOCAI_RELEASE_VERSION` set to the published version.
+- Failure in `stage versioned release on Alibaba Cloud OSS`: nothing was published yet (no tag, no release, no `main` push); fix the OSS issue and rerun the workflow from scratch.
+- Failure in `promote OSS latest release`: the GitHub release is already live but OSS `releases/latest/` — and therefore the site `/download*` redirects — still serve the previous build. Rerunning the release job trips the `main moved` guard; surface it and only promote manually (`.github/scripts/publish-oss-release.py promote`) with explicit approval.
+- A post-publish `verify *` job failure means the release is already published; each verifier retries internally (~2 minutes), so a hard failure is usually a real asset/manifest problem, not propagation lag. Diagnose before touching release state.
+- If the `/download*` redirects serve a stale build after a release, check the run's `promote OSS latest release` step first — do not rerun the release for that. Use the `socai-site-deployment` skill (redeploy with `SOCAI_RELEASE_VERSION` set to the published version) only for site-level failures such as bad redirect rules or HTTP errors on `socai.io`.
 
 ## Verify the published release
 
@@ -204,19 +212,45 @@ Expected:
 
 - `isDraft: false`
 - `isPrerelease: false`
-- Asset list includes `socai-macos-universal.dmg`, `socai-macos-universal.app.tar.gz`, `socai-macos-universal.app.tar.gz.sig`, `socai-windows-x86_64-setup.exe`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json`
+- Asset list includes the desktop set — `socai-macos-universal.dmg`, `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe` + `.sig`, `latest.json` — and the CLI set — `install.sh`, `socai-cli-macos-universal.tar.gz` + `.sha256`, `install.ps1`, `socai-cli-windows-x86_64.zip` + `.sha256` (12 assets total)
 
-Verify download redirects:
+Verify download redirects. The site's `/download*` redirects resolve to the OSS mirror's stable `releases/latest/` URLs, which do not embed the tag — so "redirects resolve to the new tag's assets" means each `latest/` object is byte-identical to the immutable `releases/vX.Y.Z/` copy staged for this release (compare `ETag` / `x-oss-hash-crc64ecma` / `Content-Length`), and/or matches the GitHub asset size:
 
 ```bash
 tag="$(gh release view --repo socai-io/socai --json tagName --jq '.tagName')"
-curl -I https://socai.io/download
+oss_base="https://socai-download.oss-cn-beijing.aliyuncs.com/releases"
+
 curl -I -L --max-time 30 -o /dev/null -w 'code=%{http_code}\nfinal=%{url_effective}\n' https://socai.io/download
+# code=200, final=${oss_base}/latest/socai-macos-universal.dmg
+
+# The OSS latest updater manifest embeds the promoted version:
+curl -fsSL -H 'Cache-Control: no-cache' "${oss_base}/latest/latest.json" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])'   # X.Y.Z of ${tag}
+
+# latest/ objects must be identical to the versioned copies:
+for asset in socai-macos-universal.dmg socai-windows-x86_64-setup.exe; do
+  latest="$(curl -sI "${oss_base}/latest/${asset}" | tr -d '\r' | grep -iE '^(etag|x-oss-hash-crc64ecma|content-length):' | sort)"
+  tagged="$(curl -sI "${oss_base}/${tag}/${asset}" | tr -d '\r' | grep -iE '^(etag|x-oss-hash-crc64ecma|content-length):' | sort)"
+  if [ -n "${latest}" ] && [ "${latest}" = "${tagged}" ]; then
+    echo "ok: latest/${asset} matches ${tag}"
+  else
+    printf 'MISMATCH %s\nlatest:\n%s\ntagged:\n%s\n' "${asset}" "${latest}" "${tagged}"
+  fi
+done
+
+# GitHub's own latest pointer must also resolve to the new tag:
 curl -sSI https://github.com/socai-io/socai/releases/latest/download/socai-macos-universal.dmg | grep -F "/releases/download/${tag}/socai-macos-universal.dmg"
 curl -sSI https://github.com/socai-io/socai/releases/latest/download/socai-windows-x86_64-setup.exe | grep -F "/releases/download/${tag}/socai-windows-x86_64-setup.exe"
 ```
 
-Expected final URLs should resolve through GitHub latest release download and produce a successful response. Confirm the site checks as a mandatory step (see [Verify the website deployment](#verify-the-website-deployment-mandatory)).
+Cross-check against GitHub asset sizes if anything looks off (each `size` must equal the matching OSS `Content-Length`):
+
+```bash
+gh release view "${tag}" --repo socai-io/socai --json assets \
+  --jq '.assets[] | select(.name == "socai-macos-universal.dmg" or .name == "socai-windows-x86_64-setup.exe") | "\(.name) \(.size)"'
+```
+
+The OSS checks confirm the mirror the site actually serves; the GitHub checks confirm the GitHub latest pointer (used by the updater fallback and the CLI installers). Confirm the site checks as a mandatory step (see [Verify the website deployment](#verify-the-website-deployment-mandatory)).
 
 Optional artifact check:
 
@@ -239,8 +273,8 @@ Include:
 - Ref used (`main` for production)
 - GitHub Actions run URL and conclusion
 - Published tag/version and release URL
-- Asset presence (`socai-macos-universal.dmg` + `socai-windows-x86_64-setup.exe`, plus updater `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, and `latest.json`)
-- `/download` + `/download/windows` verification summary
-- `socai.io` site verification summary (mandatory): `/`, `www`, `/download`, `/download/windows`, `/github` all behave as expected, and both download redirects resolve to assets of the published tag
+- Asset presence (desktop: `socai-macos-universal.dmg` + `socai-windows-x86_64-setup.exe`, updater `socai-macos-universal.app.tar.gz` + `.sig`, `socai-windows-x86_64-setup.exe.sig`, `latest.json`; CLI: `install.sh`, `socai-cli-macos-universal.tar.gz` + `.sha256`, `install.ps1`, `socai-cli-windows-x86_64.zip` + `.sha256`)
+- `/download` + `/download/macos` + `/download/windows` verification summary
+- `socai.io` site verification summary (mandatory): `/`, `www`, `/download`, `/download/macos`, `/download/windows`, `/github` all behave as expected, and the OSS `releases/latest/` download targets match the published tag's staged copies
 - Whether the Git-integration auto-deploy was sufficient, or a manual `socai-site-deployment` redeploy fallback was needed
 - Any failures, cleanup performed, or manual blockers


### PR DESCRIPTION
The `socai-release` skill runbook drifted from what `.github/workflows/release.yml` and the `site/vercel.json` redirects actually do, observed during the v0.4.17 release ([run 30472854038](https://github.com/socai-io/socai/actions/runs/30472854038)). Runbook-only change — no workflow or site edits.

## What changed

**Website verification** — `/download`, `/download/macos` (previously missing from the runbook entirely), and `/download/windows` now 307 to the Alibaba Cloud OSS mirror's `releases/latest/` objects, not the GitHub latest release. Since those URLs are stable and never embed the tag, "redirects resolve to the new tag's assets" is now documented as a content-identity check: compare `ETag` / `x-oss-hash-crc64ecma` / `Content-Length` between `releases/latest/<asset>` and the immutable `releases/vX.Y.Z/<asset>` copy, check the `latest/latest.json` version field, and optionally cross-check GitHub asset sizes.

**Workflow description** — now covers the four parallel build jobs (macOS app + DMG, macOS CLI, Windows CLI, Windows NSIS), the Windows updater-fragment merge, OSS **stage** before anything touches GitHub, OSS **promote** after undrafting (`latest.json` uploaded last), and the four post-publish verify jobs. Added failure semantics: a stage failure aborts with nothing published; a promote failure leaves GitHub live but downloads stale (rerunning trips the `main moved` guard); a stale `/download` is an OSS-promote problem that a site redeploy cannot fix.

**Expected assets** — the release asset list now matches the workflow's `required_artifacts` exactly: 12 assets including the CLI set (`install.sh`, `install.ps1`, `socai-cli-macos-universal.tar.gz` + `.sha256`, `socai-cli-windows-x86_64.zip` + `.sha256`).

## Verification

Every snippet in the updated runbook was run live against v0.4.17: all six site redirect checks pass, the OSS `latest/` DMG and setup.exe are byte-identical to the `v0.4.17/` copies, and `latest/latest.json` reports `0.4.17`.

`scripts/create-release.sh` is untouched — it only dispatches/watches the workflow, which hasn't drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)