### PR TITLE
xhs: normalize edited-note dates + extract author verification (认证)

### DIFF
--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -60,6 +60,11 @@ pub struct XhsAuthorProfile {
     pub profile_url: String,
     pub bio: String,
     pub ip_location: String,
+    /// Official-verification (认证) badge on the profile header: `verified`
+    /// flags it, `verification` carries the label ("企业认证" / "个人认证").
+    /// Both stay off the wire for regular accounts.
+    pub verified: bool,
+    pub verification: String,
     pub followers: String,
     pub following: String,
     pub likes_and_collections: String,
@@ -76,6 +81,14 @@ impl XhsAuthorProfile {
         map.insert("url".into(), json!(normalize_url(&self.profile_url)));
         map.insert("bio".into(), json!(self.bio));
         map.insert("ip_location".into(), json!(self.ip_location));
+        // Official verification is the exception to always-emit: absent for
+        // regular accounts so existing author payloads keep their shape.
+        if self.verified {
+            map.insert("verified".into(), json!(true));
+        }
+        if !self.verification.is_empty() {
+            map.insert("verification".into(), json!(self.verification));
+        }
         // Counts are kept as the raw displayed strings ("1.2万"); the parsed
         // `*_value` integers were redundant, so they're no longer emitted.
         map.insert("followers".into(), json!(self.followers));

--- a/core/src/sites/xhs/entities.rs
+++ b/core/src/sites/xhs/entities.rs
@@ -21,6 +21,11 @@ pub struct XhsNote {
     pub content_source: String,
     pub hashtags: Vec<String>,
     pub date: String,
+    /// True when the note's date bar showed "编辑于 …" — [`Self::date`] is
+    /// then the last-edited date, not the original publish date. Omitted from
+    /// the wire shape when false so older artifacts stay byte-identical.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub date_edited: bool,
     /// Note POI / geo-tag label (the place the author tagged on the note).
     /// Distinct from [`Self::ip_location`], the author's IP territory.
     pub location: String,
@@ -216,6 +221,7 @@ impl Default for XhsNote {
             content_source: String::new(),
             hashtags: Vec::new(),
             date: String::new(),
+            date_edited: false,
             location: String::new(),
             ip_location: String::new(),
             likes: String::new(),

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -1855,6 +1855,10 @@ fn parse_note(body: &Value) -> XhsNote {
         content_source: s("content_source"),
         hashtags,
         date: s("date"),
+        date_edited: body
+            .get("date_edited")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         location: s("location"),
         ip_location: s("ip_location"),
         likes: s("likes"),

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -1167,6 +1167,11 @@ impl<'a> XhsPageRuntime<'a> {
             },
             bio: string_field(&info, "bio"),
             ip_location: string_field(&info, "ip_location"),
+            verified: info
+                .get("verified")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            verification: string_field(&info, "verification"),
             followers: string_field(&info, "followers"),
             following: string_field(&info, "following"),
             likes_and_collections: string_field(&info, "likes_and_collections"),

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -626,11 +626,23 @@ const SocaiXhsPageScripts = (() => {
   // posts ("刚刚", "5分钟前", "11小时前", "今天 13:31", "昨天 13:31", "前天",
   // "5天前"). The previous extractor only matched the absolute forms, so any
   // relative date came back empty. Resolve relative dates against now so the
-  // field is comparable downstream; fall back to the trimmed raw text rather
-  // than emptying the field on anything unrecognized.
+  // field is comparable downstream; fall back to the cleaned text (edit
+  // prefix / territory tail stripped) rather than emptying the field on
+  // anything unrecognized.
   function normalizeXhsDate(value) {
-    const t = norm(value);
+    let t = norm(value);
     if (!t) return '';
+    // Edited notes show "编辑于 3天前 北京" — the prefix defeats the
+    // start-anchored relative patterns below, so strip it (callers that care
+    // read the edit marker separately via isEditedDate). Then drop a trailing
+    // territory token, mirroring extractIpLocation's tail heuristic — that
+    // function keeps reading the original text, not this cleaned core.
+    t = t.replace(/^编辑于\s*/, '');
+    const tokens = t.split(/\s+/);
+    const tail = tokens.length > 1 ? tokens[tokens.length - 1] : '';
+    if (/^\D{1,10}$/.test(tail) && !/[前刚今昨于:]/.test(tail)) {
+      t = tokens.slice(0, -1).join(' ');
+    }
     // Absolute token wins (scoped to the short `.date` text, so this can't grab
     // a "13-15" fragment from the note body). Pass it through unchanged.
     const abs = t.match(/\d{4}-\d{1,2}-\d{1,2}|\d{1,2}-\d{1,2}/);
@@ -655,6 +667,13 @@ const SocaiXhsPageScripts = (() => {
     const dm = t.match(/^(\d+)\s*天前/);
     if (dm) return fmt(daysAgo(parseInt(dm[1], 10)));
     return t;
+  }
+
+  // "编辑于 …" in the `.date` bar means the note shows its last-edited date,
+  // not the original publish date. Surfaced as `date_edited` so downstream
+  // consumers don't have to infer it from a string prefix.
+  function isEditedDate(value) {
+    return /^编辑于/.test(norm(value));
   }
 
   // The author's IP territory ("广东") as shown on the note detail. The note's
@@ -987,6 +1006,7 @@ const SocaiXhsPageScripts = (() => {
       content,
       content_source: contentSource,
       date,
+      date_edited: isEditedDate(dateText),
       location: locationText,
       ip_location: ipLocation,
       likes: likes === '赞' ? '' : likes,
@@ -1164,7 +1184,9 @@ const SocaiXhsPageScripts = (() => {
       text: content,
       likes,
       like_count: parseCount(likes),
-      time,
+      // Comment times reuse the note-date normalizer: "10小时前北京" (glued
+      // territory, no space) becomes a resolvable date token.
+      time: normalizeXhsDate(time),
       is_author_reply: /作者|博主|楼主/.test(badge),
       is_pinned: /置顶/.test(top),
       reply_count: subs.length,

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -1031,6 +1031,38 @@ const SocaiXhsPageScripts = (() => {
     };
   }
 
+  // Official-verification (认证) status of the profile being viewed. The page
+  // state carries only a numeric type (`user.userPageData.verifyInfo
+  // .redOfficialVerifyType`: 1 = personal red-V, 2 = enterprise); the desktop
+  // DOM renders just the matching badge icon (sprite symbol `red` / `company`)
+  // next to the display name, no text label. Prefer state, fall back to the
+  // icon, and derive the human-readable label from the type.
+  function profileVerification() {
+    let type = 0;
+    let label = '';
+    try {
+      const user = unwrapStateValue((window.__INITIAL_STATE__ || {}).user) || {};
+      const pageData = unwrapStateValue(user.userPageData) || {};
+      const info = unwrapStateValue(pageData.verifyInfo) || {};
+      type = Number(unwrapStateValue(info.redOfficialVerifyType)) || 0;
+      label = ['redOfficialVerifyContent', 'verifyContent']
+        .map((key) => norm(String(unwrapStateValue(info[key]) || '')))
+        .find(Boolean) || '';
+    } catch (e) {}
+    if (!type && !label) {
+      // Scoped to the header's name row so verify badges elsewhere on the
+      // page (e.g. recommended-user chips) can't false-positive.
+      const use = $('.user-name .verify-icon use');
+      const ref = use ? String(use.getAttribute('xlink:href') || use.getAttribute('href') || '') : '';
+      if (use) type = /company/i.test(ref) ? 2 : 1;
+    }
+    const verified = type > 0 || !!label;
+    if (verified && !label) {
+      label = type === 2 ? '企业认证' : type === 1 ? '个人认证' : '官方认证';
+    }
+    return { verified, verification: label };
+  }
+
   function profileInfo() {
     const displayName = firstVisibleText(
       ['.user-name', '.profile-name', '.nickname', '.name', 'h1'],
@@ -1044,6 +1076,7 @@ const SocaiXhsPageScripts = (() => {
       const re = new RegExp(`([0-9.,万wWkK+]+)\\s*(?:${label})`);
       return (body.match(re) || [])[1] || '';
     };
+    const verification = profileVerification();
     return {
       ok: true,
       display_name: displayName,
@@ -1051,6 +1084,8 @@ const SocaiXhsPageScripts = (() => {
       profile_url: location.href,
       bio,
       ip_location: ipLocation,
+      verified: verification.verified,
+      verification: verification.verification,
       followers: statText('粉丝'),
       following: statText('关注'),
       likes_and_collections: statText('获赞与收藏|获赞|赞与收藏'),

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -4504,6 +4504,7 @@ impl Tool for AuthorScanTool {
     fn description(&self) -> &str {
         "Xiaohongshu author/creator scan: open an author's profile page by id → \
          read the author header (display name, xhs id, bio, IP location, \
+         official-verification/认证 status when present, \
          follower/following/liked-&-collected counts) → collect their note \
          summary cards in page order (pass `num_notes` to scroll the grid for \
          more, omit for just the first screen) → open each collected note and \
@@ -4660,6 +4661,11 @@ impl Tool for AuthorScanTool {
             profile_url,
             bio: get_str(&info, "bio").unwrap_or("").to_string(),
             ip_location: get_str(&info, "ip_location").unwrap_or("").to_string(),
+            verified: info
+                .get("verified")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            verification: get_str(&info, "verification").unwrap_or("").to_string(),
             followers: get_str(&info, "followers").unwrap_or("").to_string(),
             following: get_str(&info, "following").unwrap_or("").to_string(),
             likes_and_collections: get_str(&info, "likes_and_collections")

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -2316,6 +2316,9 @@ const LEAN_NOTE_FIELDS: &[&str] = &[
     "author_id",
     "content",
     "date",
+    // Only present (true) when `date` is the note's last-edited date rather
+    // than its publish date, so unedited notes pay nothing for it.
+    "date_edited",
     "likes",
     "favorites",
     "comments_count",


### PR DESCRIPTION
Two data-enrichment changes to the XHS extraction layer so the agent gets machine-readable **time** and **authority** signals instead of inferring both from raw strings. Motivated by the 换线 ("when did the gym last change routes") runs, where an official account's stale notice outranked its fresh one and edited-note dates leaked through raw; a follow-up prompt-policy change will ground on these fields.

## Date normalization (`fix:` commit)

`编辑于 3天前 北京` fell through `normalizeXhsDate` raw: the `编辑于` prefix defeats the start-anchored relative-date patterns. Downstream, `parse_posted_at_ms` returned `None` and the app's note cards lost their date entirely.

- Strip the leading `编辑于` and the trailing IP-territory token before matching (same tail heuristic as `extractIpLocation`, which still reads the original text).
- Surface the edit marker as a new `date_edited: true` field on `XhsNote` — `#[serde(default, skip_serializing_if)]`, so it's absent when false and **older artifacts stay byte-identical**.
- Add `date_edited` to `LEAN_NOTE_FIELDS` so the flag actually reaches the LLM-facing payload (only ever present when true).
- Comment `time` fields run through the same normalizer (`10小时前北京` → `07-31`).

Note: entities replayed from the history cache (`~/.socai/xhs/history.json`) were scraped before this fix and keep raw dates — relative dates can't be re-resolved once the scrape-time anchor is gone. Accepted; no migration.

## Author verification (`feat:` commit)

Profile headers now expose the official-verification (认证) badge. Source of truth is page state — `user.userPageData.verifyInfo.redOfficialVerifyType` (1 = personal red-V, 2 = enterprise), confirmed against live pages — with the header badge icon (sprite `red`/`company`) as DOM fallback. Desktop web renders no text label, so the label derives from the type.

- New `verified: bool` + `verification: string` on `XhsAuthorProfile`, emitted skip-when-empty so regular-account payloads keep their existing shape; wired through both parse sites (`extract_profile`, `author_scan`).
- `author_scan` tool description mentions the new header fields.

## Verified live

- Fresh scrape of the previously-broken specimen (`7月换线通知`): `{"date": "07-26", "date_edited": true, "ip_location": "北京"}`; its app NoteStore record now carries `posted_at`. Comment times normalize (`10小时前北京` → `07-29`).
- Positive control (Climb On Gym攀岩, official): `"verified": true, "verification": "企业认证"`. Negative control (墙上飞, personal): both keys absent.
- `cargo test -p socai-core`: 91 passed, 0 failed (no test edits needed); each commit compiles standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)