### PR TITLE
feat(app): add paid cloud voice input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,8 +182,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          node scripts/prepare-sherpa-onnx-libs.mjs aarch64-apple-darwin x86_64-apple-darwin
+          export SHERPA_ONNX_ARCHIVE_DIR="$PWD/target/sherpa-onnx-archives"
           cargo build -p socai-cli --release --target aarch64-apple-darwin
           cargo build -p socai-cli --release --target x86_64-apple-darwin
+          cargo build -p socai-asr --release --target aarch64-apple-darwin
+          cargo build -p socai-asr --release --target x86_64-apple-darwin
 
           cli_dir="target/socai-cli-macos-universal"
           mkdir -p "${cli_dir}"
@@ -191,15 +195,22 @@ jobs:
             target/aarch64-apple-darwin/release/socai \
             target/x86_64-apple-darwin/release/socai \
             -output "${cli_dir}/socai"
+          lipo -create \
+            target/aarch64-apple-darwin/release/socai-asr \
+            target/x86_64-apple-darwin/release/socai-asr \
+            -output "${cli_dir}/socai-asr"
           chmod 0755 "${cli_dir}/socai"
+          chmod 0755 "${cli_dir}/socai-asr"
 
-          actual_archs="$(lipo -archs "${cli_dir}/socai")"
-          echo "${cli_dir}/socai architectures: ${actual_archs}"
-          for expected_arch in arm64 x86_64; do
-            if [[ " ${actual_archs} " != *" ${expected_arch} "* ]]; then
-              echo "expected ${cli_dir}/socai to include ${expected_arch}, got: ${actual_archs}" >&2
-              exit 1
-            fi
+          for binary in socai socai-asr; do
+            actual_archs="$(lipo -archs "${cli_dir}/${binary}")"
+            echo "${cli_dir}/${binary} architectures: ${actual_archs}"
+            for expected_arch in arm64 x86_64; do
+              if [[ " ${actual_archs} " != *" ${expected_arch} "* ]]; then
+                echo "expected ${cli_dir}/${binary} to include ${expected_arch}, got: ${actual_archs}" >&2
+                exit 1
+              fi
+            done
           done
 
           version_output="$("${cli_dir}/socai" --version)"
@@ -219,10 +230,15 @@ jobs:
 
           BUILD_SHA="${SOCAI_BUILD_SHA:?SOCAI_BUILD_SHA not set by apply release version step}"
           cli_binary="target/socai-cli-macos-universal/socai"
+          asr_binary="target/socai-cli-macos-universal/socai-asr"
           mkdir -p dist-artifacts
 
           if [ ! -x "${cli_binary}" ]; then
             echo "no CLI binary found at ${cli_binary}" >&2
+            exit 1
+          fi
+          if [ ! -x "${asr_binary}" ]; then
+            echo "no local ASR helper found at ${asr_binary}" >&2
             exit 1
           fi
 
@@ -230,7 +246,9 @@ jobs:
           rm -rf "${package_dir}"
           mkdir -p "${package_dir}"
           cp "${cli_binary}" "${package_dir}/socai"
+          cp "${asr_binary}" "${package_dir}/socai-asr"
           chmod 0755 "${package_dir}/socai"
+          chmod 0755 "${package_dir}/socai-asr"
           created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           cat > "${package_dir}/manifest.json" <<EOF
           {
@@ -242,14 +260,14 @@ jobs:
           }
           EOF
 
-          tar -C "${package_dir}" -czf dist-artifacts/socai-cli-macos-universal.tar.gz socai manifest.json
+          tar -C "${package_dir}" -czf dist-artifacts/socai-cli-macos-universal.tar.gz socai socai-asr manifest.json
           (cd dist-artifacts && shasum -a 256 socai-cli-macos-universal.tar.gz > socai-cli-macos-universal.tar.gz.sha256)
           cp scripts/install-cli.sh dist-artifacts/install.sh
 
           (cd dist-artifacts && shasum -a 256 -c socai-cli-macos-universal.tar.gz.sha256)
           archive_listing="${RUNNER_TEMP}/socai-cli-archive-files.txt"
           tar -tzf dist-artifacts/socai-cli-macos-universal.tar.gz > "${archive_listing}"
-          for required_file in socai manifest.json; do
+          for required_file in socai socai-asr manifest.json; do
             if ! grep -Fxq "${required_file}" "${archive_listing}"; then
               echo "CLI archive missing ${required_file}" >&2
               exit 1
@@ -700,7 +718,9 @@ jobs:
           SOCAI_PRO_BASE_URL: ${{ secrets.SOCAI_PRO_BASE_URL }}
         run: |
           $ErrorActionPreference = 'Stop'
-          cargo build -p socai-cli --release
+          node scripts/prepare-sherpa-onnx-libs.mjs x86_64-pc-windows-msvc
+          $env:SHERPA_ONNX_ARCHIVE_DIR = Join-Path $PWD 'target/sherpa-onnx-archives'
+          cargo build -p socai-cli -p socai-asr --release
           $versionOutput = & .\target\release\socai.exe --version
           $versionOutput
           if ($versionOutput -ne "socai $env:VERSION") {
@@ -762,6 +782,7 @@ jobs:
           Remove-Item -Recurse -Force $dist, $packageDir -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $dist, $packageDir | Out-Null
           Copy-Item .\target\release\socai.exe (Join-Path $packageDir 'socai.exe')
+          Copy-Item .\target\release\socai-asr.exe (Join-Path $packageDir 'socai-asr.exe')
           $createdAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
           [ordered]@{
             base_sha = $env:BASE_SHA
@@ -772,7 +793,7 @@ jobs:
           } | ConvertTo-Json | Set-Content -Encoding utf8NoBOM (Join-Path $packageDir 'manifest.json')
 
           $archive = Join-Path $dist 'socai-cli-windows-x86_64.zip'
-          Compress-Archive -Path (Join-Path $packageDir 'socai.exe'), (Join-Path $packageDir 'manifest.json') -DestinationPath $archive
+          Compress-Archive -Path (Join-Path $packageDir 'socai.exe'), (Join-Path $packageDir 'socai-asr.exe'), (Join-Path $packageDir 'manifest.json') -DestinationPath $archive
           $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
           $checksumPath = "$archive.sha256"
           [System.IO.File]::WriteAllText($checksumPath, "$hash  socai-cli-windows-x86_64.zip`n", [System.Text.Encoding]::ASCII)
@@ -788,6 +809,9 @@ jobs:
           $versionOutput = & (Join-Path $verifyDir 'socai.exe') --version
           if ($versionOutput -ne "socai $env:VERSION") {
             throw "expected archive CLI version 'socai $env:VERSION', got: $versionOutput"
+          }
+          if (-not (Test-Path (Join-Path $verifyDir 'socai-asr.exe'))) {
+            throw 'archive missing socai-asr.exe'
           }
           $manifest = Get-Content -Raw (Join-Path $verifyDir 'manifest.json') | ConvertFrom-Json
           if ($manifest.version -ne $env:VERSION) { throw 'manifest version mismatch' }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +478,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +832,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +914,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1090,6 +1161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1257,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1456,6 +1534,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fast-float2"
@@ -1855,9 +1939,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2126,6 +2212,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hmac-sha256"
@@ -2528,6 +2623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,10 +3008,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3779,7 +3904,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -3790,7 +3915,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -3885,6 +4010,16 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4649,6 +4784,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5099,6 +5235,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sherpa-onnx"
+version = "1.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4ef11f6b23c916a8e36c3cf65201f796d0e6aa30182a18d4f798d0b7f62547"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sherpa-onnx-sys",
+]
+
+[[package]]
+name = "sherpa-onnx-sys"
+version = "1.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566aad07d0924a7ed897cc035cc67ad71cdfddb959717dbf445031d5d4b58d4d"
+dependencies = [
+ "bzip2 0.4.4",
+ "tar",
+ "ureq 2.12.1",
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,6 +5367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socai-asr"
+version = "0.5.5"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "sherpa-onnx",
+ "symphonia",
+]
+
+[[package]]
 name = "socai-cli"
 version = "0.5.5"
 dependencies = [
@@ -5236,6 +5406,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
+ "fs2",
  "futures",
  "image",
  "libc",
@@ -5243,6 +5414,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "symphonia",
  "tempfile",
  "thiserror 2.0.18",
@@ -5441,9 +5613,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-pcm",
  "symphonia-core",
  "symphonia-format-isomp4",
+ "symphonia-format-riff",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -5470,6 +5679,18 @@ dependencies = [
  "symphonia-core",
  "symphonia-metadata",
  "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -6571,6 +6792,22 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -6954,6 +7191,24 @@ name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7741,6 +7996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7815,6 +8079,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -7847,6 +8125,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2 0.5.2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.14.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -7897,6 +8205,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5457,6 +5457,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
+ "uuid",
  "zip 8.6.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "app/src-tauri",
+    "asr",
     "core",
     "cli",
 ]

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "dev:desktop:kill": "pkill -f 'target/debug/socai_ap[p]' 2>/dev/null; lsof -ti :1421 | xargs kill 2>/dev/null; for i in $(seq 1 20); do lsof -ti :1421 >/dev/null 2>&1 || break; sleep 0.1; done; true",
     "build": "tsc && vite build",
     "prepare:lark-cli": "node scripts/prepare-lark-cli.mjs",
+    "prepare:asr-helper": "node scripts/prepare-asr-helper.mjs",
     "build:mac": "tauri build --ci --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"macOS\":{\"signingIdentity\":\"-\"}}}'",
     "build:mac:universal": "tauri build --ci --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"macOS\":{\"signingIdentity\":\"-\"}}}'",
     "build:mac:apple-silicon": "tauri build --ci --target aarch64-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"macOS\":{\"signingIdentity\":\"-\"}}}'",

--- a/app/scripts/prepare-asr-helper.mjs
+++ b/app/scripts/prepare-asr-helper.mjs
@@ -1,0 +1,63 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const APP_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_DIR = path.resolve(APP_DIR, "..");
+const BIN_DIR = path.join(APP_DIR, "src-tauri", "binaries");
+const explicitTarget = process.env.TAURI_ENV_TARGET_TRIPLE;
+const release = process.env.TAURI_ENV_DEBUG === "false" || explicitTarget === "universal-apple-darwin";
+const profile = release ? "release" : "debug";
+
+mkdirSync(BIN_DIR, { recursive: true });
+
+function rustHost() {
+  const output = execFileSync("rustc", ["-vV"], { cwd: REPO_DIR, encoding: "utf8" });
+  const line = output.split("\n").find((item) => item.startsWith("host: "));
+  if (!line) throw new Error("rustc -vV did not report a host target");
+  return line.slice("host: ".length).trim();
+}
+
+function build(target) {
+  const args = ["build", "-p", "socai-asr", "--target", target];
+  if (release) args.push("--release");
+  execFileSync("cargo", args, {
+    cwd: REPO_DIR,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      SHERPA_ONNX_ARCHIVE_DIR: path.join(REPO_DIR, "target", "sherpa-onnx-archives"),
+    },
+  });
+  const extension = target.includes("windows") ? ".exe" : "";
+  const source = path.join(REPO_DIR, "target", target, profile, `socai-asr${extension}`);
+  if (!existsSync(source)) throw new Error(`ASR helper build missing: ${source}`);
+  const destination = path.join(BIN_DIR, `socai-asr-${target}${extension}`);
+  copyFileSync(source, destination);
+  if (!extension) chmodSync(destination, 0o755);
+  console.log(`[socai-asr] ready ${path.relative(APP_DIR, destination)}`);
+  return destination;
+}
+
+const target = explicitTarget || rustHost();
+if (target === "universal-apple-darwin") {
+  execFileSync(
+    process.execPath,
+    [path.join(REPO_DIR, "scripts", "prepare-sherpa-onnx-libs.mjs"), "aarch64-apple-darwin", "x86_64-apple-darwin"],
+    { cwd: REPO_DIR, stdio: "inherit" },
+  );
+  const arm = build("aarch64-apple-darwin");
+  const intel = build("x86_64-apple-darwin");
+  const universal = path.join(BIN_DIR, "socai-asr-universal-apple-darwin");
+  execFileSync("lipo", ["-create", arm, intel, "-output", universal], { stdio: "inherit" });
+  chmodSync(universal, 0o755);
+  console.log(`[socai-asr] ready ${path.relative(APP_DIR, universal)}`);
+} else {
+  execFileSync(
+    process.execPath,
+    [path.join(REPO_DIR, "scripts", "prepare-sherpa-onnx-libs.mjs"), target],
+    { cwd: REPO_DIR, stdio: "inherit" },
+  );
+  build(target);
+}

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 cap-std = "4"
 tempfile = "3"
+uuid = { version = "1", features = ["v4"] }
 dirs = "5"
 dunce = "1"
 calamine = "0.36.1"

--- a/app/src-tauri/Entitlements.plist
+++ b/app/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/app/src-tauri/Info.plist
+++ b/app/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>socai uses the microphone only while you record a voice prompt for transcription.</string>
+</dict>
+</plist>

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod connectors;
 mod tasks;
 mod telemetry;
 mod timeline;
+mod voice_input;
 
 use std::collections::HashSet;
 use std::sync::{
@@ -363,6 +364,8 @@ pub fn run() {
             commands::billing_create_alipay_order,
             commands::billing_order_status,
             commands::billing_mock_recharge,
+            voice_input::voice_input_status,
+            voice_input::voice_input_transcribe,
             connectors::feishu::feishu_status,
             connectors::feishu::feishu_accounts,
             connectors::feishu::feishu_account_identity,

--- a/app/src-tauri/src/voice_input.rs
+++ b/app/src-tauri/src/voice_input.rs
@@ -1,0 +1,269 @@
+use std::io::Write;
+use std::time::Duration;
+
+use base64::Engine;
+use serde::Serialize;
+
+const MAX_WAV_BYTES: usize = 4 * 1024 * 1024;
+const EXPECTED_SAMPLE_RATE: u32 = 16_000;
+const MAX_RECORDING_SECONDS: u64 = 120;
+
+#[derive(Serialize)]
+pub struct VoiceInputStatus {
+    ready: bool,
+    route: String,
+    state: String,
+    local_state: String,
+    downloaded_bytes: u64,
+    total_bytes: u64,
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct VoiceTranscript {
+    text: String,
+}
+
+#[tauri::command]
+pub async fn voice_input_status() -> Result<VoiceInputStatus, String> {
+    let access = socai_core::cloud::paid_asr_access().await;
+    if access.as_ref().is_ok_and(|access| access.ready) {
+        return Ok(VoiceInputStatus {
+            ready: true,
+            route: "cloud".into(),
+            state: "cloud_ready".into(),
+            local_state: "not_checked".into(),
+            downloaded_bytes: 0,
+            total_bytes: 0,
+            error: None,
+        });
+    }
+
+    let local = socai_core::media::local_asr_status()
+        .await
+        .map_err(|error| format!("failed to inspect local ASR: {error:#}"))?;
+    let (state, error) = match access {
+        Ok(access) if !access.logged_in => ("login_required", None),
+        Ok(access) if !access.active_subscription => ("subscription_required", None),
+        Ok(access) if access.balance_points <= 0 => ("credits_required", None),
+        Ok(_) => ("local_only", None),
+        Err(error) => ("billing_unavailable", Some(format!("{error:#}"))),
+    };
+    Ok(VoiceInputStatus {
+        ready: false,
+        route: "local".into(),
+        state: state.into(),
+        local_state: local.state,
+        downloaded_bytes: local.downloaded_bytes,
+        total_bytes: local.total_bytes,
+        error: error.or(local.error),
+    })
+}
+
+#[tauri::command]
+pub async fn voice_input_transcribe(audio_base64: String) -> Result<VoiceTranscript, String> {
+    let access = socai_core::cloud::paid_asr_access()
+        .await
+        .map_err(|error| format!("could not verify cloud ASR access: {error:#}"))?;
+    if !access.ready {
+        return Err("paid cloud ASR is not available for this account".into());
+    }
+    if audio_base64.len() > MAX_WAV_BYTES.saturating_mul(4).div_ceil(3) + 16 {
+        return Err("recorded audio is too large".into());
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(audio_base64.as_bytes())
+        .map_err(|_| "recorded audio is not valid base64".to_string())?;
+    let duration_s = validate_pcm_wav(&bytes)?;
+
+    let mut audio = tempfile::Builder::new()
+        .prefix("socai-voice-")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(|error| format!("could not create temporary voice recording: {error}"))?;
+    audio
+        .write_all(&bytes)
+        .map_err(|error| format!("could not save temporary voice recording: {error}"))?;
+    audio
+        .flush()
+        .map_err(|error| format!("could not flush temporary voice recording: {error}"))?;
+
+    let client_task_id = format!("voice-{}", uuid::Uuid::new_v4());
+    let result = socai_core::cloud::transcribe_audio_file(
+        audio.path(),
+        duration_s as i64,
+        Duration::from_secs(180),
+        Some(&client_task_id),
+    )
+    .await;
+    let final_status = if result.is_ok() {
+        "completed"
+    } else {
+        "failed"
+    };
+    // Settlement is idempotent. If these retries all hit a transient network
+    // error, the durable server-side task remains available for stale-task
+    // recovery; never discard a transcript the provider already produced.
+    let _settlement =
+        crate::commands::settle_hosted_task_with_retry(&client_task_id, final_status).await;
+
+    match result {
+        Ok(result) => Ok(VoiceTranscript {
+            text: result.transcript.trim().to_string(),
+        }),
+        Err(error) => Err(format!("{error:#}")),
+    }
+}
+
+fn validate_pcm_wav(bytes: &[u8]) -> Result<u64, String> {
+    if bytes.len() < 44 || bytes.len() > MAX_WAV_BYTES {
+        return Err("recorded audio has an invalid size".into());
+    }
+    if bytes.get(0..4) != Some(b"RIFF") || bytes.get(8..12) != Some(b"WAVE") {
+        return Err("recorded audio is not a WAV file".into());
+    }
+    let riff_bytes = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "recorded WAV header is invalid")?,
+    ) as usize;
+    if riff_bytes.checked_add(8) != Some(bytes.len()) {
+        return Err("recorded WAV length does not match its header".into());
+    }
+
+    let mut cursor = 12usize;
+    let mut format = None;
+    let mut data_bytes = None;
+    while cursor.saturating_add(8) <= bytes.len() {
+        let id = &bytes[cursor..cursor + 4];
+        let size = u32::from_le_bytes(
+            bytes[cursor + 4..cursor + 8]
+                .try_into()
+                .map_err(|_| "recorded WAV chunk is invalid")?,
+        ) as usize;
+        let start = cursor + 8;
+        let end = start
+            .checked_add(size)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| "recorded WAV chunk is truncated".to_string())?;
+        if id == b"fmt " {
+            if format.is_some() {
+                return Err("recorded WAV has duplicate format chunks".into());
+            }
+            if size < 16 {
+                return Err("recorded WAV format chunk is too short".into());
+            }
+            let audio_format = u16::from_le_bytes([bytes[start], bytes[start + 1]]);
+            let channels = u16::from_le_bytes([bytes[start + 2], bytes[start + 3]]);
+            let sample_rate = u32::from_le_bytes(
+                bytes[start + 4..start + 8]
+                    .try_into()
+                    .map_err(|_| "recorded WAV format is invalid")?,
+            );
+            let byte_rate = u32::from_le_bytes(
+                bytes[start + 8..start + 12]
+                    .try_into()
+                    .map_err(|_| "recorded WAV byte rate is invalid")?,
+            );
+            let block_align = u16::from_le_bytes([bytes[start + 12], bytes[start + 13]]);
+            let bits_per_sample = u16::from_le_bytes([bytes[start + 14], bytes[start + 15]]);
+            format = Some((
+                audio_format,
+                channels,
+                sample_rate,
+                byte_rate,
+                block_align,
+                bits_per_sample,
+            ));
+        } else if id == b"data" {
+            if data_bytes.is_some() {
+                return Err("recorded WAV has duplicate audio data chunks".into());
+            }
+            data_bytes = Some(size);
+        }
+        cursor = end.saturating_add(size % 2);
+    }
+    if cursor != bytes.len() {
+        return Err("recorded WAV has trailing or incomplete chunk data".into());
+    }
+
+    let (audio_format, channels, sample_rate, byte_rate, block_align, bits_per_sample) =
+        format.ok_or_else(|| "recorded WAV has no format chunk".to_string())?;
+    if audio_format != 1
+        || channels != 1
+        || sample_rate != EXPECTED_SAMPLE_RATE
+        || byte_rate != EXPECTED_SAMPLE_RATE * 2
+        || block_align != 2
+        || bits_per_sample != 16
+    {
+        return Err("recorded audio must be mono 16 kHz PCM WAV".into());
+    }
+    let data_bytes = data_bytes.ok_or_else(|| "recorded WAV has no audio data".to_string())?;
+    if data_bytes % usize::from(block_align) != 0 {
+        return Err("recorded WAV audio data is not sample-aligned".into());
+    }
+    let bytes_per_second = u64::from(sample_rate) * u64::from(channels) * 2;
+    let duration_s = (data_bytes as u64).div_ceil(bytes_per_second);
+    if duration_s == 0 {
+        return Err("recorded audio is empty".into());
+    }
+    if duration_s > MAX_RECORDING_SECONDS {
+        return Err("recorded audio is longer than two minutes".into());
+    }
+    Ok(duration_s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_pcm_wav;
+
+    fn wav(samples: usize) -> Vec<u8> {
+        let data_bytes = samples * 2;
+        let mut bytes = vec![0; 44 + data_bytes];
+        bytes[0..4].copy_from_slice(b"RIFF");
+        bytes[4..8].copy_from_slice(&(36 + data_bytes as u32).to_le_bytes());
+        bytes[8..12].copy_from_slice(b"WAVE");
+        bytes[12..16].copy_from_slice(b"fmt ");
+        bytes[16..20].copy_from_slice(&16u32.to_le_bytes());
+        bytes[20..22].copy_from_slice(&1u16.to_le_bytes());
+        bytes[22..24].copy_from_slice(&1u16.to_le_bytes());
+        bytes[24..28].copy_from_slice(&16_000u32.to_le_bytes());
+        bytes[28..32].copy_from_slice(&32_000u32.to_le_bytes());
+        bytes[32..34].copy_from_slice(&2u16.to_le_bytes());
+        bytes[34..36].copy_from_slice(&16u16.to_le_bytes());
+        bytes[36..40].copy_from_slice(b"data");
+        bytes[40..44].copy_from_slice(&(data_bytes as u32).to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn validates_the_browser_recording_contract() {
+        assert_eq!(validate_pcm_wav(&wav(16_000)).unwrap(), 1);
+        assert_eq!(validate_pcm_wav(&wav(16_001)).unwrap(), 2);
+    }
+
+    #[test]
+    fn rejects_non_wav_audio() {
+        assert!(validate_pcm_wav(&vec![0; 44]).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_data_chunks_and_inconsistent_lengths() {
+        let mut duplicate = wav(16_000);
+        duplicate.extend_from_slice(b"data");
+        duplicate.extend_from_slice(&0u32.to_le_bytes());
+        let riff_size = (duplicate.len() - 8) as u32;
+        duplicate[4..8].copy_from_slice(&riff_size.to_le_bytes());
+        assert!(validate_pcm_wav(&duplicate).is_err());
+
+        let mut inconsistent = wav(16_000);
+        inconsistent[4..8].copy_from_slice(&36u32.to_le_bytes());
+        assert!(validate_pcm_wav(&inconsistent).is_err());
+
+        let mut short_format = wav(16_000);
+        short_format.splice(12..12, [b'f', b'm', b't', b' ', 0, 0, 0, 0]);
+        let riff_size = (short_format.len() - 8) as u32;
+        short_format[4..8].copy_from_slice(&riff_size.to_le_bytes());
+        assert!(validate_pcm_wav(&short_format).is_err());
+    }
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.5.5",
   "identifier": "com.socai.app",
   "build": {
-    "beforeDevCommand": "pnpm run prepare:lark-cli && pnpm run dev",
+    "beforeDevCommand": "pnpm run prepare:lark-cli && pnpm run prepare:asr-helper && pnpm run dev",
     "devUrl": "http://localhost:1421",
-    "beforeBuildCommand": "pnpm run prepare:lark-cli && pnpm run build",
+    "beforeBuildCommand": "pnpm run prepare:lark-cli && pnpm run prepare:asr-helper && pnpm run build",
     "frontendDist": "../dist"
   },
   "app": {
@@ -38,7 +38,8 @@
     "active": true,
     "targets": "all",
     "externalBin": [
-      "binaries/lark-cli"
+      "binaries/lark-cli",
+      "binaries/socai-asr"
     ],
     "resources": [
       "third-party/lark-cli-LICENSE"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -51,6 +51,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "macOS": {
+      "infoPlist": "Info.plist",
+      "entitlements": "Entitlements.plist"
+    },
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper"

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -269,6 +269,84 @@ const messages = {
     zh: "暂时无法发起支付，请稍后重试。",
   },
 
+  "voice.start": { en: "start cloud voice input", zh: "开始云端语音输入" },
+  "voice.stop": { en: "stop recording and transcribe", zh: "停止录音并转写" },
+  "voice.requesting": { en: "requesting microphone access…", zh: "正在请求麦克风权限…" },
+  "voice.transcribingCloud": { en: "transcribing with cloud ASR…", zh: "正在使用云端 ASR 转写…" },
+  "voice.unavailable.taskBusy": {
+    en: "voice input is unavailable while this task is running.",
+    zh: "任务运行期间无法使用语音输入。",
+  },
+  "voice.unavailable.browser": {
+    en: "voice input is unavailable in this webview.",
+    zh: "当前 WebView 不支持语音输入。",
+  },
+  "voice.unavailable.checking": {
+    en: "checking voice input availability…",
+    zh: "正在检测语音输入状态…",
+  },
+  "voice.unavailable.login": {
+    en: "sign in and activate a paid subscription to use cloud voice input. Audio tasks currently use local Whisper small; microphone input is not available for the local route yet.",
+    zh: "登录并开通付费服务后可使用云端语音输入。当前音频任务使用本地 Whisper small，本地路由暂未开放麦克风输入。",
+  },
+  "voice.unavailable.subscription": {
+    en: "this account has no active paid subscription. Audio tasks use local Whisper small; microphone input is not available for the local route yet.",
+    zh: "当前账号未开通有效付费服务，音频任务使用本地 Whisper small，本地路由暂未开放麦克风输入。",
+  },
+  "voice.unavailable.credits": {
+    en: "this account has no remaining credits. Audio tasks use local Whisper small; microphone input is not available for the local route yet.",
+    zh: "当前账号 credits 已用完，音频任务使用本地 Whisper small，本地路由暂未开放麦克风输入。",
+  },
+  "voice.unavailable.billing": {
+    en: "cloud ASR access could not be verified. Audio tasks fall back to local Whisper small; microphone input is temporarily unavailable.",
+    zh: "暂时无法确认云端 ASR 付费状态，音频任务将回退到本地 Whisper small，麦克风输入暂不可用。",
+  },
+  "voice.unavailable.localOnly": {
+    en: "audio tasks use local Whisper small; microphone input is not available for the local route yet.",
+    zh: "音频任务使用本地 Whisper small，本地路由暂未开放麦克风输入。",
+  },
+  "voice.local.modelMissing": {
+    en: "The first local transcription downloads the fixed {size} model.",
+    zh: "首次执行本地转写时将下载固定的 {size} 模型。",
+  },
+  "voice.local.downloading": {
+    en: "The local model is downloading ({percent}%).",
+    zh: "本地模型正在下载（{percent}%）。",
+  },
+  "voice.local.ready": {
+    en: "The local model is ready.",
+    zh: "本地模型已就绪。",
+  },
+  "voice.local.helperMissing": {
+    en: "The bundled local ASR helper is unavailable; reinstall socai to restore it.",
+    zh: "内置本地 ASR 组件不可用，请重新安装 socai。",
+  },
+  "voice.local.failed": {
+    en: "The local model setup failed and will retry on the next audio task.",
+    zh: "本地模型准备失败，将在下次音频任务中重试。",
+  },
+  "voice.error.permission": {
+    en: "microphone permission was denied. allow it in system settings and try again.",
+    zh: "麦克风权限被拒绝，请在系统设置中允许后重试。",
+  },
+  "voice.error.noDevice": { en: "no microphone was found.", zh: "未找到可用的麦克风。" },
+  "voice.error.capture": {
+    en: "the microphone could not be started.",
+    zh: "无法启动麦克风。",
+  },
+  "voice.error.tooShort": {
+    en: "the recording is too short. speak for a little longer and try again.",
+    zh: "录音太短，请多说一会儿后重试。",
+  },
+  "voice.error.maxDuration": {
+    en: "recording stopped after two minutes. start a new recording to continue.",
+    zh: "录音已在两分钟后自动停止，请重新开始录音。",
+  },
+  "voice.error.noSpeech": {
+    en: "no speech was recognized.",
+    zh: "没有识别到语音内容。",
+  },
+
   "settings.aria": { en: "settings", zh: "设置" },
   "settings.title": { en: "settings", zh: "设置" },
   "settings.general": { en: "general", zh: "通用" },

--- a/app/src/lib/voice-input.ts
+++ b/app/src/lib/voice-input.ts
@@ -1,0 +1,341 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { t } from "./i18n";
+
+export type VoicePhase = "idle" | "requesting" | "recording" | "transcribing";
+
+interface VoiceInputStatus {
+  ready: boolean;
+  route: "cloud" | "local";
+  state:
+    | "cloud_ready"
+    | "login_required"
+    | "subscription_required"
+    | "credits_required"
+    | "billing_unavailable"
+    | "local_only";
+  local_state: "not_checked" | "ready" | "helper_missing" | "model_missing" | "downloading" | "error";
+  downloaded_bytes: number;
+  total_bytes: number;
+  error: string | null;
+}
+
+export interface ComposerVoiceState {
+  available: boolean;
+  phase: VoicePhase;
+  title: string;
+  error: string;
+}
+
+interface VoiceTranscript {
+  text: string;
+}
+
+const TARGET_SAMPLE_RATE = 16_000;
+const MAX_RECORDING_MS = 120_000;
+
+export namespace voiceInput {
+  let status: VoiceInputStatus | null = null;
+  let phase: VoicePhase = "idle";
+  let operationError = "";
+  let statusUnavailable = false;
+  let onChange: () => void = () => {};
+  let refreshPromise: Promise<void> | null = null;
+
+  let stream: MediaStream | null = null;
+  let audioContext: AudioContext | null = null;
+  let sourceNode: MediaStreamAudioSourceNode | null = null;
+  let processorNode: ScriptProcessorNode | null = null;
+  let silentGain: GainNode | null = null;
+  let chunks: Float32Array[] = [];
+  let capturedSampleRate = TARGET_SAMPLE_RATE;
+  let recordingTimer: number | null = null;
+  let captureGeneration = 0;
+  let automaticTranscriptHandler: ((text: string) => void) | null = null;
+
+  export async function initialize(changeHandler: () => void): Promise<void> {
+    onChange = changeHandler;
+    await refresh(false);
+  }
+
+  export async function refresh(notify = true): Promise<void> {
+    if (refreshPromise) return refreshPromise;
+    refreshPromise = refreshStatus(notify).finally(() => {
+      refreshPromise = null;
+    });
+    return refreshPromise;
+  }
+
+  export function isBusy(): boolean {
+    return phase !== "idle";
+  }
+
+  export function composerState(): ComposerVoiceState {
+    const mediaSupported = !!navigator.mediaDevices?.getUserMedia && typeof AudioContext !== "undefined";
+    const available = !!status?.ready && status.route === "cloud" && mediaSupported;
+    let title: string;
+    if (phase === "recording") title = t("voice.stop");
+    else if (phase === "requesting") title = t("voice.requesting");
+    else if (phase === "transcribing") title = t("voice.transcribingCloud");
+    else if (!mediaSupported) title = t("voice.unavailable.browser");
+    else if (!status && !statusUnavailable) title = t("voice.unavailable.checking");
+    else if (!status) title = t("voice.unavailable.billing");
+    else if (status.ready) title = t("voice.start");
+    else title = `${accountStatusText(status)} ${localStatusText(status)}`.trim();
+    return { available, phase, title, error: operationError };
+  }
+
+  /** Start on the first click; stop, transcribe, and return text on the next. */
+  export async function toggle(
+    onAutomaticTranscript?: (text: string) => void,
+  ): Promise<string | null> {
+    if (phase === "recording") return stopAndTranscribe();
+    if (phase !== "idle" || !composerState().available) return null;
+    automaticTranscriptHandler = onAutomaticTranscript ?? null;
+    await startRecording();
+    return null;
+  }
+
+  export function cancelRecording(message = ""): void {
+    if (phase !== "recording" && phase !== "requesting") return;
+    captureGeneration += 1;
+    automaticTranscriptHandler = null;
+    cleanupRecording();
+    phase = "idle";
+    operationError = message;
+    onChange();
+  }
+
+  async function refreshStatus(notify: boolean): Promise<void> {
+    try {
+      status = await invoke<VoiceInputStatus>("voice_input_status");
+      statusUnavailable = false;
+    } catch (error) {
+      console.error("voice_input_status failed:", error);
+      status = null;
+      statusUnavailable = true;
+    }
+    if (notify) onChange();
+  }
+
+  async function startRecording(): Promise<void> {
+    const generation = captureGeneration + 1;
+    captureGeneration = generation;
+    phase = "requesting";
+    operationError = "";
+    onChange();
+    try {
+      const capturedStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+        video: false,
+      });
+      if (generation !== captureGeneration) {
+        capturedStream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      stream = capturedStream;
+      audioContext = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+      capturedSampleRate = audioContext.sampleRate;
+      chunks = [];
+      sourceNode = audioContext.createMediaStreamSource(stream);
+      processorNode = audioContext.createScriptProcessor(4096, 1, 1);
+      silentGain = audioContext.createGain();
+      silentGain.gain.value = 0;
+      processorNode.onaudioprocess = (event) => {
+        chunks.push(new Float32Array(event.inputBuffer.getChannelData(0)));
+        event.outputBuffer.getChannelData(0).fill(0);
+      };
+      sourceNode.connect(processorNode);
+      processorNode.connect(silentGain);
+      silentGain.connect(audioContext.destination);
+      phase = "recording";
+      recordingTimer = window.setTimeout(() => {
+        const handler = automaticTranscriptHandler;
+        void stopAndTranscribe().then((text) => {
+          if (text && handler) handler(text);
+        });
+      }, MAX_RECORDING_MS);
+    } catch (error) {
+      console.error("microphone capture failed:", error);
+      automaticTranscriptHandler = null;
+      cleanupRecording();
+      phase = "idle";
+      operationError = microphoneError(error);
+    }
+    onChange();
+  }
+
+  async function stopAndTranscribe(): Promise<string | null> {
+    captureGeneration += 1;
+    phase = "transcribing";
+    operationError = "";
+    const samples = mergeChunks(chunks);
+    const sourceRate = capturedSampleRate;
+    automaticTranscriptHandler = null;
+    cleanupRecording();
+    onChange();
+
+    try {
+      if (samples.length < sourceRate / 4) {
+        throw new Error(t("voice.error.tooShort"));
+      }
+      const mono16k = resampleMono(samples, sourceRate, TARGET_SAMPLE_RATE)
+        .subarray(0, TARGET_SAMPLE_RATE * (MAX_RECORDING_MS / 1000));
+      const wav = encodePcm16Wav(mono16k, TARGET_SAMPLE_RATE);
+      const result = await invoke<VoiceTranscript>("voice_input_transcribe", {
+        audioBase64: bytesToBase64(wav),
+      });
+      const text = result.text.trim();
+      if (!text) throw new Error(t("voice.error.noSpeech"));
+      void refresh();
+      return text;
+    } catch (error) {
+      console.error("voice_input_transcribe failed:", error);
+      operationError = error instanceof Error ? error.message : `${error}`;
+      return null;
+    } finally {
+      phase = "idle";
+      onChange();
+    }
+  }
+
+  function accountStatusText(value: VoiceInputStatus): string {
+    switch (value.state) {
+      case "login_required":
+        return t("voice.unavailable.login");
+      case "subscription_required":
+        return t("voice.unavailable.subscription");
+      case "credits_required":
+        return t("voice.unavailable.credits");
+      case "billing_unavailable":
+        return t("voice.unavailable.billing");
+      case "local_only":
+        return t("voice.unavailable.localOnly");
+      case "cloud_ready":
+        return "";
+    }
+  }
+
+  function localStatusText(value: VoiceInputStatus): string {
+    const size = formatBytes(value.total_bytes);
+    switch (value.local_state) {
+      case "model_missing":
+        return t("voice.local.modelMissing", { size });
+      case "downloading":
+        return t("voice.local.downloading", { percent: downloadPercent(value) });
+      case "ready":
+        return t("voice.local.ready");
+      case "helper_missing":
+        return t("voice.local.helperMissing");
+      case "error":
+        return t("voice.local.failed");
+      case "not_checked":
+        return "";
+    }
+  }
+
+  function cleanupRecording(): void {
+    if (recordingTimer !== null) window.clearTimeout(recordingTimer);
+    recordingTimer = null;
+    if (processorNode) {
+      processorNode.onaudioprocess = null;
+      processorNode.disconnect();
+    }
+    sourceNode?.disconnect();
+    silentGain?.disconnect();
+    stream?.getTracks().forEach((track) => track.stop());
+    if (audioContext && audioContext.state !== "closed") void audioContext.close();
+    stream = null;
+    audioContext = null;
+    sourceNode = null;
+    processorNode = null;
+    silentGain = null;
+    chunks = [];
+  }
+
+  function microphoneError(error: unknown): string {
+    const name = error instanceof DOMException ? error.name : "";
+    if (name === "NotAllowedError" || name === "SecurityError") return t("voice.error.permission");
+    if (name === "NotFoundError" || name === "DevicesNotFoundError") return t("voice.error.noDevice");
+    return t("voice.error.capture");
+  }
+}
+
+function downloadPercent(status: VoiceInputStatus): number {
+  if (!status.total_bytes) return 0;
+  return Math.min(100, Math.max(0, Math.round((status.downloaded_bytes / status.total_bytes) * 100)));
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "359 MiB";
+  return `${Math.round(bytes / (1024 * 1024))} MiB`;
+}
+
+function mergeChunks(chunks: Float32Array[]): Float32Array {
+  const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const merged = new Float32Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+function resampleMono(input: Float32Array, sourceRate: number, targetRate: number): Float32Array {
+  if (sourceRate === targetRate) return input;
+  const ratio = sourceRate / targetRate;
+  const output = new Float32Array(Math.max(1, Math.floor(input.length / ratio)));
+  for (let index = 0; index < output.length; index += 1) {
+    const start = Math.floor(index * ratio);
+    const end = Math.min(input.length, Math.max(start + 1, Math.floor((index + 1) * ratio)));
+    let sum = 0;
+    for (let cursor = start; cursor < end; cursor += 1) sum += input[cursor];
+    output[index] = sum / (end - start);
+  }
+  return output;
+}
+
+function encodePcm16Wav(samples: Float32Array, sampleRate: number): Uint8Array {
+  const dataBytes = samples.length * 2;
+  const buffer = new ArrayBuffer(44 + dataBytes);
+  const view = new DataView(buffer);
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataBytes, true);
+  for (let index = 0; index < samples.length; index += 1) {
+    const value = Math.max(-1, Math.min(1, samples[index]));
+    view.setInt16(44 + index * 2, value < 0 ? value * 0x8000 : value * 0x7fff, true);
+  }
+  return new Uint8Array(buffer);
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const blockSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += blockSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + blockSize));
+  }
+  return btoa(binary);
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { check, type Update } from "@tauri-apps/plugin-updater";
+import { voiceInput } from "./lib/voice-input";
 
 import {
   applyLanguageToDocument,
@@ -297,6 +298,7 @@ function render(): void {
         settingsMenu.loadConfig(),
         agentPanel.refreshModels(),
         subscriptionMenu.refresh(authMenu.isLoggedIn()),
+        voiceInput.refresh(),
       ]);
       if (authMenu.isLoggedIn()) await agentPanel.selectSocaiAgent();
     },
@@ -304,6 +306,7 @@ function render(): void {
   subscriptionMenu.bind(state, async () => {
     const alreadyHadPro = authMenu.hasProAccess();
     await authMenu.refreshWallet();
+    await voiceInput.refresh();
     if (!alreadyHadPro && authMenu.hasProAccess()) {
       await settingsMenu.selectRemoteForNewPro(state);
     }
@@ -317,6 +320,7 @@ function render(): void {
       await Promise.all([
         authMenu.refreshWallet(),
         subscriptionMenu.refresh(authMenu.isLoggedIn()),
+        voiceInput.refresh(),
       ]);
     },
   );
@@ -755,7 +759,7 @@ async function main(): Promise<void> {
       void agentPanel.loadTaskNotes(event.payload.task_id, shell());
       void agentPanel.loadTaskArtifacts(event.payload.task_id, shell());
       maybeRelaunchReadyUpdate();
-      void authMenu.refreshWallet().then(render);
+      void authMenu.refreshWallet().then(() => voiceInput.refresh());
     }
   });
   await listen<BackgroundMediaEvent>("agent_task:notes_updated", (event) => {
@@ -790,6 +794,9 @@ async function main(): Promise<void> {
   await subscriptionMenu.refresh(authMenu.isLoggedIn());
   await agentPanel.prepareArtifactDownloads();
   render();
+  // Account/local-model inspection may hash the installed Whisper model on
+  // the first check. Keep that work off the initial-render critical path.
+  void voiceInput.initialize(() => render());
   bindGlobalDismiss();
   bindExternalLinks();
   installUpdatePreviewHook();
@@ -803,6 +810,7 @@ async function main(): Promise<void> {
     agentPanel.refreshModels()
       .then(() => render())
       .catch((e) => console.error("agent_list_models refresh failed:", e));
+    void voiceInput.refresh();
     // Foreground is the primary update-check trigger; the check throttles itself.
     void maybeCheckForUpdate();
   };

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -30,6 +30,7 @@ import {
   taskStatusLabel,
 } from "../lib/i18n";
 import { sendShortcutLabel } from "../lib/shortcuts";
+import type { ComposerVoiceState } from "../lib/voice-input";
 import feishuLogo from "../assets/connectors/feishu.png";
 import chromeRemoteDebuggingImage from "../assets/chrome-remote-debugging.png";
 import chromeAllowDialogImage from "../assets/chrome-allow-dialog.png";
@@ -55,6 +56,8 @@ export interface ComposerProps {
   remoteProfile: boolean;
   /** Existing Chrome has exposed its CDP endpoint after the user opted in. */
   remoteDebuggingReady: boolean;
+  /** Cloud microphone availability and the current recording phase. */
+  voice: ComposerVoiceState;
 }
 
 export interface ConversationProps {
@@ -704,7 +707,20 @@ function renderComposer(c: ComposerProps): string {
   // A remote profile submits while disconnected: the run reconnects (minting
   // a fresh hosted session) on demand.
   const needsConnection = !connected && !c.remoteProfile;
-  const sendDisabled = disabled || !c.value.trim() || needsConnection || !c.modelReady;
+  const sendDisabled = disabled
+    || !c.value.trim()
+    || needsConnection
+    || !c.modelReady
+    || c.voice.phase !== "idle";
+  const voiceDisabled = c.voice.phase === "recording"
+    ? false
+    : disabled
+      || c.voice.phase === "requesting"
+      || c.voice.phase === "transcribing"
+      || !c.voice.available;
+  const voiceTitle = disabled && c.voice.phase === "idle"
+    ? t("voice.unavailable.taskBusy")
+    : c.voice.title;
   const placeholder = c.running
     ? t("task.working")
     : c.mode === "new"
@@ -713,6 +729,11 @@ function renderComposer(c: ComposerProps): string {
   const glyph = c.submitting
     ? `<span class="composer__send-dot" aria-hidden="true"></span>`
     : `<svg class="composer__send-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 7 16 13 8 13"></polyline><polyline points="11 10 8 13 11 16"></polyline></svg>`;
+  const voiceGlyph = c.voice.phase === "recording"
+    ? `<span class="composer__voice-stop" aria-hidden="true"></span>`
+    : c.voice.phase === "requesting" || c.voice.phase === "transcribing"
+      ? `<span class="composer__send-dot" aria-hidden="true"></span>`
+      : `<svg class="composer__voice-glyph" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="3" width="6" height="11" rx="3"></rect><path d="M5.5 10.5a6.5 6.5 0 0 0 13 0"></path><path d="M12 17v4"></path><path d="M9 21h6"></path></svg>`;
   const connectHint = connected
     ? ""
     : c.remoteProfile
@@ -737,6 +758,16 @@ function renderComposer(c: ComposerProps): string {
             placeholder="${esc(placeholder)}"
             ${disabled ? "disabled" : ""}
           >${esc(c.value)}</textarea>
+          <span class="composer__voice-wrap" title="${esc(voiceTitle)}">
+            <button
+              id="composer-voice"
+              type="button"
+              class="composer__voice ${c.voice.phase === "recording" ? "is-recording" : ""}"
+              aria-label="${esc(voiceTitle)}"
+              aria-pressed="${c.voice.phase === "recording" ? "true" : "false"}"
+              ${voiceDisabled ? "disabled" : ""}
+            >${voiceGlyph}</button>
+          </span>
           <button
             id="composer-send"
             type="submit"
@@ -749,6 +780,7 @@ function renderComposer(c: ComposerProps): string {
       </form>
       ${connectHint}
       ${keyHint}
+      ${c.voice.error ? `<pre class="composer__error">${esc(c.voice.error)}</pre>` : ""}
       ${c.error ? `<pre class="composer__error">${esc(c.error)}</pre>` : ""}
     </div>
   `;

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -16,6 +16,7 @@ import type {
 import { esc } from "../lib/html";
 import { t } from "../lib/i18n";
 import { isSendShortcut } from "../lib/shortcuts";
+import { voiceInput } from "../lib/voice-input";
 import { settingsMenu } from "./settings";
 import { renderConfirmDeleteDialog, renderSidebar as renderSidebarMarkup } from "./task_history";
 import {
@@ -943,6 +944,7 @@ export namespace agentPanel {
       running: false,
       remoteProfile: settingsMenu.isRemoteProfile(),
       remoteDebuggingReady,
+      voice: voiceInput.composerState(),
     };
   }
 
@@ -957,6 +959,7 @@ export namespace agentPanel {
       running,
       remoteProfile: settingsMenu.isRemoteProfile(),
       remoteDebuggingReady,
+      voice: voiceInput.composerState(),
     };
   }
 
@@ -967,6 +970,7 @@ export namespace agentPanel {
       return task ? answerTextForTurn(task, turnIndex) : null;
     });
     document.getElementById("sidebar-new")?.addEventListener("click", () => {
+      voiceInput.cancelRecording();
       clearArtifactPreview();
       view = "compose";
       shell.rerender();
@@ -1049,6 +1053,7 @@ export namespace agentPanel {
       const select = (): void => {
         const taskId = button.dataset.taskId;
         if (!taskId) return;
+        voiceInput.cancelRecording();
         if (artifactPreview?.taskId !== taskId) clearArtifactPreview();
         selectedTaskId = taskId;
         view = "detail";
@@ -1448,6 +1453,25 @@ export namespace agentPanel {
       if (composerTask) await submitReply(shell, composerTask.task_id);
       else await startAgentTask(shell);
     });
+    document.getElementById("composer-voice")?.addEventListener("click", async () => {
+      const replyTaskId = composerTask?.task_id ?? null;
+      const applyTranscript = (transcript: string): void => {
+        if (replyTaskId && selectedTaskId === replyTaskId && view === "detail") {
+          replyDraft = appendTranscript(replyDraft, transcript);
+        } else if (!replyTaskId && view === "compose") {
+          draft = appendTranscript(draft, transcript);
+        }
+        shell.rerender();
+        const refreshedInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+        refreshedInput?.focus();
+        if (refreshedInput) {
+          refreshedInput.selectionStart = refreshedInput.value.length;
+          refreshedInput.selectionEnd = refreshedInput.value.length;
+        }
+      };
+      const transcript = await voiceInput.toggle(applyTranscript);
+      if (transcript) applyTranscript(transcript);
+    });
     document.getElementById("composer-connect")?.addEventListener("click", () => {
       invoke("cdp_connect").catch((e) => console.error("cdp_connect failed:", e));
     });
@@ -1519,7 +1543,12 @@ export namespace agentPanel {
       shell.status.state !== "connected" && !settingsMenu.isRemoteProfile();
     const selected = selectedModel();
     const modelReady = task ? true : !!selected && selected.has_key;
-    button.disabled = submitting || running || !value.trim() || needsConnection || !modelReady;
+    button.disabled = submitting
+      || running
+      || !value.trim()
+      || needsConnection
+      || !modelReady
+      || voiceInput.isBusy();
   }
 
   // Grows the composer textarea with its content instead of leaving multi-line
@@ -1528,6 +1557,11 @@ export namespace agentPanel {
   function autosizeComposerInput(el: HTMLTextAreaElement): void {
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
+  }
+
+  function appendTranscript(current: string, transcript: string): string {
+    const prefix = current.trimEnd();
+    return prefix ? `${prefix}\n${transcript.trim()}` : transcript.trim();
   }
 
   async function startAgentTask(shell: ShellState): Promise<void> {
@@ -1687,6 +1721,7 @@ export namespace agentPanel {
       if (key.startsWith(`${taskId}#`)) activityOpen.delete(key);
     }
     if (selectedTaskId === taskId) {
+      voiceInput.cancelRecording();
       const next = sorted[idx + 1] ?? sorted[idx - 1];
       selectedTaskId = next?.task_id ?? null;
       if (!selectedTaskId) view = "compose";

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2000,6 +2000,40 @@ body.has-paper > * { position: relative; z-index: 1; }
   cursor: pointer;
   transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
 }
+.composer__voice-wrap {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+}
+.composer__voice {
+  appearance: none;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--fg-soft);
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+.composer__voice:hover:not(:disabled) { color: var(--ink-0); background: var(--ink-7); }
+.composer__voice:disabled { color: var(--fg-faint); cursor: not-allowed; }
+.composer__voice.is-recording {
+  color: var(--ink-9);
+  background: var(--ink-0);
+}
+.composer__voice.is-recording:hover:not(:disabled) { color: var(--ink-9); background: var(--ink-1); }
+.composer__voice-glyph { display: block; }
+.composer__voice-stop {
+  width: 8px;
+  height: 8px;
+  border-radius: 1px;
+  background: currentColor;
+}
 .composer__send:hover:not(:disabled) { color: var(--ink-0); background: var(--ink-7); }
 .composer__send:disabled { color: var(--fg-faint); cursor: not-allowed; }
 .composer__send-glyph { display: block; }

--- a/asr/Cargo.toml
+++ b/asr/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "socai-asr"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "socai-asr"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sherpa-onnx = "=1.13.7"
+symphonia = { version = "0.5", default-features = false, features = ["aac", "isomp4", "mp3", "pcm", "wav"] }
+
+[lints]
+workspace = true

--- a/asr/src/main.rs
+++ b/asr/src/main.rs
@@ -1,0 +1,339 @@
+use std::fs::File;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use sherpa_onnx::{
+    LinearResampler, OfflineRecognizer, OfflineRecognizerConfig, OfflineWhisperModelConfig,
+    VadModelConfig, VoiceActivityDetector,
+};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{Decoder, DecoderOptions};
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+const PROTOCOL_VERSION: u32 = 1;
+const TARGET_SAMPLE_RATE: i32 = 16_000;
+const MAX_AUDIO_SECONDS: u64 = 60 * 60;
+const MAX_AUDIO_CHANNELS: usize = 8;
+const MAX_PACKET_FRAMES: u64 = 1_048_576;
+
+#[derive(Deserialize)]
+struct Request {
+    protocol: u32,
+    id: u64,
+    path: String,
+    max_seconds: u64,
+}
+
+#[derive(Serialize)]
+struct Response {
+    protocol: u32,
+    id: u64,
+    ok: bool,
+    transcript: Option<String>,
+    error: Option<String>,
+}
+
+struct ModelPaths {
+    encoder: PathBuf,
+    decoder: PathBuf,
+    tokens: PathBuf,
+    vad: PathBuf,
+}
+
+impl ModelPaths {
+    fn new(root: &Path) -> Self {
+        Self {
+            encoder: root.join("small-encoder.int8.onnx"),
+            decoder: root.join("small-decoder.int8.onnx"),
+            tokens: root.join("small-tokens.txt"),
+            vad: root.join("silero_vad.onnx"),
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let model_dir = parse_model_dir()?;
+    let paths = ModelPaths::new(&model_dir);
+    let recognizer = create_recognizer(&paths)?;
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::BufWriter::new(std::io::stdout().lock());
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(request) if request.protocol == PROTOCOL_VERSION => {
+                match transcribe_file(
+                    Path::new(&request.path),
+                    request.max_seconds,
+                    &paths,
+                    &recognizer,
+                ) {
+                    Ok(transcript) => Response {
+                        protocol: PROTOCOL_VERSION,
+                        id: request.id,
+                        ok: true,
+                        transcript: Some(transcript),
+                        error: None,
+                    },
+                    Err(error) => Response {
+                        protocol: PROTOCOL_VERSION,
+                        id: request.id,
+                        ok: false,
+                        transcript: None,
+                        error: Some(format!("{error:#}")),
+                    },
+                }
+            }
+            Ok(request) => Response {
+                protocol: PROTOCOL_VERSION,
+                id: request.id,
+                ok: false,
+                transcript: None,
+                error: Some(format!(
+                    "unsupported ASR protocol {}; expected {PROTOCOL_VERSION}",
+                    request.protocol
+                )),
+            },
+            Err(error) => Response {
+                protocol: PROTOCOL_VERSION,
+                id: 0,
+                ok: false,
+                transcript: None,
+                error: Some(format!("invalid ASR request: {error}")),
+            },
+        };
+        serde_json::to_writer(&mut stdout, &response)?;
+        stdout.write_all(b"\n")?;
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
+fn parse_model_dir() -> Result<PathBuf> {
+    let mut args = std::env::args_os().skip(1);
+    let mut serve = false;
+    let mut model_dir = None;
+    while let Some(arg) = args.next() {
+        if arg == "--serve" {
+            serve = true;
+        } else if arg == "--model-dir" {
+            model_dir = args.next().map(PathBuf::from);
+        } else {
+            anyhow::bail!("unknown argument: {}", PathBuf::from(arg).display());
+        }
+    }
+    if !serve {
+        anyhow::bail!("socai-asr is an internal worker and requires --serve");
+    }
+    model_dir.context("--model-dir is required")
+}
+
+fn transcribe_file(
+    path: &Path,
+    max_seconds: u64,
+    paths: &ModelPaths,
+    recognizer: &OfflineRecognizer,
+) -> Result<String> {
+    let samples = decode_audio_file(path, max_seconds)?;
+    if samples.is_empty() {
+        anyhow::bail!("{} contains no decoded audio samples", path.display());
+    }
+
+    let mut vad_config = VadModelConfig::default();
+    vad_config.silero_vad.model = Some(paths.vad.display().to_string());
+    vad_config.silero_vad.threshold = 0.5;
+    vad_config.silero_vad.min_silence_duration = 0.2;
+    vad_config.silero_vad.min_speech_duration = 0.2;
+    vad_config.silero_vad.max_speech_duration = 20.0;
+    vad_config.silero_vad.window_size = 512;
+    vad_config.sample_rate = 16_000;
+    vad_config.num_threads = 1;
+    vad_config.provider = Some("cpu".into());
+    let vad = VoiceActivityDetector::create(&vad_config, 30.0)
+        .ok_or_else(|| anyhow!("failed to initialize local Silero VAD"))?;
+
+    let mut transcripts = Vec::new();
+    for chunk in samples.chunks(512) {
+        vad.accept_waveform(chunk);
+        decode_ready_segments(&vad, recognizer, &mut transcripts);
+    }
+    vad.flush();
+    decode_ready_segments(&vad, recognizer, &mut transcripts);
+
+    if transcripts.is_empty() && samples.len() <= 30 * 16_000 {
+        decode_samples(recognizer, &samples, &mut transcripts);
+    }
+    let transcript = transcripts.join("\n").trim().to_string();
+    if transcript.is_empty() {
+        anyhow::bail!("local Whisper small found no speech in {}", path.display());
+    }
+    Ok(transcript)
+}
+
+fn create_recognizer(paths: &ModelPaths) -> Result<OfflineRecognizer> {
+    let mut config = OfflineRecognizerConfig::default();
+    config.model_config.whisper = OfflineWhisperModelConfig {
+        encoder: Some(paths.encoder.display().to_string()),
+        decoder: Some(paths.decoder.display().to_string()),
+        task: Some("transcribe".into()),
+        ..Default::default()
+    };
+    config.model_config.tokens = Some(paths.tokens.display().to_string());
+    config.model_config.provider = Some("cpu".into());
+    config.model_config.num_threads = std::thread::available_parallelism()
+        .map(|count| count.get().clamp(2, 4) as i32)
+        .unwrap_or(2);
+    OfflineRecognizer::create(&config).ok_or_else(|| anyhow!("failed to load Whisper small model"))
+}
+
+fn decode_ready_segments(
+    vad: &VoiceActivityDetector,
+    recognizer: &OfflineRecognizer,
+    transcripts: &mut Vec<String>,
+) {
+    while let Some(segment) = vad.front() {
+        let samples = segment.samples().to_vec();
+        drop(segment);
+        vad.pop();
+        decode_samples(recognizer, &samples, transcripts);
+    }
+}
+
+fn decode_samples(recognizer: &OfflineRecognizer, samples: &[f32], transcripts: &mut Vec<String>) {
+    if samples.is_empty() {
+        return;
+    }
+    let stream = recognizer.create_stream();
+    stream.accept_waveform(16_000, samples);
+    recognizer.decode(&stream);
+    if let Some(result) = stream.get_result() {
+        let text = result.text.trim();
+        if !text.is_empty() {
+            transcripts.push(text.to_string());
+        }
+    }
+}
+
+fn decode_audio_file(path: &Path, max_seconds: u64) -> Result<Vec<f32>> {
+    if !(1..=MAX_AUDIO_SECONDS).contains(&max_seconds) {
+        anyhow::bail!("max_seconds must be between 1 and {MAX_AUDIO_SECONDS}, got {max_seconds}");
+    }
+    let max_samples = max_seconds
+        .checked_mul(TARGET_SAMPLE_RATE as u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .context("requested audio duration is too large")?;
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let stream = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
+        hint.with_extension(ext);
+    }
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            stream,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .with_context(|| format!("unsupported media container in {}", path.display()))?;
+    let mut format = probed.format;
+    let (track_id, mut decoder) = audio_decoder(&mut *format)
+        .ok_or_else(|| anyhow!("no supported audio track in {}", path.display()))?;
+    let mut output = Vec::with_capacity(max_samples.min(4 * 1024 * 1024));
+    let mut sample_rate = None;
+    let mut resampler = None;
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(SymphoniaError::IoError(err))
+                if err.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(SymphoniaError::ResetRequired) => {
+                anyhow::bail!("audio stream changed format in {}", path.display())
+            }
+            Err(err) => return Err(err.into()),
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        let decoded = match decoder.decode(&packet) {
+            Ok(decoded) => decoded,
+            Err(SymphoniaError::DecodeError(_)) => continue,
+            Err(err) => return Err(err.into()),
+        };
+        let spec = *decoded.spec();
+        if !(8_000..=384_000).contains(&spec.rate) {
+            anyhow::bail!("unsupported audio sample rate {} Hz", spec.rate);
+        }
+        let channels = spec.channels.count();
+        if !(1..=MAX_AUDIO_CHANNELS).contains(&channels) {
+            anyhow::bail!("unsupported audio channel count {channels}");
+        }
+        if decoded.capacity() as u64 > MAX_PACKET_FRAMES {
+            anyhow::bail!(
+                "decoded audio packet is too large: {} frames",
+                decoded.capacity()
+            );
+        }
+        let rate = spec.rate as i32;
+        if sample_rate.is_some_and(|current| current != rate) {
+            anyhow::bail!("audio sample rate changed in {}", path.display());
+        }
+        if sample_rate.is_none() {
+            sample_rate = Some(rate);
+            if rate != TARGET_SAMPLE_RATE {
+                resampler = Some(
+                    LinearResampler::create(rate, TARGET_SAMPLE_RATE).ok_or_else(|| {
+                        anyhow!("failed to create {rate} Hz to {TARGET_SAMPLE_RATE} Hz resampler")
+                    })?,
+                );
+            }
+        }
+        let mut buffer = SampleBuffer::<f32>::new(decoded.capacity() as u64, spec);
+        buffer.copy_interleaved_ref(decoded);
+        let mut mono = Vec::with_capacity(buffer.samples().len() / channels);
+        for frame in buffer.samples().chunks(channels) {
+            mono.push(frame.iter().copied().sum::<f32>() / frame.len() as f32);
+        }
+        let chunk = match &resampler {
+            Some(resampler) => resampler.resample(&mono, false),
+            None => mono,
+        };
+        let remaining = max_samples.saturating_sub(output.len());
+        output.extend(chunk.into_iter().take(remaining));
+        if output.len() >= max_samples {
+            return Ok(output);
+        }
+    }
+    sample_rate.ok_or_else(|| anyhow!("{} contains no decoded audio", path.display()))?;
+    if let Some(resampler) = resampler {
+        let remaining = max_samples.saturating_sub(output.len());
+        output.extend(resampler.resample(&[], true).into_iter().take(remaining));
+    }
+    Ok(output)
+}
+
+fn audio_decoder(
+    format: &mut dyn symphonia::core::formats::FormatReader,
+) -> Option<(u32, Box<dyn Decoder>)> {
+    for track in format.tracks() {
+        if let Ok(decoder) =
+            symphonia::default::get_codecs().make(&track.codec_params, &DecoderOptions::default())
+        {
+            return Some((track.id, decoder));
+        }
+    }
+    None
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,9 +22,11 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 # Image compositing/resizing for batching note images into 2x2 vision grids.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-# Pure-Rust mp4 demux for transcription: the AAC track is repacked as ADTS and
-# uploaded as-is (cloud ASR accepts aac), so no decoder and no ffmpeg needed.
+# Pure-Rust mp4 demux for managed ASR. Local Whisper decodes in the bundled
+# helper so the core only needs the existing MP4 container support.
 symphonia = { version = "0.5", default-features = false, features = ["isomp4"] }
+sha2 = "0.10"
+fs2 = "0.4"
 # Local OCR engine (PP-OCRv6 tiny via ONNX Runtime). Default features pull a
 # prebuilt ONNX Runtime at build time (download-binaries) + SIMD CPU kernels.
 # CPU-only by design: benchmarks showed CoreML/DirectML run PP-OCR slower, so we

--- a/core/src/cloud/asr.rs
+++ b/core/src/cloud/asr.rs
@@ -44,11 +44,10 @@ pub async fn transcribe_audio_file(
 ) -> Result<CloudAsrResult> {
     let base_url = configured_base_url()
         .ok_or_else(|| anyhow::anyhow!("socai server URL is not configured"))?;
-    let creds = load_credentials().ok_or_else(|| {
-        anyhow::anyhow!("sign in and select socai agent before requesting video transcription")
-    })?;
-    if creds.user_id.trim().is_empty() || !creds.hosted_llm_selected {
-        anyhow::bail!("sign in and select socai agent before requesting video transcription");
+    let creds = load_credentials()
+        .ok_or_else(|| anyhow::anyhow!("sign in before requesting cloud transcription"))?;
+    if creds.user_id.trim().is_empty() || creds.device_token.trim().is_empty() {
+        anyhow::bail!("sign in before requesting cloud transcription");
     }
     // The extension matters: the server passes the filename through to
     // DashScope, which detects the audio format from it.
@@ -56,6 +55,7 @@ pub async fn transcribe_audio_file(
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("audio.aac");
+    let content_type = audio_content_type(path);
     let size_bytes = tokio::fs::metadata(path)
         .await
         .with_context(|| format!("failed to read metadata for {}", path.display()))?
@@ -73,7 +73,7 @@ pub async fn transcribe_audio_file(
             .post(format!("{base_url}/v1/asr/upload-url"))
             .json(&json!({
                 "filename": filename,
-                "content_type": "audio/aac",
+                "content_type": content_type,
                 "size_bytes": size_bytes,
                 "duration_s": duration_s.max(0),
                 "client_task_id": client_task_id.unwrap_or(""),
@@ -163,6 +163,22 @@ pub async fn transcribe_audio_file(
     }
 }
 
+fn audio_content_type(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("wav") => "audio/wav",
+        Some("mp3") => "audio/mpeg",
+        Some("m4a") => "audio/mp4",
+        Some("flac") => "audio/flac",
+        Some("ogg") | Some("opus") => "audio/ogg",
+        _ => "audio/aac",
+    }
+}
+
 async fn poll_task(
     client: &reqwest::Client,
     base_url: &str,
@@ -191,4 +207,17 @@ fn short_error(error: &str) -> String {
     }
     let head: String = trimmed.chars().take(MAX).collect();
     format!("{head}… (truncated)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::audio_content_type;
+    use std::path::Path;
+
+    #[test]
+    fn upload_content_type_follows_audio_extension() {
+        assert_eq!(audio_content_type(Path::new("voice.wav")), "audio/wav");
+        assert_eq!(audio_content_type(Path::new("clip.aac")), "audio/aac");
+        assert_eq!(audio_content_type(Path::new("speech.MP3")), "audio/mpeg");
+    }
 }

--- a/core/src/cloud/billing.rs
+++ b/core/src/cloud/billing.rs
@@ -15,6 +15,27 @@ pub struct WalletBalance {
     pub active_until: Option<String>,
 }
 
+impl WalletBalance {
+    pub fn has_active_subscription(&self) -> bool {
+        self.active_until
+            .as_deref()
+            .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+            .is_some_and(|until| until > chrono::Utc::now())
+    }
+
+    pub fn has_paid_asr_access(&self) -> bool {
+        self.has_active_subscription() && self.balance_points > 0
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PaidAsrAccess {
+    pub logged_in: bool,
+    pub active_subscription: bool,
+    pub balance_points: i64,
+    pub ready: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentPlan {
     pub enabled: bool,
@@ -83,6 +104,61 @@ pub async fn wallet_balance() -> Result<WalletBalance> {
         .await?;
     cache_wallet_snapshot(wallet.balance_points, wallet.active_until.clone());
     Ok(wallet)
+}
+
+/// Resolve cloud-ASR access against the live wallet. A saved login or the
+/// signup credit gift alone is not paid access: the subscription must still be
+/// active and at least one credit must remain.
+pub async fn paid_asr_access() -> Result<PaidAsrAccess> {
+    let session = super::auth::auth_session()?;
+    if !session.logged_in {
+        return Ok(PaidAsrAccess {
+            logged_in: false,
+            active_subscription: false,
+            balance_points: 0,
+            ready: false,
+        });
+    }
+    let wallet = wallet_balance().await?;
+    let active_subscription = wallet.has_active_subscription();
+    Ok(PaidAsrAccess {
+        logged_in: true,
+        active_subscription,
+        balance_points: wallet.balance_points,
+        ready: wallet.has_paid_asr_access(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WalletBalance;
+
+    fn wallet(balance_points: i64, active_until: Option<String>) -> WalletBalance {
+        WalletBalance {
+            balance_points,
+            points_per_cny: 100,
+            starter_points: 50,
+            active_until,
+        }
+    }
+
+    #[test]
+    fn starter_points_without_subscription_do_not_enable_paid_asr() {
+        assert!(!wallet(50, None).has_paid_asr_access());
+    }
+
+    #[test]
+    fn active_subscription_requires_remaining_credits() {
+        let future = (chrono::Utc::now() + chrono::Duration::days(1)).to_rfc3339();
+        assert!(wallet(1, Some(future.clone())).has_paid_asr_access());
+        assert!(!wallet(0, Some(future)).has_paid_asr_access());
+    }
+
+    #[test]
+    fn expired_subscription_does_not_enable_paid_asr() {
+        let past = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+        assert!(!wallet(100, Some(past)).has_paid_asr_access());
+    }
 }
 
 pub async fn payment_plan() -> Result<PaymentPlan> {

--- a/core/src/cloud/mod.rs
+++ b/core/src/cloud/mod.rs
@@ -13,9 +13,9 @@ pub use auth::{
     InviteRedemption, LlmGatewayConfig, SmsChallengeResponse,
 };
 pub use billing::{
-    create_alipay_order, create_wechat_order, mock_recharge, payment_order, payment_plan,
-    settle_llm_task, wallet_balance, LlmSettlement, PaymentOrder, PaymentPlan, RechargeReceipt,
-    WalletBalance,
+    create_alipay_order, create_wechat_order, mock_recharge, paid_asr_access, payment_order,
+    payment_plan, settle_llm_task, wallet_balance, LlmSettlement, PaidAsrAccess, PaymentOrder,
+    PaymentPlan, RechargeReceipt, WalletBalance,
 };
 pub use browser::{create_browser_session, release_browser_session, BrowserSessionInfo};
 

--- a/core/src/media/asr.rs
+++ b/core/src/media/asr.rs
@@ -1,0 +1,606 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime};
+
+use anyhow::{anyhow, Context, Result};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+
+const MODEL_ID: &str = "sherpa-onnx-whisper-small-int8";
+const MODEL_BASE_URL: &str = "https://huggingface.co/csukuangfj/sherpa-onnx-whisper-small/resolve/8f3c18b358db4d1f2fc1eae49d75cd20989e4309";
+const ENCODER_FILE: &str = "small-encoder.int8.onnx";
+const ENCODER_SHA256: &str = "4cbe7b22fa9026b843b60a68640c747de05bafb1a11b57edc0e66c232d9f33a9";
+const ENCODER_BYTES: u64 = 112_442_483;
+const DECODER_FILE: &str = "small-decoder.int8.onnx";
+const DECODER_SHA256: &str = "acad50b5c782696e91b55914cc5ab4f756f1532f76e22aa6fc615f39fb69a8ee";
+const DECODER_BYTES: u64 = 262_226_114;
+const TOKENS_FILE: &str = "small-tokens.txt";
+const TOKENS_SHA256: &str = "b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126";
+const TOKENS_BYTES: u64 = 816_730;
+const VAD_FILE: &str = "silero_vad.onnx";
+const VAD_URL: &str =
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx";
+const VAD_SHA256: &str = "9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6";
+const VAD_BYTES: u64 = 643_854;
+const PROTOCOL_VERSION: u32 = 1;
+
+struct AsrModelStatus {
+    installed: bool,
+    model_dir: String,
+    missing_files: Vec<String>,
+}
+
+#[derive(Clone)]
+struct ModelPaths {
+    root: PathBuf,
+    encoder: PathBuf,
+    decoder: PathBuf,
+    tokens: PathBuf,
+    vad: PathBuf,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ModelFingerprint {
+    root: PathBuf,
+    files: Vec<(u64, SystemTime)>,
+}
+
+impl ModelPaths {
+    fn from_root(root: PathBuf) -> Self {
+        Self {
+            encoder: root.join(ENCODER_FILE),
+            decoder: root.join(DECODER_FILE),
+            tokens: root.join(TOKENS_FILE),
+            vad: root.join(VAD_FILE),
+            root,
+        }
+    }
+
+    fn invalid_files(&self) -> Result<Vec<String>> {
+        let files = [
+            (&self.encoder, ENCODER_BYTES, ENCODER_SHA256),
+            (&self.decoder, DECODER_BYTES, DECODER_SHA256),
+            (&self.tokens, TOKENS_BYTES, TOKENS_SHA256),
+            (&self.vad, VAD_BYTES, VAD_SHA256),
+        ];
+        let mut invalid = Vec::new();
+        let mut fingerprint = Vec::with_capacity(files.len());
+        for (path, expected_bytes, _) in &files {
+            let Ok(metadata) = std::fs::metadata(path) else {
+                invalid.push(relative_display(&self.root, path));
+                continue;
+            };
+            if !metadata.is_file() || metadata.len() != *expected_bytes {
+                invalid.push(relative_display(&self.root, path));
+                continue;
+            }
+            let Ok(modified) = metadata.modified() else {
+                invalid.push(relative_display(&self.root, path));
+                continue;
+            };
+            fingerprint.push((metadata.len(), modified));
+        }
+        if !invalid.is_empty() {
+            return Ok(invalid);
+        }
+
+        let fingerprint = ModelFingerprint {
+            root: self.root.clone(),
+            files: fingerprint,
+        };
+        let verified = VERIFIED_MODEL.get_or_init(|| std::sync::Mutex::new(None));
+        if verified
+            .lock()
+            .is_ok_and(|cached| cached.as_ref() == Some(&fingerprint))
+        {
+            return Ok(Vec::new());
+        }
+        for (path, _, expected_sha256) in files {
+            if sha256_file(path)? != expected_sha256 {
+                invalid.push(relative_display(&self.root, path));
+            }
+        }
+        if invalid.is_empty() {
+            if let Ok(mut cached) = verified.lock() {
+                *cached = Some(fingerprint);
+            }
+        }
+        Ok(invalid)
+    }
+}
+
+#[derive(Serialize)]
+struct WorkerRequest<'a> {
+    protocol: u32,
+    id: u64,
+    path: &'a str,
+    max_seconds: u64,
+}
+
+#[derive(Deserialize)]
+struct WorkerResponse {
+    protocol: u32,
+    id: u64,
+    ok: bool,
+    transcript: Option<String>,
+    error: Option<String>,
+}
+
+struct AsrWorker {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Lines<BufReader<ChildStdout>>,
+    next_id: u64,
+}
+
+static WORKER: OnceLock<tokio::sync::Mutex<Option<AsrWorker>>> = OnceLock::new();
+static INSTALL: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+static VERIFIED_MODEL: OnceLock<std::sync::Mutex<Option<ModelFingerprint>>> = OnceLock::new();
+
+async fn asr_model_status(deadline: Instant) -> Result<AsrModelStatus> {
+    model_status_for_paths(model_paths()?, deadline).await
+}
+
+async fn model_status_for_paths(paths: ModelPaths, deadline: Instant) -> Result<AsrModelStatus> {
+    let model_dir = paths.root.display().to_string();
+    let remaining = remaining_before(deadline, "verifying the local ASR model")?;
+    let verification = tokio::time::timeout(
+        remaining,
+        tokio::task::spawn_blocking(move || paths.invalid_files()),
+    )
+    .await
+    .map_err(|_| anyhow!("local Whisper small timed out while verifying model files"))?
+    .context("local ASR model verification task failed")?;
+    let missing_files = verification?;
+    let installed = missing_files.is_empty();
+    Ok(AsrModelStatus {
+        installed,
+        model_dir,
+        missing_files,
+    })
+}
+
+struct InstallFileLock(std::fs::File);
+
+impl Drop for InstallFileLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+async fn acquire_install_lock(path: PathBuf, deadline: Instant) -> Result<InstallFileLock> {
+    let remaining = remaining_before(deadline, "waiting for another ASR model installation")?;
+    let task = tokio::task::spawn_blocking(move || -> Result<InstallFileLock> {
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("failed to open ASR install lock {}", path.display()))?;
+        fs2::FileExt::lock_exclusive(&file)
+            .with_context(|| format!("failed to lock ASR install path {}", path.display()))?;
+        Ok(InstallFileLock(file))
+    });
+    tokio::time::timeout(remaining, task)
+        .await
+        .map_err(|_| anyhow!("local Whisper small timed out waiting for model installation"))?
+        .context("ASR install lock task failed")?
+}
+
+async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
+    let install = INSTALL.get_or_init(|| tokio::sync::Mutex::new(()));
+    let remaining = remaining_before(deadline, "waiting for local ASR model setup")?;
+    let _guard = tokio::time::timeout(remaining, install.lock())
+        .await
+        .map_err(|_| anyhow!("local Whisper small timed out waiting for model setup"))?;
+    let paths = model_paths()?;
+    let parent = paths
+        .root
+        .parent()
+        .ok_or_else(|| {
+            anyhow!(
+                "ASR model directory has no parent: {}",
+                paths.root.display()
+            )
+        })?
+        .to_path_buf();
+    tokio::fs::create_dir_all(&parent).await?;
+    let _file_lock =
+        acquire_install_lock(parent.join(format!(".{MODEL_ID}.lock")), deadline).await?;
+    cleanup_stale_install_dirs(&parent).await?;
+    // Another process may have completed the installation while this process
+    // waited for the filesystem lock. Verify that winner before replacing it.
+    let status = asr_model_status(deadline).await?;
+    if status.installed {
+        return Ok(status);
+    }
+    let staging = parent.join(format!(".{MODEL_ID}.install-{}", uuid::Uuid::new_v4()));
+    tokio::fs::create_dir_all(&staging).await?;
+    let staged = ModelPaths::from_root(staging.clone());
+
+    let install_result = async {
+        download_model_file(
+            ENCODER_FILE,
+            &staged.encoder,
+            ENCODER_SHA256,
+            ENCODER_BYTES,
+            deadline,
+        )
+        .await?;
+        download_model_file(
+            DECODER_FILE,
+            &staged.decoder,
+            DECODER_SHA256,
+            DECODER_BYTES,
+            deadline,
+        )
+        .await?;
+        download_model_file(
+            TOKENS_FILE,
+            &staged.tokens,
+            TOKENS_SHA256,
+            TOKENS_BYTES,
+            deadline,
+        )
+        .await?;
+        download_verified(VAD_URL, &staged.vad, VAD_SHA256, Some(VAD_BYTES), deadline).await?;
+
+        let staged_status = model_status_for_paths(staged.clone(), deadline).await?;
+        if !staged_status.installed {
+            anyhow::bail!(
+                "downloaded Whisper small model is incomplete or corrupt: {}",
+                staged_status.missing_files.join(", ")
+            );
+        }
+        if paths.root.exists() {
+            tokio::fs::remove_dir_all(&paths.root)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to replace incomplete ASR model at {}",
+                        paths.root.display()
+                    )
+                })?;
+        }
+        tokio::fs::rename(&staging, &paths.root)
+            .await
+            .with_context(|| format!("failed to install ASR model at {}", paths.root.display()))?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    if install_result.is_err() {
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+    }
+    install_result?;
+
+    let status = asr_model_status(deadline).await?;
+    if !status.installed {
+        anyhow::bail!(
+            "ASR model install completed with missing or invalid files: {}",
+            status.missing_files.join(", ")
+        );
+    }
+    Ok(status)
+}
+
+async fn cleanup_stale_install_dirs(parent: &Path) -> Result<()> {
+    let prefix = format!(".{MODEL_ID}.install-");
+    let mut entries = tokio::fs::read_dir(parent).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with(&prefix) || !entry.file_type().await?.is_dir() {
+            continue;
+        }
+        tokio::fs::remove_dir_all(entry.path())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to remove stale ASR installation {}",
+                    entry.path().display()
+                )
+            })?;
+    }
+    Ok(())
+}
+
+async fn download_model_file(
+    filename: &str,
+    target: &Path,
+    sha256: &str,
+    bytes: u64,
+    deadline: Instant,
+) -> Result<()> {
+    let url = format!("{MODEL_BASE_URL}/{filename}");
+    download_verified(&url, target, sha256, Some(bytes), deadline).await
+}
+
+pub(crate) async fn transcribe_local_file_with_timeout(
+    path: impl AsRef<Path>,
+    max_seconds: u64,
+    timeout: Duration,
+) -> Result<String> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .context("local ASR timeout is too large")?;
+    transcribe_local_file_inner(path.as_ref(), max_seconds, timeout, deadline).await
+}
+
+async fn transcribe_local_file_inner(
+    path: &Path,
+    max_seconds: u64,
+    timeout: Duration,
+    deadline: Instant,
+) -> Result<String> {
+    let helper = find_asr_helper()
+        .context("local ASR helper is unavailable; reinstall socai or set SOCAI_ASR_HELPER")?;
+    let status = install_asr_model(deadline)
+        .await
+        .with_context(|| "failed to prepare the default local Whisper small model on first use")?;
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("failed to resolve media path {}", path.display()))?;
+    let path_text = path
+        .to_str()
+        .ok_or_else(|| anyhow!("media path is not valid UTF-8: {}", path.display()))?;
+
+    let worker_slot = WORKER.get_or_init(|| tokio::sync::Mutex::new(None));
+    let remaining = remaining_before(deadline, "waiting for the local ASR worker")?;
+    let mut slot = tokio::time::timeout(remaining, worker_slot.lock())
+        .await
+        .map_err(|_| anyhow!("local Whisper small timed out after {}s", timeout.as_secs()))?;
+    let stopped = match slot.as_mut() {
+        Some(worker) => worker.child.try_wait()?.is_some(),
+        None => false,
+    };
+    if stopped {
+        *slot = None;
+    }
+    if slot.is_none() {
+        let remaining = remaining_before(deadline, "starting the local ASR worker")?;
+        *slot = Some(
+            tokio::time::timeout(remaining, start_worker(&helper, &status.model_dir))
+                .await
+                .map_err(|_| anyhow!("local Whisper small timed out while starting"))??,
+        );
+    }
+    let remaining = remaining_before(deadline, "transcribing audio with local Whisper small")?;
+    let result = match tokio::time::timeout(
+        remaining,
+        slot.as_mut()
+            .expect("worker initialized")
+            .transcribe(path_text, max_seconds),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow!(
+            "local Whisper small timed out after {}s",
+            timeout.as_secs()
+        )),
+    };
+    if result.is_err() {
+        // A transport or protocol error can leave a late response in stdout.
+        // Drop the worker so the next request starts with a clean protocol stream.
+        *slot = None;
+    }
+    result
+}
+
+impl AsrWorker {
+    async fn transcribe(&mut self, path: &str, max_seconds: u64) -> Result<String> {
+        self.next_id = self.next_id.saturating_add(1);
+        let id = self.next_id;
+        let mut request = serde_json::to_vec(&WorkerRequest {
+            protocol: PROTOCOL_VERSION,
+            id,
+            path,
+            max_seconds,
+        })?;
+        request.push(b'\n');
+        self.stdin.write_all(&request).await?;
+        self.stdin.flush().await?;
+        let line = self
+            .stdout
+            .next_line()
+            .await?
+            .context("local ASR helper exited without a response")?;
+        let response: WorkerResponse = serde_json::from_str(&line)
+            .with_context(|| format!("invalid local ASR helper response: {line}"))?;
+        if response.protocol != PROTOCOL_VERSION || response.id != id {
+            anyhow::bail!(
+                "local ASR protocol mismatch: expected v{PROTOCOL_VERSION} request {id}, got v{} request {}",
+                response.protocol,
+                response.id
+            );
+        }
+        if response.ok {
+            response
+                .transcript
+                .filter(|text| !text.trim().is_empty())
+                .context("local ASR helper returned an empty transcript")
+        } else {
+            anyhow::bail!(
+                "{}",
+                response.error.unwrap_or_else(|| "local ASR failed".into())
+            )
+        }
+    }
+}
+
+async fn start_worker(helper: &Path, model_dir: &str) -> Result<AsrWorker> {
+    let mut child = Command::new(helper)
+        .arg("--serve")
+        .arg("--model-dir")
+        .arg(model_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("failed to start local ASR helper {}", helper.display()))?;
+    let stdin = child
+        .stdin
+        .take()
+        .context("ASR helper stdin is unavailable")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("ASR helper stdout is unavailable")?;
+    Ok(AsrWorker {
+        child,
+        stdin,
+        stdout: BufReader::new(stdout).lines(),
+        next_id: 0,
+    })
+}
+
+fn find_asr_helper() -> Option<PathBuf> {
+    let filename = if cfg!(windows) {
+        "socai-asr.exe"
+    } else {
+        "socai-asr"
+    };
+    let mut candidates = Vec::new();
+    if let Some(path) = std::env::var_os("SOCAI_ASR_HELPER") {
+        candidates.push(PathBuf::from(path));
+    }
+    if let Ok(executable) = std::env::current_exe() {
+        if let Some(dir) = executable.parent() {
+            candidates.push(dir.join(filename));
+            if dir.file_name().is_some_and(|name| name == "deps") {
+                if let Some(profile_dir) = dir.parent() {
+                    candidates.push(profile_dir.join(filename));
+                }
+            }
+        }
+    }
+    if let Some(workspace) = Path::new(env!("CARGO_MANIFEST_DIR")).parent() {
+        candidates.push(workspace.join("target").join("debug").join(filename));
+        candidates.push(workspace.join("target").join("release").join(filename));
+    }
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+fn model_paths() -> Result<ModelPaths> {
+    let root = if let Some(path) = std::env::var_os("SOCAI_ASR_MODEL_DIR") {
+        PathBuf::from(path)
+    } else if let Some(home) = std::env::var_os("SOCAI_HOME") {
+        PathBuf::from(home).join("models").join(MODEL_ID)
+    } else {
+        dirs::home_dir()
+            .context("could not resolve home directory for local ASR model")?
+            .join(".socai")
+            .join("models")
+            .join(MODEL_ID)
+    };
+    Ok(ModelPaths::from_root(root))
+}
+
+async fn download_verified(
+    url: &str,
+    target: &Path,
+    expected_sha256: &str,
+    expected_size: Option<u64>,
+    deadline: Instant,
+) -> Result<()> {
+    let part = target.with_extension(format!(
+        "{}.part",
+        target
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or("download")
+    ));
+    if part.exists() {
+        tokio::fs::remove_file(&part).await?;
+    }
+    let remaining = remaining_before(deadline, "downloading the local ASR model")?;
+    let response = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(15).min(remaining))
+        .build()?
+        .get(url)
+        .timeout(remaining)
+        .send()
+        .await?
+        .error_for_status()?;
+    if let (Some(actual), Some(expected)) = (response.content_length(), expected_size) {
+        if actual != expected {
+            anyhow::bail!(
+                "content length mismatch for {url}: expected {expected} bytes, got {actual}"
+            );
+        }
+    }
+    let mut stream = response.bytes_stream();
+    let mut file = tokio::fs::File::create(&part).await?;
+    let mut hasher = Sha256::new();
+    let mut downloaded = 0u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        let next_downloaded = downloaded
+            .checked_add(chunk.len() as u64)
+            .context("ASR download byte count overflowed")?;
+        if expected_size.is_some_and(|limit| next_downloaded > limit) {
+            drop(file);
+            let _ = tokio::fs::remove_file(&part).await;
+            anyhow::bail!(
+                "download exceeded pinned size for {url}: expected at most {} bytes",
+                expected_size.unwrap_or_default()
+            );
+        }
+        file.write_all(&chunk).await?;
+        hasher.update(&chunk);
+        downloaded = next_downloaded;
+    }
+    file.flush().await?;
+    drop(file);
+    if expected_size.is_some_and(|expected| downloaded != expected) {
+        let _ = tokio::fs::remove_file(&part).await;
+        anyhow::bail!(
+            "download size mismatch for {url}: expected {} bytes, got {downloaded}",
+            expected_size.unwrap_or_default()
+        );
+    }
+    let digest = format!("{:x}", hasher.finalize());
+    if digest != expected_sha256 {
+        let _ = tokio::fs::remove_file(&part).await;
+        anyhow::bail!("checksum mismatch for {url}: expected {expected_sha256}, got {digest}");
+    }
+    tokio::fs::rename(&part, target).await?;
+    Ok(())
+}
+
+fn remaining_before(deadline: Instant, operation: &str) -> Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| anyhow!("local Whisper small timed out while {operation}"))
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open ASR model file {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read ASR model file {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn relative_display(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}

--- a/core/src/media/asr.rs
+++ b/core/src/media/asr.rs
@@ -28,12 +28,31 @@ const VAD_URL: &str =
     "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx";
 const VAD_SHA256: &str = "9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6";
 const VAD_BYTES: u64 = 643_854;
+const MODEL_TOTAL_BYTES: u64 = ENCODER_BYTES + DECODER_BYTES + TOKENS_BYTES + VAD_BYTES;
 const PROTOCOL_VERSION: u32 = 1;
 
 struct AsrModelStatus {
     installed: bool,
     model_dir: String,
     missing_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LocalAsrStatus {
+    pub ready: bool,
+    pub state: String,
+    pub model_name: String,
+    pub model_dir: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct InstallProgress {
+    installing: bool,
+    downloaded_bytes: u64,
+    error: Option<String>,
 }
 
 #[derive(Clone)]
@@ -142,6 +161,61 @@ struct AsrWorker {
 static WORKER: OnceLock<tokio::sync::Mutex<Option<AsrWorker>>> = OnceLock::new();
 static INSTALL: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 static VERIFIED_MODEL: OnceLock<std::sync::Mutex<Option<ModelFingerprint>>> = OnceLock::new();
+static INSTALL_PROGRESS: OnceLock<std::sync::Mutex<InstallProgress>> = OnceLock::new();
+
+fn install_progress() -> InstallProgress {
+    INSTALL_PROGRESS
+        .get_or_init(|| std::sync::Mutex::new(InstallProgress::default()))
+        .lock()
+        .map(|progress| progress.clone())
+        .unwrap_or_default()
+}
+
+fn update_install_progress(installing: bool, downloaded_bytes: u64, error: Option<String>) {
+    if let Ok(mut progress) = INSTALL_PROGRESS
+        .get_or_init(|| std::sync::Mutex::new(InstallProgress::default()))
+        .lock()
+    {
+        progress.installing = installing;
+        progress.downloaded_bytes = downloaded_bytes.min(MODEL_TOTAL_BYTES);
+        progress.error = error;
+    }
+}
+
+pub async fn local_asr_status() -> Result<LocalAsrStatus> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let model = asr_model_status(deadline).await?;
+    let progress = install_progress();
+    let helper_available = find_asr_helper().is_some();
+    let (ready, state, error) = if !helper_available {
+        (
+            false,
+            "helper_missing",
+            Some("the bundled local ASR helper is unavailable".to_string()),
+        )
+    } else if model.installed {
+        (true, "ready", None)
+    } else if progress.installing {
+        (false, "downloading", None)
+    } else if let Some(error) = progress.error {
+        (false, "error", Some(error))
+    } else {
+        (false, "model_missing", None)
+    };
+    Ok(LocalAsrStatus {
+        ready,
+        state: state.to_string(),
+        model_name: "Whisper small".to_string(),
+        model_dir: model.model_dir,
+        downloaded_bytes: if model.installed {
+            MODEL_TOTAL_BYTES
+        } else {
+            progress.downloaded_bytes
+        },
+        total_bytes: MODEL_TOTAL_BYTES,
+        error,
+    })
+}
 
 async fn asr_model_status(deadline: Instant) -> Result<AsrModelStatus> {
     model_status_for_paths(model_paths()?, deadline).await
@@ -179,6 +253,7 @@ async fn acquire_install_lock(path: PathBuf, deadline: Instant) -> Result<Instal
     let task = tokio::task::spawn_blocking(move || -> Result<InstallFileLock> {
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&path)
@@ -218,8 +293,10 @@ async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
     // waited for the filesystem lock. Verify that winner before replacing it.
     let status = asr_model_status(deadline).await?;
     if status.installed {
+        update_install_progress(false, MODEL_TOTAL_BYTES, None);
         return Ok(status);
     }
+    update_install_progress(true, 0, None);
     let staging = parent.join(format!(".{MODEL_ID}.install-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&staging).await?;
     let staged = ModelPaths::from_root(staging.clone());
@@ -230,6 +307,7 @@ async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
             &staged.encoder,
             ENCODER_SHA256,
             ENCODER_BYTES,
+            0,
             deadline,
         )
         .await?;
@@ -238,6 +316,7 @@ async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
             &staged.decoder,
             DECODER_SHA256,
             DECODER_BYTES,
+            ENCODER_BYTES,
             deadline,
         )
         .await?;
@@ -246,10 +325,19 @@ async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
             &staged.tokens,
             TOKENS_SHA256,
             TOKENS_BYTES,
+            ENCODER_BYTES + DECODER_BYTES,
             deadline,
         )
         .await?;
-        download_verified(VAD_URL, &staged.vad, VAD_SHA256, Some(VAD_BYTES), deadline).await?;
+        download_verified(
+            VAD_URL,
+            &staged.vad,
+            VAD_SHA256,
+            Some(VAD_BYTES),
+            ENCODER_BYTES + DECODER_BYTES + TOKENS_BYTES,
+            deadline,
+        )
+        .await?;
 
         let staged_status = model_status_for_paths(staged.clone(), deadline).await?;
         if !staged_status.installed {
@@ -286,6 +374,7 @@ async fn install_asr_model(deadline: Instant) -> Result<AsrModelStatus> {
             status.missing_files.join(", ")
         );
     }
+    update_install_progress(false, MODEL_TOTAL_BYTES, None);
     Ok(status)
 }
 
@@ -314,13 +403,14 @@ async fn download_model_file(
     target: &Path,
     sha256: &str,
     bytes: u64,
+    completed_bytes: u64,
     deadline: Instant,
 ) -> Result<()> {
     let url = format!("{MODEL_BASE_URL}/{filename}");
-    download_verified(&url, target, sha256, Some(bytes), deadline).await
+    download_verified(&url, target, sha256, Some(bytes), completed_bytes, deadline).await
 }
 
-pub(crate) async fn transcribe_local_file_with_timeout(
+pub async fn transcribe_local_file_with_timeout(
     path: impl AsRef<Path>,
     max_seconds: u64,
     timeout: Duration,
@@ -339,9 +429,16 @@ async fn transcribe_local_file_inner(
 ) -> Result<String> {
     let helper = find_asr_helper()
         .context("local ASR helper is unavailable; reinstall socai or set SOCAI_ASR_HELPER")?;
-    let status = install_asr_model(deadline)
-        .await
-        .with_context(|| "failed to prepare the default local Whisper small model on first use")?;
+    let status = match install_asr_model(deadline).await {
+        Ok(status) => status,
+        Err(error) => {
+            let message = format!("{error:#}");
+            update_install_progress(false, install_progress().downloaded_bytes, Some(message));
+            return Err(error).with_context(|| {
+                "failed to prepare the default local Whisper small model on first use"
+            });
+        }
+    };
     let path = path
         .canonicalize()
         .with_context(|| format!("failed to resolve media path {}", path.display()))?;
@@ -370,20 +467,17 @@ async fn transcribe_local_file_inner(
         );
     }
     let remaining = remaining_before(deadline, "transcribing audio with local Whisper small")?;
-    let result = match tokio::time::timeout(
-        remaining,
-        slot.as_mut()
-            .expect("worker initialized")
-            .transcribe(path_text, max_seconds),
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => Err(anyhow!(
-            "local Whisper small timed out after {}s",
-            timeout.as_secs()
-        )),
-    };
+    let worker = slot
+        .as_mut()
+        .context("local ASR worker was not initialized")?;
+    let result =
+        match tokio::time::timeout(remaining, worker.transcribe(path_text, max_seconds)).await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!(
+                "local Whisper small timed out after {}s",
+                timeout.as_secs()
+            )),
+        };
     if result.is_err() {
         // A transport or protocol error can leave a late response in stdout.
         // Drop the worker so the next request starts with a clean protocol stream.
@@ -507,6 +601,7 @@ async fn download_verified(
     target: &Path,
     expected_sha256: &str,
     expected_size: Option<u64>,
+    completed_bytes: u64,
     deadline: Instant,
 ) -> Result<()> {
     let part = target.with_extension(format!(
@@ -539,6 +634,7 @@ async fn download_verified(
     let mut file = tokio::fs::File::create(&part).await?;
     let mut hasher = Sha256::new();
     let mut downloaded = 0u64;
+    update_install_progress(true, completed_bytes, None);
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
         let next_downloaded = downloaded
@@ -555,6 +651,7 @@ async fn download_verified(
         file.write_all(&chunk).await?;
         hasher.update(&chunk);
         downloaded = next_downloaded;
+        update_install_progress(true, completed_bytes.saturating_add(downloaded), None);
     }
     file.flush().await?;
     drop(file);

--- a/core/src/media/audio.rs
+++ b/core/src/media/audio.rs
@@ -10,12 +10,13 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
+use crate::media::asr::transcribe_local_file_with_timeout;
 use crate::media::common::{ensure_dir, url_suffix, MediaUnavailable};
 use crate::media::processor::MediaProcessor;
 
 impl MediaProcessor {
-    /// Transcribe a video/audio source through socai's managed cloud ASR — the
-    /// only transcription path (local whisper was removed as uncontrollable).
+    /// Transcribe a video/audio source through managed cloud ASR for paid
+    /// sessions, or through the bundled local Whisper small worker otherwise.
     pub async fn transcribe_audio(&self, source: &str, referer: &str) -> Result<String> {
         let t0 = Instant::now();
         let result = self.transcribe_audio_inner(source, referer).await;
@@ -26,10 +27,22 @@ impl MediaProcessor {
     async fn transcribe_audio_inner(&self, source: &str, referer: &str) -> Result<String> {
         if !self.config.use_cloud_asr {
             anyhow::bail!(MediaUnavailable(
-                "video transcription requires a signed-in account with socai agent selected".into()
+                "video transcription is disabled for this media request".into()
             ));
         }
         let source_path = self.local_audio_source(source, referer).await?;
+        let managed_paid_session = self
+            .llm_provider
+            .as_ref()
+            .is_some_and(|provider| provider.provider() == "socai");
+        if !managed_paid_session {
+            return transcribe_local_file_with_timeout(
+                &source_path,
+                self.config.max_audio_seconds,
+                Duration::from_secs(self.config.asr_timeout_s.max(60)),
+            )
+            .await;
+        }
         // Real clip duration (the clip is already capped at
         // max_audio_seconds); the server uses it for usage accounting.
         let (aac, duration) = self.extract_audio_aac(&source_path).await?;

--- a/core/src/media/audio.rs
+++ b/core/src/media/audio.rs
@@ -31,11 +31,17 @@ impl MediaProcessor {
             ));
         }
         let source_path = self.local_audio_source(source, referer).await?;
-        let managed_paid_session = self
-            .llm_provider
-            .as_ref()
-            .is_some_and(|provider| provider.provider() == "socai");
-        if !managed_paid_session {
+        // Cloud ASR is a paid account capability, independent of the selected
+        // LLM provider. If the live wallet cannot be checked, stay functional
+        // and private by falling back to the bundled local model.
+        let cloud_ready = match crate::cloud::paid_asr_access().await {
+            Ok(access) => access.ready,
+            Err(error) => {
+                tracing::warn!(%error, "cloud ASR access check failed; using local ASR");
+                false
+            }
+        };
+        if !cloud_ready || self.billing_task_id.is_none() {
             return transcribe_local_file_with_timeout(
                 &source_path,
                 self.config.max_audio_seconds,

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -1,11 +1,12 @@
 //! Optional local/media processing used by site runtimes.
 //!
 //! Nothing here shells out to external media tools: video covers come from
-//! their own CDN URL, audio transcription is cloud-only (socai takes the
-//! demuxed aac as-is), and OCR runs in-process. Site runtimes can opt into
-//! this crate for heavier media enrichment while keeping plain DOM extraction
-//! fast and portable.
+//! their own CDN URL, OCR runs in-process, and Whisper small audio transcription
+//! runs in a bundled local worker. Site runtimes can opt into this crate for
+//! heavier media enrichment while keeping plain DOM extraction fast and
+//! portable.
 
+mod asr;
 mod audio;
 mod background;
 mod common;

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -17,14 +17,15 @@ mod processor;
 mod timing;
 mod video;
 
-pub use self::background::{
-    begin_background_media_generation, cancel_background_media_for_run,
-    current_background_media_generation, subscribe_background_media_events, BackgroundMediaEvent,
-};
+pub use self::asr::{local_asr_status, transcribe_local_file_with_timeout, LocalAsrStatus};
 pub(crate) use self::background::{
     background_media_run_is_cancelled, background_video_download_semaphore,
     emit_background_media_event, reserve_background_video_download,
     subscribe_background_media_cancellation, wait_for_background_media_cancellation,
+};
+pub use self::background::{
+    begin_background_media_generation, cancel_background_media_for_run,
+    current_background_media_generation, subscribe_background_media_events, BackgroundMediaEvent,
 };
 pub use self::common::{MediaConfig, MediaUnavailable};
 pub use self::ocr::diagnostics as ocr_diagnostics;

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -80,7 +80,9 @@ pub fn xhs_tools_with_llm_provider(
     llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
-    let asr_enabled = crate::cloud::hosted_llm_selected();
+    // Transcription is available for every account: paid sessions route to
+    // managed ASR and all other sessions route to local Whisper small.
+    let asr_enabled = true;
     vec![
         Arc::new(GetNotesTool {
             page: page.clone(),
@@ -140,7 +142,7 @@ pub fn xhs_macro_tools_with_llm_provider(
     llm_provider: Option<Arc<dyn LlmProvider>>,
 ) -> Vec<Arc<dyn Tool>> {
     let history = Arc::new(XhsHistoryStore::open_default());
-    let asr_enabled = crate::cloud::hosted_llm_selected();
+    let asr_enabled = true;
     // The app/TUI agent interface always downloads note media so the offline
     // files are on hand for deeper analysis, and always OCRs every image; the
     // CLI keeps its --download-media / --ocr opt-ins via the full tool set above.
@@ -253,7 +255,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     key: "transcribe_audio",
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
-                    help: "For video notes, transcribe audio while signed in with socai agent selected.",
+                    help: "For video notes, transcribe audio with managed ASR for paid sessions or local Whisper small otherwise.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -330,7 +332,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
                     help: "For opened video notes, download the video file and transcribe audio \
-                           while signed in with socai agent selected. Ignored with --preview.",
+                           with managed ASR for paid sessions or local Whisper small otherwise. Ignored with --preview.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -406,7 +408,7 @@ pub static XHS_SITE: SiteSpec = SiteSpec {
                     long: Some("transcribe-audio"),
                     value_name: "TRANSCRIBE_AUDIO",
                     help: "For opened video notes, download the video file and transcribe audio \
-                           while signed in with socai agent selected. Ignored with --preview.",
+                           with managed ASR for paid sessions or local Whisper small otherwise. Ignored with --preview.",
                     required: false,
                     kind: ArgKind::Flag,
                 },
@@ -3165,7 +3167,7 @@ impl Tool for GetNotesTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For video notes, download the video and transcribe audio while signed in with socai agent selected.",
+                    "description": "For video notes, download the video and transcribe audio with managed ASR for paid sessions or local Whisper small otherwise.",
                     "default": false
                 }
             },
@@ -3404,8 +3406,7 @@ pub struct ReadNoteTool {
     page: Arc<PageSession>,
     llm_provider: Option<Arc<dyn LlmProvider>>,
     history: Arc<XhsHistoryStore>,
-    /// Signed in with socai agent selected; when false, managed-ASR arguments
-    /// are hidden from the schema and skipped at runtime.
+    /// Whether the current runtime exposes audio transcription arguments.
     asr_enabled: bool,
 }
 
@@ -4123,7 +4124,7 @@ impl Tool for SearchTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For opened video notes, download the video file and transcribe audio while signed in with socai agent selected. Ignored in preview mode.",
+                    "description": "For opened video notes, download the video file and transcribe audio with managed ASR for paid sessions or local Whisper small otherwise. Ignored in preview mode.",
                     "default": false
                 },
                 "preview": {
@@ -4958,7 +4959,7 @@ impl Tool for AuthorScanTool {
                 },
                 "transcribe_audio": {
                     "type": "boolean",
-                    "description": "For opened video notes, download the video file and transcribe audio while signed in with socai agent selected. Ignored in preview mode.",
+                    "description": "For opened video notes, download the video file and transcribe audio with managed ASR for paid sessions or local Whisper small otherwise. Ignored in preview mode.",
                     "default": false
                 }
             },

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -48,8 +48,12 @@ try {
     Expand-Archive -Force -Path $ArchivePath -DestinationPath $UnpackDir
 
     $SourceExe = Join-Path $UnpackDir 'socai.exe'
+    $SourceAsrExe = Join-Path $UnpackDir 'socai-asr.exe'
     if (-not (Test-Path -LiteralPath $SourceExe)) {
         throw 'release archive did not contain socai.exe'
+    }
+    if (-not (Test-Path -LiteralPath $SourceAsrExe)) {
+        throw 'release archive did not contain socai-asr.exe'
     }
 
     $DestExe = Join-Path $InstallDir 'socai.exe'
@@ -71,6 +75,7 @@ try {
         }
     }
     Copy-Item -Force -LiteralPath $SourceExe -Destination $DestExe
+    Copy-Item -Force -LiteralPath $SourceAsrExe -Destination (Join-Path $InstallDir 'socai-asr.exe')
 
     Write-Host "installed socai to $DestExe"
     & $DestExe --version

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -73,8 +73,13 @@ if [ ! -f "$unpack_dir/socai" ]; then
   echo "release archive did not contain ./socai" >&2
   exit 1
 fi
+if [ ! -f "$unpack_dir/socai-asr" ]; then
+  echo "release archive did not contain ./socai-asr" >&2
+  exit 1
+fi
 
 install -m 0755 "$unpack_dir/socai" "$install_dir/socai"
+install -m 0755 "$unpack_dir/socai-asr" "$install_dir/socai-asr"
 
 printf 'installed socai to %s\n' "$install_dir/socai"
 "$install_dir/socai" --version

--- a/scripts/prepare-sherpa-onnx-libs.mjs
+++ b/scripts/prepare-sherpa-onnx-libs.mjs
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, open, rename, rm, stat } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const REPO_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ARCHIVE_DIR = path.join(REPO_DIR, "target", "sherpa-onnx-archives");
+const RELEASE_URL = "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.7";
+
+const ARCHIVES = {
+  "aarch64-apple-darwin": {
+    name: "sherpa-onnx-v1.13.7-osx-arm64-static-lib.tar.bz2",
+    bytes: 20_339_537,
+    sha256: "126daa2e8c09a4c5d54dc985722c43bd22f598adc56445905b377454b1b27e38",
+  },
+  "x86_64-apple-darwin": {
+    name: "sherpa-onnx-v1.13.7-osx-x64-static-lib.tar.bz2",
+    bytes: 20_017_522,
+    sha256: "8d8db6199af0119b16f6e2b01c5548b90c4392a462388dd59491e8c471283cca",
+  },
+  "x86_64-pc-windows-msvc": {
+    name: "sherpa-onnx-v1.13.7-win-x64-static-MT-Release-lib.tar.bz2",
+    bytes: 120_228_352,
+    sha256: "04734146fb3a21a297604c586ea826346dbb167c19b9ccc79c1f85d39f490395",
+  },
+};
+
+function rustHost() {
+  const output = execFileSync("rustc", ["-vV"], { cwd: REPO_DIR, encoding: "utf8" });
+  const line = output.split("\n").find((item) => item.startsWith("host: "));
+  if (!line) throw new Error("rustc -vV did not report a host target");
+  return line.slice("host: ".length).trim();
+}
+
+async function sha256(filePath) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function archiveIsValid(filePath, expected) {
+  try {
+    const metadata = await stat(filePath);
+    return metadata.size === expected.bytes && (await sha256(filePath)) === expected.sha256;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadArchive(target) {
+  const expected = ARCHIVES[target];
+  if (!expected) throw new Error(`unsupported sherpa-onnx target: ${target}`);
+  const destination = path.join(ARCHIVE_DIR, expected.name);
+  if (await archiveIsValid(destination, expected)) {
+    console.log(`[sherpa-onnx] verified ${expected.name}`);
+    return;
+  }
+
+  await rm(destination, { force: true });
+  const partial = `${destination}.part-${process.pid}`;
+  await rm(partial, { force: true });
+  const response = await fetch(`${RELEASE_URL}/${expected.name}`, { redirect: "follow" });
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to download ${expected.name}: HTTP ${response.status}`);
+  }
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength !== expected.bytes) {
+    throw new Error(
+      `size header mismatch for ${expected.name}: expected ${expected.bytes}, got ${contentLength}`,
+    );
+  }
+
+  const file = await open(partial, "wx");
+  const hash = createHash("sha256");
+  let downloaded = 0;
+  try {
+    for await (const chunk of Readable.fromWeb(response.body)) {
+      downloaded += chunk.length;
+      if (downloaded > expected.bytes) {
+        throw new Error(`download exceeded pinned size for ${expected.name}`);
+      }
+      hash.update(chunk);
+      await file.write(chunk);
+    }
+    await file.sync();
+  } catch (error) {
+    await file.close();
+    await rm(partial, { force: true });
+    throw error;
+  }
+  await file.close();
+
+  const digest = hash.digest("hex");
+  if (downloaded !== expected.bytes || digest !== expected.sha256) {
+    await rm(partial, { force: true });
+    throw new Error(
+      `verification failed for ${expected.name}: ${downloaded} bytes, sha256 ${digest}`,
+    );
+  }
+  await rename(partial, destination);
+  console.log(`[sherpa-onnx] downloaded and verified ${expected.name}`);
+}
+
+export async function prepareSherpaArchives(targets) {
+  await mkdir(ARCHIVE_DIR, { recursive: true });
+  for (const target of [...new Set(targets)]) await downloadArchive(target);
+}
+
+const invokedDirectly = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const targets = process.argv.slice(2);
+  await prepareSherpaArchives(targets.length > 0 ? targets : [rustHost()]);
+}


### PR DESCRIPTION
## Summary

- replace the previous whisper.cpp quality-selection draft with one paid cloud voice-input path built on the fixed Whisper small fallback in PR #290
- enable the Desktop microphone only when the user is signed in, has an active paid subscription, and has remaining credits
- keep the microphone grey and disabled for logged-out, unpaid, expired, depleted, local-only, or billing-unavailable states
- show the exact account and local Whisper cold-start state in a Chinese or English hover explanation
- record mono 16 kHz PCM WAV, validate its RIFF/chunk contract, upload it to cloud ASR, and settle the usage through credits

## Product behavior

- paid and ready: the microphone records and cloud ASR appends the transcript to the current composer draft
- local or unpaid: audio/video tools use local Whisper small, while direct microphone input remains visibly unavailable for now
- first local ASR use downloads the fixed 376,129,181-byte model lazily; opening the app or hovering the microphone does not trigger a download
- model integrity inspection runs after the first Desktop render, so a cold local status check does not block app startup
- reaching two minutes automatically stops and transcribes the capped recording
- there is no low, medium, or high model selector

## Billing and safety

- entitlement is checked from the live wallet before recording is offered and again before upload
- every recording receives a unique billing task id
- successful transcripts are returned even if the idempotent settlement retry is temporarily unavailable; the durable server task remains recoverable
- WAV size, RIFF length, format/data uniqueness, sample rate, channel count, sample alignment, and duration are validated before upload
- the server remeasures duration and enforces aggregate credit capacity before invoking the paid provider

## Dependencies

- local ASR and routing: https://github.com/socai-io/socai/pull/290
- cloud authorization and settlement: https://github.com/socai-io/socai-server/pull/29

## Validation

- `pnpm --dir app run build`
- `cargo test -p socai_app --lib`: 6 passed
- focused voice-input tests: 3 passed
- `cargo test -p socai-core --lib`: 103 passed, 2 ignored
- `git diff --check`
- two-round Codex review completed; transcript settlement, WAV validation, two-minute capture, startup cold path, account routing, and billing concurrency findings were addressed
