### PR TITLE
fix: harden Feishu export flow

### DIFF
--- a/app/src-tauri/src/connectors/feishu.rs
+++ b/app/src-tauri/src/connectors/feishu.rs
@@ -83,6 +83,13 @@ pub struct FeishuAccount {
     active: bool,
 }
 
+#[derive(Serialize)]
+pub struct FeishuAccountIdentity {
+    profile: String,
+    avatar_url: Option<String>,
+    tenant_key: Option<String>,
+}
+
 #[derive(Clone, Serialize)]
 struct FeishuConnectEvent {
     stage: &'static str,
@@ -127,18 +134,63 @@ pub async fn feishu_status(
 
 #[tauri::command]
 pub async fn feishu_accounts(app: AppHandle) -> Result<Vec<FeishuAccount>, String> {
-    let mut accounts = list_accounts(&app).await?;
-    for account in &mut accounts {
-        if !account.connected {
-            continue;
-        }
-        if let Some((avatar_url, tenant_key)) = read_account_identity(&app, &account.profile).await
-        {
-            account.avatar_url = avatar_url;
-            account.tenant_key = tenant_key;
-        }
+    list_accounts(&app).await
+}
+
+#[tauri::command]
+pub async fn feishu_account_identity(
+    app: AppHandle,
+    profile: String,
+) -> Result<FeishuAccountIdentity, String> {
+    let (avatar_url, tenant_key) = read_account_identity(&app, &profile).await?;
+    Ok(FeishuAccountIdentity {
+        profile,
+        avatar_url,
+        tenant_key,
+    })
+}
+
+#[tauri::command]
+pub async fn feishu_report_failure(
+    tasks: State<'_, AgentTaskRegistry>,
+    telemetry: State<'_, DesktopTelemetry>,
+    task_id: String,
+    destination: String,
+    stage: String,
+    duration_ms: u64,
+    error: String,
+) -> Result<(), String> {
+    if !matches!(destination.as_str(), "setup" | "document" | "chat") {
+        return Err("unknown Feishu failure destination".into());
     }
-    Ok(accounts)
+    if !matches!(
+        stage.as_str(),
+        "load_accounts"
+            | "select_account"
+            | "connect_account"
+            | "reconnect_account"
+            | "disconnect_account"
+            | "prepare_document"
+            | "open_document"
+            | "load_chats"
+    ) {
+        return Err("unknown Feishu failure stage".into());
+    }
+    let run_id = tasks.get(&task_id).await.and_then(|task| task.run_id);
+    let error = short_error(&format!("[{stage}] {}", short_error(&error)));
+    telemetry.capture(
+        "socai_feishu_export",
+        json!({
+            "task_id": task_id,
+            "run_id": run_id,
+            "destination": destination,
+            "stage": stage,
+            "outcome": "failed",
+            "duration_ms": duration_ms,
+            "error": error,
+        }),
+    );
+    Ok(())
 }
 
 #[tauri::command]
@@ -515,12 +567,18 @@ fn capture_export_result<T>(
         Ok(_) => ("completed", None),
         Err(error) => ("failed", Some(short_error(error))),
     };
+    let stage = match destination {
+        "document" => "export_document",
+        "chat" => "send_chat",
+        _ => "unknown",
+    };
     telemetry.capture(
         "socai_feishu_export",
         json!({
             "task_id": task_id,
             "run_id": run_id,
             "destination": destination,
+            "stage": stage,
             "outcome": outcome,
             "duration_ms": u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
             "error": error,
@@ -605,7 +663,14 @@ async fn wait_for_user_identity(app: &AppHandle, profile: &str) -> FeishuStatus 
 }
 
 async fn list_accounts(app: &AppHandle) -> Result<Vec<FeishuAccount>, String> {
-    let output = run_cli(app, vec!["profile".into(), "list".into()], None).await?;
+    let output = run_cli_bounded(
+        app,
+        vec!["profile".into(), "list".into()],
+        None,
+        Duration::from_secs(5),
+        "读取飞书账户超时，请重试",
+    )
+    .await?;
     if !output.success {
         let combined = format!("{}\n{}", output.stdout, output.stderr);
         if combined.contains("not configured") || combined.contains("no active profile") {
@@ -1030,8 +1095,8 @@ fn validated_user_authorization_url(candidate: &str) -> Option<String> {
 async fn read_account_identity(
     app: &AppHandle,
     profile: &str,
-) -> Option<(Option<String>, Option<String>)> {
-    let output = run_cli(
+) -> Result<(Option<String>, Option<String>), String> {
+    let output = run_cli_bounded(
         app,
         vec![
             "--profile".into(),
@@ -1043,13 +1108,14 @@ async fn read_account_identity(
             "user".into(),
         ],
         None,
+        Duration::from_secs(8),
+        "读取飞书账户信息超时",
     )
-    .await
-    .ok()?;
+    .await?;
     if !output.success {
-        return None;
+        return Err(cli_error_message(&output));
     }
-    let value = parse_json(&output.stdout)?;
+    let value = parse_json(&output.stdout).ok_or_else(|| cli_error_message(&output))?;
     let data = cli_data(&value);
     let avatar_url = data
         .get("avatar_thumb")
@@ -1060,7 +1126,7 @@ async fn read_account_identity(
         .get("tenant_key")
         .and_then(Value::as_str)
         .map(str::to_string);
-    Some((avatar_url, tenant_key))
+    Ok((avatar_url, tenant_key))
 }
 
 fn encoded_app_addons() -> Result<String, String> {
@@ -1157,6 +1223,23 @@ async fn run_cli(
     args: Vec<String>,
     current_dir: Option<&Path>,
 ) -> Result<CliOutput, String> {
+    run_cli_bounded(
+        app,
+        args,
+        current_dir,
+        Duration::from_secs(60),
+        "飞书 CLI 执行超时，请重试",
+    )
+    .await
+}
+
+async fn run_cli_bounded(
+    app: &AppHandle,
+    args: Vec<String>,
+    current_dir: Option<&Path>,
+    timeout: Duration,
+    timeout_message: &str,
+) -> Result<CliOutput, String> {
     let mut command = app
         .shell()
         .sidecar("lark-cli")
@@ -1165,14 +1248,48 @@ async fn run_cli(
     if let Some(dir) = current_dir {
         command = command.current_dir(dir);
     }
-    let output = command
-        .output()
-        .await
-        .map_err(|error| format!("飞书 CLI 执行失败：{error}"))?;
+    let (mut events, child) = command
+        .spawn()
+        .map_err(|error| format!("无法启动飞书 CLI：{error}"))?;
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut exit_code = None;
+
+    loop {
+        let event = tokio::select! {
+            event = events.recv() => event,
+            _ = &mut deadline => {
+                let _ = child.kill();
+                return Err(timeout_message.into());
+            }
+        };
+        let Some(event) = event else {
+            break;
+        };
+        match event {
+            CommandEvent::Stdout(bytes) => {
+                stdout.push_str(&String::from_utf8_lossy(&bytes));
+                stdout.push('\n');
+            }
+            CommandEvent::Stderr(bytes) => {
+                stderr.push_str(&String::from_utf8_lossy(&bytes));
+                stderr.push('\n');
+            }
+            CommandEvent::Error(error) => stderr.push_str(&error),
+            CommandEvent::Terminated(payload) => {
+                exit_code = payload.code;
+                break;
+            }
+            _ => {}
+        }
+    }
+
     Ok(CliOutput {
-        success: output.status.success(),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        success: exit_code == Some(0),
+        stdout,
+        stderr,
     })
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -201,6 +201,8 @@ pub fn run() {
             commands::pro_activate,
             connectors::feishu::feishu_status,
             connectors::feishu::feishu_accounts,
+            connectors::feishu::feishu_account_identity,
+            connectors::feishu::feishu_report_failure,
             connectors::feishu::feishu_select_account,
             connectors::feishu::feishu_disconnect_account,
             connectors::feishu::feishu_connect,

--- a/app/src/connectors/feishu.ts
+++ b/app/src/connectors/feishu.ts
@@ -27,6 +27,11 @@ type FeishuAccount = {
   connected: boolean;
   active: boolean;
 };
+type FeishuAccountIdentity = {
+  profile: string;
+  avatar_url?: string | null;
+  tenant_key?: string | null;
+};
 type FeishuDocument = { document_id: string; url: string; title: string };
 type FeishuChat = { chat_id: string; name: string; description?: string | null };
 type FeishuConnectEvent = {
@@ -35,6 +40,16 @@ type FeishuConnectEvent = {
   url?: string | null;
 };
 type Destination = "document" | "group";
+type FeishuFailureDestination = "setup" | "document" | "chat";
+type FeishuFailureStage =
+  | "load_accounts"
+  | "select_account"
+  | "connect_account"
+  | "reconnect_account"
+  | "disconnect_account"
+  | "prepare_document"
+  | "open_document"
+  | "load_chats";
 type FeishuPhase =
   | "closed"
   | "loading_accounts"
@@ -64,11 +79,15 @@ let chatError = "";
 let errorMessage = "";
 let connectMessage = "";
 let eventsBound = false;
+let escapeBound = false;
 let operation = 0;
 
 const CONNECT_ACCOUNT_VALUE = "__connect_account__";
 const CHAT_STORAGE_KEY = "socai-feishu-last-chat";
 const PROFILE_STORAGE_KEY = "socai-feishu-profile";
+const ACCOUNT_LOAD_TIMEOUT_MS = 10_000;
+const ACCOUNT_IDENTITY_TIMEOUT_MS = 8_000;
+const CHAT_LOAD_TIMEOUT_MS = 15_000;
 
 export function renderFeishuConnector(tasks: ConnectorTask[]): string {
   if (phase === "closed") return "";
@@ -119,6 +138,7 @@ export function bindFeishuConnector(
   resolveAnswer: AnswerResolver,
 ): void {
   bindConnectEvents(shell);
+  bindEscapeKey(shell);
   document.querySelectorAll<HTMLButtonElement>("[data-feishu-export]").forEach((button) => {
     button.addEventListener("click", () => {
       const selectedTaskId = button.dataset.feishuExport;
@@ -132,7 +152,7 @@ export function bindFeishuConnector(
     button.addEventListener("click", () => closeDialog(shell));
   });
   document.querySelector<HTMLElement>("[data-feishu-scrim]")?.addEventListener("click", (event) => {
-    if (event.target === event.currentTarget && !isBusy()) closeDialog(shell);
+    if (event.target === event.currentTarget && canDismiss()) closeDialog(shell);
   });
   document.querySelector<HTMLSelectElement>("[data-feishu-account]")?.addEventListener("change", (event) => {
     const select = event.currentTarget as HTMLSelectElement;
@@ -307,6 +327,16 @@ function renderProgress(message: string): string {
   `;
 }
 
+function bindEscapeKey(shell: ShellState): void {
+  if (escapeBound) return;
+  escapeBound = true;
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || phase === "closed" || !canDismiss()) return;
+    event.preventDefault();
+    closeDialog(shell);
+  });
+}
+
 function bindConnectEvents(shell: ShellState): void {
   if (eventsBound) return;
   eventsBound = true;
@@ -323,6 +353,54 @@ function bindConnectEvents(shell: ShellState): void {
   }).catch((error) => {
     console.error("feishu event listener failed:", error);
     eventsBound = false;
+  });
+}
+
+function invokeWithTimeout<T>(
+  command: string,
+  args: Record<string, unknown> | undefined,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(timeoutMessage), timeoutMs);
+    invoke<T>(command, args).then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function loadAccountList(): Promise<FeishuAccount[]> {
+  return invokeWithTimeout(
+    "feishu_accounts",
+    undefined,
+    ACCOUNT_LOAD_TIMEOUT_MS,
+    t("feishu.accountLoadTimeout"),
+  );
+}
+
+function reportFeishuFailure(
+  stage: FeishuFailureStage,
+  destination: FeishuFailureDestination,
+  startedAt: number,
+  error: unknown,
+): void {
+  if (!taskId) return;
+  void invoke("feishu_report_failure", {
+    taskId,
+    destination,
+    stage,
+    durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+    error: `${error}`,
+  }).catch((reportError) => {
+    console.error("failed to report Feishu failure:", reportError);
   });
 }
 
@@ -348,11 +426,12 @@ async function openDialog(
 
 async function loadAccounts(shell: ShellState): Promise<void> {
   const currentOperation = ++operation;
+  const startedAt = performance.now();
   phase = "loading_accounts";
   errorMessage = "";
   shell.rerender();
   try {
-    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    accounts = await loadAccountList();
     if (currentOperation !== operation) return;
     const remembered = localStorage.getItem(PROFILE_STORAGE_KEY) ?? "";
     const preferred =
@@ -362,9 +441,11 @@ async function loadAccounts(shell: ShellState): Promise<void> {
     selectedProfile = preferred?.profile ?? "";
     phase = "choose";
     shell.rerender();
+    void enrichAccountIdentities(shell, currentOperation);
     await refreshChats(shell, currentOperation);
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("load_accounts", "setup", startedAt, error);
     errorMessage = `${error}`;
     phase = "error";
   } finally {
@@ -372,8 +453,43 @@ async function loadAccounts(shell: ShellState): Promise<void> {
   }
 }
 
+async function enrichAccountIdentities(
+  shell: ShellState,
+  currentOperation: number,
+): Promise<void> {
+  const profiles = accounts.filter((account) => account.connected).map((account) => account.profile);
+  const identities = await Promise.all(
+    profiles.map(async (profile) => {
+      try {
+        return await invokeWithTimeout<FeishuAccountIdentity>(
+          "feishu_account_identity",
+          { profile },
+          ACCOUNT_IDENTITY_TIMEOUT_MS,
+          t("feishu.accountIdentityTimeout"),
+        );
+      } catch {
+        // Avatar and tenant metadata are optional decoration. Keep the usable
+        // account list visible when identity enrichment is slow or unavailable.
+        return null;
+      }
+    }),
+  );
+  if (currentOperation !== operation) return;
+  const byProfile = new Map(
+    identities
+      .filter((identity): identity is FeishuAccountIdentity => identity !== null)
+      .map((identity) => [identity.profile, identity]),
+  );
+  accounts = accounts.map((account) => {
+    const identity = byProfile.get(account.profile);
+    return identity ? { ...account, ...identity } : account;
+  });
+  shell.rerender();
+}
+
 async function selectAccount(shell: ShellState, profile: string): Promise<void> {
   const currentOperation = ++operation;
+  const startedAt = performance.now();
   selectedProfile = profile;
   phase = "loading_accounts";
   shell.rerender();
@@ -390,6 +506,7 @@ async function selectAccount(shell: ShellState, profile: string): Promise<void> 
     await refreshChats(shell, currentOperation);
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("select_account", "setup", startedAt, error);
     errorMessage = `${error}`;
     phase = "error";
   } finally {
@@ -399,6 +516,7 @@ async function selectAccount(shell: ShellState, profile: string): Promise<void> 
 
 async function connectNewAccount(shell: ShellState): Promise<void> {
   const currentOperation = ++operation;
+  const startedAt = performance.now();
   phase = "connecting";
   connectMessage = t("feishu.creatingApp");
   errorMessage = "";
@@ -411,16 +529,18 @@ async function connectNewAccount(shell: ShellState): Promise<void> {
     if (currentOperation !== operation) return;
     selectedProfile = status.profile;
     localStorage.setItem(PROFILE_STORAGE_KEY, selectedProfile);
-    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    accounts = await loadAccountList();
     if (currentOperation !== operation) return;
     destination = null;
     documentResult = null;
     chats = [];
     phase = "choose";
     shell.rerender();
+    void enrichAccountIdentities(shell, currentOperation);
     await refreshChats(shell, currentOperation);
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("connect_account", "setup", startedAt, error);
     errorMessage = `${error}`;
     phase = "error";
   } finally {
@@ -431,6 +551,7 @@ async function connectNewAccount(shell: ShellState): Promise<void> {
 async function reconnectAccount(shell: ShellState): Promise<void> {
   if (!selectedProfile) return;
   const currentOperation = ++operation;
+  const startedAt = performance.now();
   phase = "connecting";
   connectMessage = t("feishu.authorizing");
   errorMessage = "";
@@ -443,16 +564,18 @@ async function reconnectAccount(shell: ShellState): Promise<void> {
     if (currentOperation !== operation) return;
     selectedProfile = status.profile;
     localStorage.setItem(PROFILE_STORAGE_KEY, selectedProfile);
-    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    accounts = await loadAccountList();
     if (currentOperation !== operation) return;
     destination = null;
     documentResult = null;
     chats = [];
     phase = "choose";
     shell.rerender();
+    void enrichAccountIdentities(shell, currentOperation);
     await refreshChats(shell, currentOperation);
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("reconnect_account", "setup", startedAt, error);
     errorMessage = `${error}`;
     phase = "error";
   } finally {
@@ -463,12 +586,13 @@ async function reconnectAccount(shell: ShellState): Promise<void> {
 async function disconnectAccount(shell: ShellState): Promise<void> {
   if (!selectedProfile) return;
   const currentOperation = ++operation;
+  const startedAt = performance.now();
   phase = "disconnecting";
   shell.rerender();
   try {
     await invoke("feishu_disconnect_account", { profile: selectedProfile });
     if (currentOperation !== operation) return;
-    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    accounts = await loadAccountList();
     if (currentOperation !== operation) return;
     const preferred = accounts.find((account) => account.active) ?? accounts[0];
     selectedProfile = preferred?.profile ?? "";
@@ -483,9 +607,11 @@ async function disconnectAccount(shell: ShellState): Promise<void> {
     chatsLoading = false;
     phase = "choose";
     shell.rerender();
+    void enrichAccountIdentities(shell, currentOperation);
     await refreshChats(shell, currentOperation);
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("disconnect_account", "setup", startedAt, error);
     errorMessage = `${error}`;
     phase = "error";
   } finally {
@@ -519,7 +645,7 @@ async function ensureConnected(currentOperation: number): Promise<string> {
   selectedProfile = profile;
   localStorage.setItem(PROFILE_STORAGE_KEY, profile);
   if (reconnected) {
-    accounts = await invoke<FeishuAccount[]>("feishu_accounts");
+    accounts = await loadAccountList();
     if (currentOperation !== operation) throw new Error("cancelled");
   }
   return profile;
@@ -528,6 +654,10 @@ async function ensureConnected(currentOperation: number): Promise<string> {
 async function createDocument(shell: ShellState): Promise<void> {
   if (!taskId || !answerContent) return;
   const currentOperation = ++operation;
+  const startedAt = performance.now();
+  let nativeCommandStarted = false;
+  let documentCreated = false;
+  let openStartedAt = startedAt;
   destination = "document";
   documentResult = null;
   errorMessage = "";
@@ -541,17 +671,25 @@ async function createDocument(shell: ShellState): Promise<void> {
     if (currentOperation !== operation) return;
     phase = "exporting";
     shell.rerender();
+    nativeCommandStarted = true;
     documentResult = await invoke<FeishuDocument>("feishu_export_task", {
       taskId,
       profile,
       content: answerContent,
     });
+    documentCreated = true;
     if (currentOperation !== operation) return;
     phase = "ready";
     shell.rerender();
+    openStartedAt = performance.now();
     await invoke("open_external", { url: documentResult.url });
   } catch (error) {
     if (currentOperation !== operation || `${error}` === "Error: cancelled") return;
+    if (!nativeCommandStarted) {
+      reportFeishuFailure("prepare_document", "document", startedAt, error);
+    } else if (documentCreated) {
+      reportFeishuFailure("open_document", "document", openStartedAt, error);
+    }
     errorMessage = `${error}`;
     phase = "error";
     shell.rerender();
@@ -592,17 +730,22 @@ async function refreshChats(shell: ShellState, currentOperation: number): Promis
     return;
   }
   chatsLoading = true;
+  const startedAt = performance.now();
   chats = [];
   chatError = "";
   shell.rerender();
   try {
-    const result = await invoke<FeishuChat[]>("feishu_list_chats", {
-      profile: selectedProfile,
-    });
+    const result = await invokeWithTimeout<FeishuChat[]>(
+      "feishu_list_chats",
+      { profile: selectedProfile },
+      CHAT_LOAD_TIMEOUT_MS,
+      t("feishu.chatLoadTimeout"),
+    );
     if (currentOperation !== operation) return;
     chats = result;
   } catch (error) {
     if (currentOperation !== operation) return;
+    reportFeishuFailure("load_chats", "chat", startedAt, error);
     chatError = `${error}`;
   } finally {
     if (currentOperation === operation) {
@@ -620,6 +763,10 @@ function isBusy(): boolean {
     "sending",
     "disconnecting",
   ].includes(phase);
+}
+
+function canDismiss(): boolean {
+  return phase === "loading_accounts" || !isBusy();
 }
 
 function closeDialog(shell: ShellState): void {

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -212,6 +212,14 @@ const messages = {
   "feishu.dialogAria": { en: "export to feishu", zh: "导出到飞书" },
   "feishu.title": { en: "export to feishu", zh: "导出到飞书" },
   "feishu.loadingAccounts": { en: "loading accounts…", zh: "正在加载飞书账户…" },
+  "feishu.accountLoadTimeout": {
+    en: "Loading Feishu accounts timed out. Please retry.",
+    zh: "读取飞书账户超时，请重试。",
+  },
+  "feishu.accountIdentityTimeout": {
+    en: "Loading Feishu account details timed out.",
+    zh: "读取飞书账户信息超时。",
+  },
   "feishu.account": { en: "choose account", zh: "选择账户" },
   "feishu.unknownAccount": { en: "connected account", zh: "已连接账户" },
   "feishu.noAccount": { en: "no connected account", zh: "尚未连接账户" },
@@ -231,6 +239,10 @@ const messages = {
   },
   "feishu.exporting": { en: "creating document…", zh: "正在创建飞书文档…" },
   "feishu.loadingGroups": { en: "loading groups…", zh: "正在加载群聊…" },
+  "feishu.chatLoadTimeout": {
+    en: "Loading Feishu groups timed out. Document export is still available.",
+    zh: "读取飞书群聊超时，仍可导出到文档。",
+  },
   "feishu.noGroups": { en: "no joined groups found.", zh: "没有找到已加入的群聊。" },
   "feishu.chooseGroup": { en: "choose a group", zh: "选择群聊" },
   "feishu.send": { en: "send", zh: "发送" },

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -210,7 +210,10 @@ function render(): void {
       </header>
       <div class="body">
         ${sidebarOpen ? agentPanel.renderSidebar() : ""}
-        <main class="workspace-main">${agentPanel.renderWorkspace(state)}</main>
+        <div class="workspace-stack">
+          <main class="workspace-main">${agentPanel.renderWorkspace(state)}</main>
+          ${agentPanel.renderWorkspaceOverlays()}
+        </div>
       </div>
     </div>
   `;

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -680,24 +680,30 @@ export namespace agentPanel {
 
   // The main pane: the centered new-task compose (hero + chat composer,
   // masked by the connect overlay while chrome is down), or the selected
-  // task's conversation with the same composer in "reply" mode. The
-  // delete-confirm dialog (a fixed overlay) rides along with either.
+  // task's conversation with the same composer in "reply" mode.
   export function renderWorkspace(shell: ShellState): string {
-    const deleteRequest = tasks.find((task) => task.task_id === deleteRequestTaskId);
-    const dialog = deleteRequest ? renderConfirmDeleteDialog(deleteRequest) : "";
-    const feishuDialog = renderFeishuConnector(tasks);
     const task = view === "compose" ? null : selectedTask() ?? null;
-    if (!task) return `${renderComposePane(newComposer(shell))}${dialog}${feishuDialog}`;
+    if (!task) return renderComposePane(newComposer(shell));
     // Point the note UI at this task's archive; the thread's card groups and
     // answer citations resolve refs against it, and so does the viewer.
     setNoteRegistry(task.notes, task.run_dir);
     const running = task.status === "running" || task.status === "queued";
-    return `${renderConversation({
+    return renderConversation({
       task,
       running,
       isActivityOpen: (turnIndex, defaultOpen) => isActivityOpen(task.task_id, turnIndex, defaultOpen),
       composer: replyComposer(shell, running),
-    })}${dialog}${feishuDialog}`;
+    });
+  }
+
+  // Dialogs live in a sibling layer above the right-side task view, rather
+  // than inside its clipped content tree. This keeps their centering relative
+  // to the workspace (not the whole window/sidebar) without relying on WebKit
+  // fixed-position behavior under an overflow:hidden ancestor.
+  export function renderWorkspaceOverlays(): string {
+    const deleteRequest = tasks.find((task) => task.task_id === deleteRequestTaskId);
+    const dialog = deleteRequest ? renderConfirmDeleteDialog(deleteRequest) : "";
+    return `<div class="workspace-overlay-root">${dialog}${renderFeishuConnector(tasks)}</div>`;
   }
 
   function newComposer(shell: ShellState): ComposerProps {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -677,6 +677,14 @@ body.has-paper > * { position: relative; z-index: 1; }
   flex-direction: column;
 }
 
+.workspace-stack {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  overflow: hidden;
+}
 .workspace-main {
   flex: 1;
   min-width: 0;
@@ -684,6 +692,12 @@ body.has-paper > * { position: relative; z-index: 1; }
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+.workspace-overlay-root {
+  position: absolute;
+  inset: 0;
+  z-index: 80;
+  pointer-events: none;
 }
 @media (max-width: 760px) {
   .sidebar, .topbar-left { flex-basis: 220px; width: 220px; }
@@ -789,20 +803,22 @@ body.has-paper > * { position: relative; z-index: 1; }
 
 /* the universal confirm dialog — centered alertdialog on a dimmed scrim */
 .modal-scrim {
-  position: fixed;
+  position: absolute;
   inset: 0;
-  z-index: 80;
   display: grid;
   place-items: center;
   background: rgba(0, 0, 0, 0.32);
   padding: var(--sp-5);
+  pointer-events: auto;
 }
 .confirm-dialog {
   width: min(340px, 100%);
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
   padding: var(--sp-5);
+  overflow: auto;
   background: var(--surface);
   border: var(--hairline);
   border-radius: var(--r-4);

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -168,7 +168,7 @@ and model in use are captured on `socai_agent_task_start`.
 | `socai_agent_task_start` | A task begins running | `task_id`, `provider`, `model`, `task_len`, `task_text` |
 | `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `steps`, token/cache usage, estimated cost breakdown, `duration_ms`, `error` |
 | `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, `query_text`, `query_len`, `metadata`, `note_id_present` |
-| `socai_feishu_export` | A Feishu document export or group send completes or fails | `task_id`, `run_id`, `destination`, `outcome`, `duration_ms`, `error` |
+| `socai_feishu_export` | A Feishu export completes/fails, including user-visible setup failures before the native export command starts | `task_id`, `run_id`, `destination`, optional `stage`, `outcome`, `duration_ms`, `error` |
 
 Desktop field semantics:
 
@@ -194,13 +194,15 @@ Desktop field semantics:
 | `task_len` | number | Agent prompt length in Unicode scalar values. |
 | `task_text` | string | Full agent prompt. Always sent on desktop; see privacy boundaries. |
 | `turn` / `sequence` | number | Position of a tool call within the run. |
-| `destination` | string | Feishu export target: `document` or `chat`. |
+| `destination` | string | Feishu export target: `document`, `chat`, or `setup` for failures before a destination can be used. |
+| `stage` | string | Feishu operation stage, such as `load_accounts`, `connect_account`, `prepare_document`, `export_document`, `load_chats`, or `send_chat`. |
 
 For `socai_feishu_export`, `outcome` is `completed` or `failed`. The event is
-emitted at the native command boundary, so it records the result of the Feishu
-operation rather than only the frontend button click. `run_id` links the action
-back to the agent turn shown in the trace viewer. It does not include the
-exported content, document URL/ID, chat ID, or Feishu account/profile.
+emitted at the native command boundary for document/group operations. A
+user-visible failure before that boundary is also emitted through a dedicated
+Tauri reporting command with a bounded `stage` allowlist. `run_id` links both
+forms back to the agent turn shown in the trace viewer. Neither form includes
+the exported content, document URL/ID, chat ID, or Feishu account/profile.
 
 `socai_tool_call` mirrors the CLI tool trace's argument summary: the tool's
 `query` argument is lifted to `query_text` + `query_len`, a `note_id` argument


### PR DESCRIPTION
## What changed

- center Feishu and confirmation dialogs in a dedicated overlay layer scoped to the right-side task workspace
- show the account chooser before optional Feishu identity enrichment completes
- add bounded CLI execution, frontend loading timeouts, and dismissible account loading
- report setup, CLI, document, and chat failures through `socai_feishu_export` with task/run linkage and bounded errors

## Why

A user could click export and see only a dimmed surface. The dialog lived inside a clipped workspace content tree, while account loading synchronously waited on unbounded CLI and remote identity calls. Failures before the native export command were also invisible to trace diagnostics.

## Impact

The modal remains centered within the right task area, account setup can no longer block indefinitely, and user-visible Feishu failures are traceable without exporting task content, account data, URLs, IDs, or credentials.

## Validation

- `pnpm build`
- `cargo check -p socai_app`
- `rustfmt --edition 2021 --check --config skip_children=true app/src-tauri/src/connectors/feishu.rs app/src-tauri/src/lib.rs`
- `git diff --check`