### PR TITLE
Report Pro activation status in run traces

### DIFF
--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -316,6 +316,10 @@ fn enrich_trace_resource(payload: &mut Value, config: &WorkerConfig) {
     ] {
         attributes.push(json!({ "key": key, "value": { "stringValue": value } }));
     }
+    attributes.push(json!({
+        "key": "socai.pro_activated",
+        "value": { "boolValue": crate::cloud::pro_activated() },
+    }));
 }
 
 /// `SOCAI_TRACES_ENDPOINT` overrides the production proxy for local testing

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -315,6 +315,9 @@ pipeline for reading what an agent actually did:
   one provider call.
 - root span — `socai.task_text` (capped at 8,000 chars) plus run status and step
   count.
+- trace resource — `socai.pro_activated`, a boolean snapshot taken at upload
+  time that records whether Socai Pro is activated. No account identifier or
+  device token is included.
 
 Never uploaded, regardless of settings: image bytes/screenshots, Anthropic
 thinking signatures, encrypted reasoning items, and browser cookies/session


### PR DESCRIPTION
## Summary
- add a boolean Pro activation snapshot to uploaded trace resources
- evaluate activation at upload time so the value reflects the current local state
- document that no account identifier or device token is included

## Validation
- rustfmt --edition 2021 --check core/src/telemetry/mod.rs
- cargo check -p socai-core
- git diff --check