### PR TITLE
feat: expand video transcription access

### DIFF
--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -209,7 +209,6 @@ const messages = {
   "subscription.renewPro": { en: "renew pro", zh: "续订 Pro" },
   "subscription.proPoints": { en: "500 points", zh: "500 点数" },
   "subscription.proXhs": { en: "use xiaohongshu without signing in", zh: "免登录小红书" },
-  "subscription.proTranscript": { en: "extract video transcripts", zh: "获取视频文字稿" },
   "subscription.active": { en: "subscribed", zh: "已订阅" },
   "subscription.inactive": { en: "not subscribed", zh: "未订阅" },
   "subscription.loginHint": {

--- a/app/src/panels/auth.ts
+++ b/app/src/panels/auth.ts
@@ -210,7 +210,6 @@ export namespace authMenu {
         <ul class="auth-pro-benefits t-small">
           <li>${esc(t("subscription.proPoints"))}</li>
           <li>${esc(t("subscription.proXhs"))}</li>
-          <li>${esc(t("subscription.proTranscript"))}</li>
         </ul>
       `}
       ${upgradeExpanded ? `<section class="auth-upgrade-panel" aria-label="${esc(t("subscription.upgradePro"))}">${subscriptionContent}</section>` : ""}

--- a/core/src/cloud/asr.rs
+++ b/core/src/cloud/asr.rs
@@ -4,10 +4,13 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::json;
+use tokio::io::AsyncReadExt;
 
 use super::auth::{bearer, configured_base_url, http_client, load_credentials};
 
 const TASK_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const AUDIO_UPLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+const MAX_AUDIO_UPLOAD_BYTES: u64 = 128 * 1024 * 1024;
 /// Consecutive poll failures tolerated before giving up on a submitted task.
 const MAX_POLL_FAILURES: u32 = 3;
 
@@ -40,19 +43,29 @@ pub async fn transcribe_audio_file(
     client_task_id: Option<&str>,
 ) -> Result<CloudAsrResult> {
     let base_url = configured_base_url()
-        .ok_or_else(|| anyhow::anyhow!("socai pro server URL is not configured"))?;
+        .ok_or_else(|| anyhow::anyhow!("socai server URL is not configured"))?;
     let creds = load_credentials().ok_or_else(|| {
-        anyhow::anyhow!("socai pro is not activated; run `socai pro activate <invite_code>`")
+        anyhow::anyhow!("sign in and select socai agent before requesting video transcription")
     })?;
+    if creds.user_id.trim().is_empty() || !creds.hosted_llm_selected {
+        anyhow::bail!("sign in and select socai agent before requesting video transcription");
+    }
     // The extension matters: the server passes the filename through to
     // DashScope, which detects the audio format from it.
     let filename = path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("audio.aac");
-    let bytes = tokio::fs::read(path)
+    let size_bytes = tokio::fs::metadata(path)
         .await
-        .with_context(|| format!("failed to read {}", path.display()))?;
+        .with_context(|| format!("failed to read metadata for {}", path.display()))?
+        .len();
+    if size_bytes > MAX_AUDIO_UPLOAD_BYTES {
+        anyhow::bail!(
+            "audio upload is too large: {} bytes exceeds the 128 MiB limit",
+            size_bytes
+        );
+    }
     let client = http_client()?;
     let started = Instant::now();
     let upload: UploadUrlResponse = bearer(
@@ -61,7 +74,7 @@ pub async fn transcribe_audio_file(
             .json(&json!({
                 "filename": filename,
                 "content_type": "audio/aac",
-                "size_bytes": bytes.len(),
+                "size_bytes": size_bytes,
                 "duration_s": duration_s.max(0),
                 "client_task_id": client_task_id.unwrap_or(""),
             })),
@@ -73,7 +86,23 @@ pub async fn transcribe_audio_file(
     .json()
     .await?;
 
-    let mut put = client.put(&upload.upload_url).body(bytes);
+    let file = tokio::fs::File::open(path)
+        .await
+        .with_context(|| format!("failed to open {} for upload", path.display()))?;
+    let stream = futures::stream::try_unfold(file, |mut file| async move {
+        let mut chunk = vec![0u8; 64 * 1024];
+        let read = file.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok::<_, std::io::Error>(None);
+        }
+        chunk.truncate(read);
+        Ok(Some((chunk, file)))
+    });
+    let mut put = client
+        .put(&upload.upload_url)
+        .timeout(AUDIO_UPLOAD_TIMEOUT)
+        .header(reqwest::header::CONTENT_LENGTH, size_bytes)
+        .body(reqwest::Body::wrap_stream(stream));
     for (key, value) in &upload.headers {
         put = put.header(key, value);
     }
@@ -115,7 +144,7 @@ pub async fn transcribe_audio_file(
                                  spoken content to transcribe"
                             );
                         }
-                        anyhow::bail!("socai pro ASR failed: {}", short_error(&error));
+                        anyhow::bail!("video transcription failed: {}", short_error(&error));
                     }
                     _ => {}
                 }
@@ -123,12 +152,12 @@ pub async fn transcribe_audio_file(
             Err(err) => {
                 poll_failures += 1;
                 if poll_failures >= MAX_POLL_FAILURES {
-                    return Err(err.context("socai pro ASR status polling failed"));
+                    return Err(err.context("video transcription status polling failed"));
                 }
             }
         }
         if Instant::now() >= deadline {
-            anyhow::bail!("socai pro ASR timed out after {}s", timeout.as_secs());
+            anyhow::bail!("video transcription timed out after {}s", timeout.as_secs());
         }
         tokio::time::sleep(TASK_POLL_INTERVAL).await;
     }

--- a/core/src/media/audio.rs
+++ b/core/src/media/audio.rs
@@ -9,14 +9,13 @@ use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
-use symphonia::core::units::TimeBase;
 
 use crate::media::common::{ensure_dir, url_suffix, MediaUnavailable};
 use crate::media::processor::MediaProcessor;
 
 impl MediaProcessor {
-    /// Transcribe a video/audio source through socai pro cloud ASR — the only
-    /// transcription path (local whisper was removed as uncontrollable).
+    /// Transcribe a video/audio source through socai's managed cloud ASR — the
+    /// only transcription path (local whisper was removed as uncontrollable).
     pub async fn transcribe_audio(&self, source: &str, referer: &str) -> Result<String> {
         let t0 = Instant::now();
         let result = self.transcribe_audio_inner(source, referer).await;
@@ -27,7 +26,7 @@ impl MediaProcessor {
     async fn transcribe_audio_inner(&self, source: &str, referer: &str) -> Result<String> {
         if !self.config.use_cloud_asr {
             anyhow::bail!(MediaUnavailable(
-                "audio transcription requires socai pro (cloud ASR)".into()
+                "video transcription requires a signed-in account with socai agent selected".into()
             ));
         }
         let source_path = self.local_audio_source(source, referer).await?;
@@ -134,16 +133,17 @@ fn demux_aac_to_adts(source: &Path, target: &Path, max_seconds: u64) -> Result<f
         .as_deref()
         .ok_or_else(|| MediaUnavailable("AAC track has no decoder config".into()))?;
     let header = AdtsHeader::from_asc(asc)?;
-    let time_base = track
-        .codec_params
-        .time_base
-        .unwrap_or_else(|| TimeBase::new(1, sample_rate));
-
     let mut writer = std::io::BufWriter::new(
         std::fs::File::create(target)
             .with_context(|| format!("failed to create {}", target.display()))?,
     );
-    let mut end_ts = 0u64;
+    // The emitted ADTS header declares one 1024-sample AAC frame per packet.
+    // Bound the output using that exact duration contract, which is also what
+    // socai-server validates after upload. Using the source packet timestamp
+    // allowed the last frame to cross the configured limit while the client
+    // still reported the capped value.
+    let max_samples = max_seconds.saturating_mul(u64::from(sample_rate));
+    let mut written_samples = 0u64;
     loop {
         let packet = match format.next_packet() {
             Ok(packet) => packet,
@@ -157,26 +157,22 @@ fn demux_aac_to_adts(source: &Path, target: &Path, max_seconds: u64) -> Result<f
         if packet.track_id() != track_id {
             continue;
         }
-        if timestamp_seconds(time_base, packet.ts) >= max_seconds as f64 {
+        const SAMPLES_PER_AAC_FRAME: u64 = 1024;
+        if written_samples.saturating_add(SAMPLES_PER_AAC_FRAME) > max_samples {
             break;
         }
         writer.write_all(&header.for_frame(packet.data.len())?)?;
         writer.write_all(&packet.data)?;
-        end_ts = packet.ts + packet.dur;
+        written_samples += SAMPLES_PER_AAC_FRAME;
     }
     writer.flush()?;
-    if end_ts == 0 {
+    if written_samples == 0 {
         anyhow::bail!(MediaUnavailable(format!(
             "AAC track in {} contains no audio packets",
             source.display()
         )));
     }
-    Ok(timestamp_seconds(time_base, end_ts).min(max_seconds as f64))
-}
-
-fn timestamp_seconds(time_base: TimeBase, ts: u64) -> f64 {
-    let time = time_base.calc_time(ts);
-    time.seconds as f64 + time.frac
+    Ok(written_samples as f64 / f64::from(sample_rate))
 }
 
 /// Fixed part of an ADTS header for an AAC-LC stream; only the per-frame

--- a/core/src/media/common.rs
+++ b/core/src/media/common.rs
@@ -26,8 +26,8 @@ impl MediaConfig {
         Self {
             base_dir: base_dir.into(),
             request_timeout_s: 25,
-            asr_timeout_s: 300,
-            max_audio_seconds: 300,
+            asr_timeout_s: 1_800,
+            max_audio_seconds: 20 * 60,
             use_ocr: true,
             use_vision: true,
             use_cloud_asr: false,

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -1,7 +1,7 @@
 //! Optional local/media processing used by site runtimes.
 //!
 //! Nothing here shells out to external media tools: video covers come from
-//! their own CDN URL, audio transcription is cloud-only (socai pro takes the
+//! their own CDN URL, audio transcription is cloud-only (socai takes the
 //! demuxed aac as-is), and OCR runs in-process. Site runtimes can opt into
 //! this crate for heavier media enrichment while keeping plain DOM extraction
 //! fast and portable.

--- a/core/src/media/video.rs
+++ b/core/src/media/video.rs
@@ -7,7 +7,7 @@ use crate::media::processor::MediaProcessor;
 
 /// Wall-clock cap for fetching a note's video file. Generous because XHS video
 /// CDN throughput varies; still bounded so a stalled download can't hang a scan.
-const VIDEO_DOWNLOAD_TIMEOUT_S: u64 = 180;
+const VIDEO_DOWNLOAD_TIMEOUT_S: u64 = 600;
 
 impl MediaProcessor {
     /// OCR a video note's already-downloaded poster in place: read
@@ -296,8 +296,8 @@ impl MediaProcessor {
         }
 
         // Inline transcription only when cloud ASR is enabled for this run;
-        // attempting it without pro would just stamp every enriched video with
-        // a "requires socai pro" transcript_error.
+        // attempting it without an eligible hosted-agent session would stamp
+        // every enriched video with the same availability error.
         if !source.is_empty() && self.config.use_cloud_asr {
             if let Some(map) = result.as_object_mut() {
                 map.remove("transcript_error");

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -137,8 +137,11 @@ Shared options (same meaning for both):
   pipelined behind the browse loop so it's near-free). Each note gets `ocr_text`
   as a per-image array (cover first); implies `download_media`; in `preview` mode
   it OCRs each card's cover only.
-- `transcribe_audio=true` — transcribe a video note's audio in the cloud
-  (socai pro), attaching `video.transcript`; a
+- `transcribe_audio=true` — transcribe a video note's audio in the cloud,
+  attaching `video.transcript`. This is available only when the user is signed
+  in and has selected socai agent in the model picker. If it is unavailable,
+  fails, or the user asks how to enable it, tell them to sign in and select
+  socai agent. A
   `transcript_error` saying no speech was detected means the video genuinely
   has no narration — report that as the answer.
 

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -77,7 +77,7 @@ pub fn xhs_tools_with_llm_provider(
     llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
-    let pro = crate::cloud::pro_activated();
+    let asr_enabled = crate::cloud::hosted_llm_selected();
     vec![
         Arc::new(GetNotesTool {
             page: page.clone(),
@@ -85,7 +85,7 @@ pub fn xhs_tools_with_llm_provider(
             history: history.clone(),
             always_download_media: false,
             always_ocr: false,
-            pro,
+            asr_enabled,
         }) as Arc<dyn Tool>,
         Arc::new(ExtractSearchCardsTool {
             page: page.clone(),
@@ -99,13 +99,13 @@ pub fn xhs_tools_with_llm_provider(
             page: page.clone(),
             llm_provider: llm_provider.clone(),
             history: history.clone(),
-            pro,
+            asr_enabled,
         }),
         Arc::new(ExtractNoteTool {
             page: page.clone(),
             llm_provider: llm_provider.clone(),
             history: history.clone(),
-            pro,
+            asr_enabled,
         }),
         Arc::new(ExtractCommentsTool { page: page.clone() }),
         Arc::new(ScrollInNoteTool { page: page.clone() }),
@@ -117,14 +117,14 @@ pub fn xhs_tools_with_llm_provider(
             history: history.clone(),
             always_download_media: false,
             always_ocr: false,
-            pro,
+            asr_enabled,
         }),
         Arc::new(AuthorScanTool {
             page: page.clone(),
             history,
             always_download_media: false,
             always_ocr: false,
-            pro,
+            asr_enabled,
         }),
         Arc::new(WaitForLoginTool { page: page.clone() }),
         Arc::new(WaitForRateLimitTool),
@@ -137,7 +137,7 @@ pub fn xhs_macro_tools_with_llm_provider(
     llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
-    let pro = crate::cloud::pro_activated();
+    let asr_enabled = crate::cloud::hosted_llm_selected();
     // The app/TUI agent interface always downloads note media so the offline
     // files are on hand for deeper analysis, and always OCRs every image; the
     // CLI keeps its --download-media / --ocr opt-ins via the full tool set above.
@@ -148,7 +148,7 @@ pub fn xhs_macro_tools_with_llm_provider(
             history: history.clone(),
             always_download_media: true,
             always_ocr: true,
-            pro,
+            asr_enabled,
         }) as Arc<dyn Tool>,
         Arc::new(SearchTool {
             page: page.clone(),
@@ -156,14 +156,14 @@ pub fn xhs_macro_tools_with_llm_provider(
             history: history.clone(),
             always_download_media: true,
             always_ocr: true,
-            pro,
+            asr_enabled,
         }) as Arc<dyn Tool>,
         Arc::new(AuthorScanTool {
             page: page.clone(),
             history,
             always_download_media: true,
             always_ocr: true,
-            pro,
+            asr_enabled,
         }),
         Arc::new(WaitForLoginTool { page }),
         Arc::new(WaitForRateLimitTool),
@@ -250,7 +250,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     key: "transcribe_audio",
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
-                    help: "For video notes, transcribe audio through socai pro.",
+                    help: "For video notes, transcribe audio while signed in with socai agent selected.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -327,7 +327,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
                     help: "For opened video notes, download the video file and transcribe audio \
-                           through socai pro. Ignored with --preview.",
+                           while signed in with socai agent selected. Ignored with --preview.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -403,7 +403,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
                     help: "For opened video notes, download the video file and transcribe audio \
-                           through socai pro. Ignored with --preview.",
+                           while signed in with socai agent selected. Ignored with --preview.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -864,35 +864,31 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
     }
 }
 
-/// Tool args that require an activated socai pro device. Today that's cloud
-/// ASR (`transcribe_audio`); future pro-only args just get added here.
-const PRO_ARG_KEYS: &[&str] = &["transcribe_audio"];
+/// Tool args available only to signed-in users while socai agent is selected.
+const HOSTED_AGENT_ARG_KEYS: &[&str] = &["transcribe_audio"];
 
-/// Attached to a result when a non-pro call asked for a pro-only arg, so the
-/// agent can relay why instead of the whole call failing.
-const PRO_SKIP_NOTE: &str = "transcribe_audio requires socai pro; the call ran without \
-     transcription. Activate with `socai pro activate <invite_code>`.";
+/// Attached when an unavailable call asked for a hosted-agent-only argument,
+/// so the agent can relay the remedy instead of failing the whole call.
+const HOSTED_AGENT_SKIP_NOTE: &str = "video transcription requires a signed-in account \
+     with socai agent selected; the call ran without transcription.";
 
-/// Remove pro-only properties from a tool input schema so a non-pro session
-/// never shows the agent args it cannot use.
-fn strip_pro_schema(schema: &mut Value) {
+/// Hide hosted-agent-only properties when the current session cannot use them.
+fn strip_hosted_agent_schema(schema: &mut Value) {
     if let Some(props) = schema.get_mut("properties").and_then(Value::as_object_mut) {
-        for key in PRO_ARG_KEYS {
+        for key in HOSTED_AGENT_ARG_KEYS {
             props.remove(*key);
         }
     }
 }
 
-/// Drop pro-only args from a non-pro call's input (the schema hides them, but
-/// a stale conversation or hallucinated arg can still carry one). Returns
-/// whether any was actually requested, so the caller can attach
-/// [`PRO_SKIP_NOTE`] to its result.
-fn strip_pro_input(input: &mut Value) -> bool {
+/// Drop hosted-agent-only args when unavailable (a stale conversation can
+/// still carry one). Returns whether the argument was actually requested.
+fn strip_hosted_agent_input(input: &mut Value) -> bool {
     let Some(obj) = input.as_object_mut() else {
         return false;
     };
     let mut requested = false;
-    for key in PRO_ARG_KEYS {
+    for key in HOSTED_AGENT_ARG_KEYS {
         requested |= obj
             .remove(*key)
             .and_then(|value| value.as_bool())
@@ -901,12 +897,15 @@ fn strip_pro_input(input: &mut Value) -> bool {
     requested
 }
 
-fn attach_pro_skip_note(payload: &mut Value, skipped: bool) {
+fn attach_hosted_agent_skip_note(payload: &mut Value, skipped: bool) {
     if !skipped {
         return;
     }
     if let Some(obj) = payload.as_object_mut() {
-        obj.insert("transcribe_audio_skipped".into(), json!(PRO_SKIP_NOTE));
+        obj.insert(
+            "transcribe_audio_skipped".into(),
+            json!(HOSTED_AGENT_SKIP_NOTE),
+        );
     }
 }
 
@@ -3112,7 +3111,7 @@ pub struct GetNotesTool {
     history: Arc<XhsHistoryStore>,
     always_download_media: bool,
     always_ocr: bool,
-    pro: bool,
+    asr_enabled: bool,
 }
 
 #[async_trait]
@@ -3166,15 +3165,15 @@ impl Tool for GetNotesTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For video notes, download the video and transcribe audio through socai pro.",
+                    "description": "For video notes, download the video and transcribe audio while signed in with socai agent selected.",
                     "default": false
                 }
             },
             "required": ["notes"],
             "additionalProperties": false
         });
-        if !self.pro {
-            strip_pro_schema(&mut schema);
+        if !self.asr_enabled {
+            strip_hosted_agent_schema(&mut schema);
         }
         schema
     }
@@ -3184,7 +3183,7 @@ impl Tool for GetNotesTool {
     }
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let targets = direct_note_refs(&input)?;
         let gate = XhsPageRuntime::new(&self.page);
         let login = match gate.login_gate(true).await {
@@ -3395,7 +3394,7 @@ impl Tool for GetNotesTool {
             .map(|rel| ctx.run_dir.join(rel).to_string_lossy().into_owned());
         lean_scan_payload(&mut payload);
         attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
-        attach_pro_skip_note(&mut payload, pro_skipped);
+        attach_hosted_agent_skip_note(&mut payload, asr_skipped);
         Ok(json_result(&payload))
     }
 }
@@ -3405,9 +3404,9 @@ pub struct ReadNoteTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
-    /// socai pro activated on this device; when false, pro-only args
-    /// ([`PRO_ARG_KEYS`]) are hidden from the schema and skipped at runtime.
-    pro: bool,
+    /// Signed in with socai agent selected; when false, managed-ASR arguments
+    /// are hidden from the schema and skipped at runtime.
+    asr_enabled: bool,
 }
 
 #[async_trait]
@@ -3436,14 +3435,14 @@ impl Tool for ReadNoteTool {
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 }
             }
         });
-        if !self.pro {
-            strip_pro_schema(&mut schema);
+        if !self.asr_enabled {
+            strip_hosted_agent_schema(&mut schema);
         }
         schema
     }
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let note_id = get_str(&input, "note_id").map(str::to_string);
         let index = input
             .get("index")
@@ -3522,7 +3521,7 @@ impl Tool for ReadNoteTool {
         if let Some(perf) = value.as_object_mut().and_then(|map| map.remove("perf")) {
             write_run_perf_file(ctx, "read.json", &json!({ "read": perf }));
         }
-        attach_pro_skip_note(&mut value, pro_skipped);
+        attach_hosted_agent_skip_note(&mut value, asr_skipped);
         Ok(json_result(&value))
     }
 }
@@ -3532,8 +3531,8 @@ pub struct ExtractNoteTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
-    /// See [`ReadNoteTool::pro`].
-    pro: bool,
+    /// See [`ReadNoteTool::asr_enabled`].
+    asr_enabled: bool,
 }
 
 #[async_trait]
@@ -3559,14 +3558,14 @@ impl Tool for ExtractNoteTool {
                 "max_images": { "type": "integer", "default": 12, "minimum": 1 }
             }
         });
-        if !self.pro {
-            strip_pro_schema(&mut schema);
+        if !self.asr_enabled {
+            strip_hosted_agent_schema(&mut schema);
         }
         schema
     }
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let wait_seconds = get_f64(&input, "wait_seconds", 8.0);
         let options = read_note_options(&input);
         let xhs = XhsPageRuntime::new_with_media(
@@ -3587,7 +3586,7 @@ impl Tool for ExtractNoteTool {
         attach_top_comments(&xhs, &mut value).await;
         self.history
             .record(&value, &options.level, options.include_media);
-        attach_pro_skip_note(&mut value, pro_skipped);
+        attach_hosted_agent_skip_note(&mut value, asr_skipped);
         Ok(json_result(&value))
     }
 }
@@ -4032,8 +4031,8 @@ pub struct SearchTool {
     /// `ocr` input. Set by the app/TUI macro factory so the desktop agent always
     /// gets OCR; the CLI/full set leaves it to the `--ocr` flag.
     always_ocr: bool,
-    /// See [`ReadNoteTool::pro`].
-    pro: bool,
+    /// See [`ReadNoteTool::asr_enabled`].
+    asr_enabled: bool,
 }
 
 fn effective_macro_input(
@@ -4124,7 +4123,7 @@ impl Tool for SearchTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For opened video notes, download the video file and transcribe audio through socai pro. Ignored in preview mode.",
+                    "description": "For opened video notes, download the video file and transcribe audio while signed in with socai agent selected. Ignored in preview mode.",
                     "default": false
                 },
                 "preview": {
@@ -4135,8 +4134,8 @@ impl Tool for SearchTool {
             },
             "required": ["query"]
         });
-        if !self.pro {
-            strip_pro_schema(&mut schema);
+        if !self.asr_enabled {
+            strip_hosted_agent_schema(&mut schema);
         }
         schema
     }
@@ -4151,7 +4150,7 @@ impl Tool for SearchTool {
     }
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let query = get_str(&input, "query")
             .ok_or_else(|| anyhow::anyhow!("missing query"))?
             .to_string();
@@ -4790,7 +4789,7 @@ impl Tool for SearchTool {
         // agent/CLI output stays small, then point at the artifact for the rest.
         lean_scan_payload(&mut payload);
         attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
-        attach_pro_skip_note(&mut payload, pro_skipped);
+        attach_hosted_agent_skip_note(&mut payload, asr_skipped);
         Ok(json_result(&payload))
     }
 }
@@ -4814,8 +4813,8 @@ pub struct AuthorScanTool {
     /// `ocr` input. Set by the app/TUI macro factory; the CLI/full set leaves it
     /// to the `--ocr` flag.
     always_ocr: bool,
-    /// See [`ReadNoteTool::pro`].
-    pro: bool,
+    /// See [`ReadNoteTool::asr_enabled`].
+    asr_enabled: bool,
 }
 
 #[async_trait]
@@ -4878,14 +4877,14 @@ impl Tool for AuthorScanTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For opened video notes, download the video file and transcribe audio through socai pro. Ignored in preview mode.",
+                    "description": "For opened video notes, download the video file and transcribe audio while signed in with socai agent selected. Ignored in preview mode.",
                     "default": false
                 }
             },
             "required": ["author_id"]
         });
-        if !self.pro {
-            strip_pro_schema(&mut schema);
+        if !self.asr_enabled {
+            strip_hosted_agent_schema(&mut schema);
         }
         schema
     }
@@ -4895,7 +4894,7 @@ impl Tool for AuthorScanTool {
     }
 
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
-        let pro_skipped = !self.pro && strip_pro_input(&mut input);
+        let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let author_id = get_str(&input, "author_id")
             .map(str::trim)
             .filter(|id| !id.is_empty())
@@ -5227,7 +5226,7 @@ impl Tool for AuthorScanTool {
         // agent/CLI output stays small, then point at the artifact for the rest.
         lean_scan_payload(&mut payload);
         attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
-        attach_pro_skip_note(&mut payload, pro_skipped);
+        attach_hosted_agent_skip_note(&mut payload, asr_skipped);
         Ok(json_result(&payload))
     }
 }
@@ -5324,7 +5323,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_pro_schema_hides_pro_args() {
+    fn strip_hosted_agent_schema_hides_asr_args() {
         let mut schema = json!({
             "type": "object",
             "properties": {
@@ -5332,22 +5331,22 @@ mod tests {
                 "transcribe_audio": { "type": "boolean" }
             }
         });
-        strip_pro_schema(&mut schema);
+        strip_hosted_agent_schema(&mut schema);
         assert!(schema["properties"].get("transcribe_audio").is_none());
         assert!(schema["properties"].get("query").is_some());
     }
 
     #[test]
-    fn strip_pro_input_drops_args_and_reports_requests() {
+    fn strip_hosted_agent_input_drops_args_and_reports_requests() {
         let mut input = json!({ "query": "咖啡", "transcribe_audio": true });
-        assert!(strip_pro_input(&mut input));
+        assert!(strip_hosted_agent_input(&mut input));
         assert!(input.get("transcribe_audio").is_none());
         assert_eq!(input["query"], json!("咖啡"));
 
         // Not requested (absent or false) → no skip note owed.
         let mut plain = json!({ "query": "咖啡" });
-        assert!(!strip_pro_input(&mut plain));
+        assert!(!strip_hosted_agent_input(&mut plain));
         let mut off = json!({ "query": "咖啡", "transcribe_audio": false });
-        assert!(!strip_pro_input(&mut off));
+        assert!(!strip_hosted_agent_input(&mut off));
     }
 }


### PR DESCRIPTION
## Summary

- allow video transcription for every signed-in user who selects socai agent
- raise the supported duration to 20 minutes and align client timeouts
- stream audio uploads and improve AAC duration boundary handling
- teach the agent the login and model-selection requirements

## Validation

- cargo check -p socai-core -p socai_app
- pnpm build in app
- existing hosted-agent gate tests: 2 passed
- 20-minute production ASR smoke test completed without truncation