### PR TITLE
fix(agent): inject platform-aware shell runtime context

### DIFF
--- a/core/src/agent/file_bash_tools.rs
+++ b/core/src/agent/file_bash_tools.rs
@@ -24,6 +24,7 @@
 //! working directory set to the current run dir.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -405,6 +406,65 @@ impl ShellTool {
     }
 }
 
+/// Compact host context injected into the system prompt whenever `shell` is
+/// available. The model sees this before its first tool call, so it can choose
+/// the platform's real shell contract instead of guessing from a generic
+/// `shell` tool name. Runtime discovery is process-free and cached.
+pub(crate) fn shell_runtime_prompt() -> String {
+    let runtime = crate::util::machine::runtime_platform_info();
+    let os_name = match runtime.os {
+        "macos" => "macOS",
+        "windows" => "Windows",
+        "linux" => "Linux",
+        other => other,
+    };
+    let os = if runtime.os_version.trim().is_empty() {
+        os_name.to_string()
+    } else {
+        format!("{os_name} {}", runtime.os_version.trim())
+    };
+    let mut facts = vec![format!("os={os}"), format!("arch={}", runtime.arch)];
+    if !runtime.os_kernel_version.trim().is_empty()
+        && runtime.os_kernel_version.trim() != runtime.os_version.trim()
+    {
+        facts.push(format!("kernel={}", runtime.os_kernel_version.trim()));
+    }
+    let shell_program = shell_runtime_program();
+    facts.push(format!("shell={}", shell_runtime_name()));
+    if shell_program.is_absolute() {
+        facts.push(format!("shell_path={}", shell_program.display()));
+    } else {
+        facts.push(format!("shell_command={}", shell_program.display()));
+    }
+
+    let guidance = match runtime.os {
+        "windows" => "Use PowerShell syntax for `shell` commands. Do not call `bash`, `sh`, or use POSIX-only syntax unless the user explicitly provides such an environment.",
+        "macos" => "Use POSIX `sh` syntax for `shell` commands; commands are executed with `sh -c`. macOS ships BSD userland tools, so do not assume GNU-only command flags.",
+        "linux" => "Use POSIX `sh` syntax for `shell` commands; commands are executed with `sh -c`. Do not assume Bash-only syntax unless `bash` is explicitly invoked and available.",
+        _ => "Use the reported shell and its native syntax for `shell` commands. Do not assume shell-specific extensions unless their interpreter is explicitly invoked and available.",
+    };
+
+    format!("Runtime environment: {}. {guidance}", facts.join("; "))
+}
+
+#[cfg(not(windows))]
+fn shell_runtime_name() -> &'static str {
+    "POSIX sh"
+}
+
+#[cfg(windows)]
+fn shell_runtime_name() -> &'static str {
+    let executable = shell_runtime_program()
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("powershell");
+    if executable.eq_ignore_ascii_case("pwsh") {
+        "PowerShell (pwsh)"
+    } else {
+        "Windows PowerShell (powershell.exe)"
+    }
+}
+
 #[async_trait]
 impl Tool for ShellTool {
     fn name(&self) -> &str {
@@ -414,14 +474,14 @@ impl Tool for ShellTool {
     fn description(&self) -> &str {
         #[cfg(windows)]
         if !self.roots.is_empty() {
-            "Run a Windows PowerShell command and return its stdout/stderr and \
+            "Run a PowerShell command and return its stdout/stderr and \
              exit code. Working directory is the current run dir. Confined to \
              socai's data directories — commands referencing paths outside \
              them are rejected. Use this to write output files (e.g. \
              Set-Content), list/search run artifacts, create directories, etc. within \
              those directories."
         } else {
-            "Run a Windows PowerShell command and return its stdout/stderr and exit \
+            "Run a PowerShell command and return its stdout/stderr and exit \
              code. Working directory is the current run dir under ~/.socai/runs, so \
              relative paths land there; use absolute paths for other run dirs or \
              the session dir. Use this to write output files, list/search artifacts, \
@@ -453,7 +513,7 @@ impl Tool for ShellTool {
         json!({
             "type": "object",
             "properties": {
-                "command": { "type": "string", "description": "Platform-native shell command: Windows PowerShell on Windows, `sh -c` elsewhere." },
+                "command": { "type": "string", "description": "Platform-native shell command: PowerShell on Windows, `sh -c` elsewhere." },
                 "timeout_ms": { "type": "integer", "description": "Optional timeout in milliseconds (default 120000)." }
             },
             "required": ["command"]
@@ -533,7 +593,7 @@ impl Tool for ShellTool {
 
 #[cfg(not(windows))]
 fn shell_command(command: &str) -> tokio::process::Command {
-    let mut cmd = tokio::process::Command::new("sh");
+    let mut cmd = tokio::process::Command::new(shell_runtime_program());
     cmd.arg("-c").arg(command);
     cmd
 }
@@ -543,10 +603,94 @@ fn shell_command(command: &str) -> tokio::process::Command {
     let script = format!(
         "$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n{command}"
     );
-    let mut cmd = tokio::process::Command::new("powershell.exe");
+    let mut cmd = tokio::process::Command::new(shell_runtime_program());
     cmd.args(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"])
         .arg(script);
     cmd
+}
+
+/// Resolve once so the prompt and every command use the same executable.
+fn shell_runtime_program() -> &'static Path {
+    static PROGRAM: OnceLock<PathBuf> = OnceLock::new();
+    PROGRAM.get_or_init(resolve_shell_program).as_path()
+}
+
+/// Use the system POSIX shell on macOS and Linux instead of the user's
+/// interactive shell (`$SHELL` may be zsh, fish, etc.). `/bin/sh` is the
+/// execution contract exposed by this tool; PATH lookup is only a fallback
+/// for Unix-like targets whose system shell lives elsewhere.
+#[cfg(not(windows))]
+fn resolve_shell_program() -> PathBuf {
+    for candidate in [PathBuf::from("/bin/sh"), PathBuf::from("/usr/bin/sh")] {
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    executable_on_path("sh").unwrap_or_else(|| PathBuf::from("sh"))
+}
+
+/// Prefer the modern `pwsh` executable (PowerShell 7 in its standard install
+/// location) for `&&` and predictable UTF-8 behavior, then fall back to the
+/// Windows PowerShell installation that ships with the OS. Resolution is
+/// filesystem-only so building the first prompt never launches shell code.
+#[cfg(windows)]
+fn resolve_shell_program() -> PathBuf {
+    for root in [
+        std::env::var_os("ProgramFiles"),
+        std::env::var_os("ProgramW6432"),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let root = PathBuf::from(root);
+        if !root.is_absolute() {
+            continue;
+        }
+        let candidate = root.join("PowerShell").join("7").join("pwsh.exe");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    if let Some(path) = executable_on_path("pwsh.exe") {
+        return path;
+    }
+
+    if let Some(system_root) = std::env::var_os("SystemRoot").or_else(|| std::env::var_os("WINDIR"))
+    {
+        let system_root = PathBuf::from(system_root);
+        let candidate = system_root
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0")
+            .join("powershell.exe");
+        if system_root.is_absolute() && candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    if let Some(path) = executable_on_path("powershell.exe") {
+        return path;
+    }
+
+    PathBuf::from("powershell.exe")
+}
+
+fn executable_on_path(name: &str) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    std::env::var_os("PATH")
+        .into_iter()
+        .flat_map(|paths| std::env::split_paths(&paths).collect::<Vec<_>>())
+        .map(|dir| {
+            if dir.is_absolute() {
+                dir.join(name)
+            } else {
+                cwd.join(dir).join(name)
+            }
+        })
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.canonicalize().unwrap_or(candidate))
 }
 
 /// Backward-compatible Rust API alias. The agent-facing tool is named `shell`.

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -1,5 +1,7 @@
 //! Default system prompt for the agent loop.
 
+use crate::agent::file_bash_tools::shell_runtime_prompt;
+
 pub const BASE_SYSTEM_PROMPT: &str =
     "You are a computer-use agent. Use the provided tools when they help complete\n\
 the user's task. Think briefly, take one or more useful actions, verify results\n\
@@ -18,6 +20,9 @@ pub fn build_system_prompt(tool_names: &[&str], extra_instructions: &str) -> Str
         "Today's date is {}.",
         chrono::Local::now().format("%Y-%m-%d (%A)")
     ));
+    if tool_names.contains(&"shell") {
+        parts.push(shell_runtime_prompt());
+    }
     if !tool_names.is_empty() {
         let listing = tool_names
             .iter()

--- a/core/src/util/machine.rs
+++ b/core/src/util/machine.rs
@@ -24,6 +24,28 @@ pub struct MachineInfo {
     pub os_kernel_version: String,
 }
 
+/// Process-free platform snapshot for latency-sensitive prompt construction.
+/// Unlike [`machine_info`], this never launches host commands: Linux reads
+/// procfs/os-release, macOS reads SystemVersion.plist and calls `uname(2)`, and
+/// Windows reads its version through `RtlGetVersion`.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimePlatformInfo {
+    pub os: &'static str,
+    pub arch: &'static str,
+    pub os_version: String,
+    pub os_kernel_version: String,
+}
+
+pub(crate) fn runtime_platform_info() -> &'static RuntimePlatformInfo {
+    static INFO: OnceLock<RuntimePlatformInfo> = OnceLock::new();
+    INFO.get_or_init(|| RuntimePlatformInfo {
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        os_version: runtime_os_version(),
+        os_kernel_version: runtime_kernel_version(),
+    })
+}
+
 /// Process-global machine info, collected on first use.
 pub fn machine_info() -> &'static MachineInfo {
     static INFO: OnceLock<MachineInfo> = OnceLock::new();
@@ -128,6 +150,96 @@ fn os_kernel_version() -> String {
         return command_output("cmd", &["/C", "ver"]);
     }
     #[allow(unreachable_code)]
+    String::new()
+}
+
+#[cfg(target_os = "macos")]
+fn runtime_os_version() -> String {
+    let Ok(text) = std::fs::read_to_string("/System/Library/CoreServices/SystemVersion.plist")
+    else {
+        return String::new();
+    };
+    let Some(after_key) = text
+        .split_once("<key>ProductVersion</key>")
+        .map(|(_, rest)| rest)
+    else {
+        return String::new();
+    };
+    let Some(after_open) = after_key.split_once("<string>").map(|(_, rest)| rest) else {
+        return String::new();
+    };
+    after_open
+        .split_once("</string>")
+        .map(|(value, _)| value.trim().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "linux")]
+fn runtime_os_version() -> String {
+    linux_pretty_name().unwrap_or_default()
+}
+
+#[cfg(target_os = "windows")]
+fn runtime_os_version() -> String {
+    #[repr(C)]
+    struct OsVersionInfoW {
+        size: u32,
+        major: u32,
+        minor: u32,
+        build: u32,
+        platform_id: u32,
+        service_pack: [u16; 128],
+    }
+
+    #[link(name = "ntdll")]
+    extern "system" {
+        fn RtlGetVersion(version: *mut OsVersionInfoW) -> i32;
+    }
+
+    let mut version = OsVersionInfoW {
+        size: std::mem::size_of::<OsVersionInfoW>() as u32,
+        major: 0,
+        minor: 0,
+        build: 0,
+        platform_id: 0,
+        service_pack: [0; 128],
+    };
+    if unsafe { RtlGetVersion(&mut version) } == 0 {
+        format!("{}.{}.{}", version.major, version.minor, version.build)
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn runtime_os_version() -> String {
+    String::new()
+}
+
+#[cfg(target_os = "linux")]
+fn runtime_kernel_version() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn runtime_kernel_version() -> String {
+    use std::ffi::CStr;
+
+    let mut info = std::mem::MaybeUninit::<libc::utsname>::zeroed();
+    if unsafe { libc::uname(info.as_mut_ptr()) } != 0 {
+        return String::new();
+    }
+    let info = unsafe { info.assume_init() };
+    unsafe { CStr::from_ptr(info.release.as_ptr()) }
+        .to_string_lossy()
+        .trim()
+        .to_string()
+}
+
+#[cfg(not(unix))]
+fn runtime_kernel_version() -> String {
     String::new()
 }
 


### PR DESCRIPTION
## Summary

- Inject OS name/version, architecture, kernel, and the exact shell executable into the system prompt whenever `shell` is available. The context is present before model request 1.
- Cover Windows, macOS, and Linux explicitly instead of treating every non-Windows host as one generic runtime.
- Keep prompt construction process-free: Windows version comes from `RtlGetVersion`, Linux metadata from `/etc/os-release` and `/proc`, and macOS metadata from `SystemVersion.plist` plus `uname(2)`.
- Resolve and cache the same shell executable used by both prompt reporting and command execution.

## Trace context

- `87dff837032e74a2b70f2ff11aeb3215` — 53 legacy `bash` failures appeared across a Windows conversation, repeatedly returning `failed to run command: program not found`.
- `89b56933bdf8257fe8c8ef3cea87ac55` — 36 repeated `bash` failures appeared while the agent tried to inspect prior artifacts on Windows.
- `f92d42dee924ba242cbb3bd7f8d9f5b1` — 25 repeated `bash` failures appeared across follow-up turns in one long-running account analysis.

These traces show that the model lacked reliable platform and shell context before acting. The fix provides the runtime contract in the first system prompt instead of waiting for a tool-dispatch failure.

## Behavior

| Platform | Runtime facts | Shell contract | Platform guidance |
| --- | --- | --- | --- |
| Windows | Windows version, architecture, resolved executable | PowerShell; standard PowerShell 7 path / `pwsh` on PATH preferred, built-in Windows PowerShell fallback | PowerShell syntax; do not assume Bash, `sh`, or POSIX syntax |
| macOS | macOS product version, architecture, Darwin kernel, `/bin/sh` | POSIX `sh -c` | POSIX syntax and BSD userland; do not assume GNU-only flags |
| Linux | distribution pretty name, architecture, Linux kernel, `/bin/sh` | POSIX `sh -c` | POSIX syntax; do not assume Bash-only extensions |

Absolute executables are reported as `shell_path`. If only a bare fallback command exists, it is reported as `shell_command`, avoiding a false path claim.

## Shell resolution

- Shell selection is cached in one `OnceLock<PathBuf>`.
- Prompt labeling and `tokio::process::Command` consume that same cached value.
- POSIX hosts prefer `/bin/sh`, then `/usr/bin/sh`, then an absolute/canonicalized PATH match.
- Windows checks standard PowerShell 7 locations, then absolute/canonicalized PATH matches for `pwsh.exe`, then built-in Windows PowerShell.
- PATH entries are resolved against the process cwd before the tool changes to the run directory, preventing executable identity drift.
- Resolution only reads environment/filesystem metadata; it never launches `pwsh`, `powershell`, `cmd`, or another shell while building the prompt.

## Prompt timing

`core/src/agent/loop.rs` derives the currently available schemas first. `build_system_prompt` receives those names and adds runtime context only when `shell` is actually exposed, before request payload construction and the first backend call.

Unknown/unavailable tool dispatch, site gating, schemas, permissions, and sandbox policy are unchanged. This PR does not register a `bash` alias.

## OpenClaw reference

The design follows OpenClaw's two relevant patterns:

- Runtime prompt context identifies the host platform before tool use.
- Shell resolution is platform-aware, prefers PowerShell 7 on Windows, and falls back to the system PowerShell installation.

References:

- https://github.com/openclaw/openclaw/blob/main/src/agents/system-prompt.ts
- https://github.com/openclaw/openclaw/blob/main/src/agents/shell-utils.ts

## Test plan

- [x] `rustfmt --edition 2021 core/src/agent/file_bash_tools.rs core/src/agent/system_prompt.rs core/src/util/machine.rs`
- [x] `git diff --check refs/remotes/upstream/main...HEAD`
- [x] `cargo check --tests -p socai-core --no-default-features`
- [x] `cargo test -p socai-core --no-default-features` — 91 passed, 2 ignored, 0 failed
- [x] Codex initial review and focused re-review; all reported findings addressed
- [x] Confirmed unknown/unavailable tool error behavior is unchanged
- [x] Confirmed the branch is exactly one commit ahead of the current PR base
- [ ] Windows/Linux full Cargo builds were not run locally because those Rust targets are not installed; target installation timed out. Their conditional paths received focused static review.

## Commit structure

This PR is intentionally squashed to one commit.
