### PR TITLE
fix(app): allow 3:4 portrait window resizing

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "theme": "Light",
         "width": 1180,
         "height": 860,
-        "minWidth": 980,
+        "minWidth": 680,
         "minHeight": 720,
         "resizable": true
       }

--- a/app/src-tauri/tauri.dev.conf.json
+++ b/app/src-tauri/tauri.dev.conf.json
@@ -11,7 +11,7 @@
         "theme": "Light",
         "width": 1180,
         "height": 860,
-        "minWidth": 980,
+        "minWidth": 680,
         "minHeight": 720,
         "resizable": true
       }


### PR DESCRIPTION
## Summary

- Lower the desktop window minimum width from 980 to 680 in both production and development Tauri configurations.
- Keep the default launch size at 1180×860 and the minimum height at 720.
- Allow operators to resize the real desktop window to a 3:4 portrait layout for screenshots and vertical-content review.

## Before and after

| Area | Before | After |
| --- | --- | --- |
| Default launch size | 1180×860 | 1180×860 |
| Production minimum | 980×720 | 680×720 |
| Development minimum | 980×720 | 680×720 |
| 3:4 portrait window | A 684×912 window was blocked by the 980px width floor | A 684×912 window is reachable by normal edge dragging |
| Unified macOS titlebar | Existing implementation | Unchanged |

## Reproduction

- Launch the desktop app from `main`.
- Drag the right window edge toward a portrait layout.
- The window stops at 980px wide, so common 3:4 capture sizes such as 684×912 cannot be reached.

## Implementation

- Change `app/src-tauri/tauri.conf.json` so `minWidth` is 680.
- Apply the same value in `app/src-tauri/tauri.dev.conf.json` so development and packaged behavior remain aligned.
- Leave `width`, `height`, `minHeight`, `resizable`, titlebar setup, native window code, and dependencies unchanged.

An earlier local revision also reapplied AppKit frame/content constraints and scheduled a 750ms Tauri retry. Source inspection and review confirmed that configured constraints are installed before the user setup hook, making those writes redundant. The retry could overwrite another early runtime constraint update, so the final change is intentionally config-only.

## Real window validation

The final config-only implementation was launched as a real Tauri desktop app. System-level mouse events resized the native window, and CoreGraphics read back the on-screen level-0 window bounds:

| Step | CoreGraphics bounds | Ratio |
| --- | --- | ---: |
| Default launch | 1180×860 | 1.3721 |
| Drag right edge | 684×860 | 0.7953 |
| Drag bottom edge | 684×912 | 0.7500 |

The application did not reset the portrait dimensions after the drag.

## Scope

- No forced portrait launch mode.
- No screenshot/export feature.
- No frontend layout or CSS changes; existing narrow-width rules remain in use.
- No macOS-specific window mutation or new native dependency.
- Windows and Linux consume the same production minimum-width configuration.

## Test plan

- [x] `pnpm run build` — 81 modules transformed
- [x] `cargo check -p socai_app`
- [x] Asserted both Tauri configs keep `1180×860`, use `min=680×720`, and remain resizable
- [x] `git diff --check`
- [x] Launched the final Tauri app and resized the native window to 684×912 with system-level mouse events
- [x] Verified the resulting CoreGraphics ratio is exactly 0.7500
- [x] Codex initial review found the redundant delayed retry; it was removed
- [x] Codex focused re-review reported no actionable findings in the final two-line diff

## Commit structure

This PR is intentionally a single commit.
