### PR TITLE
Simplify API key model settings

### DIFF
--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -126,10 +126,17 @@ const messages = {
   "auth.accountAria": { en: "open account menu", zh: "打开账号菜单" },
   "auth.loginTitle": { en: "sign in with phone", zh: "手机号登录" },
   "auth.loginAgentHint": {
-    en: "sign in to get 30 points of agent credit",
-    zh: "登录后获赠30点 agent额度",
+    en: "sign in to get 50 points of agent credit",
+    zh: "登录后获赠50点 agent额度",
   },
-  "auth.useOwnApiKey": { en: "or use your own api key", zh: "或自己输入 API key" },
+  "auth.useOwnApiKey": {
+    en: "or use your own API key, no sign-in required",
+    zh: "或自己输入API key，无需登录",
+  },
+  "auth.useOwnApiKeyNoPoints": {
+    en: "or use your own API key without points",
+    zh: "或自己输入API key，不使用点数",
+  },
   "auth.phone": { en: "phone", zh: "手机号" },
   "auth.sendCode": { en: "send code", zh: "获取验证码" },
   "auth.sending": { en: "sending…", zh: "发送中…" },

--- a/app/src/panels/auth.ts
+++ b/app/src/panels/auth.ts
@@ -196,7 +196,8 @@ export namespace authMenu {
             <svg viewBox="0 0 20 20"><path d="m5 7.5 5 5 5-5" /></svg>
           </span>
         </button>
-        ${modelExpanded ? `<div class="auth-expanded-panel">${modelConfigContent}</div>` : ""}
+        <p class="t-small subtle auth-model-hint">${esc(t("auth.useOwnApiKeyNoPoints"))}</p>
+        ${modelExpanded ? modelConfigContent : ""}
       </section>
       ${activeUntil ? `
         <div class="auth-pro-status">

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -367,6 +367,8 @@ body.has-paper > * { position: relative; z-index: 1; }
   stroke-linejoin: round;
 }
 .auth-byok .auth-expanded-panel { margin-top: var(--sp-3); }
+.auth-model-hint { margin: var(--sp-1) 0 0; }
+.auth-model-picker .agent-account-config { margin-top: var(--sp-3); }
 .agent-account-config {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- update the login credit hint from 30 to 50 points
- clarify that users can provide their own API key without signing in or consuming points
- remove the redundant outer container around the expanded model list

## User impact
The login and model settings are clearer and the expanded list uses less vertical space.

## Validation
- `pnpm build` from `app/`
- `git diff --check`