### PR TITLE
fix(tasks): rebind running task after browser reconnect

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1491,11 +1491,20 @@ async fn run_agent_task_on_shared_page(
         .ensure_site_page_with_browser_options(site.id, site.home_url, browser_options)
         .await?;
     let target_id = page.target_id().to_string();
-    label_controlled_page(&page, &title_label).await;
+    let page_url = page
+        .evaluate_json("location.href")
+        .await
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| site.home_url.to_string());
+    let page_title_marker = format!("task:{task_id}");
+    label_controlled_page(&page, &format!("{page_title_marker} · {title_label}")).await;
     if let Some(registry) = &registry {
         if let Some(snapshot) = registry
             .update(&task_id, |snapshot| {
                 snapshot.target_id = Some(target_id.clone());
+                snapshot.page_url = Some(page_url.clone());
+                snapshot.page_title_marker = Some(page_title_marker.clone());
             })
             .await
         {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -248,6 +248,18 @@ pub fn run() {
                         RuntimeBrowserEvent::TargetsChanged(targets) => {
                             let generation =
                                 browser_event_generation.fetch_add(1, Ordering::SeqCst) + 1;
+                            for snapshot in tasks.rebind_missing_targets(&targets).await {
+                                let task_id = snapshot.task_id.clone();
+                                commands::emit_task_event(
+                                    &handle,
+                                    &tasks,
+                                    &task_id,
+                                    "tab_rebound",
+                                    "chrome target rebound after reconnect".into(),
+                                    Some(snapshot),
+                                )
+                                .await;
+                            }
                             let active_targets: HashSet<String> =
                                 targets.into_iter().map(|target| target.target_id).collect();
                             let interruption_reason = latest_disconnect_reason

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 use socai_core::agent::{mark_agent_run_status, Conversation};
+use socai_core::runtime::BrowserTargetInfo;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::AbortHandle;
 
@@ -41,6 +42,8 @@ pub struct AgentTaskSnapshot {
     pub(crate) run_dir: Option<String>,
     pub(crate) session_dir: Option<String>,
     pub(crate) target_id: Option<String>,
+    pub(crate) page_url: Option<String>,
+    pub(crate) page_title_marker: Option<String>,
     // Hydrated from `<run_dir>/report.md` for API responses; not persisted in tasks.json.
     pub(crate) final_text: Option<String>,
     pub(crate) error: Option<String>,
@@ -149,6 +152,8 @@ impl AgentTaskRegistry {
             run_dir: Some(run_dir),
             session_dir: Some(session_dir),
             target_id: None,
+            page_url: None,
+            page_title_marker: None,
             final_text: None,
             error: None,
             steps: None,
@@ -281,6 +286,61 @@ impl AgentTaskRegistry {
         out
     }
 
+    pub(crate) async fn rebind_missing_targets(
+        &self,
+        targets: &[BrowserTargetInfo],
+    ) -> Vec<AgentTaskSnapshot> {
+        let active_targets: HashSet<&str> = targets
+            .iter()
+            .map(|target| target.target_id.as_str())
+            .collect();
+        let mut guard = self.inner.lock().await;
+        let mut rebound = Vec::new();
+        for task in &mut guard.tasks {
+            if task.status != "running"
+                || task
+                    .target_id
+                    .as_deref()
+                    .is_some_and(|target_id| active_targets.contains(target_id))
+            {
+                continue;
+            }
+            let marker_match = task
+                .page_title_marker
+                .as_deref()
+                .and_then(|marker| targets.iter().find(|target| target.title.contains(marker)));
+            let site_matches: Vec<&BrowserTargetInfo> = task
+                .page_url
+                .as_deref()
+                .map(site_key)
+                .filter(|site| !site.is_empty())
+                .map(|site| {
+                    targets
+                        .iter()
+                        .filter(|target| site_key(&target.url) == site)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let candidate = marker_match.or_else(|| {
+                if site_matches.len() == 1 {
+                    site_matches.first().copied()
+                } else {
+                    None
+                }
+            });
+            let Some(candidate) = candidate else {
+                continue;
+            };
+            task.target_id = Some(candidate.target_id.clone());
+            task.page_url = Some(candidate.url.clone());
+            rebound.push(task.clone());
+        }
+        if !rebound.is_empty() {
+            persist_task_index(&guard.tasks);
+        }
+        rebound
+    }
+
     pub(crate) async fn list(&self) -> Vec<AgentTaskSnapshot> {
         self.inner
             .lock()
@@ -409,6 +469,18 @@ impl AgentTaskRegistry {
         persist_task_index(&guard.tasks);
         Some(hydrate_task_snapshot(snapshot))
     }
+}
+
+fn site_key(url: &str) -> String {
+    url.trim()
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or_default()
+        .trim_start_matches("www.")
+        .to_ascii_lowercase()
 }
 
 pub(crate) fn now_ms() -> u64 {


### PR DESCRIPTION
## Summary

- Persist the controlled page URL and a task-specific title marker when a desktop task acquires its Xiaohongshu tab.
- Rebind a running task whose CDP target id disappeared by matching the title marker first, then a single same-site target as a conservative fallback.
- Emit `tab_rebound` and persist the replacement target before the existing missing-target interruption path evaluates the task.

## Trace context

- `0325ebb0fab278c9a042de73fd472d24` — a Xiaohongshu search failed with `Current page is not Xiaohongshu: about:blank` after the browser target changed during a multi-turn task.
- The trace shows the task continuing against a stale page identity; the desktop registry currently persists only the original CDP target id and cannot associate a replacement target with the running task.

## Reproduction

- On `main`, start a desktop task and let the registry store the controlled tab's target id.
- Reconnect Chrome so the same logical Xiaohongshu tab is reported with a replacement target id.
- `TargetsChanged` sees the old id as missing and sends the running task through the interruption path because no stable page metadata is available for reconciliation.

## Before / after

| Area | Before | After |
| --- | --- | --- |
| Task-to-tab identity | Original CDP target id only | Target id plus task title marker and page URL |
| Reconnect handling | Replacement target remains unrelated | Running task rebinds before missing-target evaluation |
| Matching order | No reconciliation | Exact task marker, then one unambiguous same-site target |
| Task events | Missing target can become interrupted | Successful replacement emits `tab_rebound` |

## Scope

- The change is limited to desktop task metadata and target reconciliation in `app/src-tauri`.
- Browser ownership, CDP connection creation, page sessions, and the existing interruption policy remain unchanged.
- The fallback does not select a same-site target when multiple candidates exist.
- CDP recovery timing and remote lease handling remain separate work in #256.

## Test plan

- `rustfmt --edition 2021 --check app/src-tauri/src/commands.rs app/src-tauri/src/lib.rs app/src-tauri/src/tasks.rs`
- `cargo check -p socai_app`
- `git diff --check main...feat/browser-target-rebind`