### PR TITLE
fix: Windows Alipay URL truncation and settings version display

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -504,8 +504,10 @@ pub fn open_external(url: String) -> Result<(), String> {
     };
     #[cfg(target_os = "windows")]
     let mut command = {
-        let mut c = Command::new("cmd");
-        c.args(["/C", "start", "", &url]);
+        // Avoid `cmd /C start`: cmd.exe treats `&` in query strings as command
+        // separators, truncating URLs like Alipay checkout (missing-method).
+        let mut c = Command::new("rundll32");
+        c.args(["url.dll,FileProtocolHandler", &url]);
         c
     };
 

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -312,6 +312,7 @@ const messages = {
     en: "could not save settings.",
     zh: "无法保存设置。",
   },
+  "settings.version": { en: "app version", zh: "应用版本" },
   "settings.loadFailed": {
     en: "could not load settings.",
     zh: "无法加载设置。",

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -645,6 +645,7 @@ async function main(): Promise<void> {
   }
   try {
     currentVersion = await getVersion();
+    settingsMenu.setAppVersion(currentVersion);
   } catch (e) {
     console.error("getVersion failed:", e);
   }

--- a/app/src/panels/settings.ts
+++ b/app/src/panels/settings.ts
@@ -71,6 +71,12 @@ export namespace settingsMenu {
   let status: SaveStatus = "";
   let inviteMessage = "";
   let statusTimer: number | null = null;
+  let appVersion = "";
+
+  /** Installed app version — set once at startup from Tauri's `getVersion()`. */
+  export function setAppVersion(version: string): void {
+    appVersion = version.trim();
+  }
 
   /** Load the persisted config once at startup. Best-effort: a failure leaves
    *  the menu in a "could not load" state without blocking the app. */
@@ -160,6 +166,7 @@ export namespace settingsMenu {
       return `
         <div class="topbar-popover settings-popover" role="dialog" aria-label="${esc(t("settings.title"))}">
           <p class="t-small subtle result-error">${esc(t("settings.loadFailed"))}</p>
+          ${renderVersionFooter()}
         </div>
       `;
     }
@@ -168,6 +175,7 @@ export namespace settingsMenu {
       return `
         <div class="topbar-popover settings-popover" role="dialog" aria-label="${esc(t("settings.title"))}">
           <p class="t-small subtle">${esc(t("common.loading"))}</p>
+          ${renderVersionFooter()}
         </div>
       `;
     }
@@ -177,8 +185,14 @@ export namespace settingsMenu {
         ${renderOutputGroup(config, draft)}
         ${renderInviteGroup(draft)}
         ${renderStatus()}
+        ${renderVersionFooter()}
       </div>
     `;
+  }
+
+  function renderVersionFooter(): string {
+    if (!appVersion) return "";
+    return `<p class="settings-version" aria-label="${esc(t("settings.version"))}">${esc(appVersion)}</p>`;
   }
 
   function renderInviteGroup(d: SettingsDraft): string {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -764,6 +764,17 @@ body.has-paper > * { position: relative; z-index: 1; }
 .settings-path-row .btn-ghost { flex: 0 0 auto; white-space: nowrap; }
 /* auto-save status line (saving… / saved / error / idle hint) */
 .settings-status { margin: 0; min-height: 16px; }
+.settings-version {
+  margin: var(--sp-3) 0 0;
+  padding-top: var(--sp-3);
+  border-top: var(--hairline);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: var(--ls-mono);
+  text-align: center;
+  color: var(--fg-soft);
+}
 
 /* segmented control (chrome source) */
 .seg-toggle {


### PR DESCRIPTION
## Summary
- Fix Windows `open_external` to use `rundll32 url.dll,FileProtocolHandler` instead of `cmd /C start`, so URLs with `&` query parameters (e.g. Alipay checkout) are not truncated at the first ampersand.
- Show the installed app version at the bottom of the settings popover on macOS and Windows.

## Test plan
- [ ] On Windows, click「支付宝支付」and confirm the browser opens the full Alipay checkout page (not `missing-method`).
- [ ] On macOS/Windows, open settings and confirm the version appears at the bottom of the menu.

Made with [Cursor](https://cursor.com)