### PR TITLE
fix: defer interruption during transient CDP disconnects

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -5,12 +5,82 @@ mod telemetry;
 mod timeline;
 
 use std::collections::HashSet;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
 
 use serde_json::json;
 use socai_core::runtime::{RuntimeBrowserEvent, SocaiRuntime};
 use tasks::AgentTaskRegistry;
 use tauri::{Emitter, Manager};
 use telemetry::{duration_ms, DesktopTelemetry};
+
+const BROWSER_RECOVERY_GRACE: Duration = Duration::from_secs(15);
+
+async fn interrupt_missing_browser_targets(
+    active_targets: HashSet<String>,
+    interruption_reason: String,
+    tasks: AgentTaskRegistry,
+    telemetry: DesktopTelemetry,
+    handle: tauri::AppHandle,
+) {
+    for (mut snapshot, abort_handle) in tasks
+        .interrupt_missing_targets(&active_targets, &interruption_reason)
+        .await
+    {
+        let task_id = snapshot.task_id.clone();
+        if snapshot.provider.as_deref() == Some("socai") && socai_core::cloud::pro_activated() {
+            if let Some(settlement) =
+                commands::settle_hosted_task_with_retry(&task_id, "interrupted").await
+            {
+                if let Some(updated) = tasks
+                    .update(&task_id, |task| {
+                        task.points_used =
+                            commands::visible_billed_points(task.provider.as_deref(), &settlement);
+                    })
+                    .await
+                {
+                    snapshot = updated;
+                }
+            }
+        }
+        if let Some(handle) = abort_handle {
+            handle.abort();
+        }
+        commands::persist_run_points_used(snapshot.run_dir.as_deref(), snapshot.points_used);
+        commands::record_interrupted_run(&snapshot, &interruption_reason);
+        if let Some(run_dir) = snapshot.run_dir.as_deref() {
+            commands::upload_terminal_run_trace(run_dir, "interrupted", &telemetry).await;
+        }
+        telemetry.capture(
+            "socai_agent_task_end",
+            json!({
+                "task_id": task_id.clone(),
+                "provider": snapshot.provider.clone(),
+                "run_id": snapshot.run_id.clone(),
+                "model": snapshot.model.clone(),
+                "outcome": "interrupted",
+                "steps": snapshot.steps,
+                "input_tokens": snapshot.input_tokens,
+                "output_tokens": snapshot.output_tokens,
+                "points_used": snapshot.points_used,
+                "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
+                "error": crate::telemetry::short_error(&interruption_reason),
+            }),
+        );
+        commands::emit_task_event(
+            &handle,
+            &tasks,
+            &task_id,
+            "interrupted",
+            interruption_reason.clone(),
+            Some(snapshot),
+        )
+        .await;
+    }
+}
 
 /// macOS: attach an empty unified toolbar so AppKit itself lays the native
 /// traffic lights out on a tall (~52px) titlebar, vertically centered — the
@@ -95,6 +165,8 @@ pub fn run() {
 
                 let mut rx = runtime.subscribe_browser_events();
                 let mut latest_disconnect_reason: Option<String> = None;
+                let mut recoverable_disconnect = false;
+                let browser_event_generation = Arc::new(AtomicU64::new(0));
                 while let Ok(event) = rx.recv().await {
                     match event {
                         RuntimeBrowserEvent::StatusChanged(payload) => {
@@ -107,7 +179,9 @@ pub fn run() {
                                     remote_remaining_seconds,
                                     ..
                                 } => {
+                                    browser_event_generation.fetch_add(1, Ordering::SeqCst);
                                     latest_disconnect_reason = None;
+                                    recoverable_disconnect = false;
                                     let profile = if *remote {
                                         "remote"
                                     } else if *managed {
@@ -146,89 +220,65 @@ pub fn run() {
                             }
                             let _ = handle.emit("cdp:status_changed", payload);
                         }
+                        RuntimeBrowserEvent::Interruption {
+                            interruption_kind,
+                            reason,
+                            ..
+                        } => {
+                            recoverable_disconnect = matches!(
+                                interruption_kind,
+                                socai_core::cdp::BrowserInterruptionKind::TransportDisconnected
+                                    | socai_core::cdp::BrowserInterruptionKind::RemoteLeaseExpired
+                            );
+                            latest_disconnect_reason = Some(reason.clone());
+                            let _ = handle.emit(
+                                "cdp:recovery_changed",
+                                json!({
+                                    "status": if recoverable_disconnect { "recovering" } else { "terminal" },
+                                    "kind": interruption_kind,
+                                    "reason": reason,
+                                    "grace_seconds": if recoverable_disconnect {
+                                        Some(BROWSER_RECOVERY_GRACE.as_secs())
+                                    } else {
+                                        None
+                                    },
+                                }),
+                            );
+                        }
                         RuntimeBrowserEvent::TargetsChanged(targets) => {
+                            let generation =
+                                browser_event_generation.fetch_add(1, Ordering::SeqCst) + 1;
                             let active_targets: HashSet<String> =
                                 targets.into_iter().map(|target| target.target_id).collect();
                             let interruption_reason = latest_disconnect_reason
                                 .clone()
                                 .unwrap_or_else(|| "chrome tab was closed".into());
-                            for (mut snapshot, abort_handle) in tasks
-                                .interrupt_missing_targets(&active_targets, &interruption_reason)
-                                .await
-                            {
-                                let task_id = snapshot.task_id.clone();
-                                // The registry marks the task interrupted before this
-                                // branch runs. Settle hosted usage while the runner still
-                                // holds the single-task permit, so a queued
-                                // task cannot race the server cleanup and receive a 409
-                                // for this now-terminal task.
-                                if snapshot.provider.as_deref() == Some("socai")
-                                    && socai_core::cloud::pro_activated()
-                                {
-                                    if let Some(settlement) =
-                                        commands::settle_hosted_task_with_retry(
-                                            &task_id,
-                                            "interrupted",
-                                        )
-                                        .await
-                                    {
-                                        if let Some(updated) = tasks
-                                            .update(&task_id, |task| {
-                                                task.points_used = commands::visible_billed_points(
-                                                    task.provider.as_deref(),
-                                                    &settlement,
-                                                );
-                                            })
-                                            .await
-                                        {
-                                            snapshot = updated;
-                                        }
+                            if active_targets.is_empty() && recoverable_disconnect {
+                                let generation_counter = browser_event_generation.clone();
+                                let delayed_tasks = tasks.clone();
+                                let delayed_telemetry = telemetry.clone();
+                                let delayed_handle = handle.clone();
+                                tauri::async_runtime::spawn(async move {
+                                    tokio::time::sleep(BROWSER_RECOVERY_GRACE).await;
+                                    if generation_counter.load(Ordering::SeqCst) != generation {
+                                        return;
                                     }
-                                }
-                                if let Some(handle) = abort_handle {
-                                    handle.abort();
-                                }
-                                commands::persist_run_points_used(
-                                    snapshot.run_dir.as_deref(),
-                                    snapshot.points_used,
-                                );
-                                commands::record_interrupted_run(&snapshot, &interruption_reason);
-                                if let Some(run_dir) = snapshot.run_dir.as_deref() {
-                                    commands::upload_terminal_run_trace(
-                                        run_dir,
-                                        "interrupted",
-                                        &telemetry,
+                                    interrupt_missing_browser_targets(
+                                        active_targets,
+                                        interruption_reason,
+                                        delayed_tasks,
+                                        delayed_telemetry,
+                                        delayed_handle,
                                     )
                                     .await;
-                                }
-                                telemetry.capture(
-                                    "socai_agent_task_end",
-                                    json!({
-                                        "task_id": task_id.clone(),
-                                        "provider": snapshot.provider.clone(),
-                                        "run_id": snapshot.run_id.clone(),
-                                        "model": snapshot.model.clone(),
-                                        "outcome": "interrupted",
-                                        "steps": snapshot.steps,
-                                        "input_tokens": snapshot.input_tokens,
-                                        "output_tokens": snapshot.output_tokens,
-                                        "points_used": snapshot.points_used,
-                                        "duration_ms": duration_ms(
-                                            snapshot.started_at,
-                                            snapshot.finished_at,
-                                        ),
-                                        "error": crate::telemetry::short_error(
-                                            &interruption_reason,
-                                        ),
-                                    }),
-                                );
-                                commands::emit_task_event(
-                                    &handle,
-                                    &tasks,
-                                    &task_id,
-                                    "interrupted",
-                                    interruption_reason.clone(),
-                                    Some(snapshot),
+                                });
+                            } else {
+                                interrupt_missing_browser_targets(
+                                    active_targets,
+                                    interruption_reason,
+                                    tasks.clone(),
+                                    telemetry.clone(),
+                                    handle.clone(),
                                 )
                                 .await;
                             }

--- a/core/src/cdp/connection.rs
+++ b/core/src/cdp/connection.rs
@@ -270,6 +270,19 @@ impl From<&CdpState> for StatusPayload {
 pub enum BrowserEvent {
     StatusChanged(StatusPayload),
     TargetsChanged(Vec<TargetInfo>),
+    Interruption {
+        interruption_kind: BrowserInterruptionKind,
+        reason: String,
+        target_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserInterruptionKind {
+    TargetClosedByUser,
+    TransportDisconnected,
+    RemoteLeaseExpired,
 }
 
 /// Connection state + event broadcast. Cheaply cloneable; each clone shares the

--- a/core/src/cdp/lifecycle.rs
+++ b/core/src/cdp/lifecycle.rs
@@ -5,8 +5,8 @@ use serde_json::{json, Value};
 use tracing::{debug, warn};
 
 use crate::cdp::connection::{
-    page_list_from, BrowserEvent, BrowserOwner, Cdp, CdpState, ChromeConnectOptions, ChromeProfile,
-    RemoteSession, StatusPayload, TargetInfo,
+    page_list_from, BrowserEvent, BrowserInterruptionKind, BrowserOwner, Cdp, CdpState,
+    ChromeConnectOptions, ChromeProfile, RemoteSession, StatusPayload, TargetInfo,
 };
 use crate::cdp::endpoint::{self, Endpoint};
 use crate::cdp::launch;
@@ -495,7 +495,7 @@ async fn on_connection_lost(cdp: Cdp, transport_error: String) {
     if !matches!(*guard, CdpState::Connected { .. }) {
         return;
     }
-    let reason = match &*guard {
+    let interruption_kind = match &*guard {
         CdpState::Connected {
             owner: BrowserOwner::Remote(session),
             ..
@@ -504,11 +504,21 @@ async fn on_connection_lost(cdp: Cdp, transport_error: String) {
             .saturating_duration_since(std::time::Instant::now())
             <= Duration::from_secs(30) =>
         {
-            format!(
-                "remote browser session expired after {}s; transport error: {transport_error}",
-                session.timeout.as_secs()
-            )
+            BrowserInterruptionKind::RemoteLeaseExpired
         }
+        _ => BrowserInterruptionKind::TransportDisconnected,
+    };
+    let reason = match (&*guard, interruption_kind) {
+        (
+            CdpState::Connected {
+                owner: BrowserOwner::Remote(session),
+                ..
+            },
+            BrowserInterruptionKind::RemoteLeaseExpired,
+        ) => format!(
+            "remote browser session expired after {}s; transport error: {transport_error}",
+            session.timeout.as_secs()
+        ),
         _ => format!("cdp connection lost; transport error: {transport_error}"),
     };
     warn!(error = %reason, "cdp connection lost");
@@ -518,6 +528,15 @@ async fn on_connection_lost(cdp: Cdp, transport_error: String) {
     };
     *guard = CdpState::Disconnected { reason };
     let payload: StatusPayload = (&*guard).into();
+    let reason = match &payload {
+        StatusPayload::Disconnected { reason } => reason.clone(),
+        _ => String::new(),
+    };
+    cdp.emit(BrowserEvent::Interruption {
+        interruption_kind,
+        reason,
+        target_id: None,
+    });
     cdp.emit(BrowserEvent::StatusChanged(payload));
     cdp.emit(BrowserEvent::TargetsChanged(Vec::new()));
     drop(guard);
@@ -594,8 +613,15 @@ fn spawn_target_poll_loop(cdp: Cdp, browser_client: RawCdpClient) -> tokio::task
             match browser_ws_targets(&browser_client).await {
                 Ok(targets) => {
                     failures = 0;
-                    if let Some(pages) = replace_targets(&cdp, targets).await {
-                        cdp.emit(BrowserEvent::TargetsChanged(pages));
+                    if let Some(change) = replace_targets(&cdp, targets).await {
+                        for target_id in change.closed_page_ids {
+                            cdp.emit(BrowserEvent::Interruption {
+                                interruption_kind: BrowserInterruptionKind::TargetClosedByUser,
+                                reason: "chrome tab was closed by user".into(),
+                                target_id: Some(target_id),
+                            });
+                        }
+                        cdp.emit(BrowserEvent::TargetsChanged(change.pages));
                     }
                 }
                 Err(err) => {
@@ -614,10 +640,15 @@ fn spawn_target_poll_loop(cdp: Cdp, browser_client: RawCdpClient) -> tokio::task
 
 /// Replace cached targets. Returns the new visible page list when it changed;
 /// `None` means either no visible page change or the connection is inactive.
+struct TargetChange {
+    pages: Vec<TargetInfo>,
+    closed_page_ids: Vec<String>,
+}
+
 async fn replace_targets(
     cdp: &Cdp,
     next_targets: HashMap<String, TargetInfo>,
-) -> Option<Vec<TargetInfo>> {
+) -> Option<TargetChange> {
     let state = cdp.state();
     let mut guard = state.lock().await;
     let CdpState::Connected { targets, .. } = &mut *guard else {
@@ -625,8 +656,16 @@ async fn replace_targets(
     };
     let before = page_list_from(targets);
     let after = page_list_from(&next_targets);
+    let closed_page_ids = before
+        .iter()
+        .filter(|target| !next_targets.contains_key(&target.target_id))
+        .map(|target| target.target_id.clone())
+        .collect();
     *targets = next_targets;
-    (before != after).then_some(after)
+    (before != after).then_some(TargetChange {
+        pages: after,
+        closed_page_ids,
+    })
 }
 
 async fn browser_ws_targets(client: &RawCdpClient) -> anyhow::Result<HashMap<String, TargetInfo>> {

--- a/core/src/cdp/mod.rs
+++ b/core/src/cdp/mod.rs
@@ -8,7 +8,8 @@ pub mod session;
 pub mod snapshot;
 
 pub use self::connection::{
-    BrowserEvent, Cdp, CdpState, ChromeConnectOptions, ChromeProfile, StatusPayload, TargetInfo,
+    BrowserEvent, BrowserInterruptionKind, Cdp, CdpState, ChromeConnectOptions, ChromeProfile,
+    StatusPayload, TargetInfo,
 };
 pub use self::endpoint::{
     discover_existing_chrome_endpoint, managed_chrome_user_data_dir, open_remote_debugging_page,


### PR DESCRIPTION
## Summary

- Classify browser interruptions as a user-closed target, transport disconnect, or expired remote lease and emit the structured reason to the Desktop runtime.
- Give transport and lease disconnects a 15-second grace window, cancelled by a fresh connected status or target update.
- Preserve immediate interruption for a target closed by the user.

## Trace context

- `069a8ba5fd45a68f38515993a6b9f1ea` — the same conversation recorded `Current page is not Xiaohongshu: about:blank`, `CDP command timed out: Runtime.evaluate`, and `CDP session is closed`, followed by repeated user retries.
- `10c274924169c6389abb375c4e740545` — a search failed with `Session with given id not found (-32001)`.
- `0325ebb0fab278c9a042de73fd472d24` — a search reached an `about:blank` page after browser lifecycle loss.

Historical `interrupted` task events carry limited interruption context, leaving exact transport-event-to-run attribution unavailable. The code path supplies the causal link: `on_connection_lost` emits an empty target list, and the Desktop handler previously treated that list the same as a user-closed controlled tab.

## Reproduction

- Local Chrome exposed port `9222` while its browser WebSocket remained unresponsive for 20 seconds. This reproduced the transport-loss/connect-failure condition.
- Static call-path verification reproduced the terminal transition: transport loss emits empty targets, then `interrupt_missing_targets` immediately marks the active task `interrupted`.
- End-to-end reruns for a live recovery within 15 seconds and a controlled-tab close remain pending. Chrome 147 presents a manual “Allow remote debugging” confirmation in the current environment.
- The isolated PR branch passes the compile checks below.

## Before / after

| Event | Before | After |
| --- | --- | --- |
| Transport disconnect | Empty targets immediately settle and persist the task as `interrupted` | Empty targets wait 15 seconds; a fresh browser event cancels the pending terminal transition |
| Remote lease expiry | Shares the generic connection-lost reason and immediate terminal path | Carries `remote_lease_expired` and uses the same bounded grace window |
| User closes the controlled tab | Missing target interrupts the bound task immediately | `target_closed_by_user` keeps the immediate terminal behavior |
| Terminal bookkeeping | Inline in the target event branch | Moved into one helper with the existing settlement, persistence, trace upload, telemetry, and UI event order |

## Scope

- The core change adds interruption classification at the two existing lifecycle emission points.
- The Desktop change delays terminal bookkeeping only when the target list is empty and the latest interruption is transport- or lease-related.
- The grace timer is invalidated by the next connected status or target-list generation.
- Automatic reconnect, target rebinding, checkpointing, automatic task resume, tool retry, and broader fallback behavior remain separate work.

## Test plan

- [x] `cargo check -p socai-core -p socai_app`
- [x] `cargo check --tests -p socai_app`
- [x] `git diff --check main..feat/cdp-recovery-grace`
- [ ] Reconnect Chrome within 15 seconds and confirm the active task remains running.
- [ ] Close the controlled Chrome tab and confirm the task is interrupted immediately.
