### PR TITLE
fix(app): preserve sidebar position and restore help link

### DIFF
--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -109,6 +109,7 @@ function renderConnectOverlay(status: Status): string {
         ${connecting ? "disabled" : ""}
       >${esc(connecting ? t("chrome.connectingCta") : t("chrome.connectCta"))}</button>
       <a
+        id="overlay-remote-debugging-help"
         class="connect-overlay-link t-small"
         href="https://socai.io/connect"
         target="_blank"

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -912,6 +912,17 @@ export namespace agentPanel {
     document.getElementById("overlay-chrome-connect")?.addEventListener("click", () => {
       invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
     });
+    // WKWebView marks target=_blank navigation as defaultPrevented before the
+    // document-level external-link delegate runs. Bind this help link directly
+    // so it reaches the same backend opener first; the global delegate then
+    // sees the prevented event and correctly avoids a duplicate open.
+    document.getElementById("overlay-remote-debugging-help")?.addEventListener("click", (event) => {
+      event.preventDefault();
+      const href = (event.currentTarget as HTMLAnchorElement).getAttribute("href");
+      if (href) {
+        invoke("open_external", { url: href }).catch((e) => console.error("open_external failed:", e));
+      }
+    });
   }
 
   // Toggling `disabled` on every keystroke via a full shell.rerender() would

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -59,6 +59,9 @@ export namespace agentPanel {
   let tasks: AgentTaskView[] = [];
   let pendingEvents = new Map<string, AgentTaskEventPayload[]>();
   let selectedTaskId: string | null = null;
+  // Full shell renders replace the sidebar DOM. Keep its viewport stable when
+  // selecting a task (and across any other render) instead of jumping to top.
+  let sidebarScrollTop = 0;
   // Confirm-first delete: every affordance (row ×, conversation-head button)
   // opens the centered dialog by setting this; the delete only runs on confirm.
   let deleteRequestTaskId: string | null = null;
@@ -734,6 +737,7 @@ export namespace agentPanel {
   }
 
   export function bind(shell: ShellState): void {
+    restoreSidebarScroll();
     bindFeishuConnector(shell, (taskId, turnIndex) => {
       const task = tasks.find((item) => item.task_id === taskId);
       return task ? answerTextForTurn(task, turnIndex) : null;
@@ -816,6 +820,17 @@ export namespace agentPanel {
     if (selected && (selected.status === "running" || selected.status === "queued")) {
       updateLiveStrip(selected);
     }
+  }
+
+  // A shell render rebuilds the left rail, so restore the task list's previous
+  // viewport and keep recording it for the next render.
+  function restoreSidebarScroll(): void {
+    const list = document.querySelector<HTMLDivElement>(".sidebar-list");
+    if (!list) return;
+    list.scrollTop = sidebarScrollTop;
+    list.addEventListener("scroll", () => {
+      sidebarScrollTop = list.scrollTop;
+    });
   }
 
   // Put the freshly rebuilt event stream back where the user left it: at the


### PR DESCRIPTION
## Summary

- preserve the task-history sidebar scroll offset across full shell renders
- restore the remote-debugging help link by binding it directly before WKWebView prevents target-blank navigation

## Root cause

Selecting a task rebuilds the sidebar DOM, resetting its scroll offset to zero. Separately, the generic document-level external-link delegate skips events already marked default-prevented; WKWebView marks this target-blank help link before that delegate runs, so the backend opener was never invoked.

## User impact

The task list stays at the position the user was browsing, and the remote-debugging setup guide opens in the system browser again.

## Validation

- `pnpm run build`
- `cargo check -p socai_app`
- `git diff --check`
- manual macOS verification of the help link