### PR TITLE
xhs: diagnose and recover from rate-limited pages

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1282,8 +1282,9 @@ fn pump_agent_task_events(
                     // Same shared summarizer the CLI daemon uses: the search
                     // query is lifted into query_text/query_len (gated by
                     // query_text_enabled) and every other arg folds into
-                    // metadata; result counts are extracted from the output.
-                    // Tool OUTPUT text (note bodies) is never included.
+                    // metadata; result counts and bounded unexpected-page OCR
+                    // diagnostics are extracted from the output. Note bodies
+                    // and comments are never included.
                     props.extend(summarize_tool_args(input, query_text_enabled()));
                     props.extend(summarize_tool_result(content));
                     telemetry.capture("socai_tool_call", Value::Object(props));

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -452,7 +452,7 @@ pub(crate) fn user_label(name: &str) -> String {
         "scroll_in_note" => "scrolled note",
         "collect_carousel_images" => "collected carousel images",
         "extract_profile" => "read author profile",
-        "wait_for_rate_limit" => "waiting for xiaohongshu cooldown",
+        "wait_for_rate_limit" => "waiting for xiaohongshu's rate limit",
         "page_state" => "checked page state",
         _ => return name.replace('_', " "),
     }

--- a/app/src-tauri/src/timeline.rs
+++ b/app/src-tauri/src/timeline.rs
@@ -452,6 +452,7 @@ pub(crate) fn user_label(name: &str) -> String {
         "scroll_in_note" => "scrolled note",
         "collect_carousel_images" => "collected carousel images",
         "extract_profile" => "read author profile",
+        "wait_for_rate_limit" => "waiting for xiaohongshu cooldown",
         "page_state" => "checked page state",
         _ => return name.replace('_', " "),
     }

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use self::background::{
 };
 pub use self::common::{MediaConfig, MediaUnavailable};
 pub use self::ocr::diagnostics as ocr_diagnostics;
+pub(crate) use self::ocr::ocr_images_bytes;
 pub use self::ocr::warm_up as ocr_warm_up;
 pub use self::processor::MediaProcessor;
 pub use self::timing::{timing_delta, TimingRecord, TimingSnapshot};

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -39,7 +39,23 @@ blank/404/app-only detail pages, or copy such as "帖子不见了" / "内容无�
 "page unavailable", do not loop the same macro with identical inputs. Treat it
 as a platform/session/rate-limit blocker: use whatever evidence was collected,
 try at most one narrower or slower query/profile path if it materially changes
-the route, and otherwise explain the blocker to the user.
+the route, and otherwise explain the blocker to the user. The structured
+`reason:"rate_limited"` case is the exception: follow the cooldown protocol
+below instead of changing routes or retrying immediately.
+
+## Rate-Limit Recovery
+
+Unexpected XHS pages are checked with OCR over the center of the viewport. If
+that OCR sees `访问频繁` or error code `300013`, the macro returns
+`{ok:false, reason:"rate_limited", recovery_tool:"wait_for_rate_limit"}` and
+stops opening more notes.
+
+**On `reason:"rate_limited"`, do NOT immediately retry any XHS tool.** Call
+`wait_for_rate_limit`; it remains visible as the current agent step while it
+waits for a random 5-6 minute cooldown. After it returns, retry the original
+tool once. If that retry again returns `reason:"rate_limited"`, call
+`wait_for_rate_limit` again before the next single retry. Repeat this
+wait-then-one-retry cycle until the original tool succeeds or the user cancels.
 
 ## Login Detection
 

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -39,23 +39,14 @@ blank/404/app-only detail pages, or copy such as "帖子不见了" / "内容无�
 "page unavailable", do not loop the same macro with identical inputs. Treat it
 as a platform/session/rate-limit blocker: use whatever evidence was collected,
 try at most one narrower or slower query/profile path if it materially changes
-the route, and otherwise explain the blocker to the user. The structured
-`reason:"rate_limited"` case is the exception: follow the cooldown protocol
-below instead of changing routes or retrying immediately.
+the route, and otherwise explain the blocker to the user. For
+`reason:"rate_limited"`, follow the protocol below.
 
 ## Rate-Limit Recovery
 
-Unexpected XHS pages are checked with OCR over the center of the viewport. If
-that OCR sees `访问频繁` or error code `300013`, the macro returns
-`{ok:false, reason:"rate_limited", recovery_tool:"wait_for_rate_limit"}` and
-stops opening more notes.
-
-**On `reason:"rate_limited"`, do NOT immediately retry any XHS tool.** Call
-`wait_for_rate_limit`; it remains visible as the current agent step while it
-waits for a random 5-6 minute cooldown. After it returns, retry the original
-tool once. If that retry again returns `reason:"rate_limited"`, call
-`wait_for_rate_limit` again before the next single retry. Repeat this
-wait-then-one-retry cycle until the original tool succeeds or the user cancels.
+On `reason:"rate_limited"`, call `wait_for_rate_limit` instead of retrying.
+After it returns, retry the original tool once; if still limited, repeat this
+wait-then-one-retry cycle until success or cancellation.
 
 ## Login Detection
 

--- a/core/src/sites/xhs/mod.rs
+++ b/core/src/sites/xhs/mod.rs
@@ -2,6 +2,7 @@ pub mod entities;
 pub mod history;
 mod media_manifest;
 pub mod page;
+mod page_diagnostics;
 pub mod tools;
 
 pub use self::entities::{parse_count_text, XhsAuthorProfile, XhsNote, XhsNoteCard};

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -245,6 +245,10 @@ impl<'a> XhsPageRuntime<'a> {
         self.expect_object("pageState", None).await
     }
 
+    pub(crate) async fn attach_page_failure_diagnostic(&self, result: &mut Value) {
+        super::page_diagnostics::attach(self.page, result).await;
+    }
+
     pub async fn search_notes(
         &self,
         query: &str,
@@ -296,7 +300,7 @@ impl<'a> XhsPageRuntime<'a> {
         if let Some(state) = submit.get_mut("state").and_then(Value::as_object_mut) {
             state.remove("url_keyword");
         }
-        Ok(json!({
+        let mut result = json!({
             "ok": ok,
             "query": keyword,
             "submit": submit,
@@ -305,17 +309,19 @@ impl<'a> XhsPageRuntime<'a> {
             "count": cards.len(),
             "cards": cards,
             "reason": if ok { "" } else { submit.get("error").and_then(Value::as_str).unwrap_or("search_submit_failed") },
-        }))
+        });
+        if !ok {
+            self.attach_page_failure_diagnostic(&mut result).await;
+        }
+        Ok(result)
     }
 
     pub async fn submit_search(&self, query: &str, wait_seconds: f64) -> Result<Value> {
-        let loc = self.expect_object("searchInput", None).await?;
+        let mut loc = self.expect_object("searchInput", None).await?;
         if !script_ok(&loc) {
-            return Ok(json!({
-                "ok": false,
-                "strategy": "search_input_unavailable",
-                "error": loc.get("error").and_then(Value::as_str).unwrap_or_default(),
-            }));
+            loc["strategy"] = json!("search_input_unavailable");
+            self.attach_page_failure_diagnostic(&mut loc).await;
+            return Ok(loc);
         }
 
         if let Some(input) = loc.get("input") {
@@ -352,7 +358,7 @@ impl<'a> XhsPageRuntime<'a> {
                 .expect_object("setSearchInput", Some(&json!({ "query": query })))
                 .await?;
             if !script_ok(&set_result) {
-                return Ok(json!({
+                let mut result = json!({
                     "ok": false,
                     "strategy": "set_search_input_failed",
                     "state": set_result,
@@ -360,7 +366,9 @@ impl<'a> XhsPageRuntime<'a> {
                         .get("error")
                         .and_then(Value::as_str)
                         .unwrap_or("Search input did not accept the requested keyword"),
-                }));
+                });
+                self.attach_page_failure_diagnostic(&mut result).await;
+                return Ok(result);
             }
         }
 
@@ -400,7 +408,7 @@ impl<'a> XhsPageRuntime<'a> {
             }
         }
 
-        Ok(json!({
+        let mut result = json!({
             "ok": false,
             "strategy": "manual_submit_failed",
             "state": state,
@@ -410,7 +418,9 @@ impl<'a> XhsPageRuntime<'a> {
             } else {
                 "Search did not transition to a valid Xiaohongshu result page"
             },
-        }))
+        });
+        self.attach_page_failure_diagnostic(&mut result).await;
+        Ok(result)
     }
 
     pub async fn wait_for_search_transition(&self, query: &str, timeout_s: f64) -> Result<Value> {
@@ -515,9 +525,16 @@ impl<'a> XhsPageRuntime<'a> {
         wait_seconds: f64,
     ) -> Result<Value> {
         let cards = self.extract_search_cards().await?;
-        let selected = select_card(&cards, note_id, index).ok_or_else(|| {
-            anyhow::anyhow!("Could not resolve note target from current search cards.")
-        })?;
+        let Some(selected) = select_card(&cards, note_id, index) else {
+            let mut result = json!({
+                "ok": false,
+                "url": self.current_url().await?,
+                "strategy": "card_lookup_failed",
+                "error": "card_not_found",
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
+        };
 
         let mut click_arg = Map::new();
         if !selected.note_id.is_empty() {
@@ -533,14 +550,21 @@ impl<'a> XhsPageRuntime<'a> {
             .expect_object("clickCard", Some(&Value::Object(click_arg.clone())))
             .await?;
         if !script_ok(&target) {
-            anyhow::bail!(
-                "Could not locate card to click for note {}: {}",
-                selected.note_id,
-                target
-                    .get("error")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-            );
+            let error = target
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("card_not_found")
+                .to_string();
+            let mut result = json!({
+                "ok": false,
+                "target": selected,
+                "url": self.current_url().await?,
+                "state": target,
+                "strategy": "card_lookup_failed",
+                "error": error,
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         }
 
         self.set_last_note_id(String::new());
@@ -598,18 +622,26 @@ impl<'a> XhsPageRuntime<'a> {
             }
         }
 
-        Ok(json!({
+        let login_required = opened
+            .get("login_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let mut result = json!({
             "ok": false,
             "target": selected,
             "url": self.current_url().await?,
             "state": opened,
             "strategy": "card_click_failed",
-            "error": if opened.get("login_required").and_then(Value::as_bool).unwrap_or(false) {
+            "error": if login_required {
                 "login_required"
             } else {
                 "Note overlay did not open after card-click attempts; site may be throttling or layout changed"
             },
-        }))
+        });
+        if !login_required {
+            self.attach_page_failure_diagnostic(&mut result).await;
+        }
+        Ok(result)
     }
 
     pub async fn close_note(&self, wait_seconds: f64) -> Result<Value> {
@@ -680,13 +712,15 @@ impl<'a> XhsPageRuntime<'a> {
             }
         }
 
-        Ok(json!({
+        let mut result = json!({
             "ok": false,
             "strategy": "close_failed",
             "state": state,
             "url": self.current_url().await?,
             "error": "Note modal did not close after Escape, JS-dispatch Escape, and close-button attempts",
-        }))
+        });
+        self.attach_page_failure_diagnostic(&mut result).await;
+        Ok(result)
     }
 
     pub async fn read_note(
@@ -756,9 +790,15 @@ impl<'a> XhsPageRuntime<'a> {
                 perf.insert("open_strategy".into(), json!(strategy));
             }
             if !script_ok(&opened) {
-                return Ok(
-                    json!({ "ok": false, "open": opened, "error": opened.get("error").and_then(Value::as_str).unwrap_or("open_failed"), "perf": perf }),
-                );
+                let error = opened
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("open_failed")
+                    .to_string();
+                let mut result =
+                    json!({ "ok": false, "open": opened, "error": error, "perf": perf });
+                self.attach_page_failure_diagnostic(&mut result).await;
+                return Ok(result);
             }
             if options.poster_url_fallback.trim().is_empty() {
                 if let Some(cover_url) = opened
@@ -792,13 +832,15 @@ impl<'a> XhsPageRuntime<'a> {
             // breaks every subsequent open in a topic scan. Report a soft
             // failure; the caller closes the overlay and moves on intact.
             let _ = options;
-            return Ok(json!({
+            let mut result = json!({
                 "ok": false,
                 "entity": note,
                 "open": open,
                 "error": format!("stale_note: expected {note_id}, got {}", note.note_id),
                 "perf": perf,
-            }));
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         }
         Ok(json!({ "ok": true, "entity": note, "open": open, "perf": perf }))
     }
@@ -994,7 +1036,9 @@ impl<'a> XhsPageRuntime<'a> {
         let initial_raw = self.open_search_filter_panel(wait_seconds).await?;
         if !script_ok(&initial_raw) {
             self.close_search_filter_panel(None).await?;
-            return Ok(initial_raw);
+            let mut result = initial_raw;
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         }
         let initial_filters = canonical_filter_state(&initial_raw);
         let mut changed_filters = false;
@@ -1002,13 +1046,15 @@ impl<'a> XhsPageRuntime<'a> {
             let Some(option) = search_filter_option(&initial_filters, group_key, label) else {
                 self.close_search_filter_panel(Some(&initial_filters))
                     .await?;
-                return Ok(json!({
+                let mut result = json!({
                     "ok": false,
                     "error": "filter_option_not_found",
                     "group": group_key,
                     "label": label,
                     "filters": initial_filters,
-                }));
+                });
+                self.attach_page_failure_diagnostic(&mut result).await;
+                return Ok(result);
             };
             if option
                 .get("active")
@@ -1026,7 +1072,9 @@ impl<'a> XhsPageRuntime<'a> {
         let final_raw = self.expect_object("searchFilters", None).await?;
         if !script_ok(&final_raw) {
             self.close_search_filter_panel(None).await?;
-            return Ok(final_raw);
+            let mut result = final_raw;
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         }
         let final_filters = canonical_filter_state(&final_raw);
         self.close_search_filter_panel(Some(&final_filters)).await?;
@@ -1046,17 +1094,21 @@ impl<'a> XhsPageRuntime<'a> {
         let current_raw = self.open_search_filter_panel(wait_seconds).await?;
         if !script_ok(&current_raw) {
             self.close_search_filter_panel(None).await?;
-            return Ok(current_raw);
+            let mut result = current_raw;
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         }
         let current = canonical_filter_state(&current_raw);
 
         let Some(target) = current.get("reset").filter(|value| !value.is_null()) else {
             self.close_search_filter_panel(Some(&current)).await?;
-            return Ok(json!({
+            let mut result = json!({
                 "ok": false,
                 "error": "filter_reset_not_found",
                 "filters": current,
-            }));
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
         };
         let x = number(target, "x");
         let y = number(target, "y");
@@ -1259,7 +1311,15 @@ impl<'a> XhsPageRuntime<'a> {
             .append_pair("xsec_token", xsec_token)
             .append_pair("xsec_source", "pc_search");
         self.set_last_note_id(String::new());
-        self.page.navigate_with_timeout(url.as_str(), 60.0).await?;
+        if let Err(err) = self.page.navigate_with_timeout(url.as_str(), 60.0).await {
+            let mut result = json!({
+                "ok": false,
+                "reason": "navigation_failed",
+                "error": format!("{err:#}"),
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
+        }
 
         let deadline = Instant::now() + Duration::from_secs_f64(wait_seconds.max(1.0));
         let mut state = self.expect_object("pageState", None).await?;
@@ -1281,7 +1341,7 @@ impl<'a> XhsPageRuntime<'a> {
             .get("login_required")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        Ok(json!({
+        let mut result = json!({
             "ok": kind == "note_detail" && !login,
             "url": self.current_url().await?,
             "reason": if login {
@@ -1291,7 +1351,11 @@ impl<'a> XhsPageRuntime<'a> {
             } else {
                 "not_note_detail"
             },
-        }))
+        });
+        if kind != "note_detail" && !login {
+            self.attach_page_failure_diagnostic(&mut result).await;
+        }
+        Ok(result)
     }
 
     /// Navigate directly to an author's profile page by id and wait for the
@@ -1307,15 +1371,35 @@ impl<'a> XhsPageRuntime<'a> {
         // Pre-flight login gate before navigating to the profile: bail fast with
         // `login_required` rather than loading the profile only to hit the wall.
         // (The wait loop below still catches a session that expires mid-scan.)
-        if self.login_gate(true).await? == LoginGate::Required {
-            return Ok(json!({
-                "ok": false,
-                "url": self.current_url().await?,
-                "reason": "login_required",
-            }));
+        match self.login_gate(true).await {
+            Ok(LoginGate::Required) => {
+                return Ok(json!({
+                    "ok": false,
+                    "url": self.current_url().await?,
+                    "reason": "login_required",
+                }));
+            }
+            Ok(LoginGate::LoggedIn) => {}
+            Err(err) => {
+                let mut result = json!({
+                    "ok": false,
+                    "reason": "page_access_failed",
+                    "error": format!("{err:#}"),
+                });
+                self.attach_page_failure_diagnostic(&mut result).await;
+                return Ok(result);
+            }
         }
         let url = format!("https://www.xiaohongshu.com/user/profile/{id}");
-        self.page.navigate_with_timeout(&url, 60.0).await?;
+        if let Err(err) = self.page.navigate_with_timeout(&url, 60.0).await {
+            let mut result = json!({
+                "ok": false,
+                "reason": "navigation_failed",
+                "error": format!("{err:#}"),
+            });
+            self.attach_page_failure_diagnostic(&mut result).await;
+            return Ok(result);
+        }
 
         let deadline = Instant::now() + Duration::from_secs_f64(wait_seconds.max(1.0));
         let mut state = self.expect_object("pageState", None).await?;
@@ -1337,7 +1421,7 @@ impl<'a> XhsPageRuntime<'a> {
             .get("login_required")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        Ok(json!({
+        let mut result = json!({
             "ok": kind == "profile_page",
             "url": self.current_url().await?,
             "reason": if kind == "profile_page" {
@@ -1347,7 +1431,11 @@ impl<'a> XhsPageRuntime<'a> {
             } else {
                 "not_profile_page"
             },
-        }))
+        });
+        if kind != "profile_page" && !login {
+            self.attach_page_failure_diagnostic(&mut result).await;
+        }
+        Ok(result)
     }
 
     /// Collect note cards from the current profile page, scrolling the window

--- a/core/src/sites/xhs/page_diagnostics.rs
+++ b/core/src/sites/xhs/page_diagnostics.rs
@@ -1,0 +1,174 @@
+//! Bounded visual diagnostics for unexpected Xiaohongshu page failures.
+//!
+//! Failure callers only need [`attach`], [`copy`], or [`promote`]. Screenshot
+//! capture, center cropping, OCR, truncation, login-state exclusion, and reuse
+//! of an already-captured diagnostic stay isolated here.
+
+use anyhow::Result;
+use serde_json::{json, Map, Value};
+
+use crate::cdp::PageSession;
+
+/// Read the center of the current viewport so XHS's header and side navigation
+/// do not drown out the actual error page or missing-control state.
+const OCR_VIEWPORT_PERCENT: u32 = 70;
+/// Bound agent and telemetry payloads if navigation landed on a content page.
+const OCR_MAX_CHARS: usize = 200;
+const DIAGNOSTIC_FIELDS: &[&str] = &[
+    "page_ocr_text",
+    "page_ocr_region",
+    "page_ocr_truncated",
+    "page_ocr_error",
+    "page_error",
+    "page_url",
+];
+
+/// Attach or promote a failure diagnostic exactly once. Low-level failures
+/// such as `search_input_not_found` may already carry OCR; wrappers reuse it
+/// rather than taking another screenshot.
+pub(super) async fn attach(page: &PageSession, result: &mut Value) {
+    if failure_is_login(result) {
+        return;
+    }
+    if let Some(existing) = diagnostic_fields(result) {
+        merge(result, Value::Object(existing));
+        return;
+    }
+    if result.get("url").is_none() {
+        if let Some(url) = current_url(page).await {
+            result["url"] = json!(url);
+        }
+    }
+    merge(result, capture(page).await);
+}
+
+/// Copy a nested diagnostic from `source` onto a different result object.
+pub(super) fn copy(target: &mut Value, source: &Value) {
+    if let Some(diagnostic) = diagnostic_fields(source) {
+        merge(target, Value::Object(diagnostic));
+    }
+}
+
+/// Promote a nested diagnostic before compacting away its original wrapper.
+pub(super) fn promote(value: &mut Value) {
+    let Some(diagnostic) = diagnostic_fields(value) else {
+        return;
+    };
+    merge(value, Value::Object(diagnostic));
+}
+
+async fn capture(page: &PageSession) -> Value {
+    let mut diagnostic = json!({
+        "page_ocr_region": "center_70_percent",
+    });
+    let screenshot = match page.screenshot_png(false).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            diagnostic["page_ocr_error"] = json!(truncate(&format!("screenshot failed: {err}")));
+            return diagnostic;
+        }
+    };
+    let recognized =
+        tokio::task::spawn_blocking(move || ocr_center(screenshot, OCR_VIEWPORT_PERCENT)).await;
+    match recognized {
+        Ok(Ok(text)) => {
+            let trimmed = text.trim();
+            diagnostic["page_ocr_truncated"] = json!(trimmed.chars().count() > OCR_MAX_CHARS);
+            diagnostic["page_ocr_text"] = json!(truncate(trimmed));
+        }
+        Ok(Err(err)) => diagnostic["page_ocr_error"] = json!(truncate(&err.to_string())),
+        Err(err) => {
+            diagnostic["page_ocr_error"] = json!(truncate(&format!("OCR task failed: {err}")))
+        }
+    }
+    diagnostic
+}
+
+async fn current_url(page: &PageSession) -> Option<String> {
+    page.page_info()
+        .await
+        .ok()?
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn diagnostic_fields(value: &Value) -> Option<Map<String, Value>> {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("page_ocr_region") {
+                return Some(
+                    DIAGNOSTIC_FIELDS
+                        .iter()
+                        .filter_map(|field| {
+                            map.get(*field)
+                                .cloned()
+                                .map(|value| ((*field).to_string(), value))
+                        })
+                        .collect(),
+                );
+            }
+            map.values().find_map(diagnostic_fields)
+        }
+        Value::Array(items) => items.iter().find_map(diagnostic_fields),
+        _ => None,
+    }
+}
+
+fn failure_is_login(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            map.get("login_required").and_then(Value::as_bool) == Some(true)
+                || ["reason", "error"].iter().any(|key| {
+                    map.get(*key).and_then(Value::as_str) == Some("login_required")
+                })
+                || map.values().any(failure_is_login)
+        }
+        Value::Array(items) => items.iter().any(failure_is_login),
+        _ => false,
+    }
+}
+
+fn merge(target: &mut Value, diagnostic: Value) {
+    let page_url = target.get("url").cloned();
+    let page_error = target
+        .get("reason")
+        .or_else(|| target.get("error"))
+        .cloned();
+    let (Some(target), Some(diagnostic)) = (target.as_object_mut(), diagnostic.as_object()) else {
+        return;
+    };
+    for (key, value) in diagnostic {
+        target.insert(key.clone(), value.clone());
+    }
+    if let Some(page_url) = page_url {
+        target.insert("page_url".into(), page_url);
+    }
+    if let Some(page_error) = page_error {
+        target.insert("page_error".into(), page_error);
+    }
+}
+
+fn ocr_center(screenshot: Vec<u8>, percent: u32) -> Result<String> {
+    let image = image::load_from_memory(&screenshot)?;
+    let percent = percent.clamp(1, 100);
+    let width = image.width().max(1);
+    let height = image.height().max(1);
+    let crop_width = ((u64::from(width) * u64::from(percent)) / 100).max(1) as u32;
+    let crop_height = ((u64::from(height) * u64::from(percent)) / 100).max(1) as u32;
+    let x = (width.saturating_sub(crop_width)) / 2;
+    let y = (height.saturating_sub(crop_height)) / 2;
+    let cropped = image.crop_imm(x, y, crop_width, crop_height);
+    let mut encoded = std::io::Cursor::new(Vec::new());
+    cropped.write_to(&mut encoded, image::ImageFormat::Png)?;
+    let mut batch = crate::media::ocr_images_bytes(vec![(0, encoded.into_inner())]);
+    match batch.results.pop() {
+        Some((_, Ok(text))) => Ok(text),
+        Some((_, Err(err))) => Err(anyhow::anyhow!(err)),
+        None => Ok(String::new()),
+    }
+}
+
+fn truncate(text: &str) -> String {
+    text.chars().take(OCR_MAX_CHARS).collect()
+}

--- a/core/src/sites/xhs/page_diagnostics.rs
+++ b/core/src/sites/xhs/page_diagnostics.rs
@@ -21,6 +21,9 @@ const DIAGNOSTIC_FIELDS: &[&str] = &[
     "page_ocr_error",
     "page_error",
     "page_url",
+    "rate_limit_detected",
+    "rate_limit_marker",
+    "recovery_tool",
 ];
 
 /// Attach or promote a failure diagnostic exactly once. Low-level failures
@@ -32,6 +35,7 @@ pub(super) async fn attach(page: &PageSession, result: &mut Value) {
     }
     if let Some(existing) = diagnostic_fields(result) {
         merge(result, Value::Object(existing));
+        classify_rate_limit(result);
         return;
     }
     if result.get("url").is_none() {
@@ -40,12 +44,14 @@ pub(super) async fn attach(page: &PageSession, result: &mut Value) {
         }
     }
     merge(result, capture(page).await);
+    classify_rate_limit(result);
 }
 
 /// Copy a nested diagnostic from `source` onto a different result object.
 pub(super) fn copy(target: &mut Value, source: &Value) {
     if let Some(diagnostic) = diagnostic_fields(source) {
         merge(target, Value::Object(diagnostic));
+        classify_rate_limit(target);
     }
 }
 
@@ -55,6 +61,7 @@ pub(super) fn promote(value: &mut Value) {
         return;
     };
     merge(value, Value::Object(diagnostic));
+    classify_rate_limit(value);
 }
 
 async fn capture(page: &PageSession) -> Value {
@@ -73,6 +80,11 @@ async fn capture(page: &PageSession) -> Value {
     match recognized {
         Ok(Ok(text)) => {
             let trimmed = text.trim();
+            if let Some(marker) = detect_rate_limit_marker(trimmed) {
+                diagnostic["rate_limit_detected"] = json!(true);
+                diagnostic["rate_limit_marker"] = json!(marker);
+                diagnostic["recovery_tool"] = json!("wait_for_rate_limit");
+            }
             diagnostic["page_ocr_truncated"] = json!(trimmed.chars().count() > OCR_MAX_CHARS);
             diagnostic["page_ocr_text"] = json!(truncate(trimmed));
         }
@@ -108,20 +120,38 @@ fn diagnostic_fields(value: &Value) -> Option<Map<String, Value>> {
                         .collect(),
                 );
             }
-            map.values().find_map(diagnostic_fields)
+            preferred_diagnostic(map.values())
         }
-        Value::Array(items) => items.iter().find_map(diagnostic_fields),
+        Value::Array(items) => preferred_diagnostic(items.iter()),
         _ => None,
     }
+}
+
+fn preferred_diagnostic<'a>(values: impl Iterator<Item = &'a Value>) -> Option<Map<String, Value>> {
+    let mut fallback = None;
+    for value in values {
+        let Some(diagnostic) = diagnostic_fields(value) else {
+            continue;
+        };
+        if diagnostic
+            .get("rate_limit_detected")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            return Some(diagnostic);
+        }
+        fallback.get_or_insert(diagnostic);
+    }
+    fallback
 }
 
 fn failure_is_login(value: &Value) -> bool {
     match value {
         Value::Object(map) => {
             map.get("login_required").and_then(Value::as_bool) == Some(true)
-                || ["reason", "error"].iter().any(|key| {
-                    map.get(*key).and_then(Value::as_str) == Some("login_required")
-                })
+                || ["reason", "error"]
+                    .iter()
+                    .any(|key| map.get(*key).and_then(Value::as_str) == Some("login_required"))
                 || map.values().any(failure_is_login)
         }
         Value::Array(items) => items.iter().any(failure_is_login),
@@ -145,8 +175,42 @@ fn merge(target: &mut Value, diagnostic: Value) {
         target.insert("page_url".into(), page_url);
     }
     if let Some(page_error) = page_error {
-        target.insert("page_error".into(), page_error);
+        target.entry("page_error").or_insert(page_error);
     }
+}
+
+fn detect_rate_limit_marker(text: &str) -> Option<&'static str> {
+    let digits: String = text.chars().filter(char::is_ascii_digit).collect();
+    if digits.contains("300013") {
+        return Some("300013");
+    }
+    let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+    compact.contains("访问频繁").then_some("访问频繁")
+}
+
+fn classify_rate_limit(value: &mut Value) {
+    let marker = value
+        .get("rate_limit_marker")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            value
+                .get("page_ocr_text")
+                .and_then(Value::as_str)
+                .and_then(detect_rate_limit_marker)
+                .map(str::to_string)
+        });
+    let Some(marker) = marker else {
+        return;
+    };
+    let Some(map) = value.as_object_mut() else {
+        return;
+    };
+    map.insert("ok".into(), json!(false));
+    map.insert("reason".into(), json!("rate_limited"));
+    map.insert("rate_limit_detected".into(), json!(true));
+    map.insert("rate_limit_marker".into(), json!(marker));
+    map.insert("recovery_tool".into(), json!("wait_for_rate_limit"));
 }
 
 fn ocr_center(screenshot: Vec<u8>, percent: u32) -> Result<String> {

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -37,6 +37,9 @@ use crate::sites::xhs::media_manifest::{
     ensure_entity_note_id, fill_entity_from_card, search_media_manifest, write_media_manifest_file,
 };
 use crate::sites::xhs::page::{LoginGate, XHS_SEARCH_FILTERS};
+use crate::sites::xhs::page_diagnostics::{
+    copy as copy_page_diagnostic, promote as promote_page_diagnostic,
+};
 use crate::sites::xhs::{
     ReadNoteOptions, XhsAuthorProfile, XhsHistoryStore, XhsNoteCard, XhsPageRuntime, XHS_HOME_URL,
 };
@@ -1271,15 +1274,20 @@ async fn scan_card_note(
                         map.insert("open".into(), open.clone());
                     }
                 }
+                copy_page_diagnostic(&mut entry, &payload);
             }
             entry
         }
-        Err(e) => json!({
-            "source_position": card.position,
-            "ok": false,
-            "entity": card,
-            "error": format!("{e:#}"),
-        }),
+        Err(e) => {
+            let mut entry = json!({
+                "source_position": card.position,
+                "ok": false,
+                "entity": card,
+                "error": format!("{e:#}"),
+            });
+            xhs.attach_page_failure_diagnostic(&mut entry).await;
+            entry
+        }
     };
 
     // Pull comments separately after the body read: the list hydrates slower
@@ -2885,13 +2893,15 @@ async fn scan_direct_note(
     let open = match open {
         Ok(value) => value,
         Err(err) => {
-            return json!({
+            let mut result = json!({
                 "source_position": position,
                 "ok": false,
                 "entity": { "note_id": target.note_id },
                 "error": format!("{err:#}"),
                 "scan_perf": perf,
             });
+            xhs.attach_page_failure_diagnostic(&mut result).await;
+            return result;
         }
     };
     if !open.get("ok").and_then(Value::as_bool).unwrap_or(false) {
@@ -2934,7 +2944,7 @@ async fn scan_direct_note(
     let mut entity = match extracted {
         Ok(note) => serde_json::to_value(note).unwrap_or(Value::Null),
         Err(err) => {
-            return json!({
+            let mut result = json!({
                 "source_position": position,
                 "ok": false,
                 "entity": { "note_id": target.note_id, "url": open.get("url").cloned().unwrap_or(Value::Null) },
@@ -2942,6 +2952,8 @@ async fn scan_direct_note(
                 "open": open,
                 "scan_perf": perf,
             });
+            xhs.attach_page_failure_diagnostic(&mut result).await;
+            return result;
         }
     };
 
@@ -2950,7 +2962,7 @@ async fn scan_direct_note(
         .and_then(Value::as_str)
         .unwrap_or_default();
     if actual_id != target.note_id {
-        return json!({
+        let mut result = json!({
             "source_position": position,
             "ok": false,
             "entity": entity,
@@ -2958,6 +2970,8 @@ async fn scan_direct_note(
             "open": open,
             "scan_perf": perf,
         });
+        xhs.attach_page_failure_diagnostic(&mut result).await;
+        return result;
     }
     let has_detail = ["title", "author", "content"].iter().any(|key| {
         entity
@@ -2970,7 +2984,7 @@ async fn scan_direct_note(
         .is_some_and(|count| count > 0)
         || entity.get("type").and_then(Value::as_str) == Some("video");
     if !has_detail {
-        return json!({
+        let mut result = json!({
             "source_position": position,
             "ok": false,
             "entity": entity,
@@ -2978,6 +2992,8 @@ async fn scan_direct_note(
             "open": open,
             "scan_perf": perf,
         });
+        xhs.attach_page_failure_diagnostic(&mut result).await;
+        return result;
     }
 
     if comment_count > 0 {
@@ -3111,7 +3127,20 @@ impl Tool for GetNotesTool {
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         let pro_skipped = !self.pro && strip_pro_input(&mut input);
         let targets = direct_note_refs(&input)?;
-        let login = XhsPageRuntime::new(&self.page).login_gate(true).await?;
+        let gate = XhsPageRuntime::new(&self.page);
+        let login = match gate.login_gate(true).await {
+            Ok(login) => login,
+            Err(err) => {
+                let mut payload = json!({
+                    "ok": false,
+                    "notes": [],
+                    "reason": "page_access_failed",
+                    "error": format!("{err:#}"),
+                });
+                gate.attach_page_failure_diagnostic(&mut payload).await;
+                return Ok(json_result(&payload));
+            }
+        };
         if login == LoginGate::Required {
             let mut payload = json!({
                 "ok": false,
@@ -3278,6 +3307,7 @@ impl Tool for GetNotesTool {
         if !stop_reason.is_empty() {
             payload["reason"] = json!(stop_reason);
         }
+        promote_page_diagnostic(&mut payload);
         // Mid-scan login loss surfaces as a top-level `reason` too; mark it
         // for remote browsers the same way the pre-flight gate is marked.
         annotate_remote_login_gate(&self.page, &mut payload);
@@ -3850,8 +3880,23 @@ impl Tool for ExtractProfileTool {
         let max_notes = get_i64(&input, "max_notes", 20);
         let scroll_rounds = get_i64(&input, "scroll_rounds", 6);
         let xhs = XhsPageRuntime::new(&self.page);
-        let profile = xhs.extract_profile(max_notes, scroll_rounds).await?;
-        Ok(json_result(&profile.to_value()))
+        match xhs.extract_profile(max_notes, scroll_rounds).await {
+            Ok(profile) => Ok(json_result(&profile.to_value())),
+            Err(err) => {
+                let rendered = format!("{err:#}");
+                let mut result = json!({
+                    "ok": false,
+                    "reason": if rendered.contains("not a profile page") {
+                        "not_profile_page"
+                    } else {
+                        "extract_profile_failed"
+                    },
+                    "error": rendered,
+                });
+                xhs.attach_page_failure_diagnostic(&mut result).await;
+                Ok(json_result(&result))
+            }
+        }
     }
 }
 
@@ -4025,9 +4070,24 @@ impl Tool for SearchTool {
                 tokio::task::spawn_blocking(ocr_warm_up);
             }
             let xhs = XhsPageRuntime::new(&self.page);
-            let mut value = xhs
+            let mut value = match xhs
                 .search_notes(&query, filters.as_ref(), SEARCH_WAIT_SECONDS, num_notes)
-                .await?;
+                .await
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    let mut result = json!({
+                        "ok": false,
+                        "query": query.clone(),
+                        "reason": "search_failed",
+                        "error": format!("{err:#}"),
+                        "cards": [],
+                    });
+                    xhs.attach_page_failure_diagnostic(&mut result).await;
+                    result
+                }
+            };
+            promote_page_diagnostic(&mut value);
             if let Some(cards) = value.get_mut("cards") {
                 self.history.annotate_cards(cards);
             }
@@ -4164,9 +4224,21 @@ impl Tool for SearchTool {
 
         // Filters are applied after the initial search below, so don't pass
         // them here.
-        let search = xhs
+        let search = match xhs
             .search_notes(&query, None, SEARCH_WAIT_SECONDS, None)
-            .await?;
+            .await
+        {
+            Ok(value) => value,
+            Err(err) => {
+                let mut result = json!({
+                    "ok": false,
+                    "reason": "search_failed",
+                    "error": format!("{err:#}"),
+                });
+                xhs.attach_page_failure_diagnostic(&mut result).await;
+                result
+            }
+        };
 
         // If the search never landed on a results page (search box not found,
         // login required, …) bail before the browse loop. Otherwise
@@ -4195,6 +4267,7 @@ impl Tool for SearchTool {
                     "ocr": ocr,
                 },
             });
+            promote_page_diagnostic(&mut payload);
             // `reason` already summarizes the failure; keep the failed scan
             // compact too.
             lean_scan_payload(&mut payload);
@@ -4412,6 +4485,7 @@ impl Tool for SearchTool {
                 "media": media_timing,
             }
         });
+        promote_page_diagnostic(&mut payload);
         // Even the artifact keeps only the compact filter summary (changed +
         // active values); the raw panel readback with click coordinates is
         // never persisted.
@@ -4629,6 +4703,7 @@ impl Tool for AuthorScanTool {
                 "notes": [],
                 "reason": reason,
             });
+            copy_page_diagnostic(&mut payload, &open);
             annotate_remote_login_gate(&self.page, &mut payload);
             return Ok(json_result(&payload));
         }
@@ -4846,6 +4921,7 @@ impl Tool for AuthorScanTool {
             },
             "timing": { "media": media_timing },
         });
+        promote_page_diagnostic(&mut payload);
 
         // Scan perf is written to `stats/scan.json` (see above), not the artifact.
 

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -126,6 +126,7 @@ pub fn xhs_tools_with_llm_provider(
             pro,
         }),
         Arc::new(WaitForLoginTool { page: page.clone() }),
+        Arc::new(WaitForRateLimitTool),
         Arc::new(PageStateTool { page }),
     ]
 }
@@ -164,6 +165,7 @@ pub fn xhs_macro_tools_with_llm_provider(
             pro,
         }),
         Arc::new(WaitForLoginTool { page }),
+        Arc::new(WaitForRateLimitTool),
     ]
 }
 
@@ -1145,6 +1147,16 @@ impl ScanProgress {
 /// difference between those macros is where the cards come from, not how each
 /// note is read. Returns the per-note entry; the caller pushes it and closes
 /// the modal.
+fn recovery_blocker(value: &Value) -> Option<&'static str> {
+    ["reason", "error"]
+        .iter()
+        .find_map(|key| match value.get(*key).and_then(Value::as_str) {
+            Some("rate_limited") => Some("rate_limited"),
+            Some("login_required") => Some("login_required"),
+            _ => None,
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn scan_card_note(
     xhs: &XhsPageRuntime<'_>,
@@ -1289,6 +1301,16 @@ async fn scan_card_note(
             entry
         }
     };
+
+    // A rate-limit/login page is a session-level blocker, not a missing note.
+    // Avoid loading comments or touching history; the outer scan loop will stop
+    // after preserving this entry for the agent and telemetry.
+    if recovery_blocker(&entry).is_some() {
+        if let Some(map) = entry.as_object_mut() {
+            map.insert("scan_perf".into(), Value::Object(scan_perf));
+        }
+        return entry;
+    }
 
     // Pull comments separately after the body read: the list hydrates slower
     // than the body, and reaching `comment_count` may require scrolling the
@@ -3204,10 +3226,7 @@ impl Tool for GetNotesTool {
                 ocr,
             )
             .await;
-            let login_lost = entry
-                .get("error")
-                .and_then(Value::as_str)
-                .is_some_and(|reason| reason == "login_required");
+            let blocker = recovery_blocker(&entry);
             notes.push(entry);
             let idx = notes.len() - 1;
             if ocr {
@@ -3241,8 +3260,8 @@ impl Tool for GetNotesTool {
                 0,
                 total_ms,
             ));
-            if login_lost {
-                stop_reason = "login_required".to_string();
+            if let Some(blocker) = blocker {
+                stop_reason = blocker.to_string();
                 break;
             }
         }
@@ -3308,8 +3327,8 @@ impl Tool for GetNotesTool {
             payload["reason"] = json!(stop_reason);
         }
         promote_page_diagnostic(&mut payload);
-        // Mid-scan login loss surfaces as a top-level `reason` too; mark it
-        // for remote browsers the same way the pre-flight gate is marked.
+        // Mid-scan blockers surface as a top-level `reason` too; mark login
+        // loss for remote browsers the same way the pre-flight gate is marked.
         annotate_remote_login_gate(&self.page, &mut payload);
         if let Some((count, path, error)) = media_manifest_metadata {
             payload["media_manifest_count"] = json!(count);
@@ -3681,6 +3700,55 @@ impl Tool for WaitForLoginTool {
             }
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
+    }
+}
+
+/// wait_for_rate_limit — visible cooldown after OCR recognizes XHS's frequent
+/// access page. The duration is intentionally chosen inside the tool so agent
+/// retries cannot accidentally settle into a fixed interval.
+pub struct WaitForRateLimitTool;
+
+const RATE_LIMIT_WAIT_MIN_SECS: u64 = 300;
+const RATE_LIMIT_WAIT_MAX_SECS: u64 = 360;
+
+fn random_rate_limit_wait_seconds() -> u64 {
+    let uuid = uuid::Uuid::new_v4();
+    let mut seed = [0_u8; 8];
+    seed.copy_from_slice(&uuid.as_bytes()[..8]);
+    let span = RATE_LIMIT_WAIT_MAX_SECS - RATE_LIMIT_WAIT_MIN_SECS + 1;
+    RATE_LIMIT_WAIT_MIN_SECS + u64::from_le_bytes(seed) % span
+}
+
+#[async_trait]
+impl Tool for WaitForRateLimitTool {
+    fn name(&self) -> &str {
+        "wait_for_rate_limit"
+    }
+
+    fn description(&self) -> &str {
+        "Recover from Xiaohongshu rate limiting: after a tool returns \
+         `reason:rate_limited`, call this instead of immediately retrying. It \
+         visibly waits for a random 5-6 minute cooldown, then tells you to \
+         retry the original tool once. If that retry is still rate-limited, \
+         call this tool again."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false,
+        })
+    }
+
+    async fn call(&self, _input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+        let waited_seconds = random_rate_limit_wait_seconds();
+        tokio::time::sleep(std::time::Duration::from_secs(waited_seconds)).await;
+        Ok(json_result(&json!({
+            "rate_limit_wait_complete": true,
+            "waited_seconds": waited_seconds,
+            "message": "Cooldown finished. Re-run the original tool once. If it still returns reason:rate_limited, call wait_for_rate_limit again before another retry.",
+        })))
     }
 }
 
@@ -4310,6 +4378,7 @@ impl Tool for SearchTool {
         // Wall-clock markers so the perf file can show how much OCR overlapped
         // the browse loop (the pipeline benefit) vs. spilled past it.
         let browse_t0 = std::time::Instant::now();
+        let mut stop_reason = String::new();
 
         while notes.len() < want {
             let cards = xhs.extract_search_cards().await?;
@@ -4362,6 +4431,7 @@ impl Tool for SearchTool {
                 ocr,
             )
             .await;
+            let blocker = recovery_blocker(&entry);
             notes.push(entry);
             let idx = notes.len() - 1;
             if ocr {
@@ -4398,6 +4468,10 @@ impl Tool for SearchTool {
                 close_ms,
                 total_ms,
             ));
+            if let Some(blocker) = blocker {
+                stop_reason = blocker.to_string();
+                break;
+            }
         }
 
         scan_progress.finish_reading(notes.len());
@@ -4468,7 +4542,8 @@ impl Tool for SearchTool {
         };
 
         let mut payload = json!({
-            "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false),
+            "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false)
+                && stop_reason.is_empty(),
             "query": query,
             "search": search,
             "notes": notes,
@@ -4485,6 +4560,9 @@ impl Tool for SearchTool {
                 "media": media_timing,
             }
         });
+        if !stop_reason.is_empty() {
+            payload["reason"] = json!(stop_reason);
+        }
         promote_page_diagnostic(&mut payload);
         // Even the artifact keeps only the compact filter summary (changed +
         // active values); the raw panel readback with click coordinates is
@@ -4747,6 +4825,7 @@ impl Tool for AuthorScanTool {
         // By default open each collected note and read body + top comments;
         // `preview` returns the cards only and skips this.
         let mut notes: Vec<Value> = Vec::new();
+        let mut stop_reason = String::new();
         if !preview {
             // OCR and cloud ASR run in the background so they overlap the next
             // note's read + download; tasks are joined after the loop.
@@ -4785,6 +4864,7 @@ impl Tool for AuthorScanTool {
                     ocr,
                 )
                 .await;
+                let blocker = recovery_blocker(&entry);
                 notes.push(entry);
                 let idx = notes.len() - 1;
                 if ocr {
@@ -4822,6 +4902,10 @@ impl Tool for AuthorScanTool {
                     close_ms,
                     total_ms,
                 ));
+                if let Some(blocker) = blocker {
+                    stop_reason = blocker.to_string();
+                    break;
+                }
             }
             scan_progress.finish_reading(notes.len());
             let browse_ms = browse_t0.elapsed().as_millis() as u64;
@@ -4906,7 +4990,7 @@ impl Tool for AuthorScanTool {
         };
 
         let mut payload = json!({
-            "ok": true,
+            "ok": stop_reason.is_empty(),
             "author_id": author_id,
             "profile": profile_value,
             "notes": notes,
@@ -4921,6 +5005,9 @@ impl Tool for AuthorScanTool {
             },
             "timing": { "media": media_timing },
         });
+        if !stop_reason.is_empty() {
+            payload["reason"] = json!(stop_reason);
+        }
         promote_page_diagnostic(&mut payload);
 
         // Scan perf is written to `stats/scan.json` (see above), not the artifact.

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -119,6 +119,18 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     if let Some(truncated) = find_bool(data, "page_ocr_truncated") {
         props.insert("page_ocr_truncated".into(), json!(truncated));
     }
+    if let Some(detected) = find_bool(data, "rate_limit_detected") {
+        props.insert("rate_limit_detected".into(), json!(detected));
+    }
+    if let Some(marker) = find_string(data, "rate_limit_marker") {
+        props.insert("rate_limit_marker".into(), json!(marker));
+    }
+    if let Some(tool) = find_string(data, "recovery_tool") {
+        props.insert("recovery_tool".into(), json!(tool));
+    }
+    if let Some(waited_seconds) = find_u64(data, "waited_seconds") {
+        props.insert("waited_seconds".into(), json!(waited_seconds));
+    }
     if let Some(error) = find_string(data, "page_ocr_error") {
         props.insert(
             "page_ocr_error".into(),
@@ -176,6 +188,17 @@ fn find_bool(value: &Value, key: &str) -> Option<bool> {
             .and_then(Value::as_bool)
             .or_else(|| map.values().find_map(|value| find_bool(value, key))),
         Value::Array(items) => items.iter().find_map(|value| find_bool(value, key)),
+        _ => None,
+    }
+}
+
+fn find_u64(value: &Value, key: &str) -> Option<u64> {
+    match value {
+        Value::Object(map) => map
+            .get(key)
+            .and_then(Value::as_u64)
+            .or_else(|| map.values().find_map(|value| find_u64(value, key))),
+        Value::Array(items) => items.iter().find_map(|value| find_u64(value, key)),
         _ => None,
     }
 }
@@ -276,6 +299,9 @@ mod tests {
                 "page_ocr_text": page_ocr,
                 "page_ocr_region": "center_70_percent",
                 "page_ocr_truncated": true,
+                "rate_limit_detected": true,
+                "rate_limit_marker": "300013",
+                "recovery_tool": "wait_for_rate_limit",
                 "cards": [{}, {}],
                 "search": { "cards": [{}, {}, {}] },
                 "selected_cards": [{}],
@@ -293,7 +319,10 @@ mod tests {
         assert_eq!(props.get("notes_count"), Some(&json!(3)));
         assert_eq!(props.get("notes_skipped_count"), Some(&json!(2)));
         assert_eq!(props.get("has_run_dir"), Some(&json!(true)));
-        assert_eq!(props.get("failure_reason"), Some(&json!("not_profile_page")));
+        assert_eq!(
+            props.get("failure_reason"),
+            Some(&json!("not_profile_page"))
+        );
         assert_eq!(props.get("page_error"), Some(&json!("not_profile_page")));
         assert_eq!(
             props.get("page_url"),
@@ -311,6 +340,12 @@ mod tests {
             Some(&json!("center_70_percent"))
         );
         assert_eq!(props.get("page_ocr_truncated"), Some(&json!(true)));
+        assert_eq!(props.get("rate_limit_detected"), Some(&json!(true)));
+        assert_eq!(props.get("rate_limit_marker"), Some(&json!("300013")));
+        assert_eq!(
+            props.get("recovery_tool"),
+            Some(&json!("wait_for_rate_limit"))
+        );
         assert!(!props.contains_key("body"));
         assert!(!props.contains_key("comments"));
     }

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -6,13 +6,15 @@
 
 use serde_json::{json, Map, Value};
 
+const PAGE_OCR_MAX_CHARS: usize = 200;
+
 /// Summarize a tool call's input arguments. The search `query` is the one gated
 /// arg: its character length is always reported, but the raw text only when
 /// `include_query_text` is on. Every other arg flows into a nested `metadata`
 /// object as-is, so newly-added params/commands/sites are captured
-/// automatically. Only the arguments are summarized here — tool OUTPUT (note
-/// bodies, comments) is never included; see [`summarize_tool_result`] for the
-/// safe, count-only output summary.
+/// automatically. Only the arguments are summarized here — ordinary tool
+/// output (note bodies, comments) is never included; see
+/// [`summarize_tool_result`] for bounded failure-page OCR diagnostics.
 pub fn summarize_tool_args(args: &Value, include_query_text: bool) -> Map<String, Value> {
     let mut props = Map::new();
     let Some(obj) = args.as_object() else {
@@ -68,10 +70,10 @@ fn meaningful_metadata_value(value: &Value) -> Option<Value> {
     }
 }
 
-/// Extract safe, count-only metrics from a tool call's output. Reports the size
-/// of well-known result collections plus a couple of presence flags — never the
-/// note bodies, comments, or any free text. The value may be the raw tool result
-/// or wrapped in a `data` envelope (CLI daemon); both shapes are handled.
+/// Extract safe metrics from a tool call's output. Reports collection sizes and
+/// presence flags, plus the explicitly bounded unexpected-page OCR diagnostic;
+/// note bodies and comments are never copied. The value may be the raw tool
+/// result or wrapped in a `data` envelope (CLI daemon); both shapes are handled.
 pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     let mut props = Map::new();
     let data = value.get("data").unwrap_or(value);
@@ -102,7 +104,80 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     if value.get("run_dir").is_some() {
         props.insert("has_run_dir".into(), json!(true));
     }
+    if let Some(text) = find_string(data, "page_ocr_text") {
+        props.insert(
+            "page_ocr_text".into(),
+            json!(super::trace::redact_secrets(text)
+                .chars()
+                .take(PAGE_OCR_MAX_CHARS)
+                .collect::<String>()),
+        );
+    }
+    if let Some(region) = find_string(data, "page_ocr_region") {
+        props.insert("page_ocr_region".into(), json!(region));
+    }
+    if let Some(truncated) = find_bool(data, "page_ocr_truncated") {
+        props.insert("page_ocr_truncated".into(), json!(truncated));
+    }
+    if let Some(error) = find_string(data, "page_ocr_error") {
+        props.insert(
+            "page_ocr_error".into(),
+            json!(super::trace::redact_secrets(error)
+                .chars()
+                .take(PAGE_OCR_MAX_CHARS)
+                .collect::<String>()),
+        );
+    }
+    if let Some(error) = find_string(data, "page_error") {
+        props.insert(
+            "page_error".into(),
+            json!(super::trace::redact_secrets(error)
+                .chars()
+                .take(240)
+                .collect::<String>()),
+        );
+    }
+    if let Some(url) = find_string(data, "page_url") {
+        let path_only = url.split(['?', '#']).next().unwrap_or(url);
+        props.insert(
+            "page_url".into(),
+            json!(super::trace::redact_secrets(path_only)
+                .chars()
+                .take(500)
+                .collect::<String>()),
+        );
+    }
+    if data.get("ok").and_then(Value::as_bool) == Some(false) {
+        if let Some(reason) = data.get("reason").and_then(Value::as_str) {
+            props.insert(
+                "failure_reason".into(),
+                json!(reason.chars().take(120).collect::<String>()),
+            );
+        }
+    }
     props
+}
+
+fn find_string<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    match value {
+        Value::Object(map) => map
+            .get(key)
+            .and_then(Value::as_str)
+            .or_else(|| map.values().find_map(|value| find_string(value, key))),
+        Value::Array(items) => items.iter().find_map(|value| find_string(value, key)),
+        _ => None,
+    }
+}
+
+fn find_bool(value: &Value, key: &str) -> Option<bool> {
+    match value {
+        Value::Object(map) => map
+            .get(key)
+            .and_then(Value::as_bool)
+            .or_else(|| map.values().find_map(|value| find_bool(value, key))),
+        Value::Array(items) => items.iter().find_map(|value| find_bool(value, key)),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -190,10 +265,17 @@ mod tests {
 
     #[test]
     fn result_summary_extracts_safe_counts_without_copying_text() {
+        let page_ocr = "限".repeat(PAGE_OCR_MAX_CHARS + 1);
         let props = summarize_tool_result(&json!({
             "run_dir": "/tmp/socai-run",
             "data": {
-                "ok": true,
+                "ok": false,
+                "reason": "not_profile_page",
+                "page_error": "not_profile_page",
+                "page_url": "https://www.xiaohongshu.com/explore/abc?xsec_token=secret",
+                "page_ocr_text": page_ocr,
+                "page_ocr_region": "center_70_percent",
+                "page_ocr_truncated": true,
                 "cards": [{}, {}],
                 "search": { "cards": [{}, {}, {}] },
                 "selected_cards": [{}],
@@ -204,13 +286,31 @@ mod tests {
                 ]
             }
         }));
-        assert_eq!(props.get("result_ok"), Some(&json!(true)));
+        assert_eq!(props.get("result_ok"), Some(&json!(false)));
         assert_eq!(props.get("cards_count"), Some(&json!(2)));
         assert_eq!(props.get("search_cards_count"), Some(&json!(3)));
         assert_eq!(props.get("selected_cards_count"), Some(&json!(1)));
         assert_eq!(props.get("notes_count"), Some(&json!(3)));
         assert_eq!(props.get("notes_skipped_count"), Some(&json!(2)));
         assert_eq!(props.get("has_run_dir"), Some(&json!(true)));
+        assert_eq!(props.get("failure_reason"), Some(&json!("not_profile_page")));
+        assert_eq!(props.get("page_error"), Some(&json!("not_profile_page")));
+        assert_eq!(
+            props.get("page_url"),
+            Some(&json!("https://www.xiaohongshu.com/explore/abc"))
+        );
+        assert_eq!(
+            props
+                .get("page_ocr_text")
+                .and_then(Value::as_str)
+                .map(|text| text.chars().count()),
+            Some(PAGE_OCR_MAX_CHARS)
+        );
+        assert_eq!(
+            props.get("page_ocr_region"),
+            Some(&json!("center_70_percent"))
+        );
+        assert_eq!(props.get("page_ocr_truncated"), Some(&json!(true)));
         assert!(!props.contains_key("body"));
         assert!(!props.contains_key("comments"));
     }

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -16,7 +16,8 @@
 //! (`gen_ai.*`) — Axiom promotes those to first-class trace columns — with
 //! socai-specific context under `socai.*`. Tool args go through
 //! `summarize_tool_args` (query text gated by `SOCAI_TELEMETRY_QUERY_TEXT`)
-//! and tool output through the count-only `summarize_tool_result`.
+//! and tool output through `summarize_tool_result` (counts plus bounded
+//! unexpected-page OCR diagnostics).
 //!
 //! Chat content rides on the `chat` spans (gated by
 //! `SOCAI_TELEMETRY_CHAT_TEXT`): `gen_ai.input.messages` carries only the

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -151,6 +151,13 @@ Current metadata keys:
 | `notes_count` | number | Count of note result entries when present. |
 | `notes_skipped_count` | number | Count of notes marked skipped when present. |
 | `has_run_dir` | boolean | Whether the command returned a run directory. |
+| `failure_reason` | string | Semantic failure reason when a tool returns `ok=false`. |
+| `page_error` | string | Error or reason associated with the unexpected page/control diagnostic, for example `not_profile_page` or `search_input_not_found`. |
+| `page_url` | string | Unexpected page URL without query or fragment, so access failures can be identified without reporting XHS tokens. |
+| `page_ocr_text` | string | Secret-redacted OCR from the center 70% when XHS has an unexpected page state or a required page control is missing, capped at 200 Unicode characters. |
+| `page_ocr_region` | string | OCR crop identifier; currently `center_70_percent`. |
+| `page_ocr_truncated` | boolean | Whether the recognized page text exceeded 200 characters. |
+| `page_ocr_error` | string | Best-effort screenshot/OCR failure detail when no page text could be produced. |
 | `proxy_version` | number | Added by the proxy. Current value: `1`. |
 
 ## Desktop events
@@ -167,7 +174,7 @@ and model in use are captured on `socai_agent_task_start`.
 | `socai_browser_connect` | User connects Chrome | — |
 | `socai_agent_task_start` | A task begins running | `task_id`, `provider`, `model`, `task_len`, `task_text` |
 | `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `steps`, token/cache usage, estimated cost breakdown, `duration_ms`, `error` |
-| `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, `query_text`, `query_len`, `metadata`, `note_id_present` |
+| `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, query/result summaries, and bounded unexpected-page diagnostics when present |
 | `socai_feishu_export` | A Feishu export completes/fails, including user-visible setup failures before the native export command starts | `task_id`, `run_id`, `destination`, optional `stage`, `outcome`, `duration_ms`, `error` |
 
 Desktop field semantics:
@@ -208,8 +215,11 @@ the exported content, document URL/ID, chat ID, or Feishu account/profile.
 `query` argument is lifted to `query_text` + `query_len`, a `note_id` argument
 collapses to a `note_id_present` boolean (the raw id is not sent), and any other
 scalar arguments go under `metadata` — with the `tab_label` arg renamed to `tab`
-and empty strings dropped, matching the CLI. The tool's **output** (note bodies,
-comments, scraped content) is never included — only the arguments.
+and empty strings dropped, matching the CLI. Note bodies, comments, and normal
+scraped content are never included. The sole output-text exception is a
+secret-redacted, 200-character OCR excerpt from the center 70% of the viewport
+when XHS lands on an unexpected page or a required page control cannot be
+found; this is accompanied by the page URL with its query and fragment removed.
 
 Unlike the CLI's `query_text`, **the desktop has no opt-out for `task_text`**: it
 is sent whenever desktop telemetry is enabled. `SOCAI_TELEMETRY=off` is the only

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -158,6 +158,10 @@ Current metadata keys:
 | `page_ocr_region` | string | OCR crop identifier; currently `center_70_percent`. |
 | `page_ocr_truncated` | boolean | Whether the recognized page text exceeded 200 characters. |
 | `page_ocr_error` | string | Best-effort screenshot/OCR failure detail when no page text could be produced. |
+| `rate_limit_detected` | boolean | Whether page OCR recognized an XHS frequent-access blocker. |
+| `rate_limit_marker` | string | Matched OCR marker (`访问频繁` or `300013`). |
+| `recovery_tool` | string | Agent tool recommended for the recognized blocker; currently `wait_for_rate_limit`. |
+| `waited_seconds` | integer | Actual randomized cooldown duration returned by a wait tool. |
 | `proxy_version` | number | Added by the proxy. Current value: `1`. |
 
 ## Desktop events


### PR DESCRIPTION
## What changed

- OCR the center 70% of unexpected Xiaohongshu pages and return up to 200 characters with the original error
- include page diagnostics in telemetry, including `search_input_not_found` and related failure paths
- recognize `访问频繁` and `300013` from the full OCR result as `rate_limited`
- stop additional note reads when rate limiting is detected
- add the agent-visible `wait_for_rate_limit` tool with a randomized 300-360 second cooldown and retry protocol
- isolate page failure/OCR handling in `page_diagnostics.rs`

## Why

DOM selectors are unreliable on anti-bot and unexpected XHS pages. A bounded visual diagnostic gives the agent and telemetry enough context to identify the real page state, while the explicit cooldown tool avoids rapid repeated requests and makes the wait visible to users.

## Validation

- `cargo check --workspace`
- `cargo test -p socai-core telemetry::tool_call::tests` (7 passed)
- `cargo clippy -p socai-core` (passes with 12 pre-existing warnings)
- `git diff --check`
