### PR TITLE
feat(tasks): run managed tasks within global limits

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -14,8 +14,9 @@ use socai_core::agent::{
 };
 use socai_core::runtime::{
     create_llm_provider_for_task, ensure_llm_provider_configured_for,
-    run_agent_task as run_agent_with_tools, AgentRunConfig, BrowserStatus, ChromeConnectOptions,
-    ChromeProfile, RuntimePageSession, SocaiRuntime,
+    run_agent_task as run_agent_with_tools, AgentRunConfig, BrowserBusy, BrowserBusyKind,
+    BrowserLease, BrowserStatus, ChromeConnectOptions, ChromeProfile, RuntimePageSession,
+    SocaiRuntime,
 };
 use socai_core::sites::xhs::{XhsHistoryStore, XhsPageRuntime};
 use socai_core::sites::{find_site, SiteSpec};
@@ -148,31 +149,6 @@ pub async fn app_relaunch(app: AppHandle) {
     app.state::<SocaiRuntime>().disconnect_browser().await;
     app.cleanup_before_exit();
     tauri::process::restart(&app.env());
-}
-
-/// Ensure the browser is connected before an agent run and return the shared
-/// site page for the login preflight. Starting a run expresses the user's
-/// intent to resume, so a dropped connection reconnects here instead of
-/// bouncing them to the connect button. Routine for remote profiles — hosted
-/// sessions expire on a server-side timeout between runs, and reconnecting
-/// mints a fresh one — and it also revives a killed managed chrome. Bounded by
-/// the runtime's connect budget.
-async fn ensure_browser_connected(
-    runtime: &SocaiRuntime,
-) -> Result<Arc<RuntimePageSession>, String> {
-    let site =
-        app_site().map_err(|error| task_preflight_error("preflight_site", format!("{error:#}")))?;
-    let options = ChromeConnectOptions::from_config()
-        .map_err(|error| task_preflight_error("preflight_browser_config", format!("{error:#}")))?;
-    let browser_error_code = if options.profile == ChromeProfile::Remote {
-        "preflight_browser_remote"
-    } else {
-        "preflight_browser"
-    };
-    runtime
-        .ensure_site_page_with_browser_options(site.id, site.home_url, options)
-        .await
-        .map_err(|error| task_preflight_error(browser_error_code, format!("{error:#}")))
 }
 
 async fn label_controlled_page(page: &RuntimePageSession, label: &str) {
@@ -615,7 +591,7 @@ pub async fn agent_task_start(
     if task_text.is_empty() {
         return Err("task is empty".into());
     }
-    run_task_preflight(&runtime, provider.as_deref(), model.as_deref()).await?;
+    run_task_preflight(provider.as_deref(), model.as_deref()).await?;
 
     // One conversation = one folder under the runs root, named after the
     // first task; each turn's run dir nests inside it (turn-01_…, turn-02_…).
@@ -680,8 +656,8 @@ pub async fn agent_task_start(
 }
 
 /// Continue an existing task's conversation with a follow-up message. The
-/// task must be terminal (not queued/running) — replies are serialized, same
-/// as new tasks, via `MAX_CONCURRENT_AGENT_TASKS`. Keeps the same `task_id`
+/// task must be terminal (not queued/running). Replies and new tasks share the
+/// global `MAX_CONCURRENT_AGENT_TASKS` limit. Keeps the same `task_id`
 /// and `session_dir` (so the whole thread's history stays attached to one
 /// sidebar entry) but starts a fresh run dir for this turn.
 #[tauri::command]
@@ -710,7 +686,10 @@ pub async fn agent_task_reply(
     };
     let provider = existing.provider.clone();
     let model = existing.model.clone();
-    run_task_preflight(&runtime, provider.as_deref(), model.as_deref()).await?;
+    run_task_preflight(provider.as_deref(), model.as_deref()).await?;
+    if let Some(previous_run_dir) = existing.run_dir.as_deref() {
+        socai_core::media::cancel_background_media_for_run(previous_run_dir);
+    }
 
     // This turn's run dir nests inside the conversation dir. Tasks created
     // before nesting have their session dir under ~/.socai/sessions; their
@@ -728,7 +707,6 @@ pub async fn agent_task_reply(
             snapshot.finished_at = None;
             snapshot.run_id = None;
             snapshot.run_dir = Some(run_dir.display().to_string());
-            snapshot.target_id = None;
             snapshot.final_text = None;
             snapshot.error = None;
             snapshot.steps = None;
@@ -786,11 +764,7 @@ pub async fn agent_task_reply(
     Ok(snapshot)
 }
 
-async fn run_task_preflight(
-    runtime: &SocaiRuntime,
-    provider: Option<&str>,
-    model: Option<&str>,
-) -> Result<(), String> {
+async fn run_task_preflight(provider: Option<&str>, model: Option<&str>) -> Result<(), String> {
     let resolved_provider = ensure_llm_provider_configured_for(provider, model)
         .map_err(|error| task_preflight_error("preflight_model_config", format!("{error:#}")))?;
     if resolved_provider == Provider::Socai {
@@ -806,20 +780,23 @@ async fn run_task_preflight(
         validate_preflight_balance(wallet.balance_points)?;
     }
 
-    let page = ensure_browser_connected(runtime).await?;
+    Ok(())
+}
+
+async fn run_session_login_preflight(page: &RuntimePageSession) -> Result<(), String> {
     let login_error_code = if page.is_remote_browser() {
         "preflight_xhs_session"
     } else {
         "preflight_xhs_login"
     };
-    let login = XhsPageRuntime::new(&page)
+    let login = XhsPageRuntime::new(page)
         .login_gate(true)
         .await
         .map_err(|error| task_preflight_error(login_error_code, format!("{error:#}")))?;
     if login == socai_core::sites::xhs::page::LoginGate::Required {
         return Err(task_preflight_error(
             login_error_code,
-            "Xiaohongshu login is required in the active browser session",
+            "Xiaohongshu login is required in this conversation's browser session",
         ));
     }
     Ok(())
@@ -842,6 +819,174 @@ fn validate_preflight_balance(balance_points: i64) -> Result<(), String> {
     } else {
         Ok(())
     }
+}
+
+/// How many times a run retries a browser that will not open before it gives
+/// up and reports the browser's own error. Capacity waits are unbounded — the
+/// runs ahead always finish — but a browser that fails to connect may be a
+/// server outage or a spent daily remote-browser quota, and a task that never
+/// stops queueing hides that from the user.
+const MAX_BROWSER_CONNECT_ATTEMPTS: u32 = 3;
+
+/// Outcome of bringing up a run's Chrome tab. `Busy` means "ask again in a
+/// moment" and keeps the task queued; `Failed` carries a coded preflight error
+/// the UI translates.
+enum PageAdmission {
+    Busy(BrowserBusy),
+    Failed(String),
+}
+
+struct UnboundPageGuard {
+    runtime: SocaiRuntime,
+    target_id: Option<String>,
+}
+
+impl UnboundPageGuard {
+    fn disarm(&mut self) {
+        self.target_id = None;
+    }
+}
+
+impl Drop for UnboundPageGuard {
+    fn drop(&mut self) {
+        let Some(target_id) = self.target_id.take() else {
+            return;
+        };
+        let runtime = self.runtime.clone();
+        tauri::async_runtime::spawn(async move {
+            let _ = runtime.close_target(&target_id).await;
+        });
+    }
+}
+
+fn remote_browser_selected() -> bool {
+    ChromeConnectOptions::from_config()
+        .map(|options| options.profile == ChromeProfile::Remote)
+        .unwrap_or(false)
+}
+
+/// Bring up this conversation's Chrome tab under the run's browser lease.
+/// Called from the admission loop so a refusal parks the task in the queue
+/// rather than failing it.
+async fn acquire_session_page(
+    runtime: &SocaiRuntime,
+    lease: &BrowserLease,
+    session_id: &str,
+) -> Result<(Arc<RuntimePageSession>, UnboundPageGuard), PageAdmission> {
+    let site = app_site().map_err(|error| {
+        PageAdmission::Failed(task_preflight_error("preflight_site", format!("{error:#}")))
+    })?;
+    let options = ChromeConnectOptions::from_config().map_err(|error| {
+        PageAdmission::Failed(task_preflight_error(
+            "preflight_browser_config",
+            format!("{error:#}"),
+        ))
+    })?;
+    // Each conversation owns one site tab. Separate tasks run in parallel
+    // without navigating or closing another session's target; replies keep the
+    // same target while the configured browser connection stays available.
+    let page = runtime
+        .ensure_session_site_page_with_browser_options(
+            lease,
+            session_id,
+            site.id,
+            site.home_url,
+            options,
+        )
+        .await
+        .map_err(|error| match BrowserBusy::find(&error) {
+            Some(busy) => PageAdmission::Busy(busy.clone()),
+            None => PageAdmission::Failed(browser_preflight_error(format!("{error:#}"))),
+        })?;
+    let guard = UnboundPageGuard {
+        runtime: runtime.clone(),
+        target_id: Some(page.target_id().to_string()),
+    };
+    Ok((page, guard))
+}
+
+/// Associate a tab with its task as soon as browser admission succeeds. The
+/// caller keeps an armed cleanup guard across these awaits, so cancellation
+/// closes a page that has not reached the registry yet.
+async fn bind_task_page(
+    app: &AppHandle,
+    registry: &AgentTaskRegistry,
+    task_id: &str,
+    page: &RuntimePageSession,
+    title_label: &str,
+) -> bool {
+    let target_id = page.target_id().to_string();
+    let page_url = page
+        .evaluate_json("location.href")
+        .await
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string));
+    let page_title_marker = format!("task:{task_id}");
+    let Some((snapshot, target_changed)) = registry
+        .bind_target_if_active(task_id, target_id, page_url, page_title_marker.clone())
+        .await
+    else {
+        return false;
+    };
+    label_controlled_page(page, &format!("{page_title_marker} · {title_label}")).await;
+    if target_changed {
+        emit_task_event(
+            app,
+            registry,
+            task_id,
+            "tab",
+            "chrome tab marked as controlled by socai".into(),
+            Some(snapshot),
+        )
+        .await;
+    }
+    true
+}
+
+fn browser_preflight_error(detail: String) -> String {
+    task_preflight_error(browser_preflight_code(&detail), detail)
+}
+
+/// Which browser failure the user is looking at. A spent daily allowance on the
+/// hosted browser is called out separately: unlike the other remote failures it
+/// is not fixed by retrying or by checking the network.
+fn browser_preflight_code(detail: &str) -> &'static str {
+    if !remote_browser_selected() {
+        return "preflight_browser";
+    }
+    if detail
+        .to_ascii_lowercase()
+        .contains("daily remote browser time limit")
+    {
+        return "preflight_browser_remote_quota";
+    }
+    "preflight_browser_remote"
+}
+
+/// Wait out a browser refusal. Returns false once a run has spent its connect
+/// attempts, which is the point at which the browser error becomes the task's
+/// failure instead of another wait.
+async fn wait_out_browser_busy(busy: &BrowserBusy, connect_attempts: &mut u32) -> bool {
+    if busy.kind == BrowserBusyKind::Connect {
+        *connect_attempts += 1;
+        if *connect_attempts >= MAX_BROWSER_CONNECT_ATTEMPTS {
+            return false;
+        }
+    } else {
+        *connect_attempts = 0;
+    }
+    tokio::time::sleep(busy.retry_after).await;
+    true
+}
+
+/// The conversation session a task belongs to, which is also its Chrome tab's
+/// identity. Tasks created before conversations were introduced have none.
+async fn task_session_id(registry: &AgentTaskRegistry, task_id: &str) -> Option<String> {
+    let session_dir = registry
+        .get(task_id)
+        .await
+        .and_then(|task| task.session_dir)?;
+    Conversation::load(&session_dir).ok().map(|c| c.id)
 }
 
 #[tauri::command]
@@ -1943,7 +2088,9 @@ pub async fn agent_task_cancel(
         .await
         .ok_or_else(|| format!("unknown task: {task_id}"))?;
     if changed {
-        socai_core::media::begin_background_media_generation();
+        if let Some(run_dir) = snapshot.run_dir.as_deref() {
+            socai_core::media::cancel_background_media_for_run(run_dir);
+        }
     }
     if let Some(handle) = abort_handle {
         handle.abort();
@@ -2057,11 +2204,15 @@ pub(crate) fn visible_billed_points(
 /// tasks must be cancelled first; the registry enforces that.
 #[tauri::command]
 pub async fn agent_task_delete(
+    runtime: State<'_, SocaiRuntime>,
     tasks: State<'_, AgentTaskRegistry>,
     telemetry: State<'_, DesktopTelemetry>,
     task_id: String,
 ) -> Result<(), String> {
     let snapshot = tasks.delete(&task_id).await?;
+    if let Some(target_id) = snapshot.target_id.as_deref() {
+        let _ = runtime.close_target(target_id).await;
+    }
     if let Some(run_dir) = snapshot.run_dir.as_deref() {
         socai_core::media::cancel_background_media_for_run(run_dir);
     }
@@ -2134,32 +2285,131 @@ async fn run_agent_task_background(
     background_media_generation: u64,
     telemetry: DesktopTelemetry,
 ) {
-    let Some(_permit) = registry.acquire_run_permit().await else {
-        let error = "task runner queue closed".to_string();
-        if let Some(snapshot) = registry
-            .finalize_if_active(&task_id, |snapshot| {
-                snapshot.status = "failed".into();
-                snapshot.finished_at = Some(now_ms());
-                snapshot.error = Some(error.clone());
-            })
-            .await
-        {
-            record_desktop_session(&snapshot, &format!("[task failed: {error}]"), "failed");
-            telemetry.capture(
-                "socai_agent_task_end",
-                json!({
-                    "task_id": task_id.clone(),
-                    "provider": provider.clone(),
-                    "model": model.clone(),
-                    "outcome": "failed",
-                    "error": short_error(&error),
-                    "points_used": snapshot.points_used,
-                    "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
-                }),
-            );
-            emit_task_event(&app, &registry, &task_id, "failed", error, Some(snapshot)).await;
-        }
+    let Some(session_id) = task_session_id(&registry, &task_id).await else {
+        fail_task_before_run(
+            &app,
+            &registry,
+            &telemetry,
+            &task_id,
+            provider.as_deref(),
+            model.as_deref(),
+            task_preflight_error("preflight_site", "task has no conversation session"),
+        )
+        .await;
         return;
+    };
+
+    // Admission is local to this app process: each run holds one task permit
+    // and one browser lease for its entire lifetime.
+    let mut connect_attempts = 0u32;
+    let (_permit, _lease, _activity, page) = loop {
+        let Some(permit) = registry.acquire_run_permit().await else {
+            let error = "task runner queue closed".to_string();
+            fail_task_before_run(
+                &app,
+                &registry,
+                &telemetry,
+                &task_id,
+                provider.as_deref(),
+                model.as_deref(),
+                error,
+            )
+            .await;
+            return;
+        };
+        let lease = match runtime.try_acquire_browser_lease() {
+            Ok(lease) => lease,
+            Err(busy) => {
+                drop(permit);
+                if wait_out_browser_busy(&busy, &mut connect_attempts).await {
+                    continue;
+                }
+                fail_task_before_run(
+                    &app,
+                    &registry,
+                    &telemetry,
+                    &task_id,
+                    provider.as_deref(),
+                    model.as_deref(),
+                    browser_preflight_error(busy.reason),
+                )
+                .await;
+                return;
+            }
+        };
+        // Held for the whole task — LLM thinking pauses between tool calls
+        // included — so the remote idle reaper only fires between tasks.
+        let activity = runtime.begin_activity().await;
+        let (page, mut page_guard) =
+            match acquire_session_page(&runtime, &lease, &session_id).await {
+                Ok(admitted) => admitted,
+                Err(PageAdmission::Busy(busy)) => {
+                    drop(activity);
+                    drop(lease);
+                    drop(permit);
+                    if wait_out_browser_busy(&busy, &mut connect_attempts).await {
+                        continue;
+                    }
+                    fail_task_before_run(
+                        &app,
+                        &registry,
+                        &telemetry,
+                        &task_id,
+                        provider.as_deref(),
+                        model.as_deref(),
+                        browser_preflight_error(busy.reason),
+                    )
+                    .await;
+                    return;
+                }
+                Err(PageAdmission::Failed(error)) => {
+                    drop(activity);
+                    drop(lease);
+                    drop(permit);
+                    fail_task_before_run(
+                        &app,
+                        &registry,
+                        &telemetry,
+                        &task_id,
+                        provider.as_deref(),
+                        model.as_deref(),
+                        error,
+                    )
+                    .await;
+                    return;
+                }
+            };
+        if !bind_task_page(
+            &app,
+            &registry,
+            &task_id,
+            &page,
+            &format!("task · {}", title_safe(&task)),
+        )
+        .await
+        {
+            return;
+        }
+        page_guard.disarm();
+        // Every conversation owns its own tab. Validate login on that exact
+        // page before the task is marked running or sends its first LLM request.
+        if let Err(error) = run_session_login_preflight(&page).await {
+            drop(activity);
+            drop(lease);
+            drop(permit);
+            fail_task_before_run(
+                &app,
+                &registry,
+                &telemetry,
+                &task_id,
+                provider.as_deref(),
+                model.as_deref(),
+                error,
+            )
+            .await;
+            return;
+        }
+        break (permit, lease, activity, page);
     };
 
     if let Some(snapshot) = registry
@@ -2191,10 +2441,10 @@ async fn run_agent_task_background(
         }),
     );
 
-    let result = run_agent_task_on_shared_page(
+    let result = run_agent_task_on_session_page(
         app.clone(),
         task_id.clone(),
-        runtime,
+        page,
         &task,
         provider.as_deref(),
         model.as_deref(),
@@ -2202,7 +2452,6 @@ async fn run_agent_task_background(
         Some(background_media_generation),
         Some(registry.clone()),
         telemetry.clone(),
-        format!("task · {}", title_safe(&task)),
     )
     .await;
 
@@ -2315,6 +2564,41 @@ async fn run_agent_task_background(
     }
 }
 
+async fn fail_task_before_run(
+    app: &AppHandle,
+    registry: &AgentTaskRegistry,
+    telemetry: &DesktopTelemetry,
+    task_id: &str,
+    provider: Option<&str>,
+    model: Option<&str>,
+    error: String,
+) {
+    let _ = registry.remove_abort_handle(task_id).await;
+    if let Some(snapshot) = registry
+        .finalize_if_active(task_id, |snapshot| {
+            snapshot.status = "failed".into();
+            snapshot.finished_at = Some(now_ms());
+            snapshot.error = Some(error.clone());
+        })
+        .await
+    {
+        record_desktop_session(&snapshot, &format!("[task failed: {error}]"), "failed");
+        telemetry.capture(
+            "socai_agent_task_end",
+            json!({
+                "task_id": task_id,
+                "provider": provider,
+                "model": model,
+                "outcome": "failed",
+                "error": short_error(&error),
+                "points_used": snapshot.points_used,
+                "duration_ms": duration_ms(snapshot.started_at, snapshot.finished_at),
+            }),
+        );
+        emit_task_event(app, registry, task_id, "failed", error, Some(snapshot)).await;
+    }
+}
+
 pub(crate) fn record_interrupted_run(snapshot: &AgentTaskSnapshot, message: &str) {
     if let Some(run_dir) = snapshot.run_dir.as_deref() {
         let _ = mark_agent_run_status(run_dir, "interrupted", Some(message));
@@ -2396,10 +2680,10 @@ fn record_desktop_session(snapshot: &AgentTaskSnapshot, assistant: &str, status:
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_agent_task_on_shared_page(
+async fn run_agent_task_on_session_page(
     app: AppHandle,
     task_id: String,
-    runtime: SocaiRuntime,
+    page: Arc<RuntimePageSession>,
     task: &str,
     provider: Option<&str>,
     model: Option<&str>,
@@ -2407,7 +2691,6 @@ async fn run_agent_task_on_shared_page(
     background_media_generation: Option<u64>,
     registry: Option<AgentTaskRegistry>,
     telemetry: DesktopTelemetry,
-    title_label: String,
 ) -> Result<AgentRunOutcome> {
     let task = task.trim();
     if task.is_empty() {
@@ -2439,45 +2722,30 @@ async fn run_agent_task_on_shared_page(
     ensure_llm_provider_configured_for(provider, model)?;
     let llm_provider = create_llm_provider_for_task(provider, model, &task_id)?;
     let site = app_site()?;
-    // Held for the whole task — LLM thinking pauses between tool calls
-    // included — so the remote idle reaper only fires between tasks.
-    let _activity = runtime.begin_activity().await;
-    // Reuse the site tab only while it belongs to the currently configured
-    // browser profile. A user may switch local/managed/remote between turns;
-    // the options-aware runtime closes the cached page and reconnects before
-    // a follow-up can accidentally keep driving the previous browser.
-    let browser_options = ChromeConnectOptions::from_config()?;
-    let page = runtime
-        .ensure_site_page_with_browser_options(site.id, site.home_url, browser_options)
-        .await?;
-    let target_id = page.target_id().to_string();
-    let page_url = page
-        .evaluate_json("location.href")
+    let session_id =
+        session_id.ok_or_else(|| anyhow::anyhow!("task has no conversation session"))?;
+    // The tab was opened and bound to this task during admission. The browser
+    // lease and activity guard that keep it alive are held by the caller.
+    // Login is checked in the conversation's own tab rather than in a shared
+    // site tab, so a run never opens a second target just to look at the gate.
+    // Both outcomes carry a code the UI translates — a hosted browser's shared
+    // login is socai-operated, so its message differs from the local one.
+    let login_error_code = if page.is_remote_browser() {
+        "preflight_xhs_session"
+    } else {
+        "preflight_xhs_login"
+    };
+    let login = XhsPageRuntime::new(&page)
+        .login_gate(true)
         .await
-        .ok()
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| site.home_url.to_string());
-    let page_title_marker = format!("task:{task_id}");
-    label_controlled_page(&page, &format!("{page_title_marker} · {title_label}")).await;
-    if let Some(registry) = &registry {
-        if let Some(snapshot) = registry
-            .update(&task_id, |snapshot| {
-                snapshot.target_id = Some(target_id.clone());
-                snapshot.page_url = Some(page_url.clone());
-                snapshot.page_title_marker = Some(page_title_marker.clone());
-            })
-            .await
-        {
-            emit_task_event(
-                &app,
-                registry,
-                &task_id,
-                "tab",
-                "chrome tab marked as controlled by socai".into(),
-                Some(snapshot),
-            )
-            .await;
-        }
+        .map_err(|error| {
+            anyhow::anyhow!(task_preflight_error(login_error_code, format!("{error:#}")))
+        })?;
+    if login == socai_core::sites::xhs::page::LoginGate::Required {
+        anyhow::bail!(task_preflight_error(
+            login_error_code,
+            "Xiaohongshu login is required in this conversation's Chrome tab",
+        ));
     }
     let outcome = async {
         let agent_tools = site.default_agent_tools.unwrap_or(site.agent_tools);
@@ -2509,7 +2777,7 @@ async fn run_agent_task_on_shared_page(
             enabled_sites: vec![site.id.to_string()],
             seed_messages,
             run_dir,
-            session_id,
+            session_id: Some(session_id),
             background_media_generation,
             billing_task_id: Some(task_id.clone()),
             ..AgentRunConfig::default()
@@ -2545,13 +2813,6 @@ async fn run_agent_task_on_shared_page(
         })
     }
     .await;
-    if let Some(registry) = &registry {
-        let _ = registry
-            .update(&task_id, |snapshot| {
-                snapshot.target_id = None;
-            })
-            .await;
-    }
     outcome
 }
 

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -11,7 +11,7 @@ use tokio::task::AbortHandle;
 
 use crate::timeline::{self, AgentTaskEventKind, AgentTaskEventPayload};
 
-const MAX_CONCURRENT_AGENT_TASKS: usize = 1;
+const MAX_CONCURRENT_AGENT_TASKS: usize = 3;
 
 #[derive(Clone)]
 pub struct AgentTaskRegistry {
@@ -172,6 +172,32 @@ impl AgentTaskRegistry {
 
     pub(crate) async fn acquire_run_permit(&self) -> Option<OwnedSemaphorePermit> {
         self.runner_permits.clone().acquire_owned().await.ok()
+    }
+
+    pub(crate) async fn bind_target_if_active(
+        &self,
+        task_id: &str,
+        target_id: String,
+        page_url: Option<String>,
+        page_title_marker: String,
+    ) -> Option<(AgentTaskSnapshot, bool)> {
+        let mut guard = self.inner.lock().await;
+        let task = guard
+            .tasks
+            .iter_mut()
+            .find(|task| task.task_id == task_id)?;
+        if !matches!(task.status.as_str(), "queued" | "running") {
+            return None;
+        }
+        let target_changed = task.target_id.as_deref() != Some(target_id.as_str());
+        task.target_id = Some(target_id);
+        if page_url.is_some() {
+            task.page_url = page_url;
+        }
+        task.page_title_marker = Some(page_title_marker);
+        let snapshot = hydrate_task_snapshot(task.clone());
+        persist_task_index(&guard.tasks);
+        Some((snapshot, target_changed))
     }
 
     /// Register the task abort handle. Returns the handle back to the caller
@@ -596,5 +622,41 @@ fn persist_task_index(tasks: &[AgentTaskSnapshot]) {
         .collect();
     if let Ok(text) = serde_json::to_string_pretty(&records) {
         let _ = std::fs::write(path, text);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn empty_registry() -> AgentTaskRegistry {
+        AgentTaskRegistry {
+            inner: Arc::new(Mutex::new(AgentTaskRegistryInner::default())),
+            runner_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_AGENT_TASKS)),
+        }
+    }
+
+    #[tokio::test]
+    async fn three_tasks_run_while_the_fourth_waits_for_a_released_permit() {
+        let registry = empty_registry();
+        let first = registry.acquire_run_permit().await.unwrap();
+        let second = registry.acquire_run_permit().await.unwrap();
+        let third = registry.acquire_run_permit().await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), registry.acquire_run_permit())
+                .await
+                .is_err()
+        );
+
+        drop(first);
+        let fourth =
+            tokio::time::timeout(Duration::from_millis(250), registry.acquire_run_permit())
+                .await
+                .expect("the fourth task should leave the queue")
+                .expect("the runner queue should stay open");
+
+        drop((second, third, fourth));
     }
 }

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -387,6 +387,10 @@ const messages = {
   "task.you": { en: "you", zh: "你" },
   "task.working": { en: "working…", zh: "运行中…" },
   "task.activityLabel": { en: "activity", zh: "运行过程" },
+  "task.interruptedAppClosed": {
+    en: "the app was closed before this task finished.",
+    zh: "应用在任务完成前已关闭。",
+  },
   "task.searchLabel": { en: "search", zh: "搜索" },
   "task.progressReading": { en: "reading", zh: "读取笔记" },
   "task.progressOcr": { en: "reading images", zh: "识别图片文字" },
@@ -432,6 +436,10 @@ const messages = {
   "task.preflightBrowserRemote": {
     en: "socai could not connect to the hosted browser. check your network and socai account, then try again.",
     zh: "socai 无法连接云端浏览器。请检查网络和 socai 账号状态，然后重试。",
+  },
+  "task.preflightBrowserRemoteQuota": {
+    en: "this device has used up today's hosted browser time. try again tomorrow, or switch the browser source to a local chrome in settings.",
+    zh: "本设备今日的云端浏览器时长已用完。请明天再试，或在设置中将浏览器来源切换为本地 chrome。",
   },
   "task.preflightXhsLogin": {
     en: "xiaohongshu is signed out in the connected chrome profile. complete sign-in there, then try again.",
@@ -728,6 +736,7 @@ const taskPreflightMessages = {
   preflight_browser_config: "task.preflightBrowserConfig",
   preflight_browser: "task.preflightBrowser",
   preflight_browser_remote: "task.preflightBrowserRemote",
+  preflight_browser_remote_quota: "task.preflightBrowserRemoteQuota",
   preflight_xhs_login: "task.preflightXhsLogin",
   preflight_xhs_session: "task.preflightXhsSession",
 } as const satisfies Record<string, MessageKey>;
@@ -1111,6 +1120,15 @@ export function setTimezone(timezone: string): void {
 
 export function taskStatusLabel(status: TaskStatusKey): string {
   return taskStatusLabels[status][currentLanguage];
+}
+
+export function formatTaskInterruptionMessage(message: string): string {
+  const appClosed = "app was closed before this task finished";
+  const normalized = message.trim().toLowerCase();
+  if (normalized === appClosed || normalized === `[task interrupted: ${appClosed}]`) {
+    return t("task.interruptedAppClosed");
+  }
+  return message;
 }
 
 export function formatTabs(count: number): string {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -390,7 +390,18 @@ function captureTaskCommandErrorNotice(error: unknown): boolean {
 }
 
 function captureRuntimeErrorNotice(payload: AgentTaskEventPayload): boolean {
-  if (payload.kind !== "api_error" || !payload.text.trim()) return false;
+  if (!payload.text.trim()) return false;
+  if (payload.kind === "failed") {
+    const commandPresentation = formatTaskCommandErrorPresentation(payload.text);
+    if (!commandPresentation) return false;
+    showRuntimeErrorNotice({
+      key: `${payload.task_id}:${commandPresentation.fingerprint}`,
+      kind: "command",
+      error: payload.text,
+    });
+    return true;
+  }
+  if (payload.kind !== "api_error") return false;
   console.error("agent task API error:", payload.text);
   const presentation = formatTaskApiError(payload.text);
   const key = `${payload.task_id}:${presentation.fingerprint}`;

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -10,8 +10,8 @@
 //!   · the answer inline as rich markdown with note citations — no separate
 //!     panel, no "jump to answer" bridge
 //! The same chat composer serves both faces: pinned under the thread in
-//! "reply" mode (disabled while the task runs — the app owns a single agent
-//! slot), and centered with the hero in the new-task compose pane
+//! "reply" mode (disabled while that conversation runs), and centered with the
+//! hero in the new-task compose pane
 //! (renderComposePane), which the connect overlay masks until chrome is up.
 //!
 //! Rendering only; state and bindings live in tasks.ts.
@@ -21,6 +21,8 @@ import { esc } from "../lib/html";
 import {
   formatStepCount,
   formatTaskApiError,
+  formatTaskCommandErrorPresentation,
+  formatTaskInterruptionMessage,
   formatTaskTimestamp,
   formatTokenUsage,
   isTaskApiError,
@@ -291,7 +293,11 @@ function renderTurn(
   if (isLast) {
     const finishedAt = task.finished_at ? formatTaskTimestamp(task.finished_at) : null;
     const apiError = taskApiError(task);
-    if (apiError) {
+    const commandError = task.error ? formatTaskCommandErrorPresentation(task.error) : null;
+    if (commandError) {
+      answer = renderTaskCommandErrorCard(commandError);
+      if (finishedAt) metaBits.push(finishedAt);
+    } else if (apiError) {
       answer = renderTaskApiErrorCard(apiError);
       if (finishedAt) metaBits.push(finishedAt);
     } else if (task.final_text) {
@@ -314,7 +320,10 @@ function renderTurn(
         metaBits.push(t("billing.pointsUsed", { points: metrics.pointsUsed }));
       }
     } else if (task.error) {
-      answer = `<pre class="conv-error">${esc(task.error)}</pre>`;
+      const error = task.status === "interrupted"
+        ? formatTaskInterruptionMessage(task.error)
+        : task.error;
+      answer = `<pre class="conv-error">${esc(error)}</pre>`;
       if (finishedAt) metaBits.push(finishedAt);
     }
   } else if (answerText != null) {
@@ -537,7 +546,9 @@ export function renderEventRow(ev: AgentTaskEventPayload): string {
   const progressKey = ev.kind === "tool_progress" ? `${ev.id ?? ""}:${ev.phase ?? ""}` : "";
   const progressAttr = progressKey ? ` data-tool-progress="${esc(progressKey)}"` : "";
   if (ev.kind === "api_error") return renderTaskApiErrorEvent(ev);
-  const text = ev.kind === "tool_progress" ? toolProgressText(ev) : ev.text;
+  const text = ev.kind === "tool_progress"
+    ? toolProgressText(ev)
+    : formatTaskInterruptionMessage(ev.text);
   return `<div class="act-row act-row--${esc(ev.kind)}"${progressAttr}><span class="act-row__glyph" aria-hidden="true">${eventGlyph(ev.kind)}</span><span class="act-row__text">${esc(text)}</span></div>`;
 }
 
@@ -555,6 +566,19 @@ function renderTaskApiErrorEvent(ev: AgentTaskEventPayload): string {
 
 function renderTaskApiErrorCard(error: string): string {
   const presentation = formatTaskApiError(error);
+  return `<div class="task-api-error-card" role="alert">
+    <div class="task-api-error-card__heading">
+      <i class="runtime-error-notice__dot" aria-hidden="true"></i>
+      <p class="task-api-error-card__title">${esc(presentation.title)}</p>
+    </div>
+    <p class="task-api-error-card__message">${esc(presentation.message)}</p>
+    <p class="task-api-error-card__meta">${esc(presentation.meta)}</p>
+  </div>`;
+}
+
+function renderTaskCommandErrorCard(
+  presentation: NonNullable<ReturnType<typeof formatTaskCommandErrorPresentation>>,
+): string {
   return `<div class="task-api-error-card" role="alert">
     <div class="task-api-error-card__heading">
       <i class="runtime-error-notice__dot" aria-hidden="true"></i>

--- a/app/src/panels/task_history.ts
+++ b/app/src/panels/task_history.ts
@@ -49,13 +49,14 @@ function renderTaskRows(props: SidebarProps): string {
     .map((task) => {
       const active = !props.composing && task.task_id === props.selectedTaskId ? "task-row-active" : "";
       const running = task.status === "running" || task.status === "queued";
+      const statusLabel = taskStatusLabel(task.status);
       return `
         <div class="task-row ${active}">
           <button type="button" class="task-row-open" data-task-id="${esc(task.task_id)}">
-            <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true">${taskStatusGlyph(task.status)}</span>
+            <span class="task-row-glyph task-row-glyph-${esc(task.status)}" aria-hidden="true" title="${esc(statusLabel)}">${taskStatusGlyph(task.status)}</span>
             <span class="task-row-main">
               <span class="task-row-title">${esc(task.task)}</span>
-              <span class="task-row-meta">${esc(taskStatusLabel(task.status))} · ${esc(formatTaskTimestamp(task.created_at))}</span>
+              <span class="task-row-meta">${esc(statusLabel)} · ${esc(formatTaskTimestamp(task.created_at))}</span>
             </span>
           </button>
           ${running ? "" : `
@@ -93,8 +94,8 @@ export function renderConfirmDeleteDialog(task: AgentTaskView): string {
 
 function taskStatusGlyph(status: AgentTaskView["status"]): string {
   switch (status) {
-    case "queued": return "○";
-    case "running": return "●";
+    case "queued": return "";
+    case "running": return "";
     case "completed": return "✓";
     case "failed": return "×";
     case "cancelled": return "−";

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1113,16 +1113,38 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .task-row-open:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: -2px; }
 .task-row-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 18px;
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
   color: var(--fg-soft);
 }
+.task-row-glyph-queued::before,
+.task-row-glyph-running::before {
+  width: 10px;
+  height: 10px;
+  box-sizing: border-box;
+  border: 1px solid var(--fg-faint);
+  border-radius: 50%;
+  content: "";
+}
 .task-row-glyph-running {
   color: var(--ink-0);
-  animation: pulse 1.4s ease-in-out infinite;
+}
+.task-row-glyph-running::before {
+  border-color: var(--line-strong);
+  border-top-color: var(--ink-0);
+  animation: task-row-spin 0.8s linear infinite;
 }
 .task-row-glyph-failed { color: var(--status-error-fg); }
+@keyframes task-row-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .task-row-glyph-running::before { animation: pulse 1.4s ease-in-out infinite; }
+}
 .task-row-main {
   display: flex;
   min-width: 0;

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -8,6 +8,8 @@
 //! `reasoning_content` field, thinking toggles) live here too.
 
 use std::collections::HashSet;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -21,6 +23,31 @@ use crate::agent::llm::{
 use crate::agent::provider::{
     config_for, load_api_key, load_openai_credential, Credential, Provider, ProviderConfig,
 };
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const IDLE_POOL_TIMEOUT: Duration = Duration::from_secs(300);
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+fn http_client() -> anyhow::Result<reqwest::Client> {
+    if let Some(client) = HTTP_CLIENT.get() {
+        return Ok(client.clone());
+    }
+    // Agent tasks spend minutes inside browser tools between model turns. A
+    // process-wide pool lets all three tasks reuse whichever ChatGPT/OpenAI
+    // connection is still healthy instead of maintaining three independent
+    // pools that all reconnect after the same idle window. Bound the connect
+    // phase separately so a dead route reaches the existing retry loop in
+    // seconds rather than waiting for the operating system's TCP timeout.
+    let client = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .pool_idle_timeout(IDLE_POOL_TIMEOUT)
+        .tcp_keepalive(Duration::from_secs(30))
+        .build()?;
+    let _ = HTTP_CLIENT.set(client.clone());
+    Ok(HTTP_CLIENT.get().cloned().unwrap_or(client))
+}
 
 #[derive(Debug, Clone)]
 pub struct OpenAICompatBackend {
@@ -82,9 +109,7 @@ impl OpenAICompatBackend {
         } else {
             model
         };
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(180))
-            .build()?;
+        let client = http_client()?;
         Ok(Self {
             provider,
             model: resolved_model,

--- a/core/src/cloud/auth.rs
+++ b/core/src/cloud/auth.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -11,6 +12,7 @@ const AUTH_KEY: &str = "socai_pro";
 const LEGACY_AUTH_KEY: &str = "socai_cloud";
 const LEGACY_PRO_BASE_URL: &str = "http://47.94.86.171";
 const PRODUCTION_BASE_URL: &str = "https://api.socai.work";
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AuthSession {
@@ -423,10 +425,15 @@ fn normalize_mainland_phone(value: &str) -> Result<String> {
 }
 
 pub(super) fn http_client() -> Result<reqwest::Client> {
-    Ok(reqwest::Client::builder()
+    if let Some(client) = HTTP_CLIENT.get() {
+        return Ok(client.clone());
+    }
+    let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(120))
-        .build()?)
+        .build()?;
+    let _ = HTTP_CLIENT.set(client.clone());
+    Ok(HTTP_CLIENT.get().cloned().unwrap_or(client))
 }
 
 pub(super) fn bearer(request: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {

--- a/core/src/media/background.rs
+++ b/core/src/media/background.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -15,7 +15,7 @@ struct BackgroundMediaState {
     generation: AtomicU64,
     generation_tx: watch::Sender<u64>,
     events_tx: broadcast::Sender<BackgroundMediaEvent>,
-    cancelled_runs: Mutex<HashSet<String>>,
+    cancelled_runs: Mutex<CancelledRuns>,
     in_flight_videos: Mutex<HashSet<String>>,
 }
 
@@ -28,21 +28,16 @@ fn state() -> &'static BackgroundMediaState {
             generation: AtomicU64::new(1),
             generation_tx,
             events_tx,
-            cancelled_runs: Mutex::new(HashSet::new()),
+            cancelled_runs: Mutex::new(CancelledRuns::default()),
             in_flight_videos: Mutex::new(HashSet::new()),
         }
     })
 }
 
-/// Start a new user turn and cancel every unfinished background media fetch
-/// from older turns. The returned generation belongs on that turn's
-/// `ToolContext`, so a queued/older agent cannot enqueue work after the user
-/// has already moved on.
+/// Allocate a unique generation for one user turn. Parallel turns keep their
+/// own background media work; cancellation is scoped by run directory.
 pub fn begin_background_media_generation() -> u64 {
     let generation = state().generation.fetch_add(1, Ordering::AcqRel) + 1;
-    if let Ok(mut cancelled) = state().cancelled_runs.lock() {
-        cancelled.clear();
-    }
     state().generation_tx.send_replace(generation);
     generation
 }
@@ -51,23 +46,18 @@ pub fn current_background_media_generation() -> u64 {
     state().generation.load(Ordering::Acquire)
 }
 
-pub fn background_media_generation_is_current(generation: u64) -> bool {
-    current_background_media_generation() == generation
-}
-
 pub fn cancel_background_media_for_run(run_dir: &str) {
     let run_dir = run_dir.trim();
     if run_dir.is_empty() {
         return;
     }
     if let Ok(mut cancelled) = state().cancelled_runs.lock() {
-        cancelled.insert(run_dir.to_string());
+        cancelled.insert(run_dir);
     }
     // Wake generation watchers too; their cancellation predicate also checks
     // the persistent run set, so subscribers cannot miss this targeted signal.
-    state()
-        .generation_tx
-        .send_replace(current_background_media_generation());
+    let signal = state().generation.fetch_add(1, Ordering::AcqRel) + 1;
+    state().generation_tx.send_replace(signal);
 }
 
 pub(crate) fn background_media_run_is_cancelled(run_dir: &str) -> bool {
@@ -75,6 +65,37 @@ pub(crate) fn background_media_run_is_cancelled(run_dir: &str) -> bool {
         .cancelled_runs
         .lock()
         .is_ok_and(|cancelled| cancelled.contains(run_dir))
+}
+
+/// Run dirs whose background media work has been called off. Cancellation is
+/// per run now that runs go in parallel, so this can no longer be cleared at
+/// the start of each turn; it is bounded instead, oldest first. The bound is
+/// far above the number of runs that could still have downloads in flight, so
+/// an evicted entry can only belong to a run that finished long ago.
+#[derive(Default)]
+struct CancelledRuns {
+    order: VecDeque<String>,
+    members: HashSet<String>,
+}
+
+impl CancelledRuns {
+    const MAX: usize = 512;
+
+    fn insert(&mut self, run_dir: &str) {
+        if !self.members.insert(run_dir.to_string()) {
+            return;
+        }
+        self.order.push_back(run_dir.to_string());
+        while self.order.len() > Self::MAX {
+            if let Some(evicted) = self.order.pop_front() {
+                self.members.remove(&evicted);
+            }
+        }
+    }
+
+    fn contains(&self, run_dir: &str) -> bool {
+        self.members.contains(run_dir)
+    }
 }
 
 pub(crate) fn subscribe_background_media_cancellation() -> watch::Receiver<u64> {
@@ -114,12 +135,11 @@ pub(crate) fn reserve_background_video_download(
 }
 
 pub(crate) async fn wait_for_background_media_cancellation(
-    generation: u64,
     run_dir: &str,
     receiver: &mut watch::Receiver<u64>,
 ) {
     loop {
-        if *receiver.borrow() != generation || background_media_run_is_cancelled(run_dir) {
+        if background_media_run_is_cancelled(run_dir) {
             return;
         }
         if receiver.changed().await.is_err() {
@@ -134,4 +154,33 @@ pub fn subscribe_background_media_events() -> broadcast::Receiver<BackgroundMedi
 
 pub(crate) fn emit_background_media_event(event: BackgroundMediaEvent) {
     let _ = state().events_tx.send(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CancelledRuns;
+
+    #[test]
+    fn cancelled_runs_stay_bounded_and_evict_the_oldest() {
+        let mut cancelled = CancelledRuns::default();
+        for index in 0..(CancelledRuns::MAX + 2) {
+            cancelled.insert(&format!("run-{index}"));
+        }
+
+        assert_eq!(cancelled.members.len(), CancelledRuns::MAX);
+        assert!(!cancelled.contains("run-0"));
+        assert!(!cancelled.contains("run-1"));
+        assert!(cancelled.contains("run-2"));
+        assert!(cancelled.contains(&format!("run-{}", CancelledRuns::MAX + 1)));
+    }
+
+    #[test]
+    fn cancelling_the_same_run_twice_does_not_grow_the_set() {
+        let mut cancelled = CancelledRuns::default();
+        cancelled.insert("run-a");
+        cancelled.insert("run-a");
+
+        assert_eq!(cancelled.order.len(), 1);
+        assert!(cancelled.contains("run-a"));
+    }
 }

--- a/core/src/media/mod.rs
+++ b/core/src/media/mod.rs
@@ -17,9 +17,8 @@ mod timing;
 mod video;
 
 pub use self::background::{
-    background_media_generation_is_current, begin_background_media_generation,
-    cancel_background_media_for_run, current_background_media_generation,
-    subscribe_background_media_events, BackgroundMediaEvent,
+    begin_background_media_generation, cancel_background_media_for_run,
+    current_background_media_generation, subscribe_background_media_events, BackgroundMediaEvent,
 };
 pub(crate) use self::background::{
     background_media_run_is_cancelled, background_video_download_semaphore,

--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,6 +42,30 @@ const REMOTE_IDLE_TICK: Duration = Duration::from_secs(15);
 /// died mid-run — real batch turns chain multi-minute searches for 10-15
 /// minutes.
 const REMOTE_MIN_RUN_BUDGET: Duration = Duration::from_secs(600);
+
+/// Global cap on agent runs that may hold this process's browser at once.
+/// Parallel tasks all drive one browser — one hosted session on the remote
+/// profile — so the ceiling belongs to the browser, not to any one task kind.
+/// Kept in step with the desktop's `MAX_CONCURRENT_AGENT_TASKS`; the env
+/// override exists for support cases, not as a product knob.
+const DEFAULT_MAX_BROWSER_RUNS: usize = 3;
+
+/// How long a run waits before asking for the browser again. Every refusal is
+/// a "come back later", never a failure: whatever blocks admission (another
+/// run finishing, a session being re-minted, a server hiccup) resolves on its
+/// own within seconds.
+const BROWSER_BUSY_RETRY: Duration = Duration::from_millis(1_500);
+
+/// Shared backoff after a hosted session fails to mint. Without it every
+/// queued run would fire its own request at a server that just said no.
+const REMOTE_MINT_COOLDOWN: Duration = Duration::from_secs(10);
+
+/// Smallest remaining hosted-session lifetime a run will start on while other
+/// runs are still on that session. Below `REMOTE_MIN_RUN_BUDGET` a lone run
+/// re-mints; a run that cannot re-mint without killing its neighbours takes
+/// the shortened budget instead, and only waits once the session is this close
+/// to dying — at which point the neighbours are about to lose it anyway.
+const REMOTE_MIN_SHARED_BUDGET: Duration = Duration::from_secs(60);
 
 /// Work-in-flight signal for the remote idle reaper. Guards are held by the
 /// entrypoints around browser-touching work (a daemon command, a whole agent
@@ -84,6 +109,217 @@ impl Activity {
     }
 }
 
+/// The browser cannot take this run right now, but it will shortly. Callers
+/// are expected to give back whatever else they hold (a task permit, a queue
+/// slot), sleep for `retry_after`, and ask again — never to fail the run.
+#[derive(Debug, Clone)]
+pub struct BrowserBusy {
+    pub retry_after: Duration,
+    pub reason: String,
+    pub kind: BrowserBusyKind,
+}
+
+/// Why admission was refused. Capacity refusals clear themselves as soon as
+/// the runs ahead finish, so they are retried indefinitely; connect refusals
+/// may be a server outage or a spent daily quota, so callers bound them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserBusyKind {
+    Capacity,
+    Connect,
+}
+
+impl BrowserBusy {
+    fn capacity(reason: impl Into<String>, retry_after: Duration) -> Self {
+        Self {
+            retry_after,
+            reason: reason.into(),
+            kind: BrowserBusyKind::Capacity,
+        }
+    }
+
+    fn connect(reason: impl Into<String>, retry_after: Duration) -> Self {
+        Self {
+            retry_after,
+            reason: reason.into(),
+            kind: BrowserBusyKind::Connect,
+        }
+    }
+
+    /// Recover the refusal from an `anyhow` chain. Page acquisition returns
+    /// `anyhow::Result`, so this is how a caller tells "wait and retry" apart
+    /// from a genuine browser failure.
+    pub fn find(error: &anyhow::Error) -> Option<&BrowserBusy> {
+        error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<BrowserBusy>())
+    }
+}
+
+impl std::fmt::Display for BrowserBusy {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            // A capacity refusal has no underlying failure to report, so it
+            // says why it is waiting. A connect refusal carries the real
+            // browser error and shows that instead — it is what the user sees
+            // if the retries run out.
+            BrowserBusyKind::Capacity => write!(formatter, "browser is busy: {}", self.reason),
+            BrowserBusyKind::Connect => formatter.write_str(&self.reason),
+        }
+    }
+}
+
+impl std::error::Error for BrowserBusy {}
+
+/// Process-wide admission to the browser. One connection serves every run, so
+/// the count of runs holding it, the decision to tear it down, and the backoff
+/// after a failed hosted mint all live in one place.
+#[derive(Debug)]
+struct BrowserAdmission {
+    max_runs: usize,
+    leases: AtomicUsize,
+    /// Serializes the connect/teardown decision. Without it two runs starting
+    /// together could both observe "needs re-mint" and disconnect each other's
+    /// freshly minted session.
+    gate: Mutex<()>,
+    cooldown_until: std::sync::Mutex<Option<Instant>>,
+    /// Set once a run has found that the browser has to be reopened. It stops
+    /// a second lease from being handed out, so the runs waiting for the swap
+    /// drain to one and that one can do it. Without it, several waiting runs
+    /// keep each other non-exclusive and none of them ever gets to reconnect.
+    /// Any successful page acquisition clears it, so it cannot outlive the
+    /// swap it was raised for.
+    draining: AtomicBool,
+}
+
+impl BrowserAdmission {
+    fn new() -> Self {
+        Self {
+            max_runs: configured_max_browser_runs(),
+            leases: AtomicUsize::new(0),
+            gate: Mutex::new(()),
+            cooldown_until: std::sync::Mutex::new(None),
+            draining: AtomicBool::new(false),
+        }
+    }
+
+    fn cooldown_remaining(&self) -> Option<Duration> {
+        let until = (*self
+            .cooldown_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()))?;
+        let remaining = until.saturating_duration_since(Instant::now());
+        (!remaining.is_zero()).then_some(remaining)
+    }
+
+    fn start_cooldown(&self) {
+        *self
+            .cooldown_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some(Instant::now() + REMOTE_MINT_COOLDOWN);
+    }
+
+    fn clear_cooldown(&self) {
+        *self
+            .cooldown_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    fn try_acquire(self: &Arc<Self>) -> Result<BrowserLease, BrowserBusy> {
+        if let Some(remaining) = self.cooldown_remaining() {
+            return Err(BrowserBusy::connect(
+                "waiting out the backoff from a failed browser connect",
+                remaining,
+            ));
+        }
+        let draining = self.draining.load(Ordering::Acquire);
+        let mut current = self.leases.load(Ordering::Acquire);
+        loop {
+            if draining && current >= 1 {
+                return Err(BrowserBusy::capacity(
+                    "the browser is being reopened for a queued run",
+                    BROWSER_BUSY_RETRY,
+                ));
+            }
+            if current >= self.max_runs {
+                return Err(BrowserBusy::capacity(
+                    format!(
+                        "{current} of {} browser run slots are in use",
+                        self.max_runs
+                    ),
+                    BROWSER_BUSY_RETRY,
+                ));
+            }
+            match self.leases.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+        Ok(BrowserLease {
+            admission: self.clone(),
+        })
+    }
+
+    /// True when the caller is the only run holding the browser, i.e. tearing
+    /// the connection down would not pull a page out from under anyone else.
+    /// A caller without a lease (the CLI and TUI, which run one task at a
+    /// time) reads zero and is exclusive by construction.
+    fn is_exclusive(&self) -> bool {
+        self.leases.load(Ordering::Acquire) <= 1
+    }
+
+    fn begin_draining(&self) {
+        self.draining.store(true, Ordering::Release);
+    }
+
+    fn finish_draining(&self) {
+        self.draining.store(false, Ordering::Release);
+    }
+}
+
+/// Whether waiting could plausibly fix a failed connect. Transport trouble, a
+/// server hiccup and a chrome that lost a race all clear on their own; an
+/// account that is not entitled to the hosted browser, a server with it turned
+/// off, and a device that has spent its daily allowance do not.
+fn connect_failure_is_retryable(reason: &str) -> bool {
+    const PERMANENT: [&str; 5] = [
+        "requires socai pro",
+        "pro access is required",
+        "is not enabled on this server",
+        "daily remote browser time limit",
+        "is not configured",
+    ];
+    let reason = reason.to_ascii_lowercase();
+    !PERMANENT.iter().any(|signal| reason.contains(signal))
+}
+
+fn configured_max_browser_runs() -> usize {
+    std::env::var("SOCAI_MAX_BROWSER_RUNS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_BROWSER_RUNS)
+}
+
+/// One run's claim on the shared browser, held for the whole run. Dropping it
+/// frees the slot and lets a waiting run in.
+#[derive(Debug)]
+pub struct BrowserLease {
+    admission: Arc<BrowserAdmission>,
+}
+
+impl Drop for BrowserLease {
+    fn drop(&mut self) {
+        self.admission.leases.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 /// RAII marker for in-flight browser work; see [`SocaiRuntime::begin_activity`].
 pub struct ActivityGuard {
     activity: Arc<Activity>,
@@ -107,6 +343,33 @@ pub struct SocaiRuntime {
     cdp: Cdp,
     site_pages: Arc<Mutex<HashMap<String, Arc<PageSession>>>>,
     activity: Arc<Activity>,
+    admission: Arc<BrowserAdmission>,
+}
+
+/// Own a newly created target until navigation and cache insertion complete.
+/// Async task cancellation drops local values, so this guard closes a target
+/// created immediately before a cancelled navigation await.
+struct UncachedPageGuard {
+    runtime: SocaiRuntime,
+    target_id: Option<String>,
+}
+
+impl UncachedPageGuard {
+    fn disarm(&mut self) {
+        self.target_id = None;
+    }
+}
+
+impl Drop for UncachedPageGuard {
+    fn drop(&mut self) {
+        let Some(target_id) = self.target_id.take() else {
+            return;
+        };
+        let runtime = self.runtime.clone();
+        tokio::spawn(async move {
+            let _ = runtime.close_target(&target_id).await;
+        });
+    }
 }
 
 impl SocaiRuntime {
@@ -115,7 +378,15 @@ impl SocaiRuntime {
             cdp: Cdp::new(),
             site_pages: Arc::new(Mutex::new(HashMap::new())),
             activity: Arc::new(Activity::new()),
+            admission: Arc::new(BrowserAdmission::new()),
         }
+    }
+
+    /// Claim one of the global browser run slots for a whole run. Refusals are
+    /// always temporary — see [`BrowserBusy`] — so a caller that gets one gives
+    /// back its other resources, waits, and asks again.
+    pub fn try_acquire_browser_lease(&self) -> Result<BrowserLease, BrowserBusy> {
+        self.admission.try_acquire()
     }
 
     /// Mark browser work as in flight until the returned guard drops. Every
@@ -269,20 +540,64 @@ impl SocaiRuntime {
             .await
     }
 
+    /// Return one reusable site page owned by a conversation session. Different
+    /// sessions always use different Chrome targets; later turns in the same
+    /// conversation keep using that session's target while it remains open.
+    ///
+    /// Takes the run's [`BrowserLease`] because acquiring a page can require
+    /// re-connecting the shared browser, which is only safe while no other run
+    /// is on it. When it is not safe the call returns a [`BrowserBusy`] error
+    /// instead of tearing down a browser someone else is driving.
+    pub async fn ensure_session_site_page_with_browser_options(
+        &self,
+        _lease: &BrowserLease,
+        session_id: &str,
+        site_id: &str,
+        start_url: &str,
+        options: ChromeConnectOptions,
+    ) -> Result<Arc<PageSession>> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            anyhow::bail!("session_id is empty");
+        }
+        let page_key = format!("session:{session_id}:{site_id}");
+        self.ensure_site_page_inner(&page_key, start_url, Some(options))
+            .await
+    }
+
     async fn ensure_site_page_inner(
         &self,
-        site_id: &str,
+        page_key: &str,
         start_url: &str,
         options: Option<ChromeConnectOptions>,
     ) -> Result<Arc<PageSession>> {
-        let site_id = site_id.trim();
-        if site_id.is_empty() {
-            anyhow::bail!("site_id is empty");
+        let page_key = page_key.trim();
+        if page_key.is_empty() {
+            anyhow::bail!("page key is empty");
         }
         self.ensure_idle_reaper();
 
+        // One run at a time decides whether the shared browser has to be torn
+        // down and re-opened. Parallel runs would otherwise disconnect each
+        // other's freshly opened browser, or each mint their own hosted
+        // session.
+        let _admission_gate = self.admission.gate.lock().await;
+        let exclusive = self.admission.is_exclusive();
+
         if let Some(options) = options.as_ref() {
             if !browser_status_matches_options(&self.browser_status().await, options) {
+                // The live browser is not the one this run is configured for
+                // (the user switched local/managed/remote between turns).
+                // Reconnecting closes every page, so it waits for the runs
+                // already driving the old browser to finish.
+                if !exclusive {
+                    self.admission.begin_draining();
+                    return Err(BrowserBusy::capacity(
+                        "the browser source changed while other runs are still on the previous browser",
+                        BROWSER_BUSY_RETRY,
+                    )
+                    .into());
+                }
                 let _ = self.close_all_site_sessions().await;
                 self.disconnect_browser().await;
             }
@@ -290,36 +605,90 @@ impl SocaiRuntime {
 
         // A remote session near its server-side end-of-life is re-minted
         // before work starts on it rather than dying mid-run: release now,
-        // and the reconnect below mints a session with a full budget.
+        // and the reconnect below mints a session with a full budget. Only a
+        // run that has the hosted session to itself may do that; otherwise it
+        // shares whatever budget is left, and waits only once that budget is
+        // too short to be worth starting on.
         if let Some(deadline) = self.cdp.remote_session_deadline().await {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
             if remaining < REMOTE_MIN_RUN_BUDGET {
-                tracing::info!(
-                    remaining_secs = remaining.as_secs(),
-                    "remote browser session near timeout; re-minting before new work"
-                );
-                self.drop_site_sessions().await;
-                self.disconnect_browser().await;
+                if !exclusive {
+                    if remaining < REMOTE_MIN_SHARED_BUDGET {
+                        self.admission.begin_draining();
+                        return Err(BrowserBusy::capacity(
+                            "the hosted browser session is about to expire and other runs are still on it",
+                            BROWSER_BUSY_RETRY,
+                        )
+                        .into());
+                    }
+                    tracing::info!(
+                        remaining_secs = remaining.as_secs(),
+                        "remote browser session near timeout; sharing it with the runs already in flight"
+                    );
+                } else {
+                    tracing::info!(
+                        remaining_secs = remaining.as_secs(),
+                        "remote browser session near timeout; re-minting before new work"
+                    );
+                    self.drop_site_sessions().await;
+                    self.disconnect_browser().await;
+                }
             }
         }
 
         let mut pages = self.site_pages.lock().await;
-        if let Some(page) = pages.get(site_id) {
+        if let Some(page) = pages.get(page_key) {
             if page.page_info().await.is_ok() {
+                self.admission.finish_draining();
                 return Ok(page.clone());
             }
-            pages.remove(site_id);
+            pages.remove(page_key);
         }
 
-        match options {
-            Some(options) => wait_browser_connected_with_options(self, options).await?,
-            None => wait_browser_connected(self).await?,
+        let profile = options.as_ref().map(|options| options.profile);
+        let connect = match options {
+            Some(options) => wait_browser_connected_with_options(self, options).await,
+            None => wait_browser_connected(self).await,
+        };
+        match connect {
+            Ok(()) => self.admission.clear_cooldown(),
+            // Connecting failed for everyone, not just this run: a hosted mint
+            // that the server refused, a chrome that would not come up. Back
+            // the whole process off once and let the caller retry rather than
+            // failing a run on what is usually a transient condition.
+            Err(error) => {
+                let reason = format!("{error:#}");
+                // Only the run path (which passes connect options) retries;
+                // the CLI and TUI ask once and want the raw failure verbatim.
+                // A failure that waiting cannot fix — an unentitled account, a
+                // spent daily quota — is reported straight away too, so the
+                // user reads what actually went wrong instead of watching the
+                // task sit in the queue.
+                if profile.is_none() || !connect_failure_is_retryable(&reason) {
+                    tracing::warn!(profile = ?profile, error = %reason, "browser connect failed");
+                    return Err(error);
+                }
+                self.admission.start_cooldown();
+                tracing::warn!(profile = ?profile, error = %reason, "browser connect failed; backing off");
+                return Err(anyhow::Error::new(BrowserBusy::connect(
+                    reason,
+                    REMOTE_MINT_COOLDOWN,
+                )));
+            }
         }
         let page = Arc::new(self.create_page("about:blank").await?);
+        let mut page_guard = UncachedPageGuard {
+            runtime: self.clone(),
+            target_id: Some(page.target_id().to_string()),
+        };
         if !start_url.trim().is_empty() {
             page.navigate_with_timeout(start_url, 60.0).await?;
         }
-        pages.insert(site_id.to_string(), page.clone());
+        pages.insert(page_key.to_string(), page.clone());
+        page_guard.disarm();
+        // Whatever swap this run was waiting for is done; let the queued runs
+        // back in.
+        self.admission.finish_draining();
         Ok(page)
     }
 
@@ -581,6 +950,109 @@ pub async fn run_agent_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn admission(max_runs: usize) -> Arc<BrowserAdmission> {
+        Arc::new(BrowserAdmission {
+            max_runs,
+            leases: AtomicUsize::new(0),
+            gate: Mutex::new(()),
+            cooldown_until: std::sync::Mutex::new(None),
+            draining: AtomicBool::new(false),
+        })
+    }
+
+    #[test]
+    fn browser_admission_caps_concurrent_runs_and_frees_the_slot_on_drop() {
+        let admission = admission(3);
+        let first = admission.try_acquire().expect("first run admitted");
+        let second = admission.try_acquire().expect("second run admitted");
+        let third = admission.try_acquire().expect("third run admitted");
+
+        let refused = admission.try_acquire().expect_err("fourth run refused");
+        assert_eq!(refused.kind, BrowserBusyKind::Capacity);
+
+        drop(first);
+        admission.try_acquire().expect("slot freed by the drop");
+        drop((second, third));
+    }
+
+    #[test]
+    fn browser_admission_is_exclusive_only_for_a_lone_run() {
+        let admission = admission(3);
+        let first = admission.try_acquire().expect("first run admitted");
+        assert!(admission.is_exclusive());
+
+        let second = admission.try_acquire().expect("second run admitted");
+        assert!(!admission.is_exclusive());
+
+        drop(second);
+        assert!(admission.is_exclusive());
+        drop(first);
+    }
+
+    #[test]
+    fn draining_admits_one_run_at_a_time_so_the_browser_can_be_reopened() {
+        let admission = admission(3);
+        let running = admission.try_acquire().expect("run in flight");
+        admission.begin_draining();
+
+        // Nothing may join the run that still holds the old browser…
+        let refused = admission
+            .try_acquire()
+            .expect_err("no second run while draining");
+        assert_eq!(refused.kind, BrowserBusyKind::Capacity);
+
+        // …but once it finishes, the next run gets in alone and can swap.
+        drop(running);
+        let swapper = admission.try_acquire().expect("lone run admitted");
+        assert!(admission.is_exclusive());
+        assert!(admission.try_acquire().is_err());
+
+        admission.finish_draining();
+        admission.try_acquire().expect("normal admission resumes");
+        drop(swapper);
+    }
+
+    #[test]
+    fn a_failed_connect_backs_every_run_off_until_the_cooldown_clears() {
+        let admission = admission(3);
+        admission.start_cooldown();
+
+        let refused = admission
+            .try_acquire()
+            .expect_err("held off by the backoff");
+        assert_eq!(refused.kind, BrowserBusyKind::Connect);
+        assert!(refused.retry_after <= REMOTE_MINT_COOLDOWN);
+
+        admission.clear_cooldown();
+        admission
+            .try_acquire()
+            .expect("admitted once the backoff clears");
+    }
+
+    #[test]
+    fn a_spent_daily_quota_is_reported_rather_than_retried() {
+        assert!(!connect_failure_is_retryable(
+            "remote browser session request failed (429): daily remote browser time limit reached"
+        ));
+        assert!(!connect_failure_is_retryable(
+            "socai remote browser requires socai pro — run `socai pro activate <invite_code>`"
+        ));
+        assert!(connect_failure_is_retryable(
+            "CDP disconnected: browser websocket wss://…/ did not respond within 20s"
+        ));
+    }
+
+    #[test]
+    fn browser_busy_survives_an_anyhow_chain() {
+        let error: anyhow::Error =
+            BrowserBusy::capacity("all slots in use", BROWSER_BUSY_RETRY).into();
+        let wrapped = error.context("failed to open the tab for this run");
+
+        let busy = BrowserBusy::find(&wrapped).expect("marker recovered from the chain");
+        assert_eq!(busy.kind, BrowserBusyKind::Capacity);
+        assert_eq!(busy.retry_after, BROWSER_BUSY_RETRY);
+    }
 
     #[test]
     fn resolve_llm_model_for_prefers_explicit_provider_over_model_prefix() {

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -4,7 +4,8 @@ pub use self::engine::{
     create_llm_provider, create_llm_provider_for, create_llm_provider_for_task,
     ensure_llm_provider_configured, ensure_llm_provider_configured_for, resolve_llm_model,
     resolve_llm_model_for, run_agent_task, wait_browser_connected,
-    wait_browser_connected_with_options, ActivityGuard, AgentRunConfig, SocaiRuntime,
+    wait_browser_connected_with_options, ActivityGuard, AgentRunConfig, BrowserBusy,
+    BrowserBusyKind, BrowserLease, SocaiRuntime,
 };
 pub use crate::cdp::{
     BrowserEvent as RuntimeBrowserEvent, ChromeConnectOptions, ChromeProfile,

--- a/core/src/sites/xhs/tools.rs
+++ b/core/src/sites/xhs/tools.rs
@@ -17,11 +17,10 @@ use crate::agent::tool::{
 use crate::agent::{Backend as LlmProvider, Tool, ToolContext, ToolResult};
 use crate::cdp::PageSession;
 use crate::media::{
-    background_media_generation_is_current, background_media_run_is_cancelled,
-    background_video_download_semaphore, current_background_media_generation,
-    emit_background_media_event, ocr_diagnostics, ocr_warm_up, reserve_background_video_download,
-    subscribe_background_media_cancellation, timing_delta, wait_for_background_media_cancellation,
-    BackgroundMediaEvent, MediaProcessor, TimingSnapshot,
+    background_media_run_is_cancelled, background_video_download_semaphore,
+    current_background_media_generation, emit_background_media_event, ocr_diagnostics, ocr_warm_up,
+    reserve_background_video_download, subscribe_background_media_cancellation, timing_delta,
+    wait_for_background_media_cancellation, BackgroundMediaEvent, MediaProcessor, TimingSnapshot,
 };
 use async_trait::async_trait;
 use serde_json::{json, Map, Value};
@@ -2032,7 +2031,7 @@ fn emit_background_note_update(ctx: &ToolContext, note_id: &str) {
 
 /// Complete video files after a desktop macro has returned its poster-only note
 /// bundle. Downloads are process-wide bounded, survive the agent's final answer,
-/// and are canceled by the next desktop user-turn generation.
+/// and are cancelled when their own run is cancelled or superseded by a reply.
 fn spawn_background_video_downloads(
     notes: &mut [Value],
     media: &Option<MediaProcessor>,
@@ -2048,9 +2047,7 @@ fn spawn_background_video_downloads(
         .background_media_generation
         .unwrap_or_else(current_background_media_generation);
     let run_dir = ctx.run_dir.to_string_lossy().into_owned();
-    if !background_media_generation_is_current(generation)
-        || background_media_run_is_cancelled(&run_dir)
-    {
+    if background_media_run_is_cancelled(&run_dir) {
         return;
     }
 
@@ -2157,7 +2154,7 @@ fn spawn_background_video_downloads(
                     Ok(permit) => permit,
                     Err(_) => return,
                 },
-                _ = wait_for_background_media_cancellation(generation, &run_dir, &mut cancellation) => {
+                _ = wait_for_background_media_cancellation(&run_dir, &mut cancellation) => {
                     if set_recorded_video_status(&ctx, &note_id, None, None) {
                         emit_background_note_update(&ctx, &note_id);
                     }
@@ -2167,7 +2164,7 @@ fn spawn_background_video_downloads(
             let download = media.download_video_file(&video, &note_id, &title, &referer);
             let completed_video = tokio::select! {
                 video = download => video,
-                _ = wait_for_background_media_cancellation(generation, &run_dir, &mut cancellation) => {
+                _ = wait_for_background_media_cancellation(&run_dir, &mut cancellation) => {
                     if set_recorded_video_status(&ctx, &note_id, None, None) {
                         emit_background_note_update(&ctx, &note_id);
                     }
@@ -2175,9 +2172,7 @@ fn spawn_background_video_downloads(
                 },
             };
             drop(permit);
-            if !background_media_generation_is_current(generation)
-                || background_media_run_is_cancelled(&run_dir)
-            {
+            if background_media_run_is_cancelled(&run_dir) {
                 if set_recorded_video_status(&ctx, &note_id, None, None) {
                     emit_background_note_update(&ctx, &note_id);
                 }


### PR DESCRIPTION
# Summary
- Run up to 3 desktop agent tasks concurrently and keep the 4th task queued until a permit is released.
- Apply the same global browser admission limit while giving each conversation session its own Chrome target.
- Reconcile Socai managed-task capacity across devices through server-authoritative acquire and settle calls.
- Reuse one process-wide OpenAI-compatible HTTP client so long browser turns do not maintain three independent idle connection pools.

# Observed failure
Three desktop tasks started within 4.109 seconds and overlapped for about 437 seconds. Their Xiaohongshu search spans also overlapped across all three sessions, so the local scheduler did admit the full concurrency limit.

One task completed. Two tasks failed on their second ChatGPT request after 406,845 ms and 398,724 ms with:

```text
client error (Connect): tcp connect error:
Operation timed out (os error 60)
```

The failure was in connection recovery after long browser work, after all three tasks had already entered the running state.

# Implementation
- Set the desktop task semaphore and browser admission limit to 3; a 4th task waits and acquires the released permit.
- Use `session:{conversation_session_id}:{site_id}` as the page cache key, preserving one target per conversation and reusing it for follow-ups.
- Release a managed server slot before waiting on a busy or failed browser admission attempt.
- Add `UncachedPageGuard` immediately after `Target.createTarget` to close a target when navigation or cache insertion is cancelled.
- Add `UnboundPageGuard` after the runtime returns a page to close a target when task-registry binding is cancelled.
- Bind `target_id` only while the task is still queued or running, under the task registry mutex.
- Share a process-wide `reqwest::Client` with a 20-second connect timeout, 180-second request timeout, 300-second idle pool timeout, and 30-second TCP keepalive.
- Keep request authentication, provider selection, model selection, and conversation messages scoped to each task.

# Validation
- `cargo test -p socai-core --lib`: 99 passed, 2 ignored, 0 failed.
- `cargo test -p socai_app --lib`: 3 passed, 0 failed.
- `cargo check --workspace --all-targets`: passed.
- `pnpm run build`: passed, 81 modules transformed.
- `git diff --check`: passed.
- Three concurrent ChatGPT Codex probes: 3/3 passed in 2.031s, 3.126s, and 7.061s.
- Isolated Chrome probe: 3 distinct session targets, isolated title markers, 4th browser lease refused, all created targets closed.
- GitHub `agent-benchmark / probe`: passed (run 32347147837).
- The branch is rebased on current `upstream/main` and contains one commit.

# Deployment dependency
This client depends on socai-io/socai-server#26. On 2026-08-20, `POST https://api.socai.work/v1/llm/tasks/pr263-probe/acquire` still returned HTTP 404. Keep this PR in draft until the server acquire route is deployed and the same-account, cross-device 3+1 sequence can be validated end to end.
