### PR TITLE
fix: preserve trace output and Feishu failure diagnostics

### DIFF
--- a/app/src-tauri/src/connectors/feishu.rs
+++ b/app/src-tauri/src/connectors/feishu.rs
@@ -119,8 +119,47 @@ pub struct FeishuMessage {
 
 struct CliOutput {
     success: bool,
+    exit_code: Option<i32>,
     stdout: String,
     stderr: String,
+}
+
+#[derive(Default)]
+struct CliErrorDetails {
+    message: String,
+    error_type: Option<String>,
+    error_subtype: Option<String>,
+    error_code: Option<String>,
+    log_id: Option<String>,
+    update_available: bool,
+}
+
+struct FeishuOperationError {
+    stage: &'static str,
+    message: String,
+    cli: Option<CliErrorDetails>,
+    cli_exit_code: Option<i32>,
+}
+
+impl FeishuOperationError {
+    fn new(stage: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            stage,
+            message: message.into(),
+            cli: None,
+            cli_exit_code: None,
+        }
+    }
+
+    fn from_cli(stage: &'static str, output: &CliOutput) -> Self {
+        let cli = cli_error_details(output);
+        Self {
+            stage,
+            message: cli.message.clone(),
+            cli: Some(cli),
+            cli_exit_code: output.exit_code,
+        }
+    }
 }
 
 #[tauri::command]
@@ -481,15 +520,14 @@ pub async fn feishu_send_task_to_chat(
     let telemetry_task_id = task_id.clone();
     let run_id = tasks.get(&task_id).await.and_then(|task| task.run_id);
     let result = send_task_to_chat(&app, &state, &tasks, task_id, profile, content, chat_id).await;
-    capture_export_result(
+    capture_chat_result(
         app.state::<DesktopTelemetry>().inner(),
         &telemetry_task_id,
         run_id.as_deref(),
-        "chat",
         started_at,
         &result,
     );
-    result
+    result.map_err(|error| error.message)
 }
 
 async fn send_task_to_chat(
@@ -500,18 +538,27 @@ async fn send_task_to_chat(
     profile: String,
     content: String,
     chat_id: String,
-) -> Result<FeishuMessage, String> {
-    require_connected(app, &profile).await?;
-    ensure_send_scopes(app, state, &profile).await?;
-    if !chat_id.starts_with("oc_") {
-        return Err("无效的飞书群聊 ID".into());
-    }
-    let task = tasks
-        .get(&task_id)
+) -> Result<FeishuMessage, FeishuOperationError> {
+    require_connected(app, &profile)
         .await
-        .ok_or_else(|| format!("unknown task: {task_id}"))?;
+        .map_err(|error| FeishuOperationError::new("check_connection", error))?;
+    ensure_send_scopes(app, state, &profile)
+        .await
+        .map_err(|error| FeishuOperationError::new("check_send_scopes", error))?;
+    if !chat_id.starts_with("oc_") {
+        return Err(FeishuOperationError::new(
+            "validate_send_request",
+            "无效的飞书群聊 ID",
+        ));
+    }
+    let task = tasks.get(&task_id).await.ok_or_else(|| {
+        FeishuOperationError::new("validate_send_request", format!("unknown task: {task_id}"))
+    })?;
     if content.trim().is_empty() {
-        return Err("这个答案没有可发送的内容".into());
+        return Err(FeishuOperationError::new(
+            "validate_send_request",
+            "这个答案没有可发送的内容",
+        ));
     }
     let content = hydrate_note_links(&task, &content);
     let markdown = format!("**{}**\n\n{}", compact_title(&task.task), content.trim());
@@ -533,8 +580,13 @@ async fn send_task_to_chat(
         ],
         None,
     )
-    .await?;
-    let value = require_cli_success(output)?;
+    .await
+    .map_err(|error| FeishuOperationError::new("execute_send", error))?;
+    if !output.success {
+        return Err(FeishuOperationError::from_cli("execute_send", &output));
+    }
+    let value = parse_json(&output.stdout)
+        .ok_or_else(|| FeishuOperationError::new("parse_send_response", "无法解析飞书 CLI 响应"))?;
     let data = cli_data(&value);
     let message_id = data
         .get("message_id")
@@ -547,12 +599,53 @@ async fn send_task_to_chat(
         .unwrap_or(&chat_id)
         .to_string();
     if message_id.is_empty() {
-        return Err("飞书已返回成功，但响应里没有消息 ID".into());
+        return Err(FeishuOperationError::new(
+            "verify_send_response",
+            "飞书已返回成功，但响应里没有消息 ID",
+        ));
     }
     Ok(FeishuMessage {
         message_id,
         chat_id: returned_chat,
     })
+}
+
+fn capture_chat_result(
+    telemetry: &DesktopTelemetry,
+    task_id: &str,
+    run_id: Option<&str>,
+    started_at: Instant,
+    result: &Result<FeishuMessage, FeishuOperationError>,
+) {
+    let (outcome, stage, error, cli_exit_code, cli) = match result {
+        Ok(_) => ("completed", "send_chat", None, None, None),
+        Err(error) => (
+            "failed",
+            error.stage,
+            Some(short_error(&error.message)),
+            error.cli_exit_code,
+            error.cli.as_ref(),
+        ),
+    };
+    telemetry.capture(
+        "socai_feishu_export",
+        json!({
+            "task_id": task_id,
+            "run_id": run_id,
+            "destination": "chat",
+            "stage": stage,
+            "outcome": outcome,
+            "duration_ms": u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "error": error,
+            "cli_exit_code": cli_exit_code,
+            "cli_error_type": cli.and_then(|detail| detail.error_type.as_deref()),
+            "cli_error_subtype": cli.and_then(|detail| detail.error_subtype.as_deref()),
+            "cli_error_code": cli.and_then(|detail| detail.error_code.as_deref()),
+            "cli_log_id": cli.and_then(|detail| detail.log_id.as_deref()),
+            "cli_update_available": cli.map(|detail| detail.update_available),
+            "message_id_present": result.is_ok(),
+        }),
+    );
 }
 
 fn capture_export_result<T>(
@@ -1038,6 +1131,7 @@ async fn run_streaming_auth(
 
     let output = CliOutput {
         success: exit_code == Some(0),
+        exit_code,
         stdout,
         stderr,
     };
@@ -1213,6 +1307,7 @@ async fn run_cli_with_stdin(
     }
     Ok(CliOutput {
         success: exit_code == Some(0),
+        exit_code,
         stdout,
         stderr,
     })
@@ -1288,6 +1383,7 @@ async fn run_cli_bounded(
 
     Ok(CliOutput {
         success: exit_code == Some(0),
+        exit_code,
         stdout,
         stderr,
     })
@@ -1509,12 +1605,40 @@ fn cli_data(value: &Value) -> &Value {
 }
 
 fn cli_error_message(output: &CliOutput) -> String {
+    cli_error_details(output).message
+}
+
+fn cli_error_details(output: &CliOutput) -> CliErrorDetails {
     for text in [&output.stdout, &output.stderr] {
         if let Some(value) = parse_json(text) {
-            for key in ["message", "error", "hint"] {
-                if let Some(message) = find_string(&value, key) {
+            let update_available = value.pointer("/_notice/update").is_some();
+            if let Some(error) = value.get("error") {
+                let message = match error {
+                    Value::String(message) => Some(message.clone()),
+                    _ => ["message", "error", "hint"]
+                        .into_iter()
+                        .find_map(|key| find_string(error, key)),
+                };
+                if let Some(message) = message.filter(|message| !message.trim().is_empty()) {
+                    return CliErrorDetails {
+                        message: friendly_cli_error(&message),
+                        error_type: find_scalar(error, "type"),
+                        error_subtype: find_scalar(error, "subtype"),
+                        error_code: find_scalar(error, "code")
+                            .or_else(|| find_scalar(error, "api_code")),
+                        log_id: find_scalar(error, "log_id"),
+                        update_available,
+                    };
+                }
+            }
+            for key in ["message", "hint"] {
+                if let Some(message) = value.get(key).and_then(Value::as_str) {
                     if !message.trim().is_empty() {
-                        return friendly_cli_error(&message);
+                        return CliErrorDetails {
+                            message: friendly_cli_error(message),
+                            update_available,
+                            ..CliErrorDetails::default()
+                        };
                     }
                 }
             }
@@ -1540,9 +1664,32 @@ fn cli_error_message(output: &CliOutput) -> String {
             .rev()
             .collect::<Vec<_>>()
             .join("\n");
-        return friendly_cli_error(&message);
+        return CliErrorDetails {
+            message: friendly_cli_error(&message),
+            ..CliErrorDetails::default()
+        };
     }
-    "飞书 CLI 执行失败".into()
+    CliErrorDetails {
+        message: "飞书 CLI 执行失败".into(),
+        ..CliErrorDetails::default()
+    }
+}
+
+fn find_scalar(value: &Value, key: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if let Some(value) = map.get(key) {
+                match value {
+                    Value::String(text) if !text.trim().is_empty() => return Some(text.clone()),
+                    Value::Number(number) => return Some(number.to_string()),
+                    _ => {}
+                }
+            }
+            map.values().find_map(|value| find_scalar(value, key))
+        }
+        Value::Array(items) => items.iter().find_map(|value| find_scalar(value, key)),
+        _ => None,
+    }
 }
 
 fn friendly_cli_error(message: &str) -> String {

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -58,10 +58,6 @@ const CHAT_PART_MAX_CHARS: usize = 20_000;
 const CHAT_PART_TIGHT_MAX_CHARS: usize = 2_000;
 /// Cap on one serialized chat attribute (Axiom ingests spans as single events).
 const CHAT_ATTR_MAX_BYTES: usize = 150_000;
-/// Cumulative chat-content budget per run upload. The traces proxy rejects
-/// bodies over 512 KiB outright, so content must leave room for the span
-/// envelope and tool-arg summaries.
-const CHAT_BUDGET_BYTES: usize = 300_000;
 /// Max note summaries carried on one `execute_tool` span (`socai.notes`).
 const NOTES_MAX_PER_SPAN: usize = 25;
 /// Caption (note body) cap inside a note summary.
@@ -71,12 +67,12 @@ const NOTE_CAPTION_MAX_CHARS: usize = 200;
 const NOTE_TITLE_MAX_CHARS: usize = 300;
 const NOTE_ID_MAX_CHARS: usize = 100;
 const NOTE_STAT_MAX_CHARS: usize = 50;
-/// Ceiling for the assembled payload: the traces proxy rejects bodies over
-/// 512 KiB, and the uploader appends identity resource attributes. The chat
-/// budget bounds content, but span envelopes and non-content attributes ride
-/// on top of it — `enforce_payload_cap` strips content from oldest spans
-/// when the serialized whole would overshoot.
-const PAYLOAD_MAX_BYTES: usize = 460_000;
+/// Ceiling for the assembled payload: leave 64 KiB below the traces proxy's
+/// 2 MiB body limit for upload-time identity resource attributes. Span
+/// envelopes and non-content attributes ride alongside chat content, so
+/// `enforce_payload_cap` strips content from oldest spans when the serialized
+/// whole would overshoot.
+const PAYLOAD_MAX_BYTES: usize = 2 * 1024 * 1024 - 64 * 1024;
 /// What `enforce_payload_cap` may strip, in order: chat/note content first,
 /// then the unbounded summarizer strings (query text, arg metadata). Every
 /// attribute not listed here is small and bounded, so a payload with both
@@ -115,9 +111,6 @@ pub struct RunTraceBuilder {
     /// loop's authoritative totals.
     steps_seen: u32,
     usage: TokenUsage,
-    /// Remaining chat-content bytes for this run's upload; once spent, later
-    /// spans carry `socai.chat_text_dropped` instead of content.
-    chat_bytes_left: usize,
     /// Hash of the last uploaded system prompt, so `gen_ai.system_instructions`
     /// is emitted once and then only when it changes — **per run**. Follow-up
     /// runs of a conversation share the trace id but each uploads its own
@@ -161,7 +154,6 @@ impl RunTraceBuilder {
             dropped_spans: 0,
             steps_seen: 0,
             usage: TokenUsage::default(),
-            chat_bytes_left: CHAT_BUDGET_BYTES,
             last_system_hash: String::new(),
             finalized: false,
         }
@@ -225,9 +217,9 @@ impl RunTraceBuilder {
     }
 
     /// Attach chat content to a `chat` span: system prompt (when changed),
-    /// input delta, and full response, each budgeted against the run's
-    /// remaining chat bytes. Stops at the first attribute that would overrun
-    /// the budget and marks the span `socai.chat_text_dropped` instead.
+    /// input delta, and full response. The final whole-payload gate retains
+    /// the newest spans when the proxy body ceiling requires trimming, so a
+    /// long investigation does not lose its final answer prematurely.
     fn push_chat_attrs(
         &mut self,
         attrs: &mut Vec<Value>,
@@ -251,38 +243,20 @@ impl RunTraceBuilder {
             let rendered = capped_chat_json(
                 |cap| json!([{ "type": "text", "content": truncate_chars(&system, cap) }]),
             );
-            if !self.push_budgeted(attrs, "gen_ai.system_instructions", rendered) {
-                return;
-            }
+            self.push_content_attr(attrs, "gen_ai.system_instructions", rendered);
         }
         let input = capped_chat_json(|cap| input_messages_json(new_messages, cap, include_query));
-        if !self.push_budgeted(attrs, "gen_ai.input.messages", input) {
-            return;
-        }
+        self.push_content_attr(attrs, "gen_ai.input.messages", input);
         if let Some(response) = response {
             let output = capped_chat_json(|cap| output_messages_json(response, cap, include_query));
-            self.push_budgeted(attrs, "gen_ai.output.messages", output);
+            self.push_content_attr(attrs, "gen_ai.output.messages", output);
         }
     }
 
-    /// Push one chat-content attribute if it fits the remaining budget;
-    /// otherwise zero the budget and mark the span. Returns whether it fit.
-    /// The budget is charged at the attribute's wire cost — the JSON-escaped
-    /// form the upload serializes (quotes/backslashes/newlines in the content
-    /// escape a second time there), not the raw string length, so admitted
-    /// content can't push the POST past the proxy's body cap.
-    fn push_budgeted(&mut self, attrs: &mut Vec<Value>, key: &str, rendered: String) -> bool {
-        let wire_len = serde_json::to_string(&rendered)
-            .map(|escaped| escaped.len())
-            .unwrap_or(rendered.len());
-        if self.chat_bytes_left < wire_len {
-            self.chat_bytes_left = 0;
-            attrs.push(attr_bool("socai.chat_text_dropped", true));
-            return false;
-        }
-        self.chat_bytes_left -= wire_len;
+    /// Add bounded content to a span. The assembled payload is size-checked
+    /// before upload, where oldest content is removed only when necessary.
+    fn push_content_attr(&mut self, attrs: &mut Vec<Value>, key: &str, rendered: String) {
         attrs.push(attr_str(key, &rendered));
-        true
     }
 
     pub fn record_tool(
@@ -314,7 +288,7 @@ impl RunTraceBuilder {
                 if rendered.len() > CHAT_ATTR_MAX_BYTES {
                     rendered = "[notes omitted: over attribute cap]".to_string();
                 }
-                self.push_budgeted(&mut attrs, "socai.notes", rendered);
+                self.push_content_attr(&mut attrs, "socai.notes", rendered);
             }
         }
         self.push_span(

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -356,12 +356,12 @@ messages are rebuilt from the persisted (artifact-enriched) report rather than
 the raw output the earlier turn's span recorded.
 
 Size limits are enforced client-side: 20,000 chars per message part, 200-char
-note captions, 150 KB per attribute, a 300 KB per-run content budget charged at
-JSON-escaped wire length, and a final whole-payload gate that strips content
-attributes (oldest spans first, marked `socai.content_dropped`) whenever the
-assembled trace would exceed the proxy's 512 KiB body cap. The traces proxy
-stays transport-only (shape gate, body-size cap, rate limit — no field
-inspection).
+note captions, 150 KB per attribute, and a final whole-payload gate that strips
+content attributes (oldest spans first, marked `socai.content_dropped`) only
+when the assembled trace would exceed the proxy's 2 MiB body cap. This keeps
+the most recent spans — including the final answer — whenever they fit. The
+traces proxy stays transport-only (shape gate, body-size cap, rate limit — no
+field inspection).
 
 Controls: `SOCAI_TELEMETRY_CHAT_TEXT=off` removes conversation content and
 note summaries. It is **not** a text-free trace: the root span still carries

--- a/docs/telemetry-schema.md
+++ b/docs/telemetry-schema.md
@@ -189,12 +189,19 @@ and model in use are captured on `socai_agent_task_start`.
 | `socai_agent_task_start` | A task begins running | `task_id`, `provider`, `model`, `task_len`, `task_text` |
 | `socai_agent_task_end` | A task reaches a terminal state | `task_id`, `run_id`, `provider`, `model`, `outcome`, `steps`, token/cache usage, estimated cost breakdown, authoritative `points_used` when settlement completes, `duration_ms`, `error` |
 | `socai_tool_call` | Each tool call completes | `task_id`, `run_id`, `tool_name`, `turn`, `sequence`, `duration_ms`, `ok`, `error`, query/result summaries, and bounded unexpected-page diagnostics when present |
-| `socai_feishu_export` | A Feishu export completes/fails, including user-visible setup failures before the native export command starts | `task_id`, `run_id`, `destination`, optional `stage`, `outcome`, `duration_ms`, `error` |
+| `socai_feishu_export` | A Feishu export completes/fails, including user-visible setup failures before the native export command starts | `task_id`, `run_id`, `destination`, optional `stage`, `outcome`, `duration_ms`, `error`; chat sends also include privacy-safe CLI failure metadata (`cli_exit_code`, `cli_error_type`, `cli_error_subtype`, `cli_error_code`, `cli_log_id`, `cli_update_available`) and `message_id_present` |
 | `socai_server_payment_callback` | The backend accepts, rejects, or fails a merchant callback | `provider`, `stage`, `outcome`, `order_id`, `amount_fen`, `added_points`, `duration_days`, `error` |
 | `socai_server_asr` | A managed ASR task changes stage | `stage`, `outcome`, `task_id`, `client_task_id`, `provider`, audio duration/size, provider latency/cost, `error` |
 | `socai_server_browser_session` | The backend creates, denies, quota-blocks, or releases a hosted browser | `stage`, `outcome`, `browser_session_id`, timeout/spend/budget fields, `error` |
 
 Desktop field semantics:
+
+Feishu chat failures use `stage` to separate `check_connection`,
+`check_send_scopes`, `validate_send_request`, `execute_send`,
+`parse_send_response`, and `verify_send_response`. CLI notices are not treated
+as errors; `error` comes from the structured CLI error envelope when present.
+CLI log IDs are opaque provider diagnostics and no task content, account,
+profile, document/chat ID, URL, or credential is reported.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -344,7 +351,7 @@ storage. For secrets, every uploaded text field — chat content, the root
 `socai.task_text`, and `query_text` on both pipelines — passes a client-side
 scrubber for secret-shaped values before upload: `sk-`-prefixed api keys,
 JWT-shaped tokens, `Bearer` header values, and sensitive JSON fields
-(`api_key`, `device_token`, `access_token`, …). Desktop `read_file`/`bash`
+(`api_key`, `device_token`, `access_token`, …). Desktop `read_file`/`shell`
 are confined to `~/.socai`, where `auth.json` stores provider api keys and
 the socai pro `device_token`, so tool results can legitimately contain live
 secrets. The scrubber is pattern-based — a safety net for known formats, not

--- a/site/api/traces.js
+++ b/site/api/traces.js
@@ -12,7 +12,7 @@
 
 const DEFAULT_AXIOM_URL = 'https://api.axiom.co';
 const DEFAULT_DATASET = 'socai-traces-prod';
-const MAX_BODY_BYTES = 512 * 1024;
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 120;
 


### PR DESCRIPTION
## Summary

- preserve final trace output without truncating the most recent chat payload
- keep the trace proxy request budget aligned with the client payload limit
- prioritize structured lark-cli errors over update notices
- report privacy-safe Feishu chat failure stages and CLI diagnostics

## Root cause

Final trace content could be dropped by the previous producer-side budget, and Feishu CLI failures recursively selected `_notice.update.message` before the real structured `error.message`. This made failed group sends look like version-update failures.

## Impact

Trace investigations retain the final output, and future Feishu group-send failures identify the native stage plus structured CLI type, subtype, code, log ID presence, exit code, update availability, and message-ID verification without reporting task content, account data, chat IDs, URLs, or credentials.

## Validation

- `cargo check -p socai_app`
- `pnpm build` in `app/`
- `node --check site/api/traces.js`
- `git diff --check`

The isolated-worktree Cargo retry was blocked by a concurrent slow sidecar download; the identical change compiled successfully in the original checkout with its prepared sidecar.