### PR TITLE
feat: run task preflight before agent work

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -12,9 +12,9 @@ use socai_core::agent::{
 use socai_core::runtime::{
     create_llm_provider_for_task, ensure_llm_provider_configured_for,
     run_agent_task as run_agent_with_tools, AgentRunConfig, BrowserStatus, ChromeConnectOptions,
-    RuntimePageSession, SocaiRuntime,
+    ChromeProfile, RuntimePageSession, SocaiRuntime,
 };
-use socai_core::sites::xhs::XhsHistoryStore;
+use socai_core::sites::xhs::{XhsHistoryStore, XhsPageRuntime};
 use socai_core::sites::{find_site, SiteSpec};
 use socai_core::telemetry::query_text_enabled;
 use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_result};
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 const TAURI_AGENT_PREAMBLE: &str =
@@ -140,20 +141,29 @@ pub async fn app_relaunch(app: AppHandle) {
     tauri::process::restart(&app.env());
 }
 
-/// Ensure the browser is connected before an agent run, connecting when it is
-/// not. Starting a run expresses the user's intent to resume, so a dropped
-/// connection reconnects here instead of bouncing them to the connect button.
-/// Routine for remote profiles — hosted sessions expire on a server-side
-/// timeout between runs, and reconnecting mints a fresh one — and it also
-/// revives a killed managed chrome. Bounded by the runtime's connect budget.
-async fn ensure_browser_connected(runtime: &SocaiRuntime) -> Result<(), String> {
-    let site = app_site().map_err(|err| format!("{err:#}"))?;
-    let options = ChromeConnectOptions::from_config().map_err(|err| format!("{err:#}"))?;
+/// Ensure the browser is connected before an agent run and return the shared
+/// site page for the login preflight. Starting a run expresses the user's
+/// intent to resume, so a dropped connection reconnects here instead of
+/// bouncing them to the connect button. Routine for remote profiles — hosted
+/// sessions expire on a server-side timeout between runs, and reconnecting
+/// mints a fresh one — and it also revives a killed managed chrome. Bounded by
+/// the runtime's connect budget.
+async fn ensure_browser_connected(
+    runtime: &SocaiRuntime,
+) -> Result<Arc<RuntimePageSession>, String> {
+    let site =
+        app_site().map_err(|error| task_preflight_error("preflight_site", format!("{error:#}")))?;
+    let options = ChromeConnectOptions::from_config()
+        .map_err(|error| task_preflight_error("preflight_browser_config", format!("{error:#}")))?;
+    let browser_error_code = if options.profile == ChromeProfile::Remote {
+        "preflight_browser_remote"
+    } else {
+        "preflight_browser"
+    };
     runtime
         .ensure_site_page_with_browser_options(site.id, site.home_url, options)
         .await
-        .map(|_| ())
-        .map_err(|err| format!("{err:#}"))
+        .map_err(|error| task_preflight_error(browser_error_code, format!("{error:#}")))
 }
 
 async fn label_controlled_page(page: &RuntimePageSession, label: &str) {
@@ -592,13 +602,11 @@ pub async fn agent_task_start(
     provider: Option<String>,
     model: Option<String>,
 ) -> Result<AgentTaskSnapshot, String> {
-    ensure_browser_connected(&runtime).await?;
     let task_text = task.trim().to_string();
     if task_text.is_empty() {
         return Err("task is empty".into());
     }
-    ensure_llm_provider_configured_for(provider.as_deref(), model.as_deref())
-        .map_err(|e| format!("{e:#}"))?;
+    run_task_preflight(&runtime, provider.as_deref(), model.as_deref()).await?;
 
     // One conversation = one folder under the runs root, named after the
     // first task; each turn's run dir nests inside it (turn-01_…, turn-02_…).
@@ -676,7 +684,6 @@ pub async fn agent_task_reply(
     task_id: String,
     message: String,
 ) -> Result<AgentTaskSnapshot, String> {
-    ensure_browser_connected(&runtime).await?;
     let message_text = message.trim().to_string();
     if message_text.is_empty() {
         return Err("message is empty".into());
@@ -694,8 +701,7 @@ pub async fn agent_task_reply(
     };
     let provider = existing.provider.clone();
     let model = existing.model.clone();
-    ensure_llm_provider_configured_for(provider.as_deref(), model.as_deref())
-        .map_err(|e| format!("{e:#}"))?;
+    run_task_preflight(&runtime, provider.as_deref(), model.as_deref()).await?;
 
     // This turn's run dir nests inside the conversation dir. Tasks created
     // before nesting have their session dir under ~/.socai/sessions; their
@@ -769,6 +775,64 @@ pub async fn agent_task_reply(
         let _ = start_tx.send(());
     }
     Ok(snapshot)
+}
+
+async fn run_task_preflight(
+    runtime: &SocaiRuntime,
+    provider: Option<&str>,
+    model: Option<&str>,
+) -> Result<(), String> {
+    let resolved_provider = ensure_llm_provider_configured_for(provider, model)
+        .map_err(|error| task_preflight_error("preflight_model_config", format!("{error:#}")))?;
+    if resolved_provider == Provider::Socai {
+        if !socai_core::cloud::pro_activated() {
+            return Err(task_preflight_error(
+                "preflight_auth",
+                "sign in before using Socai Agent",
+            ));
+        }
+        let wallet = socai_core::cloud::wallet_balance().await.map_err(|error| {
+            task_preflight_error("preflight_region_or_account", format!("{error:#}"))
+        })?;
+        validate_preflight_balance(wallet.balance_points)?;
+    }
+
+    let page = ensure_browser_connected(runtime).await?;
+    let login_error_code = if page.is_remote_browser() {
+        "preflight_xhs_session"
+    } else {
+        "preflight_xhs_login"
+    };
+    let login = XhsPageRuntime::new(&page)
+        .login_gate(true)
+        .await
+        .map_err(|error| task_preflight_error(login_error_code, format!("{error:#}")))?;
+    if login == socai_core::sites::xhs::page::LoginGate::Required {
+        return Err(task_preflight_error(
+            login_error_code,
+            "Xiaohongshu login is required in the active browser session",
+        ));
+    }
+    Ok(())
+}
+
+fn task_preflight_error(code: &str, detail: impl std::fmt::Display) -> String {
+    json!({
+        "code": code,
+        "detail": detail.to_string(),
+    })
+    .to_string()
+}
+
+fn validate_preflight_balance(balance_points: i64) -> Result<(), String> {
+    if balance_points <= 0 {
+        Err(task_preflight_error(
+            "preflight_balance",
+            "insufficient Socai points; recharge or switch provider",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 #[tauri::command]
@@ -1996,5 +2060,18 @@ mod tests {
             selected[0].get("selected_model").and_then(Value::as_str),
             Some("o3")
         );
+    }
+
+    #[test]
+    fn preflight_rejects_empty_hosted_balance() {
+        assert!(validate_preflight_balance(100).is_ok());
+        let error = validate_preflight_balance(0).expect_err("zero balance must fail");
+        let payload: Value = serde_json::from_str(&error).expect("preflight error must be JSON");
+        assert_eq!(payload["code"], "preflight_balance");
+        assert_eq!(
+            payload["detail"],
+            "insufficient Socai points; recharge or switch provider"
+        );
+        assert!(validate_preflight_balance(-1).is_err());
     }
 }

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -397,6 +397,93 @@ const messages = {
     zh: "连接 chrome 后可继续追问",
   },
   "task.replySend": { en: "send", zh: "发送" },
+  "task.preflightModelConfig": {
+    en: "the selected model is not ready. configure its api key or account connection in the model menu, then try again.",
+    zh: "当前模型尚未完成配置。请在右上角模型菜单中添加 API Key 或完成账号连接，然后重试。",
+  },
+  "task.preflightAuth": {
+    en: "your socai account is signed out. sign in, then send the task again.",
+    zh: "当前 socai 账号尚未登录。请先登录账号，然后重新发送任务。",
+  },
+  "task.preflightBalance": {
+    en: "your socai account does not have enough points. recharge or switch to another configured model, then try again.",
+    zh: "当前 socai 账号点数不足。请充值点数或切换到其他已配置的模型，然后重试。",
+  },
+  "task.preflightAccount": {
+    en: "socai could not verify your account and point balance. check the network and account region, then try again.",
+    zh: "socai 无法验证当前账号和点数。请检查网络以及账号区域，然后重试。",
+  },
+  "task.preflightSite": {
+    en: "socai could not initialize xiaohongshu support. restart the app and update it if the problem continues.",
+    zh: "socai 无法初始化小红书运行环境。请重启应用；问题持续时请更新到最新版本。",
+  },
+  "task.preflightBrowserConfig": {
+    en: "socai could not read the chrome configuration. choose the browser source again in settings, then try again.",
+    zh: "socai 无法读取 chrome 配置。请在设置中重新选择浏览器来源，然后重试。",
+  },
+  "task.preflightBrowser": {
+    en: "socai could not prepare chrome. check the browser source in settings, keep chrome open, and reconnect.",
+    zh: "socai 无法准备 chrome 浏览器。请检查设置中的浏览器来源，保持 chrome 运行并重新连接。",
+  },
+  "task.preflightBrowserRemote": {
+    en: "socai could not connect to the hosted browser. check your network and socai account, then try again.",
+    zh: "socai 无法连接云端浏览器。请检查网络和 socai 账号状态，然后重试。",
+  },
+  "task.preflightXhsLogin": {
+    en: "xiaohongshu is signed out in the connected chrome profile. complete sign-in there, then try again.",
+    zh: "当前 chrome 配置文件尚未登录小红书。请在已连接的 chrome 中完成登录，然后重试。",
+  },
+  "task.preflightXhsSession": {
+    en: "the hosted xiaohongshu session is unavailable. reconnect the hosted browser and try again; contact support if it continues.",
+    zh: "云端小红书会话暂时不可用。请重新连接云端浏览器后重试；问题持续时请联系支持。",
+  },
+  "task.preflightUnknown": {
+    en: "socai could not complete the checks required to start this task. try again and share the error code if it continues.",
+    zh: "socai 无法完成任务启动检查。请重试；问题持续时请提供错误码。",
+  },
+  "task.preflightFailedTitle": {
+    en: "task cannot start yet",
+    zh: "任务暂时无法开始",
+  },
+  "task.errorCode": { en: "error code: {code}", zh: "错误码：{code}" },
+  "task.apiErrorAuthTitle": { en: "model authentication failed", zh: "模型认证失败" },
+  "task.apiErrorAuth": {
+    en: "{provider} rejected the current API key. update it in the model menu at the top right, then send the task again.",
+    zh: "{provider} 拒绝了当前 API Key。请在右上角模型菜单中更新 API Key，然后重新发送任务。",
+  },
+  "task.apiErrorBalanceTitle": { en: "model balance is insufficient", zh: "模型余额不足" },
+  "task.apiErrorBalance": {
+    en: "{provider} reported insufficient balance or quota. recharge the account or switch to another configured model, then try again.",
+    zh: "{provider} 返回余额或额度不足。请充值对应账号或切换到其他已配置的模型，然后重试。",
+  },
+  "task.apiErrorForbiddenTitle": { en: "model access was denied", zh: "模型访问被拒绝" },
+  "task.apiErrorForbidden": {
+    en: "{provider} denied access to this model. check the model permission and account region, or switch models.",
+    zh: "{provider} 拒绝访问当前模型。请检查模型权限和账号区域，或切换其他模型。",
+  },
+  "task.apiErrorRateLimitTitle": { en: "model requests are too frequent", zh: "模型请求过于频繁" },
+  "task.apiErrorRateLimit": {
+    en: "{provider} is rate limiting requests. wait briefly and send the task again, or switch models.",
+    zh: "{provider} 正在限制请求频率。请稍后重新发送任务，或切换其他模型。",
+  },
+  "task.apiErrorUnavailableTitle": { en: "model service is unavailable", zh: "模型服务暂时不可用" },
+  "task.apiErrorUnavailable": {
+    en: "{provider} is temporarily unavailable. wait briefly and send the task again.",
+    zh: "{provider} 服务暂时不可用。请稍后重新发送任务。",
+  },
+  "task.apiErrorNetworkTitle": { en: "model connection failed", zh: "模型连接失败" },
+  "task.apiErrorNetwork": {
+    en: "socai could not reach {provider}. check the network and proxy settings, then try again.",
+    zh: "socai 无法连接 {provider}。请检查网络和代理设置，然后重试。",
+  },
+  "task.apiErrorGenericTitle": { en: "model request failed", zh: "模型请求失败" },
+  "task.apiErrorGeneric": {
+    en: "{provider} could not complete the request. try again or switch to another configured model.",
+    zh: "{provider} 无法完成当前请求。请重试或切换到其他已配置的模型。",
+  },
+  "task.apiErrorDismissAria": { en: "dismiss error", zh: "关闭错误提示" },
+  "task.apiErrorRequestId": { en: "request {id}", zh: "请求 {id}" },
+  "task.apiErrorProvider": { en: "the model provider", zh: "模型服务" },
 
   "feishu.export": { en: "export to feishu", zh: "导出到飞书" },
   "feishu.dialogAria": { en: "export to feishu", zh: "导出到飞书" },
@@ -524,6 +611,133 @@ export function t(
     message = message.replaceAll(`{${name}}`, `${value}`);
   }
   return message;
+}
+
+const taskPreflightMessages = {
+  preflight_model_config: "task.preflightModelConfig",
+  preflight_auth: "task.preflightAuth",
+  preflight_balance: "task.preflightBalance",
+  preflight_region_or_account: "task.preflightAccount",
+  preflight_site: "task.preflightSite",
+  preflight_browser_config: "task.preflightBrowserConfig",
+  preflight_browser: "task.preflightBrowser",
+  preflight_browser_remote: "task.preflightBrowserRemote",
+  preflight_xhs_login: "task.preflightXhsLogin",
+  preflight_xhs_session: "task.preflightXhsSession",
+} as const satisfies Record<string, MessageKey>;
+
+export function formatTaskCommandError(error: unknown): string {
+  const presentation = formatTaskCommandErrorPresentation(error);
+  if (!presentation) return String(error);
+  return `${presentation.message}\n${presentation.meta}`;
+}
+
+export function formatTaskCommandErrorPresentation(
+  error: unknown,
+): TaskApiErrorPresentation | null {
+  const payload = parseTaskCommandError(error);
+  if (!payload) return null;
+  const messageKey = taskPreflightMessages[payload.code as keyof typeof taskPreflightMessages]
+    ?? "task.preflightUnknown";
+  return {
+    title: t("task.preflightFailedTitle"),
+    message: t(messageKey),
+    meta: t("task.errorCode", { code: payload.code }),
+    fingerprint: `${payload.code}:${payload.detail}`,
+  };
+}
+
+export interface TaskApiErrorPresentation {
+  title: string;
+  message: string;
+  meta: string;
+  fingerprint: string;
+}
+
+export function formatTaskApiError(error: string): TaskApiErrorPresentation {
+  const segments = error.split(/\s+\|\s+/);
+  const providerMatch = segments.shift()?.match(/^(.+?)\s+API error$/i);
+  const providerValue = providerMatch?.[1]?.trim() ?? "";
+  const provider = providerValue
+    ? `${providerValue.charAt(0).toUpperCase()}${providerValue.slice(1)}`
+    : t("task.apiErrorProvider");
+  const fields = new Map<string, string>();
+  for (const segment of segments) {
+    const separator = segment.indexOf("=");
+    if (separator <= 0) continue;
+    fields.set(segment.slice(0, separator).trim().toLowerCase(), segment.slice(separator + 1).trim());
+  }
+
+  const statusText = fields.get("status") ?? "";
+  const status = Number.parseInt(statusText, 10);
+  const type = fields.get("type") ?? "";
+  const detail = fields.get("message") ?? error;
+  const requestId = fields.get("request_id") ?? "";
+  const signal = `${type} ${detail}`.toLowerCase();
+  let titleKey: MessageKey;
+  let messageKey: MessageKey;
+  if (status === 401 || /auth|unauthor|invalid.*(?:api|x-api).*key/.test(signal)) {
+    titleKey = "task.apiErrorAuthTitle";
+    messageKey = "task.apiErrorAuth";
+  } else if (status === 402 || /insufficient.*(?:balance|point|credit|quota)/.test(signal)) {
+    titleKey = "task.apiErrorBalanceTitle";
+    messageKey = "task.apiErrorBalance";
+  } else if (status === 403 || /forbidden|permission|access denied/.test(signal)) {
+    titleKey = "task.apiErrorForbiddenTitle";
+    messageKey = "task.apiErrorForbidden";
+  } else if (status === 429 || /rate.?limit|too many requests/.test(signal)) {
+    titleKey = "task.apiErrorRateLimitTitle";
+    messageKey = "task.apiErrorRateLimit";
+  } else if (status >= 500) {
+    titleKey = "task.apiErrorUnavailableTitle";
+    messageKey = "task.apiErrorUnavailable";
+  } else if (/network|connect|timeout|timed out|dns/.test(signal)) {
+    titleKey = "task.apiErrorNetworkTitle";
+    messageKey = "task.apiErrorNetwork";
+  } else {
+    titleKey = "task.apiErrorGenericTitle";
+    messageKey = "task.apiErrorGeneric";
+  }
+
+  const errorCode = type || (Number.isFinite(status) ? `http_${status}` : "api_error");
+  const meta = [
+    t("task.errorCode", { code: errorCode }),
+    Number.isFinite(status) ? `HTTP ${status}` : "",
+    requestId ? t("task.apiErrorRequestId", { id: requestId }) : "",
+  ].filter(Boolean).join(" · ");
+  return {
+    title: t(titleKey),
+    message: t(messageKey, { provider }),
+    meta,
+    fingerprint: requestId || `${provider}:${statusText}:${type}:${detail}`,
+  };
+}
+
+function parseTaskCommandError(error: unknown): { code: string; detail: string } | null {
+  if (typeof error === "object" && error !== null) {
+    const payload = error as Record<string, unknown>;
+    if (typeof payload.code === "string" && payload.code.startsWith("preflight_")) {
+      return {
+        code: payload.code,
+        detail: typeof payload.detail === "string" ? payload.detail : "",
+      };
+    }
+  }
+
+  const raw = error instanceof Error ? error.message : String(error);
+  try {
+    const payload = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof payload.code === "string" && payload.code.startsWith("preflight_")) {
+      return {
+        code: payload.code,
+        detail: typeof payload.detail === "string" ? payload.detail : "",
+      };
+    }
+  } catch {
+    const legacy = raw.match(/^(preflight_[a-z_]+)(?::\s*(.*))?$/s);
+    if (legacy) return { code: legacy[1], detail: legacy[2] ?? "" };
+  }
+  return null;
 }
 
 export function getLocale(): string {

--- a/app/src/lib/polyfills.ts
+++ b/app/src/lib/polyfills.ts
@@ -1,0 +1,11 @@
+if (typeof Array.prototype.at !== "function") {
+  Object.defineProperty(Array.prototype, "at", {
+    configurable: true,
+    writable: true,
+    value<T>(this: T[], index: number): T | undefined {
+      const relativeIndex = Math.trunc(index) || 0;
+      const resolvedIndex = relativeIndex < 0 ? this.length + relativeIndex : relativeIndex;
+      return resolvedIndex >= 0 && resolvedIndex < this.length ? this[resolvedIndex] : undefined;
+    },
+  });
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,12 +1,19 @@
 //! Tauri desktop entry — header status/configuration plus tools / agent panels.
 
+import "./lib/polyfills";
+
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 
-import { applyLanguageToDocument, t } from "./lib/i18n";
+import {
+  applyLanguageToDocument,
+  formatTaskApiError,
+  formatTaskCommandErrorPresentation,
+  t,
+} from "./lib/i18n";
 import { authMenu } from "./panels/auth";
 import { agentPanel } from "./panels/tasks";
 import { settingsMenu } from "./panels/settings";
@@ -184,12 +191,22 @@ interface BackgroundMediaEvent {
 export interface ShellState {
   status: Status;
   rerender: () => void;
+  notifyTaskCommandError: (error: unknown) => boolean;
 }
 
 let status: Status = { state: "disconnected", reason: "starting" };
 let connectionDetailsOpen = false;
 // The sidebar (task history rail) starts expanded; the topbar toggle collapses it.
 let sidebarOpen = true;
+type RuntimeErrorNotice =
+  | { key: string; kind: "api"; error: string }
+  | { key: string; kind: "command"; error: unknown };
+let runtimeErrorNotice: RuntimeErrorNotice | null = null;
+let runtimeErrorNoticeTimer: number | null = null;
+let runtimeErrorDismissBound = false;
+const recentRuntimeErrors = new Map<string, number>();
+const RUNTIME_ERROR_NOTICE_MS = 5_000;
+const RUNTIME_ERROR_DEDUPE_MS = 30_000;
 
 // Sidebar-collapse toggle glyph (mirrors the prototype's PanelIcon). On macOS
 // the native traffic lights sit to its left; the .topbar-left gutter clears them.
@@ -201,7 +218,11 @@ const PANEL_ICON_SVG = `
 `;
 
 function shell(): ShellState {
-  return { status, rerender: render };
+  return {
+    status,
+    rerender: render,
+    notifyTaskCommandError: captureTaskCommandErrorNotice,
+  };
 }
 
 function render(): void {
@@ -234,6 +255,7 @@ function render(): void {
           ${settingsMenu.render(state)}
         </div>
       </header>
+      ${renderRuntimeErrorNotice()}
       <div class="body">
         ${sidebarOpen ? agentPanel.renderSidebar() : ""}
         <div class="workspace-stack">
@@ -246,6 +268,7 @@ function render(): void {
   bindConnectionStatusBar();
   bindUpdateChip();
   bindSidebarToggle();
+  bindRuntimeErrorNotice();
   agentPanel.bindHeader(state);
   authMenu.bind(
     state,
@@ -281,6 +304,88 @@ function render(): void {
     },
   );
   agentPanel.bind(state);
+}
+
+function renderRuntimeErrorNotice(): string {
+  if (!runtimeErrorNotice) return "";
+  const presentation = runtimeErrorNotice.kind === "api"
+    ? formatTaskApiError(runtimeErrorNotice.error)
+    : formatTaskCommandErrorPresentation(runtimeErrorNotice.error);
+  if (!presentation) return "";
+  return `
+    <aside class="runtime-error-notice" role="alert" aria-live="assertive">
+      <div class="runtime-error-notice__copy">
+        <div class="runtime-error-notice__heading">
+          <i class="runtime-error-notice__dot" aria-hidden="true"></i>
+          <p class="runtime-error-notice__title">${htmlEsc(presentation.title)}</p>
+        </div>
+        <p class="runtime-error-notice__message">${htmlEsc(presentation.message)}</p>
+        <p class="runtime-error-notice__meta">${htmlEsc(presentation.meta)}</p>
+      </div>
+      <button
+        type="button"
+        class="icon-button runtime-error-notice__dismiss"
+        data-runtime-error-dismiss
+        aria-label="${htmlEsc(t("task.apiErrorDismissAria"))}"
+      >×</button>
+    </aside>
+  `;
+}
+
+function bindRuntimeErrorNotice(): void {
+  if (runtimeErrorDismissBound) return;
+  runtimeErrorDismissBound = true;
+  document.addEventListener("click", (event) => {
+    const dismiss = event.composedPath().find((item) =>
+      item instanceof Element && item.hasAttribute("data-runtime-error-dismiss"));
+    if (!dismiss) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dismissRuntimeErrorNotice();
+  });
+}
+
+function dismissRuntimeErrorNotice(): void {
+  runtimeErrorNotice = null;
+  if (runtimeErrorNoticeTimer !== null) window.clearTimeout(runtimeErrorNoticeTimer);
+  runtimeErrorNoticeTimer = null;
+  document.querySelector(".runtime-error-notice")?.remove();
+}
+
+function showRuntimeErrorNotice(notice: RuntimeErrorNotice): void {
+  runtimeErrorNotice = notice;
+  if (runtimeErrorNoticeTimer !== null) window.clearTimeout(runtimeErrorNoticeTimer);
+  runtimeErrorNoticeTimer = window.setTimeout(() => {
+    if (runtimeErrorNotice?.key !== notice.key) return;
+    dismissRuntimeErrorNotice();
+  }, RUNTIME_ERROR_NOTICE_MS);
+}
+
+function captureTaskCommandErrorNotice(error: unknown): boolean {
+  const presentation = formatTaskCommandErrorPresentation(error);
+  if (!presentation) return false;
+  showRuntimeErrorNotice({
+    key: `command:${presentation.fingerprint}`,
+    kind: "command",
+    error,
+  });
+  return true;
+}
+
+function captureRuntimeErrorNotice(payload: AgentTaskEventPayload): boolean {
+  if (payload.kind !== "api_error" || !payload.text.trim()) return false;
+  console.error("agent task API error:", payload.text);
+  const presentation = formatTaskApiError(payload.text);
+  const key = `${payload.task_id}:${presentation.fingerprint}`;
+  const now = Date.now();
+  if ((recentRuntimeErrors.get(key) ?? 0) > now - RUNTIME_ERROR_DEDUPE_MS) return false;
+  recentRuntimeErrors.set(key, now);
+  for (const [seenKey, seenAt] of recentRuntimeErrors) {
+    if (seenAt <= now - RUNTIME_ERROR_DEDUPE_MS) recentRuntimeErrors.delete(seenKey);
+  }
+
+  showRuntimeErrorNotice({ key, kind: "api", error: payload.text });
+  return true;
 }
 
 function bindSidebarToggle(): void {
@@ -606,7 +711,8 @@ async function main(): Promise<void> {
   // run boundaries ask for a full render so the task list and conversation
   // turns update; normal stream rows append in place to preserve scroll.
   await listen<AgentTaskEventPayload>("agent_task:event", (event) => {
-    if (agentPanel.appendTaskEvent(event.payload)) render();
+    const showRuntimeError = captureRuntimeErrorNotice(event.payload);
+    if (agentPanel.appendTaskEvent(event.payload) || showRuntimeError) render();
     if (event.payload.kind === "tool_result") {
       // Each finished step's notes are on disk — refresh so the result row's
       // embed renders them now, not when the whole task ends.

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -18,7 +18,14 @@
 
 import type { AgentTaskEventPayload, AgentTaskSnapshot, Status } from "../main";
 import { esc } from "../lib/html";
-import { formatStepCount, formatTaskTimestamp, formatTokenUsage, t, taskStatusLabel } from "../lib/i18n";
+import {
+  formatStepCount,
+  formatTaskApiError,
+  formatTaskTimestamp,
+  formatTokenUsage,
+  t,
+  taskStatusLabel,
+} from "../lib/i18n";
 import { sendShortcutLabel } from "../lib/shortcuts";
 import feishuLogo from "../assets/connectors/feishu.png";
 import chromeRemoteDebuggingImage from "../assets/chrome-remote-debugging.png";
@@ -226,6 +233,10 @@ function buildTurn(
       }
     }
   }
+  const apiErrors = new Set(
+    body.filter((event) => event.kind === "api_error").map((event) => event.text.trim()),
+  );
+  body = body.filter((event) => event.kind !== "failed" || !apiErrors.has(event.text.trim()));
   return { userText, userAt, body, answerText, answerAt };
 }
 
@@ -249,7 +260,11 @@ function renderTurn(
   const metaBits: string[] = [];
   if (isLast) {
     const finishedAt = task.finished_at ? formatTaskTimestamp(task.finished_at) : null;
-    if (task.final_text) {
+    const apiError = taskApiError(task);
+    if (apiError) {
+      answer = renderTaskApiErrorCard(apiError);
+      if (finishedAt) metaBits.push(finishedAt);
+    } else if (task.final_text) {
       exportText = task.final_text;
       answer = `<div class="conv-answer result-md note-answer">${renderNoteAnswer(task.final_text)}</div>`;
       if (finishedAt) metaBits.push(finishedAt);
@@ -397,8 +412,41 @@ function renderActivity(
 export function renderEventRow(ev: AgentTaskEventPayload): string {
   const progressKey = ev.kind === "tool_progress" ? `${ev.id ?? ""}:${ev.phase ?? ""}` : "";
   const progressAttr = progressKey ? ` data-tool-progress="${esc(progressKey)}"` : "";
+  if (ev.kind === "api_error") return renderTaskApiErrorEvent(ev);
   const text = ev.kind === "tool_progress" ? toolProgressText(ev) : ev.text;
   return `<div class="act-row act-row--${esc(ev.kind)}"${progressAttr}><span class="act-row__glyph" aria-hidden="true">${eventGlyph(ev.kind)}</span><span class="act-row__text">${esc(text)}</span></div>`;
+}
+
+function renderTaskApiErrorEvent(ev: AgentTaskEventPayload): string {
+  const presentation = formatTaskApiError(ev.text);
+  return `<div class="act-row act-row--api_error">
+    <span class="act-row__glyph" aria-hidden="true">${eventGlyph(ev.kind)}</span>
+    <span class="act-row__text task-api-error-copy">
+      <span class="task-api-error-copy__title">${esc(presentation.title)}</span>
+      <span class="task-api-error-copy__message">${esc(presentation.message)}</span>
+      <span class="task-api-error-copy__meta">${esc(presentation.meta)}</span>
+    </span>
+  </div>`;
+}
+
+function renderTaskApiErrorCard(error: string): string {
+  const presentation = formatTaskApiError(error);
+  return `<div class="task-api-error-card" role="alert">
+    <div class="task-api-error-card__heading">
+      <i class="runtime-error-notice__dot" aria-hidden="true"></i>
+      <p class="task-api-error-card__title">${esc(presentation.title)}</p>
+    </div>
+    <p class="task-api-error-card__message">${esc(presentation.message)}</p>
+    <p class="task-api-error-card__meta">${esc(presentation.meta)}</p>
+  </div>`;
+}
+
+function taskApiError(task: AgentTaskView): string | null {
+  const error = task.error?.trim();
+  if (error && /\bAPI error\b/i.test(error)) return error;
+  const finalText = task.final_text?.trim();
+  if (!finalText || !/^API error:\s*/i.test(finalText)) return null;
+  return finalText.replace(/^API error:\s*/i, "");
 }
 
 function toolProgressText(ev: AgentTaskEventPayload): string {

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -706,12 +706,22 @@ export namespace agentPanel {
       return !!payload.snapshot;
     }
 
+    const failedFromApiError = payload.kind === "api_error"
+      && (task.status === "queued" || task.status === "running");
+    if (failedFromApiError) {
+      task.status = "failed";
+      task.finished_at = payload.created_at || Date.now();
+      task.error = payload.text;
+      task.target_id = null;
+      clearActivityState(task.task_id);
+    }
+
     if (payload.text.trim()) {
       const added = appendUniqueEvent(task, payload);
       if (added && !boundary) appendEventRowIfSelected(payload);
     }
 
-    return !!payload.snapshot || boundary;
+    return !!payload.snapshot || boundary || failedFromApiError;
   }
 
   // The persistent left rail: "new task" + the history list. Always rendered
@@ -806,20 +816,7 @@ export namespace agentPanel {
       });
     });
 
-    // The row's open control is a native <button>, so click/Enter/Space are
-    // handled for free — no hand-bound keydown, no role/tabindex.
-    document.querySelectorAll<HTMLButtonElement>("[data-task-id]").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        selectedTaskId = btn.dataset.taskId ?? null;
-        view = "detail";
-        // A stale draft/error from whatever task was open before shouldn't
-        // leak into this one's reply box.
-        replyDraft = "";
-        replyError = "";
-        shell.rerender();
-        if (selectedTaskId) void loadTaskNotes(selectedTaskId, shell);
-      });
-    });
+    bindTaskSelection(shell);
     // Note interactions (viewer, card carousel, citation hover, external links)
     // are wired once via delegation on document.
     bindNoteInteractions();
@@ -873,6 +870,27 @@ export namespace agentPanel {
     if (selected && (selected.status === "running" || selected.status === "queued")) {
       updateLiveStrip(selected);
     }
+  }
+
+  function bindTaskSelection(shell: ShellState): void {
+    document.querySelectorAll<HTMLButtonElement>("[data-task-id]").forEach((button) => {
+      const select = (): void => {
+        const taskId = button.dataset.taskId;
+        if (!taskId) return;
+        selectedTaskId = taskId;
+        view = "detail";
+        replyDraft = "";
+        replyError = "";
+        shell.rerender();
+        void loadTaskNotes(taskId, shell);
+      };
+      button.addEventListener("pointerdown", (event) => {
+        if (event.button === 0) select();
+      });
+      button.addEventListener("click", (event) => {
+        if (event.detail === 0) select();
+      });
+    });
   }
 
   // A shell render rebuilds the left rail, so restore the task list's previous
@@ -1059,7 +1077,8 @@ export namespace agentPanel {
       view = "detail";
       draft = "";
     } catch (err) {
-      submitError = `${err}`;
+      console.error("agent_task_start failed:", err);
+      submitError = shell.notifyTaskCommandError(err) ? "" : `${err}`;
     } finally {
       submittingTask = false;
       shell.rerender();
@@ -1090,7 +1109,8 @@ export namespace agentPanel {
       upsertTask(snapshot);
       replyDraft = "";
     } catch (err) {
-      replyError = `${err}`;
+      console.error("agent_task_reply failed:", err);
+      replyError = shell.notifyTaskCommandError(err) ? "" : `${err}`;
     } finally {
       submittingReply = false;
       shell.rerender();
@@ -1108,9 +1128,7 @@ export namespace agentPanel {
       // The answer landing auto-folds the activity: drop the task's explicit
       // fold choices so the default (closed once finished) takes over.
       if (wasActive && statusRank(existing.status) >= 2) {
-        for (const key of [...activityOpen.keys()]) {
-          if (key.startsWith(`${snapshot.task_id}#`)) activityOpen.delete(key);
-        }
+        clearActivityState(snapshot.task_id);
       }
       return existing;
     }
@@ -1118,6 +1136,12 @@ export namespace agentPanel {
     tasks = [...tasks, created];
     if (!selectedTaskId) selectedTaskId = snapshot.task_id;
     return created;
+  }
+
+  function clearActivityState(taskId: string): void {
+    for (const key of [...activityOpen.keys()]) {
+      if (key.startsWith(`${taskId}#`)) activityOpen.delete(key);
+    }
   }
 
   // Delete-confirm dialog wiring: keep, a click on the scrim itself, or Esc
@@ -1282,6 +1306,10 @@ export namespace agentPanel {
   }
 
   function stableEventKey(event: AgentTaskEventPayload): string | null {
+    if (event.kind === "api_error") {
+      const requestId = event.text.match(/(?:^|\|\s*)request_id=([^|\s]+)/)?.[1];
+      if (requestId) return `${event.task_id}:api_error:${requestId}`;
+    }
     return event.sequence > 0 ? `${event.task_id}:sequence:${event.sequence}` : null;
   }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -287,6 +287,111 @@ body.has-paper > * { position: relative; z-index: 1; }
 .update-tooltip-arrow { color: var(--ink-4); }
 .update-tooltip-new { color: var(--ink-9); font-weight: 500; }
 
+/* ── runtime error notice — temporary, actionable task failure ───── */
+.runtime-error-notice {
+  position: fixed;
+  top: calc(52px + var(--sp-2));
+  right: var(--sp-3);
+  z-index: 100;
+  width: min(360px, calc(100vw - var(--sp-6)));
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  animation: runtime-error-enter var(--t-base) var(--ease);
+}
+.runtime-error-notice__copy { flex: 1; min-width: 0; }
+.runtime-error-notice__heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.runtime-error-notice__dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--r-pill);
+  background: var(--ink-0);
+}
+.runtime-error-notice__title {
+  margin: 0;
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.35;
+  font-weight: 500;
+}
+.runtime-error-notice__message {
+  margin: 5px 0 0;
+  color: var(--fg-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.runtime-error-notice__meta {
+  margin: var(--sp-2) 0 0;
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.runtime-error-notice__dismiss {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  font-size: 18px;
+  line-height: 1;
+}
+.runtime-error-notice__dismiss:focus-visible { outline: 2px solid var(--focus-ring); }
+
+.task-api-error-card {
+  max-width: 560px;
+  padding: var(--sp-3);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  background: var(--surface);
+}
+.task-api-error-card__heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.task-api-error-card__title {
+  margin: 0;
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.35;
+  font-weight: 500;
+}
+.task-api-error-card__message {
+  margin: 5px 0 0;
+  color: var(--fg-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.task-api-error-card__meta,
+.task-api-error-copy__meta {
+  color: var(--fg-soft);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.task-api-error-card__meta { margin: var(--sp-2) 0 0; }
+.task-api-error-copy { display: flex; flex-direction: column; gap: 3px; }
+.task-api-error-copy__title { color: var(--fg); font-weight: 500; }
+.task-api-error-copy__message { color: var(--fg-muted); line-height: 1.5; }
+@keyframes runtime-error-enter {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (max-width: 640px) {
+  .runtime-error-notice { width: calc(100vw - var(--sp-6)); }
+}
+
 /* ── account + settings controls ───────────────────────────────── */
 .auth-menu,
 .settings-menu { position: relative; display: inline-flex; flex: 0 0 auto; }


### PR DESCRIPTION
## Summary

- Run one shared preflight for new tasks and follow-up turns before creating the conversation or run directory.
- Validate local provider credential presence, socai authentication and wallet balance, browser configuration, and Xiaohongshu login state.
- Return stable `preflight_*` error envelopes with diagnostic details, then let Desktop render localized, actionable guidance while retaining the error code for support.
- Distinguish local Chrome, hosted browser, local Xiaohongshu login, and hosted Xiaohongshu session failures so each path recommends the correct recovery action.
- Surface preflight and runtime model failures as temporary top-right Desktop notices, preserve unknown command errors as inline fallbacks, and deduplicate repeated runtime events by `request_id`.
- Render terminal model API failures as localized task result cards and activity rows instead of exposing raw provider strings.

## Trace context

- `71ecbb6e8d34d45190c1ed8e16f8c0cc` — a managed-model run reached the server and failed with `402 insufficient points` after run creation.
- `dbe5d0d972a519dfa67fa2d71a545828` — three managed-model runs in one trace repeated the same `402 insufficient points` outcome.
- `c7a3b93529bad879e3ba3f4c4b1fcb0c` — Xiaohongshu login remained unavailable across follow-up turns, producing completed runs whose final output only reported the login blocker.

These traces show the user-visible pattern addressed here: deterministic prerequisites surface after a run directory and task lifecycle already exist, leading to failed or blocker-only runs and repeated retries. Raw backend errors also leave Desktop users without a localized recovery action.

## Reproduction

- The historical failures are reproducible from Axiom trace output and the pre-change call order in `agent_task_start` / `agent_task_reply`.
- Before this change, Desktop assigns the rejected Tauri value directly to the composer, so users see raw English strings such as `preflight_balance: insufficient Socai points`.
- The local validation environment currently has a valid OAuth session and positive hosted balance. Compile checks cover all command branches and the existing balance test validates the serialized error envelope.
- The `preflight_xhs_login` presentation was replayed in Desktop to verify that the top-right notice renders localized guidance and the composer remains clear.

## Before / after

| | Before | After |
| --- | --- | --- |
| Provider configuration | Missing local credentials return a raw backend error | The preflight returns `preflight_model_config`; Desktop explains where to configure the model in Chinese or English |
| socai hosted balance | `402 insufficient points` arrives from the first model call after task/run creation | `/v1/billing/wallet` is checked before conversation and run creation, then Desktop recommends recharge or model switching |
| Browser and XHS login | Browser setup and login failures can surface during agent work | The configured site page and existing `login_gate` run before task creation, with separate local and hosted recovery messages |
| Follow-up turns | A new turn directory can be allocated before a deterministic prerequisite fails | The same preflight runs before allocating the follow-up turn directory |
| Error presentation | Desktop shows the rejected command string below the composer | Desktop shows localized guidance in the existing top-right notice style, displays the error code, and preserves the full envelope in the console log |

## Scope

- The backend change remains limited to Desktop task start/reply orchestration in `commands.rs`.
- Desktop i18n adds preflight and runtime error presentations shared by new-task and follow-up submission.
- Browser preflight reuses the page returned by the existing connection path, so login validation does not make a second connection attempt.
- Local providers retain the existing credential-presence check. Remote API-key validity, provider quota, model entitlement, and region support remain provider-call outcomes.
- Provider fallback, automatic model switching, retries, task cleanup, and agent-loop behavior remain separate work.

## Test plan

- [x] `pnpm build`
- [x] `cargo check -p socai-core -p socai_app`
- [x] `cargo check --tests -p socai_app`
- [x] `rustfmt --edition 2021 --check app/src-tauri/src/commands.rs`
- [x] `git diff --check`
- [x] Replay an Anthropic `401 authentication_error` preview and confirm one notice appears, matches the topbar popover style, and closes automatically after 5 seconds.
- [x] Replay `preflight_xhs_login` and confirm the localized top-right notice renders while the composer remains clear.
- [x] Replay a terminal `api_error` and confirm the running task immediately transitions to failed.
- [x] Switch from the failed task to a completed task and confirm both sidebar selection and conversation content update.
- [x] Replay pointer and keyboard sidebar selection while another task is running.
- [x] Hydrate an Anthropic `401 authentication_error` task and confirm the result card and activity row show localized guidance without the raw provider string.
- [ ] Start a socai task with an empty wallet and confirm it fails before creating a run.
- [ ] Sign out of Xiaohongshu and confirm both a new task and a follow-up return localized `preflight_xhs_login` guidance.


