### PR TITLE
fix(xhs): scope dedup per session and fill paginated results

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -21,7 +21,7 @@ use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_resul
 use socai_core::telemetry::trace::mark_run_trace_status;
 use std::collections::HashMap;
 use std::io::{BufReader, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -1042,8 +1042,17 @@ pub async fn agent_task_delete(
         socai_core::media::cancel_background_media_for_run(run_dir);
     }
     let mut dirs: Vec<String> = Vec::new();
+    // Conversation ids are their directory basenames. Derive that first so a
+    // corrupt/missing conversation.json cannot leave orphaned dedup state.
+    let mut history_session_id = snapshot.session_dir.as_deref().and_then(|session_dir| {
+        Path::new(session_dir)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+    });
     if let Some(session_dir) = &snapshot.session_dir {
         if let Ok(conversation) = Conversation::load(session_dir) {
+            history_session_id = Some(conversation.id.clone());
             dirs.extend(conversation.runs.iter().map(|run| run.run_dir.clone()));
         }
         dirs.push(session_dir.clone());
@@ -1087,7 +1096,11 @@ pub async fn agent_task_delete(
             // XHS history caches absolute media paths into these run dirs; scrub
             // them so cross-run dedupe re-downloads instead of resurrecting dead paths.
             let run_dirs: Vec<PathBuf> = dirs.iter().map(PathBuf::from).collect();
-            let scrubbed = XhsHistoryStore::open_default().scrub_media_under(&run_dirs);
+            let history = XhsHistoryStore::open_default();
+            if let Some(session_id) = history_session_id {
+                history.remove_session(&session_id);
+            }
+            let scrubbed = history.scrub_media_under(&run_dirs);
             if scrubbed > 0 {
                 eprintln!("forgot cached media for {scrubbed} notes under deleted task {task_id}");
             }

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -197,6 +197,7 @@ pub async fn run_agent_with_events(
     );
 
     let mut ctx = ToolContext::new(&run_id, &run_dir)
+        .with_session_id(options.session_id.clone())
         .with_run_state(Arc::clone(&run_state))
         .with_background_media_generation(options.background_media_generation)
         .with_billing_task_id(options.billing_task_id);

--- a/core/src/agent/tool.rs
+++ b/core/src/agent/tool.rs
@@ -142,6 +142,10 @@ impl From<&str> for ToolResult {
 pub struct ToolContext {
     pub run_id: String,
     pub run_dir: PathBuf,
+    /// Stable conversation identifier. Reused across follow-up runs so tools
+    /// can scope durable de-duplication to one conversation. Standalone calls
+    /// leave this unset and use their unique run id as the scope.
+    session_id: Option<String>,
     pub step: u32,
     pub active_tool_name: String,
     /// Desktop user-turn generation used to cancel background media work when
@@ -202,6 +206,7 @@ impl ToolContext {
         Self {
             run_id: run_id.into(),
             run_dir: run_dir.as_ref().to_path_buf(),
+            session_id: None,
             step: 0,
             active_tool_name: String::new(),
             background_media_generation: None,
@@ -230,6 +235,17 @@ impl ToolContext {
     pub fn with_billing_task_id(mut self, task_id: Option<String>) -> Self {
         self.billing_task_id = task_id;
         self
+    }
+
+    pub fn with_session_id(mut self, session_id: Option<String>) -> Self {
+        self.session_id = session_id.filter(|value| !value.trim().is_empty());
+        self
+    }
+
+    /// Scope key for durable tool de-duplication. Follow-up turns share their
+    /// conversation id; one-shot commands get an isolated run id.
+    pub fn dedup_session_id(&self) -> &str {
+        self.session_id.as_deref().unwrap_or(&self.run_id)
     }
 
     /// Best-effort progress delivery. A closed receiver must never fail the

--- a/core/src/sites/xhs/history.rs
+++ b/core/src/sites/xhs/history.rs
@@ -1,9 +1,12 @@
-//! Cross-run XHS analysis history. Tracks which notes have already been
-//! analyzed (and at what level) in a project-local JSON file so the agent
-//! can skip repeats across separate runs.
+//! XHS analysis cache with conversation-scoped de-duplication. Note entities
+//! and enrichment coverage are stored once in a global asset map; each
+//! conversation stores only the note ids it has seen.
 //!
 //! - In-run dedup still lives on `ToolContext::processed_notes`; this store
-//!   only handles cross-run persistence.
+//!   carries the same decision across follow-up runs in one conversation.
+//! - A conversation reference gates de-duplication. A note seen only in a
+//!   different conversation remains eligible, while conversations that already
+//!   reference it reuse the latest global asset.
 //! - Besides the lookup metadata (`note_id`, `title`, `author`, `url`, `level`,
 //!   `include_media`, `analysis_count`, `first_seen_at`, `last_seen_at`) we also
 //!   cache the full last-read `entity` (body + comments + images + location), so
@@ -12,10 +15,10 @@
 //!   per-run logs and would mostly point at stale paths anyway.
 //! - File at `~/.socai/xhs/history.json` (overridable via `SOCAI_HOME`).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -73,8 +76,37 @@ pub struct HistoryEntry {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct HistoryFile {
+    /// Schema version 0/1 used the global `notes` map alone; version 3 copied
+    /// complete entries into `session_notes`; version 4 keeps global assets and
+    /// conversation references separately.
+    #[serde(default)]
+    version: u32,
+    /// Canonical note assets. Existing version 0/1 files already use this
+    /// shape, so their entities stay readable without a destructive migration.
     #[serde(default)]
     notes: BTreeMap<String, HistoryEntry>,
+    /// Lightweight conversation pointers. Presence of a note id in this set
+    /// controls de-duplication; the corresponding entity lives in `notes`.
+    #[serde(default)]
+    session_refs: BTreeMap<String, BTreeSet<String>>,
+    /// Version 3 compatibility input. `normalize_loaded_entries` moves these
+    /// entries into `notes` + `session_refs`; the field is never serialized.
+    #[serde(default, rename = "session_notes", skip_serializing)]
+    legacy_session_notes: BTreeMap<String, BTreeMap<String, HistoryEntry>>,
+    /// Deleted conversation ids. A tombstone prevents a background download
+    /// that completed just after deletion from recreating that session.
+    #[serde(default)]
+    removed_sessions: BTreeSet<String>,
+}
+
+const HISTORY_VERSION: u32 = 4;
+
+/// All store instances in this process share the same history file. Serialize
+/// refresh/mutate/save sequences so foreground scans and background media
+/// completions cannot overwrite each other's newer snapshots.
+fn history_io_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 pub struct XhsHistoryStore {
@@ -101,6 +133,9 @@ impl XhsHistoryStore {
 
     pub fn open(path: impl AsRef<Path>) -> Self {
         let path = path.as_ref().to_path_buf();
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut inner = load_file(&path).unwrap_or_default();
         normalize_loaded_entries(&mut inner);
         Self {
@@ -109,12 +144,27 @@ impl XhsHistoryStore {
         }
     }
 
-    pub fn get(&self, note_id: &str) -> Option<HistoryEntry> {
+    pub fn get(&self, session_id: &str, note_id: &str) -> Option<HistoryEntry> {
+        let session_id = session_id.trim();
         let id = note_id.trim();
-        if id.is_empty() {
+        if session_id.is_empty() || id.is_empty() {
             return None;
         }
-        let guard = self.inner.lock().ok()?;
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        if !guard
+            .session_refs
+            .get(session_id)
+            .is_some_and(|refs| refs.contains(id))
+        {
+            return None;
+        }
         guard.notes.get(id).cloned()
     }
 
@@ -122,25 +172,36 @@ impl XhsHistoryStore {
     /// return complete data). False for pre-upgrade entries that only stored
     /// lookup metadata — those should be re-read to backfill the cache.
     /// Cheap: checks presence without cloning the entity.
-    pub fn has_cached_entity(&self, note_id: &str) -> bool {
+    pub fn has_cached_entity(&self, session_id: &str, note_id: &str) -> bool {
+        let session_id = session_id.trim();
         let id = note_id.trim();
-        if id.is_empty() {
+        if session_id.is_empty() || id.is_empty() {
             return false;
         }
-        let Ok(guard) = self.inner.lock() else {
-            return false;
-        };
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
         guard
-            .notes
-            .get(id)
-            .is_some_and(|entry| entry.entity.is_some())
+            .session_refs
+            .get(session_id)
+            .is_some_and(|refs| refs.contains(id))
+            && guard
+                .notes
+                .get(id)
+                .is_some_and(|entry| entry.entity.is_some())
     }
 
-    /// True when a prior analysis already covers what's being requested: recorded
-    /// level is >= requested AND every requested enrichment (vision, downloaded
-    /// media, OCR) was present in a prior read. This is what lets a repeated
-    /// search/scan reuse the cached entity instead of re-opening, re-downloading,
-    /// and re-OCR'ing the same note.
+    /// True when this session's prior analysis already covers what's being
+    /// requested: this conversation references the note, recorded level is >=
+    /// requested, and every requested enrichment (vision, downloaded media,
+    /// OCR) is available in the shared asset. Another conversation can enrich
+    /// that asset, but cannot create this conversation's reference or cause a
+    /// first-time note to be skipped here.
     ///
     /// A download request is additionally checked against the disk: cached
     /// `local_path`s point into the run dir that downloaded them, and run dirs
@@ -148,8 +209,10 @@ impl XhsHistoryStore {
     /// file is gone the request is not satisfied, so the note is re-read and
     /// re-downloaded into the current run instead of being archived media-less
     /// on every future reuse.
+    #[allow(clippy::too_many_arguments)]
     pub fn is_satisfied_by(
         &self,
+        session_id: &str,
         note_id: &str,
         level: &str,
         include_media: bool,
@@ -158,7 +221,7 @@ impl XhsHistoryStore {
         transcribe_audio: bool,
         min_comments: i64,
     ) -> bool {
-        let Some(prev) = self.get(note_id) else {
+        let Some(prev) = self.get(session_id, note_id) else {
             return false;
         };
         if level_value(&prev.level) < level_value(level) {
@@ -196,12 +259,24 @@ impl XhsHistoryStore {
     }
 
     /// Add `already_analyzed` / `history_level` / `history_include_media`
-    /// flags onto any card whose `note_id` is in the store. Mutates in place.
-    pub fn annotate_cards(&self, cards: &mut Value) {
-        let Ok(guard) = self.inner.lock() else {
+    /// flags onto cards previously seen in this session. Mutates in place.
+    pub fn annotate_cards(&self, session_id: &str, cards: &mut Value) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return;
+        }
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        let Some(refs) = guard.session_refs.get(session_id) else {
             return;
         };
-        annotate_cards_from(&guard.notes, cards);
+        annotate_cards_from_refs(&guard.notes, refs, cards);
     }
 
     /// Take an owned snapshot of all entries currently in the store. Use
@@ -209,17 +284,23 @@ impl XhsHistoryStore {
     /// `search` records every note it reads) but still wants to
     /// annotate output cards based on what was known *before* the call —
     /// otherwise the annotation reflects this run's own writes.
-    pub fn snapshot(&self) -> HistorySnapshot {
-        let entries = self
+    pub fn snapshot(&self, session_id: &str) -> HistorySnapshot {
+        let session_id = session_id.trim();
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
             .inner
             .lock()
-            .map(|guard| guard.notes.clone())
-            .unwrap_or_default();
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        let entries = referenced_entries(&guard, session_id);
         HistorySnapshot { entries }
     }
 
-    /// Upsert an entry after a read. The cache is a growing union of
-    /// information per note, kept consistent by construction:
+    /// Add this note id to the conversation's references, then upsert its
+    /// global asset. The cache is a growing union of information per note,
+    /// kept consistent by construction:
     ///
     /// - `level` / `include_media` record the deepest *request* ever served
     ///   and never downgrade.
@@ -235,7 +316,11 @@ impl XhsHistoryStore {
     /// - Attempt outcomes (`*_error` fields) are never cached: an error says
     ///   nothing durable about the note, and the absent information already
     ///   makes the next request that needs it re-read.
-    pub fn record(&self, entity: &Value, level: &str, include_media: bool) {
+    pub fn record(&self, session_id: &str, entity: &Value, level: &str, include_media: bool) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return;
+        }
         let Some(note_id) = entity
             .get("note_id")
             .and_then(Value::as_str)
@@ -252,85 +337,111 @@ impl XhsHistoryStore {
         let mut fresh = entity.clone();
         strip_error_fields(&mut fresh);
 
-        let snapshot = {
-            let Ok(mut guard) = self.inner.lock() else {
-                return;
-            };
-            let entry = guard.notes.entry(note_id.clone()).or_insert_with(|| {
-                let mut e = HistoryEntry::default();
-                e.note_id = note_id.clone();
-                e.first_seen_at = now.clone();
-                e
-            });
-            entry.note_id = note_id;
-            if !title.is_empty() {
-                entry.title = title;
-            }
-            if !author.is_empty() {
-                entry.author = author;
-            }
-            if !url.is_empty() {
-                entry.url = url;
-            }
-            if level_value(level) > level_value(&entry.level) {
-                entry.level = level.to_string();
-            }
-            if include_media {
-                entry.include_media = true;
-            }
-            let merged = match entry.entity.take() {
-                Some(prev) => merge_entities(&prev, fresh),
-                None => fresh,
-            };
-            entry.downloaded = entity_has_downloaded(&merged);
-            entry.ocr = entity_has_ocr(&merged);
-            entry.transcribed = entity_has_transcript(&merged);
-            entry.comments_loaded = entity_comment_count(&merged);
-            let total = entity_comment_total(&merged);
-            if total > entry.comments_total {
-                entry.comments_total = total;
-            }
-            entry.entity = Some(merged);
-            entry.analysis_count = entry.analysis_count.saturating_add(1);
-            entry.last_seen_at = now;
-            guard.clone()
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        guard.version = HISTORY_VERSION;
+        if guard.removed_sessions.contains(session_id) {
+            return;
+        }
+        guard
+            .session_refs
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(note_id.clone());
+        let entry = guard.notes.entry(note_id.clone()).or_insert_with(|| {
+            let mut e = HistoryEntry::default();
+            e.note_id = note_id.clone();
+            e.first_seen_at = now.clone();
+            e
+        });
+        entry.note_id = note_id;
+        if !title.is_empty() {
+            entry.title = title;
+        }
+        if !author.is_empty() {
+            entry.author = author;
+        }
+        if !url.is_empty() {
+            entry.url = url;
+        }
+        if level_value(level) > level_value(&entry.level) {
+            entry.level = level.to_string();
+        }
+        if include_media {
+            entry.include_media = true;
+        }
+        let merged = match entry.entity.take() {
+            Some(prev) => merge_entities(&prev, fresh),
+            None => fresh,
         };
+        entry.downloaded = entity_has_downloaded(&merged);
+        entry.ocr = entity_has_ocr(&merged);
+        entry.transcribed = entity_has_transcript(&merged);
+        entry.comments_loaded = entity_comment_count(&merged);
+        let total = entity_comment_total(&merged);
+        if total > entry.comments_total {
+            entry.comments_total = total;
+        }
+        entry.entity = Some(merged);
+        entry.analysis_count = entry.analysis_count.saturating_add(1);
+        entry.last_seen_at = now;
 
         // Best-effort write. A failure here just means the next process
         // won't see this entry — agent still works.
-        let _ = save_file(&self.path, &snapshot);
+        let _ = save_file(&self.path, &guard);
     }
 
     /// Forget downloaded media that lived under run dirs being deleted: strip
     /// the cached entities' `local_path`s pointing into them and downgrade the
     /// `downloaded` flag, so the next request re-reads (and re-downloads) the
     /// note instead of trusting paths that no longer exist. Returns how many
-    /// entries were scrubbed. Best-effort hygiene: a concurrently running
-    /// agent holds its own store instance and its next record can clobber
-    /// this write — the disk check in `is_satisfied_by` is the backstop.
+    /// entries were scrubbed.
     pub fn scrub_media_under(&self, run_dirs: &[PathBuf]) -> usize {
-        let (snapshot, scrubbed) = {
-            let Ok(mut guard) = self.inner.lock() else {
-                return 0;
-            };
-            let mut scrubbed = 0usize;
-            for entry in guard.notes.values_mut() {
-                let Some(entity) = entry.entity.as_mut() else {
-                    continue;
-                };
-                if !scrub_entity_media_under(entity, run_dirs) {
-                    continue;
-                }
-                entry.downloaded = entity_has_downloaded(entity);
-                scrubbed += 1;
-            }
-            if scrubbed == 0 {
-                return 0;
-            }
-            (guard.clone(), scrubbed)
-        };
-        let _ = save_file(&self.path, &snapshot);
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        let scrubbed = scrub_history_entries(&mut guard.notes, run_dirs);
+        if scrubbed == 0 {
+            return 0;
+        }
+        guard.version = HISTORY_VERSION;
+        let _ = save_file(&self.path, &guard);
         scrubbed
+    }
+
+    /// Drop all dedup state for a deleted conversation.
+    pub fn remove_session(&self, session_id: &str) -> bool {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return false;
+        }
+        let _io = history_io_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        refresh_from_disk(&self.path, &mut guard);
+        let removed = guard.session_refs.remove(session_id).is_some();
+        let tombstoned = guard.removed_sessions.insert(session_id.to_string());
+        if !removed && !tombstoned {
+            return false;
+        }
+        guard.version = HISTORY_VERSION;
+        let _ = save_file(&self.path, &guard);
+        true
     }
 }
 
@@ -347,6 +458,23 @@ impl HistorySnapshot {
 }
 
 fn annotate_cards_from(entries: &BTreeMap<String, HistoryEntry>, cards: &mut Value) {
+    annotate_cards_with(cards, |note_id| entries.get(note_id));
+}
+
+fn annotate_cards_from_refs(
+    notes: &BTreeMap<String, HistoryEntry>,
+    refs: &BTreeSet<String>,
+    cards: &mut Value,
+) {
+    annotate_cards_with(cards, |note_id| {
+        refs.contains(note_id).then(|| notes.get(note_id)).flatten()
+    });
+}
+
+fn annotate_cards_with<'a>(
+    cards: &mut Value,
+    mut lookup: impl FnMut(&str) -> Option<&'a HistoryEntry>,
+) {
     let Some(arr) = cards.as_array_mut() else {
         return;
     };
@@ -361,12 +489,44 @@ fn annotate_cards_from(entries: &BTreeMap<String, HistoryEntry>, cards: &mut Val
             .filter(|s| !s.is_empty())
             .map(str::to_string);
         let Some(note_id) = note_id else { continue };
-        if let Some(entry) = entries.get(&note_id) {
+        if let Some(entry) = lookup(&note_id) {
             map.insert("already_analyzed".into(), json!(true));
             map.insert("history_level".into(), json!(entry.level));
             map.insert("history_include_media".into(), json!(entry.include_media));
         }
     }
+}
+
+fn referenced_entries(data: &HistoryFile, session_id: &str) -> BTreeMap<String, HistoryEntry> {
+    data.session_refs
+        .get(session_id)
+        .into_iter()
+        .flatten()
+        .filter_map(|note_id| {
+            data.notes
+                .get(note_id)
+                .cloned()
+                .map(|entry| (note_id.clone(), entry))
+        })
+        .collect()
+}
+
+fn scrub_history_entries(
+    entries: &mut BTreeMap<String, HistoryEntry>,
+    run_dirs: &[PathBuf],
+) -> usize {
+    let mut scrubbed = 0usize;
+    for entry in entries.values_mut() {
+        let Some(entity) = entry.entity.as_mut() else {
+            continue;
+        };
+        if !scrub_entity_media_under(entity, run_dirs) {
+            continue;
+        }
+        entry.downloaded = entity_has_downloaded(entity);
+        scrubbed += 1;
+    }
+    scrubbed
 }
 
 fn level_value(level: &str) -> i32 {
@@ -636,20 +796,245 @@ fn merge_entities(prev: &Value, mut fresh: Value) -> Value {
     fresh
 }
 
+/// Migration must retain fields from both serialized copies. The regular
+/// runtime merge intentionally lets a fresh read replace ordinary fields, but
+/// a schema conversion has no authoritative network read and must be lossless.
+fn merge_migrated_entities(prev: &Value, fresh: Value) -> Value {
+    let merged_images = match (
+        prev.get("images").and_then(Value::as_array),
+        fresh.get("images").and_then(Value::as_array),
+    ) {
+        (Some(prev), Some(fresh)) if !prev.is_empty() && !fresh.is_empty() => {
+            Some(merge_migrated_images(prev, fresh))
+        }
+        _ => None,
+    };
+    let mut merged = merge_entities(prev, fresh);
+    let (Some(prev), Some(merged_object)) = (prev.as_object(), merged.as_object_mut()) else {
+        return merged;
+    };
+    for (key, value) in prev {
+        merged_object
+            .entry(key.clone())
+            .or_insert_with(|| value.clone());
+    }
+    if let Some(images) = merged_images {
+        merged_object.insert("image_count".into(), json!(images.len()));
+        merged_object.insert("images".into(), Value::Array(images));
+    }
+    merged
+}
+
+fn merge_migrated_images(prev: &[Value], fresh: &[Value]) -> Vec<Value> {
+    let mut merged = fresh.to_vec();
+    let fresh_len = fresh.len();
+    for (prev_position, prev_image) in prev.iter().enumerate() {
+        let prev_index = image_index(prev_image);
+        let prev_url = image_url(prev_image);
+        let match_position = prev_index
+            .and_then(|index| {
+                merged
+                    .iter()
+                    .position(|fresh_image| image_index(fresh_image) == Some(index))
+            })
+            .or_else(|| {
+                prev_url.and_then(|url| {
+                    merged
+                        .iter()
+                        .position(|fresh_image| image_url(fresh_image) == Some(url))
+                })
+            })
+            .or_else(|| {
+                (prev_index.is_none()
+                    && prev_url.is_none()
+                    && prev_position < fresh_len
+                    && image_index(&merged[prev_position]).is_none()
+                    && image_url(&merged[prev_position]).is_none())
+                .then_some(prev_position)
+            });
+        if let Some(position) = match_position {
+            merged[position] = merge_migrated_object(prev_image, &merged[position]);
+        } else {
+            merged.push(prev_image.clone());
+        }
+    }
+    merged
+}
+
+fn merge_migrated_object(prev: &Value, fresh: &Value) -> Value {
+    let (Some(prev), Some(fresh)) = (prev.as_object(), fresh.as_object()) else {
+        return fresh.clone();
+    };
+    let mut merged = fresh.clone();
+    for (key, prev_value) in prev {
+        match merged.get_mut(key) {
+            Some(fresh_value) if prev_value.is_object() && fresh_value.is_object() => {
+                *fresh_value = merge_migrated_object(prev_value, fresh_value);
+            }
+            Some(_) => {}
+            None => {
+                merged.insert(key.clone(), prev_value.clone());
+            }
+        }
+    }
+    Value::Object(merged)
+}
+
+fn image_index(image: &Value) -> Option<i64> {
+    image.get("index").and_then(Value::as_i64)
+}
+
+fn image_url(image: &Value) -> Option<&str> {
+    image
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+}
+
+fn normalize_history_entry(note_id: &str, entry: &mut HistoryEntry) {
+    entry.note_id = note_id.to_string();
+    let Some(entity) = entry.entity.as_mut() else {
+        return;
+    };
+    strip_error_fields(entity);
+    let entity = &*entity;
+    entry.downloaded = entity_has_downloaded(entity);
+    entry.ocr = entity_has_ocr(entity);
+    entry.transcribed = entity_has_transcript(entity);
+    entry.comments_loaded = entry.comments_loaded.max(entity_comment_count(entity));
+    entry.comments_total = entry.comments_total.max(entity_comment_total(entity));
+}
+
+/// Fold a legacy or freshly loaded entry into the canonical global asset.
+/// Timestamps select which entity supplies conflicting ordinary fields, while
+/// all non-conflicting serialized fields are preserved from both copies.
+fn merge_history_entry(
+    notes: &mut BTreeMap<String, HistoryEntry>,
+    note_id: &str,
+    mut incoming: HistoryEntry,
+) {
+    normalize_history_entry(note_id, &mut incoming);
+    let Some(existing) = notes.get_mut(note_id) else {
+        notes.insert(note_id.to_string(), incoming);
+        return;
+    };
+
+    let incoming_is_newer = incoming.last_seen_at.as_str() >= existing.last_seen_at.as_str();
+    if existing.title.is_empty() || (incoming_is_newer && !incoming.title.is_empty()) {
+        existing.title = incoming.title.clone();
+    }
+    if existing.author.is_empty() || (incoming_is_newer && !incoming.author.is_empty()) {
+        existing.author = incoming.author.clone();
+    }
+    if existing.url.is_empty() || (incoming_is_newer && !incoming.url.is_empty()) {
+        existing.url = incoming.url.clone();
+    }
+    if level_value(&incoming.level) > level_value(&existing.level) {
+        existing.level = incoming.level.clone();
+    }
+    existing.include_media |= incoming.include_media;
+    existing.downloaded |= incoming.downloaded;
+    existing.ocr |= incoming.ocr;
+    existing.transcribed |= incoming.transcribed;
+    existing.comments_loaded = existing.comments_loaded.max(incoming.comments_loaded);
+    existing.comments_total = existing.comments_total.max(incoming.comments_total);
+    existing.analysis_count = existing
+        .analysis_count
+        .saturating_add(incoming.analysis_count);
+    if existing.first_seen_at.is_empty()
+        || (!incoming.first_seen_at.is_empty() && incoming.first_seen_at < existing.first_seen_at)
+    {
+        existing.first_seen_at = incoming.first_seen_at.clone();
+    }
+    if incoming.last_seen_at > existing.last_seen_at {
+        existing.last_seen_at = incoming.last_seen_at.clone();
+    }
+
+    existing.entity = match (existing.entity.take(), incoming.entity.take()) {
+        (Some(current), Some(incoming)) if incoming_is_newer => {
+            Some(merge_migrated_entities(&current, incoming))
+        }
+        (Some(current), Some(incoming)) => Some(merge_migrated_entities(&incoming, current)),
+        (Some(current), None) => Some(current),
+        (None, Some(incoming)) => Some(incoming),
+        (None, None) => None,
+    };
+    normalize_history_entry(note_id, existing);
+}
+
 /// Re-establish the cache invariants on entries written by older versions:
-/// cached entities must not carry attempt outcomes, and the information flags
-/// must state what the cached entity actually holds. In-memory only; the
-/// normalized state persists with the next regular save.
+/// - v0/v1 global `notes` remain the canonical assets;
+/// - v3 per-session entries are merged into those assets and replaced by id
+///   references;
+/// - cached entities drop attempt outcomes and their capability flags are
+///   re-derived.
+///
+/// This is in-memory and persists with the next regular save.
 fn normalize_loaded_entries(data: &mut HistoryFile) {
-    for entry in data.notes.values_mut() {
-        let Some(entity) = entry.entity.as_mut() else {
-            continue;
+    data.version = HISTORY_VERSION;
+
+    let mut notes = BTreeMap::new();
+    for (map_id, entry) in std::mem::take(&mut data.notes) {
+        let note_id = if map_id.trim().is_empty() {
+            entry.note_id.trim().to_string()
+        } else {
+            map_id.trim().to_string()
         };
-        strip_error_fields(entity);
-        let entity = &*entity;
-        entry.downloaded = entity_has_downloaded(entity);
-        entry.ocr = entity_has_ocr(entity);
-        entry.transcribed = entity_has_transcript(entity);
+        if !note_id.is_empty() {
+            merge_history_entry(&mut notes, &note_id, entry);
+        }
+    }
+    data.notes = notes;
+
+    for (session_id, entries) in std::mem::take(&mut data.legacy_session_notes) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || data.removed_sessions.contains(session_id) {
+            continue;
+        }
+        for (map_id, entry) in entries {
+            let note_id = if map_id.trim().is_empty() {
+                entry.note_id.trim().to_string()
+            } else {
+                map_id.trim().to_string()
+            };
+            if note_id.is_empty() {
+                continue;
+            }
+            merge_history_entry(&mut data.notes, &note_id, entry);
+            data.session_refs
+                .entry(session_id.to_string())
+                .or_default()
+                .insert(note_id);
+        }
+    }
+
+    let asset_ids = data.notes.keys().cloned().collect::<BTreeSet<_>>();
+    let mut session_refs: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (session_id, refs) in std::mem::take(&mut data.session_refs) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || data.removed_sessions.contains(session_id) {
+            continue;
+        }
+        let refs = refs
+            .into_iter()
+            .map(|note_id| note_id.trim().to_string())
+            .filter(|note_id| !note_id.is_empty() && asset_ids.contains(note_id))
+            .collect::<BTreeSet<_>>();
+        if !refs.is_empty() {
+            session_refs
+                .entry(session_id.to_string())
+                .or_default()
+                .extend(refs);
+        }
+    }
+    data.session_refs = session_refs;
+}
+
+fn refresh_from_disk(path: &Path, current: &mut HistoryFile) {
+    if let Some(mut latest) = load_file(path) {
+        normalize_loaded_entries(&mut latest);
+        *current = latest;
     }
 }
 
@@ -664,7 +1049,7 @@ fn save_file(path: &Path, data: &HistoryFile) -> std::io::Result<()> {
     }
     let bytes = serde_json::to_vec_pretty(data)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    let tmp = path.with_extension("json.tmp");
+    let tmp = path.with_extension(format!("json.{}.tmp", std::process::id()));
     fs::write(&tmp, &bytes)?;
     fs::rename(&tmp, path)?;
     Ok(())
@@ -685,19 +1070,233 @@ mod tests {
         let store = XhsHistoryStore::open(&path);
 
         store.record(
+            "session-a",
             &json!({"note_id": "abc", "title": "T", "author": "A", "url": "u"}),
             "lite",
             false,
         );
-        let entry = store.get("abc").expect("entry present");
+        let entry = store.get("session-a", "abc").expect("entry present");
         assert_eq!(entry.note_id, "abc");
         assert_eq!(entry.level, "lite");
         assert_eq!(entry.analysis_count, 1);
         assert!(!entry.first_seen_at.is_empty());
+        assert!(store.get("session-b", "abc").is_none());
+        let persisted: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], json!(HISTORY_VERSION));
+        assert!(persisted["notes"]["abc"].is_object());
+        assert_eq!(persisted["session_refs"]["session-a"], json!(["abc"]));
+        assert!(persisted.get("session_notes").is_none());
 
-        // Reopen from disk — entries persist.
+        // Reopen from disk — both the cache and session boundary persist.
         let store2 = XhsHistoryStore::open(&path);
-        assert!(store2.get("abc").is_some());
+        assert!(store2.get("session-a", "abc").is_some());
+        assert!(store2.get("session-b", "abc").is_none());
+
+        // Separate store instances (foreground/background tool factories)
+        // merge against the latest file instead of overwriting one another.
+        let writers = (0..4)
+            .map(|index| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    XhsHistoryStore::open(path).record(
+                        &format!("concurrent-{index}"),
+                        &json!({"note_id": format!("note-{index}")}),
+                        "lite",
+                        false,
+                    );
+                })
+            })
+            .collect::<Vec<_>>();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        let merged = XhsHistoryStore::open(&path);
+        for index in 0..4 {
+            assert!(merged
+                .get(&format!("concurrent-{index}"), &format!("note-{index}"))
+                .is_some());
+        }
+
+        // A v1 global asset has no trustworthy conversation owner. It remains
+        // readable and merges with new reads, but cannot suppress a v4 session
+        // until that session records a reference itself.
+        let legacy_path = dir.path().join("legacy.json");
+        std::fs::write(
+            &legacy_path,
+            serde_json::to_vec(&json!({
+                "notes": {
+                    "legacy": {"note_id": "legacy", "level": "deep"}
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let legacy = XhsHistoryStore::open(&legacy_path);
+        assert!(legacy.get("session-a", "legacy").is_none());
+        legacy.record("session-a", &json!({"note_id": "legacy"}), "lite", false);
+        assert_eq!(legacy.get("session-a", "legacy").unwrap().level, "deep");
+
+        // A v3 file copied complete entries into every session. Opening it
+        // folds those entries into global assets and keeps only id pointers;
+        // the next normal write persists the v4 shape without data loss.
+        let v3_path = dir.path().join("v3.json");
+        std::fs::write(
+            &v3_path,
+            serde_json::to_vec(&json!({
+                "version": 3,
+                "notes": {
+                    "from-v3": {
+                        "note_id": "from-v3",
+                        "level": "lite",
+                        "entity": {
+                            "note_id": "from-v3",
+                            "global_field": "preserved global content",
+                            "images": [
+                                {
+                                    "index": 0,
+                                    "url": "https://img.example/0.jpg",
+                                    "local_path": "/tmp/preserved-image.jpg"
+                                },
+                                {
+                                    "index": 1,
+                                    "url": "https://img.example/old.jpg",
+                                    "local_path": "/tmp/old-image.jpg"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "session_notes": {
+                    "session-v3": {
+                        "from-v3": {
+                            "note_id": "from-v3",
+                            "level": "deep",
+                            "ocr": true,
+                            "entity": {
+                                "note_id": "from-v3",
+                                "desc": "preserved v3 content",
+                                "ocr_text": ["preserved OCR"],
+                                "images": [
+                                    {
+                                        "index": 0,
+                                        "url": "https://img.example/0.jpg",
+                                        "ocr_text": "preserved image OCR"
+                                    },
+                                    {
+                                        "index": 2,
+                                        "url": "https://img.example/new.jpg",
+                                        "ocr_text": "new image OCR"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let v3 = XhsHistoryStore::open(&v3_path);
+        let migrated = v3.get("session-v3", "from-v3").unwrap();
+        assert_eq!(
+            migrated.entity.unwrap()["desc"],
+            json!("preserved v3 content")
+        );
+        assert_eq!(
+            v3.get("session-v3", "from-v3").unwrap().entity.unwrap()["global_field"],
+            json!("preserved global content")
+        );
+        let migrated_image = &v3.get("session-v3", "from-v3").unwrap().entity.unwrap()["images"][0];
+        assert_eq!(
+            migrated_image["local_path"],
+            json!("/tmp/preserved-image.jpg")
+        );
+        assert_eq!(migrated_image["ocr_text"], json!("preserved image OCR"));
+        let migrated_images = v3.get("session-v3", "from-v3").unwrap().entity.unwrap()["images"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(migrated_images.len(), 3);
+        assert!(migrated_images[1].get("local_path").is_none());
+        assert_eq!(
+            migrated_images[2]["local_path"],
+            json!("/tmp/old-image.jpg")
+        );
+        assert!(v3.get("another-session", "from-v3").is_none());
+        v3.record(
+            "session-v3",
+            &json!({"note_id": "new-v4-asset"}),
+            "lite",
+            false,
+        );
+        let migrated_file: Value =
+            serde_json::from_slice(&std::fs::read(&v3_path).unwrap()).unwrap();
+        assert!(migrated_file.get("session_notes").is_none());
+        assert_eq!(
+            migrated_file["session_refs"]["session-v3"],
+            json!(["from-v3", "new-v4-asset"])
+        );
+        assert_eq!(
+            migrated_file["notes"]["from-v3"]["entity"]["desc"],
+            json!("preserved v3 content")
+        );
+        assert_eq!(
+            migrated_file["notes"]["from-v3"]["entity"]["global_field"],
+            json!("preserved global content")
+        );
+        assert_eq!(
+            migrated_file["notes"]["from-v3"]["entity"]["images"][0]["local_path"],
+            json!("/tmp/preserved-image.jpg")
+        );
+        assert_eq!(
+            migrated_file["notes"]["from-v3"]["entity"]["images"][0]["ocr_text"],
+            json!("preserved image OCR")
+        );
+        // Reopening and normalizing the persisted v4 file is idempotent.
+        let reopened = XhsHistoryStore::open(&v3_path);
+        let reopened_image = &reopened
+            .get("session-v3", "from-v3")
+            .unwrap()
+            .entity
+            .unwrap()["images"][0];
+        assert_eq!(
+            reopened_image["local_path"],
+            json!("/tmp/preserved-image.jpg")
+        );
+        assert_eq!(reopened_image["ocr_text"], json!("preserved image OCR"));
+        let reopened_images = reopened
+            .get("session-v3", "from-v3")
+            .unwrap()
+            .entity
+            .unwrap()["images"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(reopened_images.len(), 3);
+        assert!(reopened_images[1].get("local_path").is_none());
+        assert_eq!(
+            reopened_images[2]["local_path"],
+            json!("/tmp/old-image.jpg")
+        );
+
+        assert!(store2.remove_session("session-a"));
+        // A detached background completion arriving after deletion cannot
+        // recreate the removed conversation's history.
+        store2.record(
+            "session-a",
+            &json!({"note_id": "late-background-write"}),
+            "deep",
+            true,
+        );
+        assert!(XhsHistoryStore::open(&path)
+            .get("session-a", "abc")
+            .is_none());
+        assert!(XhsHistoryStore::open(&path)
+            .get("session-a", "late-background-write")
+            .is_none());
+        let after_delete: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(after_delete["notes"]["abc"].is_object());
+        assert!(after_delete["session_refs"].get("session-a").is_none());
     }
 
     #[test]
@@ -705,9 +1304,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = XhsHistoryStore::open(dir.path().join("h.json"));
 
-        store.record(&json!({"note_id": "n1"}), "deep", true);
-        store.record(&json!({"note_id": "n1"}), "lite", false);
-        let entry = store.get("n1").unwrap();
+        store.record("session", &json!({"note_id": "n1"}), "deep", true);
+        store.record("session", &json!({"note_id": "n1"}), "lite", false);
+        let entry = store.get("session", "n1").unwrap();
         assert_eq!(entry.level, "deep");
         assert!(entry.include_media);
         assert_eq!(entry.analysis_count, 2);
@@ -717,17 +1316,51 @@ mod tests {
     fn satisfied_when_prior_is_deeper_or_equal() {
         let dir = tempdir().unwrap();
         let store = XhsHistoryStore::open(dir.path().join("h.json"));
-        store.record(&json!({"note_id": "n1"}), "lite", false);
+        store.record("session", &json!({"note_id": "n1"}), "lite", false);
 
-        assert!(store.is_satisfied_by("n1", "card", false, false, false, false, 0));
-        assert!(store.is_satisfied_by("n1", "lite", false, false, false, false, 0));
-        assert!(!store.is_satisfied_by("n1", "deep", false, false, false, false, 0));
-        assert!(!store.is_satisfied_by("n1", "lite", true, false, false, false, 0));
-        assert!(!store.is_satisfied_by("unknown", "card", false, false, false, false, 0));
+        assert!(store.is_satisfied_by("session", "n1", "card", false, false, false, false, 0));
+        assert!(store.is_satisfied_by("session", "n1", "lite", false, false, false, false, 0));
+        assert!(!store.is_satisfied_by(
+            "other-session",
+            "n1",
+            "lite",
+            false,
+            false,
+            false,
+            false,
+            0
+        ));
+        assert!(!store.is_satisfied_by("session", "n1", "deep", false, false, false, false, 0));
+        assert!(!store.is_satisfied_by("session", "n1", "lite", true, false, false, false, 0));
+        assert!(!store.is_satisfied_by("session", "unknown", "card", false, false, false, false, 0));
         // download / ocr dimensions: a plain read doesn't satisfy them.
-        assert!(!store.is_satisfied_by("n1", "lite", false, true, false, false, 0));
-        assert!(!store.is_satisfied_by("n1", "lite", false, false, true, false, 0));
-        assert!(!store.is_satisfied_by("n1", "lite", false, false, false, true, 0));
+        assert!(!store.is_satisfied_by("session", "n1", "lite", false, true, false, false, 0));
+        assert!(!store.is_satisfied_by("session", "n1", "lite", false, false, true, false, 0));
+        assert!(!store.is_satisfied_by("session", "n1", "lite", false, false, false, true, 0));
+
+        // The second conversation must establish its own pointer before it can
+        // skip. Once referenced, both conversations reuse the richer shared
+        // asset rather than storing duplicate entities.
+        store.record(
+            "other-session",
+            &json!({"note_id": "n1", "ocr_text": ["other session"]}),
+            "deep",
+            true,
+        );
+        assert!(store.is_satisfied_by("other-session", "n1", "deep", true, false, true, false, 0));
+        assert!(store.is_satisfied_by("session", "n1", "deep", false, false, false, false, 0));
+        assert!(store.is_satisfied_by("session", "n1", "lite", true, false, false, false, 0));
+        assert!(store.is_satisfied_by("session", "n1", "lite", false, false, true, false, 0));
+        assert!(!store.is_satisfied_by(
+            "third-session",
+            "n1",
+            "lite",
+            false,
+            false,
+            false,
+            false,
+            0
+        ));
     }
 
     #[test]
@@ -737,6 +1370,7 @@ mod tests {
         let media = dir.path().join("x.jpg");
         std::fs::write(&media, b"jpg").unwrap();
         store.record(
+            "session",
             &json!({
                 "note_id": "n2",
                 "ocr_text": ["cover text", ""],
@@ -746,8 +1380,8 @@ mod tests {
             false,
         );
 
-        assert!(store.is_satisfied_by("n2", "deep", false, true, true, false, 0));
-        let entry = store.get("n2").unwrap();
+        assert!(store.is_satisfied_by("session", "n2", "deep", false, true, true, false, 0));
+        let entry = store.get("session", "n2").unwrap();
         assert!(entry.downloaded);
         assert!(entry.ocr);
 
@@ -755,19 +1389,19 @@ mod tests {
         // must be re-read, not resurrected with a dead path) — while text-only
         // coverage is untouched.
         std::fs::remove_file(&media).unwrap();
-        assert!(!store.is_satisfied_by("n2", "deep", false, true, true, false, 0));
-        assert!(store.is_satisfied_by("n2", "deep", false, false, true, false, 0));
+        assert!(!store.is_satisfied_by("session", "n2", "deep", false, true, true, false, 0));
+        assert!(store.is_satisfied_by("session", "n2", "deep", false, false, true, false, 0));
     }
 
     #[test]
     fn snapshot_freezes_pre_call_state() {
         let dir = tempdir().unwrap();
         let store = XhsHistoryStore::open(dir.path().join("h.json"));
-        store.record(&json!({"note_id": "old"}), "lite", false);
+        store.record("session", &json!({"note_id": "old"}), "lite", false);
 
-        let pre = store.snapshot();
+        let pre = store.snapshot("session");
         // Writes after the snapshot must not show up when annotating with it.
-        store.record(&json!({"note_id": "new_this_run"}), "deep", true);
+        store.record("session", &json!({"note_id": "new_this_run"}), "deep", true);
 
         let mut cards = json!([
             {"note_id": "old"},
@@ -783,13 +1417,18 @@ mod tests {
     fn annotate_cards_marks_known_notes() {
         let dir = tempdir().unwrap();
         let store = XhsHistoryStore::open(dir.path().join("h.json"));
-        store.record(&json!({"note_id": "seen", "title": "x"}), "deep", true);
+        store.record(
+            "session",
+            &json!({"note_id": "seen", "title": "x"}),
+            "deep",
+            true,
+        );
 
         let mut cards = json!([
             {"note_id": "seen", "title": "x"},
             {"note_id": "fresh", "title": "y"},
         ]);
-        store.annotate_cards(&mut cards);
+        store.annotate_cards("session", &mut cards);
         let arr = cards.as_array().unwrap();
         assert_eq!(arr[0]["already_analyzed"], json!(true));
         assert_eq!(arr[0]["history_level"], json!("deep"));

--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -167,10 +167,12 @@ lives locally in the run directory and is referenced from manifests.
 
 Some cards or note entries may be marked as previously analyzed (for example
 `already_analyzed`, `history_level`, `history_include_media`, `skipped`, or a
-`history` object). That means socai has durable cached evidence for that note
-from this or an earlier run. Use the returned cached entity/history as evidence
-instead of assuming the note was ignored. Only rerun with deeper settings when
-the cached level/media setting is insufficient for the current task.
+`history` object). That means the current conversation has durable cached
+evidence for that note from this or an earlier turn. Use the returned cached
+entity/history as evidence instead of assuming the note was ignored. Notes
+seen only in another conversation remain eligible here. Only rerun with deeper
+settings when the cached level/media setting is insufficient for the current
+task.
 
 ## Evidence Rules
 

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -456,22 +456,46 @@ impl<'a> XhsPageRuntime<'a> {
             .await
     }
 
-    /// Poll `extract_search_cards` until the count grows past `baseline` or
-    /// `timeout` elapses; returns the latest cards either way.
-    async fn wait_for_card_growth(
+    /// Poll `extract_search_cards` until the visible card identities change or
+    /// `timeout` elapses. Identity comparison also handles virtualized feeds
+    /// that replace a fixed-size DOM window instead of increasing its length.
+    async fn wait_for_card_change(
         &self,
-        baseline: usize,
+        baseline: &HashSet<String>,
         timeout: Duration,
-    ) -> Result<Vec<XhsNoteCard>> {
+    ) -> Result<(Vec<XhsNoteCard>, bool)> {
         const POLL: Duration = Duration::from_millis(400);
         let deadline = Instant::now() + timeout;
         loop {
             sleep_ms(POLL.as_millis() as u64).await;
             let cards = self.extract_search_cards().await?;
-            if cards.len() > baseline || Instant::now() >= deadline {
-                return Ok(cards);
+            let changed = cards
+                .iter()
+                .map(search_card_key)
+                .any(|key| !baseline.contains(&key));
+            if changed || Instant::now() >= deadline {
+                return Ok((cards, changed));
             }
         }
+    }
+
+    /// Request one more search-results page and return the latest visible
+    /// cards. A reverse nudge retries an ignored bottom jump before the caller
+    /// treats the feed as stalled.
+    pub async fn load_more_search_cards(&self) -> Result<(Vec<XhsNoteCard>, bool)> {
+        const PRE_SCROLL_DELAY: Duration = Duration::from_millis(1500);
+        const SETTLE_TIMEOUT: Duration = Duration::from_millis(5000);
+
+        let before = self.extract_search_cards().await?;
+        let baseline: HashSet<String> = before.iter().map(search_card_key).collect();
+        sleep_ms(PRE_SCROLL_DELAY.as_millis() as u64).await;
+        self.scroll_feed(false).await?;
+        let (mut cards, mut changed) = self.wait_for_card_change(&baseline, SETTLE_TIMEOUT).await?;
+        if !changed {
+            self.scroll_feed(true).await?;
+            (cards, changed) = self.wait_for_card_change(&baseline, SETTLE_TIMEOUT).await?;
+        }
+        Ok((cards, changed))
     }
 
     /// Collect search cards up to `target`, scrolling the feed and waiting for
@@ -480,32 +504,19 @@ impl<'a> XhsPageRuntime<'a> {
     /// results). Returns at most `target` cards in feed order.
     async fn collect_search_cards(&self, target: usize) -> Result<Vec<XhsNoteCard>> {
         // XHS sometimes ignores a too-fast jump to the bottom and won't fetch
-        // more, so pause before each jump; if a jump still loads nothing within
-        // SETTLE_TIMEOUT, a small reverse (upward) scroll reliably re-triggers
-        // the lazy load. Give up only after MAX_STALLS rounds where even the
-        // nudge fails (the real end of results).
-        const PRE_SCROLL_DELAY: Duration = Duration::from_millis(1500);
-        const SETTLE_TIMEOUT: Duration = Duration::from_millis(5000);
+        // more, so load_more_search_cards pauses before each jump and retries
+        // with a reverse nudge. Give up only after MAX_STALLS rounds without a
+        // new identity (the real end of results).
         const MAX_STALLS: usize = 3;
 
         let mut cards = self.extract_search_cards().await?;
+        let mut seen: HashSet<String> = cards.iter().map(search_card_key).collect();
         let mut stalls = 0usize;
         while cards.len() < target {
             let before = cards.len();
-
-            // 1) Deliberate pause, then jump to the bottom to request more.
-            sleep_ms(PRE_SCROLL_DELAY.as_millis() as u64).await;
-            self.scroll_feed(false).await?;
-            cards = self.wait_for_card_growth(before, SETTLE_TIMEOUT).await?;
-
-            // 2) Nothing loaded in time — nudge back up to jog the observer and
-            //    wait once more before counting this round as a stall.
-            if cards.len() <= before {
-                self.scroll_feed(true).await?;
-                cards = self.wait_for_card_growth(before, SETTLE_TIMEOUT).await?;
-            }
-
-            if cards.len() <= before {
+            let (page, _) = self.load_more_search_cards().await?;
+            merge_unique_search_cards(&mut cards, &mut seen, page);
+            if cards.len() == before {
                 stalls += 1;
                 if stalls >= MAX_STALLS {
                     break;
@@ -1591,7 +1602,8 @@ impl<'a> XhsPageRuntime<'a> {
 
         if options.include_media {
             let t_enrich = Instant::now();
-            self.enrich_note_media(&mut note, options.max_images).await?;
+            self.enrich_note_media(&mut note, options.max_images)
+                .await?;
             perf.insert(
                 "enrich_ms".into(),
                 json!(t_enrich.elapsed().as_millis() as u64),
@@ -2156,6 +2168,30 @@ fn value_type(value: &Value) -> &'static str {
     }
 }
 
+fn search_card_key(card: &XhsNoteCard) -> String {
+    if !card.note_id.is_empty() {
+        return format!("id:{}", card.note_id);
+    }
+    if !card.link.is_empty() {
+        return format!("link:{}", card.link);
+    }
+    format!("position:{}:{}", card.position, card.title)
+}
+
+fn merge_unique_search_cards(
+    cards: &mut Vec<XhsNoteCard>,
+    seen: &mut HashSet<String>,
+    page: Vec<XhsNoteCard>,
+) -> usize {
+    let before = cards.len();
+    for card in page {
+        if seen.insert(search_card_key(&card)) {
+            cards.push(card);
+        }
+    }
+    cards.len().saturating_sub(before)
+}
+
 async fn sleep_ms(ms: u64) {
     tokio::time::sleep(Duration::from_millis(ms)).await;
 }
@@ -2261,5 +2297,35 @@ mod tests {
         apply_video_poster_fallback(&mut video, "https://img.example/cover.jpg");
 
         assert_eq!(video["poster_url"], "https://img.example/poster.jpg");
+    }
+
+    #[test]
+    fn merge_search_cards_keeps_virtualized_replacements() {
+        let mut cards = vec![XhsNoteCard {
+            note_id: "note-a".into(),
+            position: 0,
+            ..Default::default()
+        }];
+        let mut seen: HashSet<String> = cards.iter().map(search_card_key).collect();
+        let added = merge_unique_search_cards(
+            &mut cards,
+            &mut seen,
+            vec![
+                XhsNoteCard {
+                    note_id: "note-a".into(),
+                    position: 0,
+                    ..Default::default()
+                },
+                XhsNoteCard {
+                    note_id: "note-b".into(),
+                    position: 0,
+                    ..Default::default()
+                },
+            ],
+        );
+
+        assert_eq!(added, 1);
+        assert_eq!(cards.len(), 2);
+        assert_eq!(cards[1].note_id, "note-b");
     }
 }

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -5,6 +5,7 @@
 //! visible, note modal open, etc.). The caller is responsible for creating
 //! the page and closing it after `run_agent` returns.
 
+use std::collections::VecDeque;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -852,7 +853,7 @@ fn read_note_options(input: &Value) -> ReadNoteOptions {
     ReadNoteOptions {
         // `level` is no longer a user-facing knob (body content is identical
         // across tiers; media is gated by include_media/download_media). It now
-        // only feeds the cross-run history dedup key.
+        // only feeds the current conversation's history dedup key.
         level: "lite".to_string(),
         include_media: get_bool(input, "include_media", false),
         download_media,
@@ -986,8 +987,13 @@ async fn attach_top_comments(xhs: &XhsPageRuntime<'_>, note: &mut Value) {
 /// compact provenance summary (no title/author/url repeat — those are in
 /// `entity`). Falls back to the card when history has no cached entity (e.g. a
 /// pre-upgrade entry, or one only ever seen as a card).
-fn skipped_note_entry(card: &XhsNoteCard, reason: &str, history: &XhsHistoryStore) -> Value {
-    let entry = history.get(&card.note_id);
+fn skipped_note_entry(
+    card: &XhsNoteCard,
+    reason: &str,
+    history: &XhsHistoryStore,
+    session_id: &str,
+) -> Value {
+    let entry = history.get(session_id, &card.note_id);
     let entity = entry
         .as_ref()
         .and_then(|e| e.entity.clone())
@@ -1018,7 +1024,7 @@ fn recorded_skip_entry(
     ctx: &ToolContext,
     level: &str,
 ) -> Value {
-    let entry = skipped_note_entry(card, reason, history);
+    let entry = skipped_note_entry(card, reason, history, ctx.dedup_session_id());
     if let Some(entity) = entry.get("entity").filter(|v| v.is_object()) {
         // note_data_record expects an ok-shaped entry (the media-manifest
         // builder ignores anything that isn't `ok: true`).
@@ -1147,7 +1153,7 @@ impl ScanProgress {
 }
 
 /// Open one already-selected card, read its body at `level`, attach top
-/// comments, and record it in run + cross-run history. Shared by `search`
+/// comments, and record it in run + conversation history. Shared by `search`
 /// (cards from search) and `author_scan` (cards from a profile page) — the only
 /// difference between those macros is where the cards come from, not how each
 /// note is read. Returns the per-note entry; the caller pushes it and closes
@@ -1163,6 +1169,26 @@ fn recovery_blocker(value: &Value) -> Option<&'static str> {
         })
 }
 
+fn fresh_scan_success(value: &Value) -> bool {
+    value.get("ok").and_then(Value::as_bool) == Some(true)
+}
+
+fn search_card_dedup_key(card: &XhsNoteCard) -> String {
+    if !card.note_id.is_empty() {
+        card.note_id.clone()
+    } else if !card.link.is_empty() {
+        card.link.clone()
+    } else {
+        format!("pos:{}:{}", card.position, card.title)
+    }
+}
+
+fn retain_fresh_scan_notes(payload: &mut Value) {
+    if let Some(notes) = payload.get_mut("notes").and_then(Value::as_array_mut) {
+        notes.retain(fresh_scan_success);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn scan_card_note(
     xhs: &XhsPageRuntime<'_>,
@@ -1176,7 +1202,7 @@ async fn scan_card_note(
     // Whether the caller explicitly asked for media downloads (as opposed to
     // OCR forcing `download_media` on for its own reads). Controls fetching a
     // video note's video file — an OCR-only run downloads just the poster —
-    // and is the download requirement checked against cross-run history.
+    // and is the download requirement checked against conversation history.
     download_media_requested: bool,
     // Desktop macro scans return after downloading the poster and enqueue the
     // full video separately. TUI/CLI downloads and transcription requests keep
@@ -1203,6 +1229,7 @@ async fn scan_card_note(
         !card.note_id.is_empty() && ctx.has_processed_note(&card.note_id, level, requested_media);
     if !card.note_id.is_empty()
         && history.is_satisfied_by(
+            ctx.dedup_session_id(),
             &card.note_id,
             level,
             requested_media,
@@ -1214,7 +1241,7 @@ async fn scan_card_note(
         // Only short-circuit when we actually have the cached entity to return;
         // a pre-upgrade entry without one is re-read so it backfills the cache
         // instead of degrading to a bare card.
-        && history.has_cached_entity(&card.note_id)
+        && history.has_cached_entity(ctx.dedup_session_id(), &card.note_id)
     {
         ctx.mark_processed_note(&card.note_id, level, requested_media);
         let reason = if processed_in_run {
@@ -1356,13 +1383,14 @@ async fn scan_card_note(
     // The note-level `ocr_text` array is derived at lean-trim time from each
     // image's ocr_text (see lean_scan_note), so nothing to attach here.
 
-    // Mark processed in-run + record in cross-run history.
+    // Mark processed in-run, add this conversation's note-id reference, and
+    // merge the complete entity into the shared history asset.
     if !card.note_id.is_empty() {
         ctx.mark_processed_note(&card.note_id, level, requested_media);
     }
     if entry.get("ok").and_then(Value::as_bool).unwrap_or(false) {
         if let Some(entity) = entry.get("entity") {
-            history.record(entity, level, requested_media);
+            history.record(ctx.dedup_session_id(), entity, level, requested_media);
         }
         // Archive the fully-read note (full content + resolved local media) so
         // the desktop app can render it as a rich, locally-served card without
@@ -1530,6 +1558,7 @@ async fn join_note_ocr(
     notes: &mut [Value],
     pending: Vec<(usize, tokio::task::JoinHandle<NoteOcrResult>)>,
     history: &XhsHistoryStore,
+    session_id: &str,
     level: &str,
     include_media: bool,
 ) -> Vec<NoteOcrTiming> {
@@ -1559,7 +1588,7 @@ async fn join_note_ocr(
         // the per-image OCR.
         if note.get("ok").and_then(Value::as_bool) == Some(true) {
             if let Some(entity) = note.get("entity") {
-                history.record(entity, level, include_media);
+                history.record(session_id, entity, level, include_media);
             }
         }
     }
@@ -1672,7 +1701,7 @@ async fn join_note_transcribe(
         }
         if note.get("ok").and_then(Value::as_bool) == Some(true) {
             if let Some(entity) = note.get("entity") {
-                history.record(entity, level, include_media);
+                history.record(ctx.dedup_session_id(), entity, level, include_media);
             }
             // Refresh the archived record (built before the transcript existed)
             // so the desktop app's note card shows the transcript.
@@ -2098,7 +2127,7 @@ fn spawn_background_video_downloads(
         // Re-check history at enqueue time (later than scan_card_note's cache
         // check) and reuse that file instead of fetching the same video twice.
         let completed_elsewhere = history
-            .get(&note_id)
+            .get(ctx.dedup_session_id(), &note_id)
             .and_then(|entry| entry.entity)
             .and_then(|entity| entity.get("video").cloned())
             .and_then(|video| {
@@ -2212,7 +2241,7 @@ fn spawn_background_video_downloads(
             if let Some(map) = entity.as_object_mut() {
                 map.insert("video".into(), completed_video);
             }
-            history.record(&entity, &level, include_media);
+            history.record(ctx.dedup_session_id(), &entity, &level, include_media);
 
             let src = run_relative_path(&local_path, &ctx.run_dir);
             let updated = ctx.update_recorded_note(&note_id, |record| {
@@ -2934,6 +2963,28 @@ fn direct_note_refs(input: &Value) -> anyhow::Result<Vec<DirectNoteRef>> {
 /// Open a tokenized full-screen note route, extract the same entity shape used
 /// by search/author scans, attach comments, and record it in run/history.
 #[allow(clippy::too_many_arguments)]
+fn direct_note_is_satisfied(
+    history: &XhsHistoryStore,
+    ctx: &ToolContext,
+    target: &DirectNoteRef,
+    comment_count: i64,
+    download_media_requested: bool,
+    ocr: bool,
+    transcribe_audio: bool,
+) -> bool {
+    history.is_satisfied_by(
+        ctx.dedup_session_id(),
+        &target.note_id,
+        "deep",
+        false,
+        download_media_requested,
+        ocr,
+        transcribe_audio,
+        comment_count,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn scan_direct_note(
     xhs: &XhsPageRuntime<'_>,
     history: &XhsHistoryStore,
@@ -2942,11 +2993,49 @@ async fn scan_direct_note(
     position: usize,
     comment_count: i64,
     download_media: bool,
+    download_media_requested: bool,
     download_video_file_inline: bool,
     background_video_downloads: bool,
     ocr: bool,
     defer_ocr: bool,
+    transcribe_audio: bool,
 ) -> Value {
+    if direct_note_is_satisfied(
+        history,
+        ctx,
+        target,
+        comment_count,
+        download_media_requested,
+        ocr,
+        transcribe_audio,
+    ) {
+        let cached = history
+            .get(ctx.dedup_session_id(), &target.note_id)
+            .unwrap_or_default();
+        let entity = cached
+            .entity
+            .clone()
+            .unwrap_or_else(|| json!({ "note_id": target.note_id }));
+        let entry = json!({
+            "source_position": position,
+            "ok": true,
+            "skipped": {
+                "reason": "already_analyzed",
+                "level": cached.level,
+                "analysis_count": cached.analysis_count,
+                "first_seen_at": cached.first_seen_at,
+                "last_seen_at": cached.last_seen_at,
+            },
+            "entity": entity,
+            "scan_perf": { "cache_hit": true },
+        });
+        ctx.mark_processed_note(&target.note_id, "deep", false);
+        if let Some((note_id, record)) = build_note_record(&entry, ctx, "deep") {
+            ctx.record_note(&note_id, record);
+        }
+        return entry;
+    }
+
     let mut perf = Map::new();
     let t_open = std::time::Instant::now();
     let open = xhs
@@ -3091,7 +3180,7 @@ async fn scan_direct_note(
     }
 
     ctx.mark_processed_note(&target.note_id, "deep", false);
-    history.record(&entity, "deep", false);
+    history.record(ctx.dedup_session_id(), &entity, "deep", false);
     let mut entry = json!({
         "source_position": position,
         "ok": true,
@@ -3128,9 +3217,9 @@ impl Tool for GetNotesTool {
     fn description(&self) -> &str {
         "Read one or more Xiaohongshu notes directly from note_id + xsec_token pairs. \
          Use tokens returned by search or author_scan when you need to revisit \
-         specific notes without repeating the search/profile click flow. Opens \
-         one full-screen detail route per item and returns body + top comments; \
-         latency scales with the number of notes."
+         specific notes without repeating the search/profile click flow. Reuses \
+         sufficiently complete notes already read in this conversation; otherwise \
+         opens one full-screen detail route and returns body + top comments."
     }
 
     fn input_schema(&self) -> Value {
@@ -3190,30 +3279,6 @@ impl Tool for GetNotesTool {
     async fn call(&self, mut input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         let asr_skipped = !self.asr_enabled && strip_hosted_agent_input(&mut input);
         let targets = direct_note_refs(&input)?;
-        let gate = XhsPageRuntime::new(&self.page);
-        let login = match gate.login_gate(true).await {
-            Ok(login) => login,
-            Err(err) => {
-                let mut payload = json!({
-                    "ok": false,
-                    "notes": [],
-                    "reason": "page_access_failed",
-                    "error": format!("{err:#}"),
-                });
-                gate.attach_page_failure_diagnostic(&mut payload).await;
-                return Ok(json_result(&payload));
-            }
-        };
-        if login == LoginGate::Required {
-            let mut payload = json!({
-                "ok": false,
-                "notes": [],
-                "reason": "login_required",
-            });
-            annotate_remote_login_gate(&self.page, &mut payload);
-            return Ok(json_result(&payload));
-        }
-
         let comment_count = get_i64(&input, "num_comments", TOP_COMMENTS_PER_NOTE).max(0);
         let ocr = self.always_ocr || get_bool(&input, "ocr", false);
         let transcribe_audio = get_bool(&input, "transcribe_audio", false);
@@ -3225,16 +3290,60 @@ impl Tool for GetNotesTool {
             && ctx.background_media_generation.is_some()
             && download_media_requested
             && !transcribe_audio;
-        if ocr {
+        let all_cached = targets.iter().all(|target| {
+            direct_note_is_satisfied(
+                &self.history,
+                ctx,
+                target,
+                comment_count,
+                download_media_requested,
+                ocr,
+                transcribe_audio,
+            )
+        });
+
+        // A fully cached request needs no live page, login, OCR model, or media
+        // processor. Mixed requests still preflight once before fresh reads.
+        if !all_cached {
+            let gate = XhsPageRuntime::new(&self.page);
+            let login = match gate.login_gate(true).await {
+                Ok(login) => login,
+                Err(err) => {
+                    let mut payload = json!({
+                        "ok": false,
+                        "notes": [],
+                        "reason": "page_access_failed",
+                        "error": format!("{err:#}"),
+                    });
+                    gate.attach_page_failure_diagnostic(&mut payload).await;
+                    return Ok(json_result(&payload));
+                }
+            };
+            if login == LoginGate::Required {
+                let mut payload = json!({
+                    "ok": false,
+                    "notes": [],
+                    "reason": "login_required",
+                });
+                annotate_remote_login_gate(&self.page, &mut payload);
+                return Ok(json_result(&payload));
+            }
+        }
+
+        if ocr && !all_cached {
             tokio::task::spawn_blocking(ocr_warm_up);
         }
 
-        let media = media_for(
-            ctx,
-            self.llm_provider.clone(),
-            download_media,
-            transcribe_audio,
-        )?;
+        let media = if all_cached {
+            None
+        } else {
+            media_for(
+                ctx,
+                self.llm_provider.clone(),
+                download_media,
+                transcribe_audio,
+            )?
+        };
         let media_baseline = media.as_ref().map(|value| value.timing().snapshot());
         let xhs = XhsPageRuntime::new_with_media(&self.page, media.clone());
         let mut notes = Vec::with_capacity(targets.len());
@@ -3261,16 +3370,23 @@ impl Tool for GetNotesTool {
                 position,
                 comment_count,
                 download_media,
+                download_media_requested,
                 download_media_requested && !background_video_downloads,
                 background_video_downloads,
                 ocr,
                 ocr,
+                transcribe_audio,
             )
             .await;
             let blocker = recovery_blocker(&entry);
+            let reused = entry
+                .get("skipped")
+                .and_then(|value| value.get("reason"))
+                .and_then(Value::as_str)
+                == Some("already_analyzed");
             notes.push(entry);
             let idx = notes.len() - 1;
-            if ocr {
+            if ocr && !reused {
                 if let Some(handle) = spawn_note_ocr(
                     &media,
                     &ocr_sem,
@@ -3284,8 +3400,10 @@ impl Tool for GetNotesTool {
                 } else {
                     scan_progress.ocr_completed(item_index, title.clone());
                 }
+            } else if ocr {
+                scan_progress.ocr_completed(item_index, title.clone());
             }
-            if transcribe_audio {
+            if transcribe_audio && !reused {
                 if let Some(handle) =
                     spawn_note_transcribe(&media, &asr_sem, &notes[idx], browse_t0)
                 {
@@ -3309,8 +3427,15 @@ impl Tool for GetNotesTool {
 
         scan_progress.finish_reading(notes.len());
         let browse_ms = browse_t0.elapsed().as_millis() as u64;
-        let ocr_timings =
-            join_note_ocr(&mut notes, pending_ocr, &self.history, "deep", false).await;
+        let ocr_timings = join_note_ocr(
+            &mut notes,
+            pending_ocr,
+            &self.history,
+            ctx.dedup_session_id(),
+            "deep",
+            false,
+        )
+        .await;
         join_note_transcribe(
             &mut notes,
             pending_transcribe,
@@ -3456,12 +3581,14 @@ impl Tool for ReadNoteTool {
         let wait_seconds = get_f64(&input, "wait_seconds", 6.0);
         let options = read_note_options(&input);
 
-        // Cross-run dedup: short-circuit when a previous run already covers
-        // this note at the requested level + enrichments (vision, downloaded
-        // media, OCR). Only fires when note_id is known up front; the cached
-        // entity already carries any prior local_path / ocr_text.
+        // Conversation-scoped dedup: short-circuit when this session already
+        // covers the note at the requested level + enrichments (vision,
+        // downloaded media, OCR). Another session still reads it normally.
+        // Only fires when note_id is known up front; the cached entity already
+        // carries any prior local_path / ocr_text.
         if let Some(id) = note_id.as_deref().filter(|s| !s.trim().is_empty()) {
             if self.history.is_satisfied_by(
+                ctx.dedup_session_id(),
                 id,
                 &options.level,
                 options.include_media,
@@ -3470,7 +3597,10 @@ impl Tool for ReadNoteTool {
                 options.transcribe_audio,
                 TOP_COMMENTS_PER_NOTE,
             ) {
-                let entry = self.history.get(id).unwrap_or_default();
+                let entry = self
+                    .history
+                    .get(ctx.dedup_session_id(), id)
+                    .unwrap_or_default();
                 return Ok(json_result(&json!({
                     "ok": true,
                     "skipped": true,
@@ -3517,8 +3647,12 @@ impl Tool for ReadNoteTool {
                 perf.insert("comments_ms".into(), json!(ms));
             }
             if let Some(entity) = value.get("entity") {
-                self.history
-                    .record(entity, &options.level, options.include_media);
+                self.history.record(
+                    ctx.dedup_session_id(),
+                    entity,
+                    &options.level,
+                    options.include_media,
+                );
             }
         }
         // Phase timing is a debug record, not analysis input: move it out of
@@ -3589,8 +3723,12 @@ impl Tool for ExtractNoteTool {
         // Always attach top comments — the note is already open, so reading them
         // is one extra DOM read with no extra navigation.
         attach_top_comments(&xhs, &mut value).await;
-        self.history
-            .record(&value, &options.level, options.include_media);
+        self.history.record(
+            ctx.dedup_session_id(),
+            &value,
+            &options.level,
+            options.include_media,
+        );
         attach_hosted_agent_skip_note(&mut value, asr_skipped);
         Ok(json_result(&value))
     }
@@ -3816,11 +3954,12 @@ impl Tool for ExtractSearchCardsTool {
         json!({"type": "object", "properties": {}})
     }
 
-    async fn call(&self, _input: Value, _ctx: &ToolContext) -> anyhow::Result<ToolResult> {
+    async fn call(&self, _input: Value, ctx: &ToolContext) -> anyhow::Result<ToolResult> {
         let xhs = XhsPageRuntime::new(&self.page);
         let cards = xhs.extract_search_cards().await?;
         let mut value = serde_json::to_value(&cards)?;
-        self.history.annotate_cards(&mut value);
+        self.history
+            .annotate_cards(ctx.dedup_session_id(), &mut value);
         Ok(json_result(&value))
     }
 }
@@ -4012,8 +4151,8 @@ impl Tool for ExtractProfileTool {
 /// search(query, filters?, num_notes?, download_media?, preview?) -> aggregated bundle
 ///
 /// The single Xiaohongshu search tool. Composite macro: search → optional
-/// search filters → collect up to `num_notes` cards in page order (scrolling
-/// the feed only when the first page is too small) → open each note and extract
+/// search filters → collect up to `num_notes` valid new notes in page order
+/// (actively scrolling when loaded cards are exhausted) → open each note and extract
 /// its body + top comments → bundle into one artifact. Prefer this for any
 /// "research a topic on XHS" task — it returns search results plus the note
 /// bodies plus comments in one tool call, so the agent doesn't have to chain
@@ -4081,8 +4220,8 @@ impl Tool for SearchTool {
 
     fn description(&self) -> &str {
         "Xiaohongshu search — the single XHS search tool. Default (full scan): \
-         search → optional search filters → collect up to `num_notes` cards in \
-         page order (scrolling only if the first page is too small) → open each \
+         search → optional search filters → collect up to `num_notes` valid new \
+         notes in page order (actively scrolling when loaded cards are exhausted) → open each \
          note and read its body + top comments → return one compact bundle \
          (search results + selected cards + note bodies + comments). Pass \
          `download_media=true` to download note images/videos into the run dir, \
@@ -4106,7 +4245,7 @@ impl Tool for SearchTool {
                 "filters": search_filters_schema(),
                 "num_notes": {
                     "type": "integer",
-                    "description": "Number of notes to read (body + top comments each). The first results page is used directly; only if it holds fewer than this does the feed scroll for more. Each note is opened, so latency scales with this. In preview mode, the number of cards to collect by scrolling.",
+                    "description": "Number of valid new notes to read (body + top comments each). Failed reads and history hits from this conversation do not consume this target; notes seen only in other conversations remain eligible. The feed scrolls when loaded cards are exhausted. Each note is opened, so latency scales with this. In preview mode, the number of cards to collect by scrolling.",
                     "default": DEFAULT_NUM_NOTES,
                     "minimum": 1
                 },
@@ -4198,7 +4337,7 @@ impl Tool for SearchTool {
             };
             promote_page_diagnostic(&mut value);
             if let Some(cards) = value.get_mut("cards") {
-                self.history.annotate_cards(cards);
+                self.history.annotate_cards(ctx.dedup_session_id(), cards);
             }
             // Preview OCR: read each result card's cover image (like a human
             // glancing at the results page). Covers are fetched to memory and
@@ -4329,7 +4468,7 @@ impl Tool for SearchTool {
         // record notes into the live store, but final-payload annotations
         // should reflect the state going in — otherwise a first-time scan
         // labels its own freshly-read cards as `already_analyzed`.
-        let history_snapshot = self.history.snapshot();
+        let history_snapshot = self.history.snapshot(ctx.dedup_session_id());
 
         // Filters are applied after the initial search below, so don't pass
         // them here.
@@ -4405,17 +4544,18 @@ impl Tool for SearchTool {
         let comment_count = get_i64(&input, "num_comments", AGENT_TOP_COMMENTS_PER_NOTE).max(0);
         let want = num_notes.max(1) as usize;
 
-        // Read top-to-bottom: pull cards from the results state (which only
-        // grows) in feed order and open each. Opening a card scrolls it into
-        // view, which pages the later cards in on its own — there's no
-        // separate "scroll to the bottom and collect everything first" phase.
-        // When we've consumed every loaded card, wait briefly for that async
-        // paging to land; if nothing more loads after a few tries, stop.
+        // Read top-to-bottom. When every visible card has been consumed, ask
+        // the existing page runtime to scroll the real feed container and load
+        // another page. Track identities independently from array positions so
+        // a fixed-size virtualized DOM can replace old cards with new ones.
         let mut notes: Vec<Value> = Vec::new();
         let mut selected: Vec<XhsNoteCard> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut cursor = 0usize;
+        let mut pending: VecDeque<XhsNoteCard> = VecDeque::new();
         let mut stalls = 0usize;
+        let mut successful = 0usize;
+        let mut skipped_existing = 0usize;
+        let mut failed = 0usize;
         // OCR and cloud ASR run in the background so they overlap the next
         // note's read + download; tasks are joined after the browse loop.
         let ocr_sem = Arc::new(tokio::sync::Semaphore::new(OCR_PIPELINE_CONCURRENCY));
@@ -4435,7 +4575,7 @@ impl Tool for SearchTool {
         let scan_deadline =
             std::time::Instant::now() + std::time::Duration::from_secs(SEARCH_SCAN_TIMEOUT_SECONDS);
 
-        while notes.len() < want {
+        while successful < want {
             if std::time::Instant::now() >= scan_deadline {
                 stop_reason = "search_timeout".to_string();
                 page_error = Some(format!(
@@ -4513,7 +4653,7 @@ impl Tool for SearchTool {
                                     .cloned()
                                     .unwrap_or_else(|| Value::Object(Map::new()));
                                 search = recovered;
-                                cursor = 0;
+                                pending.clear();
                                 stalls = 0;
                                 append_search_debug_event(
                                     ctx,
@@ -4559,7 +4699,32 @@ impl Tool for SearchTool {
                     break;
                 }
             };
-            if cursor >= cards.len() {
+            if pending.is_empty() {
+                pending.extend(
+                    cards
+                        .into_iter()
+                        .filter(|card| !seen.contains(&search_card_dedup_key(card))),
+                );
+            }
+            if pending.is_empty() {
+                let (cards, _) = match xhs.load_more_search_cards().await {
+                    Ok(result) => result,
+                    Err(err) => {
+                        stop_reason = "search_pagination_failed".to_string();
+                        page_error = Some(format!("{err:#}"));
+                        break;
+                    }
+                };
+                pending.extend(
+                    cards
+                        .into_iter()
+                        .filter(|card| !seen.contains(&search_card_dedup_key(card))),
+                );
+                if pending.is_empty() {
+                    stalls += 1;
+                } else {
+                    stalls = 0;
+                }
                 if stalls >= 3 {
                     let mut diagnostic = json!({ "ok": false });
                     xhs.attach_page_failure_diagnostic(&mut diagnostic).await;
@@ -4580,23 +4745,30 @@ impl Tool for SearchTool {
                                 "notes_attempted": notes.len(),
                             }),
                         );
+                    } else {
+                        stop_reason = "results_exhausted".to_string();
+                        append_search_debug_event(
+                            ctx,
+                            json!({
+                                "event": "search_results_exhausted",
+                                "elapsed_ms": browse_t0.elapsed().as_millis() as u64,
+                                "requested": want,
+                                "successful": successful,
+                                "selected": selected.len(),
+                                "skipped_existing": skipped_existing,
+                                "failed": failed,
+                            }),
+                        );
                     }
                     break;
                 }
-                stalls += 1;
-                tokio::time::sleep(std::time::Duration::from_millis(800)).await;
                 continue;
             }
             stalls = 0;
-            let card = cards[cursor].clone();
-            cursor += 1;
-            let dedup = if !card.note_id.is_empty() {
-                card.note_id.clone()
-            } else if !card.link.is_empty() {
-                card.link.clone()
-            } else {
-                format!("pos:{}", card.position)
+            let Some(card) = pending.pop_front() else {
+                continue;
             };
+            let dedup = search_card_dedup_key(&card);
             if !seen.insert(dedup) {
                 continue;
             }
@@ -4641,12 +4813,19 @@ impl Tool for SearchTool {
             )
             .await;
             let blocker = recovery_blocker(&entry);
-            if entry.get("ok").and_then(Value::as_bool) == Some(true)
-                || entry.get("skipped").is_some()
-            {
+            let fresh_success = fresh_scan_success(&entry);
+            let skipped = entry.get("skipped").is_some();
+            if fresh_success || skipped {
                 consecutive_note_failures = 0;
             } else {
                 consecutive_note_failures = consecutive_note_failures.saturating_add(1);
+            }
+            if fresh_success {
+                successful = successful.saturating_add(1);
+            } else if skipped {
+                skipped_existing = skipped_existing.saturating_add(1);
+            } else {
+                failed = failed.saturating_add(1);
             }
             let failure_limit_reached =
                 blocker.is_none() && consecutive_note_failures >= MAX_CONSECUTIVE_NOTE_FAILURES;
@@ -4731,12 +4910,19 @@ impl Tool for SearchTool {
             }
         }
 
-        scan_progress.finish_reading(notes.len());
+        scan_progress.finish_reading(successful);
         let browse_ms = browse_t0.elapsed().as_millis() as u64;
         // Join background OCR (epoch = browse start, so the timings line up with
         // browse_ms) and merge results back into the notes in place.
-        let ocr_timings =
-            join_note_ocr(&mut notes, pending_ocr, &self.history, level, include_media).await;
+        let ocr_timings = join_note_ocr(
+            &mut notes,
+            pending_ocr,
+            &self.history,
+            ctx.dedup_session_id(),
+            level,
+            include_media,
+        )
+        .await;
         // Join background ASR after OCR: both pipelines write into the video
         // object, and the transcribe join copies only its own fields.
         join_note_transcribe(
@@ -4763,7 +4949,7 @@ impl Tool for SearchTool {
         // separate debug file; the JSON artifact stays LLM-facing.
         write_scan_perf(ctx, &notes, browse_ms, &ocr_timings, &note_perfs);
         if ocr {
-            scan_progress.finish_ocr(notes.len());
+            scan_progress.finish_ocr(successful);
         }
 
         let mut media_timing = match (&media, &media_baseline) {
@@ -4799,13 +4985,17 @@ impl Tool for SearchTool {
 
         let mut payload = json!({
             "ok": search.get("ok").and_then(Value::as_bool).unwrap_or(false)
-                && stop_reason.is_empty(),
+                && stop_reason.is_empty()
+                && successful >= want,
             "query": query,
             "search": search,
             "notes": notes,
             "sampling": {
                 "num_notes": num_notes,
                 "selected": selected.len(),
+                "successful": successful,
+                "skipped_existing": skipped_existing,
+                "failed": failed,
                 "comments_per_note": comment_count,
                 "include_media": include_media,
                 "download_media": download_media,
@@ -4873,6 +5063,9 @@ impl Tool for SearchTool {
 
         // Artifact above keeps the full bundle; trim what we return so the
         // agent/CLI output stays small, then point at the artifact for the rest.
+        // Failed attempts and history hits remain in the artifact for diagnosis
+        // but do not masquerade as newly collected notes in the model result.
+        retain_fresh_scan_notes(&mut payload);
         lean_scan_payload(&mut payload);
         attach_artifact_pointer(&mut payload, artifact_path, ARTIFACT_EXTRA_NOTE_PROPERTIES);
         attach_hosted_agent_skip_note(&mut payload, asr_skipped);
@@ -5025,7 +5218,7 @@ impl Tool for AuthorScanTool {
         let xhs = XhsPageRuntime::new_with_media(&self.page, media.clone());
         // Snapshot history before reading so card annotations reflect "known
         // before this scan" rather than this scan's own writes.
-        let history_snapshot = self.history.snapshot();
+        let history_snapshot = self.history.snapshot(ctx.dedup_session_id());
 
         let open = xhs.open_profile(&author_id, 8.0).await?;
         if !open.get("ok").and_then(Value::as_bool).unwrap_or(false) {
@@ -5174,8 +5367,15 @@ impl Tool for AuthorScanTool {
             }
             scan_progress.finish_reading(notes.len());
             let browse_ms = browse_t0.elapsed().as_millis() as u64;
-            let ocr_timings =
-                join_note_ocr(&mut notes, pending_ocr, &self.history, "deep", false).await;
+            let ocr_timings = join_note_ocr(
+                &mut notes,
+                pending_ocr,
+                &self.history,
+                ctx.dedup_session_id(),
+                "deep",
+                false,
+            )
+            .await;
             join_note_transcribe(
                 &mut notes,
                 pending_transcribe,
@@ -5434,5 +5634,21 @@ mod tests {
         assert!(!strip_hosted_agent_input(&mut plain));
         let mut off = json!({ "query": "咖啡", "transcribe_audio": false });
         assert!(!strip_hosted_agent_input(&mut off));
+    }
+
+    #[test]
+    fn fresh_scan_result_excludes_failures_and_history_hits() {
+        let mut payload = json!({
+            "notes": [
+                { "ok": true, "entity": { "note_id": "fresh" } },
+                { "ok": false, "entity": { "note_id": "failed" } },
+                { "skipped": { "reason": "already_analyzed" }, "entity": { "note_id": "seen" } }
+            ]
+        });
+
+        retain_fresh_scan_notes(&mut payload);
+
+        assert_eq!(payload["notes"].as_array().map(Vec::len), Some(1));
+        assert_eq!(payload["notes"][0]["entity"]["note_id"], "fresh");
     }
 }


### PR DESCRIPTION
## Summary

- Fill the requested number of fresh Xiaohongshu notes across virtualized search-result pages.
- Scope duplicate filtering to the current conversation through lightweight note-id references.
- Keep each complete note entity and its media/OCR/transcription/comment capability state once in the global asset map.
- Preserve existing history: v0/v1 global assets load directly, and the earlier v3 per-session copies migrate losslessly into global assets plus references.
- Reuse qualifying `get_notes` results before browser/login/media preflight, while deeper or richer requests still read and enrich the note.
- Serialize foreground/background history updates and tombstone deleted conversations.

## Before and after

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Same note in conversation A and B | One global dedup decision could suppress B | B remains eligible until B records its own note-id reference |
| Same note in follow-up turns of A | Global history happened to dedup it | A's stable conversation reference deliberately dedups it |
| Stored entity | One legacy global entry, or a full copy per session in the first PR revision | One global `notes[note_id]` asset |
| Per-conversation state | Full duplicated `HistoryEntry` | Only note ids in `session_refs[conversation_id]` |
| Richer asset produced by another referenced conversation | Separate duplicated entities could drift | The shared asset is upgraded once; a conversation still needs its own reference before it can skip |
| Requested `num_notes` | History hits and failed reads consumed the target | Only fresh successful reads consume the target |
| Virtualized result pages | Same DOM-array length looked stalled | Progress is based on new note identities |

## Storage model

History schema v4 keeps ownership and references separate:

```text
HistoryFile
├── notes[note_id] -> HistoryEntry        # canonical shared asset
├── session_refs[conversation_id] -> Set<note_id>
└── removed_sessions -> Set<conversation_id>
```

`HistoryEntry` continues to hold the complete cached entity and coverage metadata: read level, vision, downloaded media, OCR, transcription, comments, timestamps, and analysis count.

A lookup succeeds only when both conditions hold:

1. the current conversation references the note id; and
2. the global asset covers the requested level and enrichments.

Another conversation can enrich the shared asset, but cannot create a reference for the current conversation or make a first-time note disappear from its results.

## Compatibility and migration

- v0/v1 `notes` remain the canonical global assets and are not re-keyed into an arbitrary conversation.
- The unmerged v3 `session_notes[session][note] = HistoryEntry` format is accepted as compatibility input.
- v3 entries are merged into global assets, while each former session receives only the corresponding note-id references.
- Complementary nested image fields such as `local_path` and `ocr_text` are merged by stable image identity (`index`, then URL); unmatched identified images are retained instead of positionally contaminating another image.
- A regular subsequent write persists v4 and omits the legacy `session_notes` field.
- Reopening and normalizing the persisted v4 format is idempotent.

## Pagination behavior

- Track search cards by note id, link, or position/title fallback rather than array length.
- Explicitly scroll when the pending card queue is exhausted, retaining the reverse-scroll nudge for ignored bottom jumps.
- Count only fresh successful detail reads toward `num_notes`.
- Keep history hits and failures in the diagnostic artifact, while the compact model-facing result contains fresh successful notes.

## Concurrency and deletion

- All store instances in the process share one history I/O lock.
- Each refresh/mutate/save operation reloads the latest file before merging and atomically replaces it afterward.
- Deleting a conversation removes only its `session_refs` entry; global note assets remain available to other references.
- A deletion tombstone prevents late background OCR/media completion from recreating the removed conversation reference.
- Deleting run artifacts still scrubs invalid local media paths from the global asset.

## Test plan

- [x] Focused history tests, including v1 compatibility, v3-to-v4 migration, nested image merge, idempotent reopen, pointer isolation, concurrent store writes, and deletion tombstones
- [x] `cargo test -p socai-core --no-default-features` — 93 passed, 2 ignored, 0 failed
- [x] `cargo check -p socai_app`
- [x] `rustfmt --edition 2021 --check core/src/agent/loop.rs core/src/agent/tool.rs core/src/sites/xhs/history.rs core/src/sites/xhs/page.rs core/src/sites/xhs/tools.rs app/src-tauri/src/commands.rs`
- [x] `git diff --check`
- [x] Two Codex review cycles; both migration findings were fixed

## Commit structure

This PR is intentionally squashed to one commit.
