### PR TITLE
fix(runtime): widen remote session re-mint margin to 600s

### DIFF
--- a/core/src/runtime/engine.rs
+++ b/core/src/runtime/engine.rs
@@ -35,8 +35,12 @@ const REMOTE_IDLE_TICK: Duration = Duration::from_secs(15);
 /// Minimum remaining session lifetime worth starting new work on. A remote
 /// session's clock starts at mint, so one reused late would hand the run an
 /// invisible, shortened deadline; re-minting up front trades a few seconds of
-/// connect latency for not dying mid-run.
-const REMOTE_MIN_RUN_BUDGET: Duration = Duration::from_secs(300);
+/// connect latency for not dying mid-run. This check runs only at task start
+/// (tools hold the page for the whole turn), so it must cover a realistic
+/// turn, not a single call: at 300s, turns inheriting a part-used session
+/// died mid-run — real batch turns chain multi-minute searches for 10-15
+/// minutes.
+const REMOTE_MIN_RUN_BUDGET: Duration = Duration::from_secs(600);
 
 /// Work-in-flight signal for the remote idle reaper. Guards are held by the
 /// entrypoints around browser-touching work (a daemon command, a whole agent


### PR DESCRIPTION
## Why

Investigation of the many 15-minute TIMED_OUT Browserbase sessions (traces + prod DB, 2026-08-18 incident): agent batch turns chain multi-minute searches for 10-15 minutes, while a remote session has a fixed lifetime from mint that nothing extends. The re-mint guard (`REMOTE_MIN_RUN_BUDGET`) runs only at task start — tools capture the page for the whole turn — so a turn inheriting a session with 5-9 minutes left passed the 300s check and died mid-run. Five consecutive batch turns on 08-18 ended `interrupted` at the exact second their session hit the 900s wall.

## What

- `REMOTE_MIN_RUN_BUDGET` 300s → 600s, with a doc comment explaining the task-start-only constraint that sizes it.

Pairs with socai-server#27 (session timeout 900s → 1800s, daily budget 120 → 180 min). Server sends `timeout_seconds` in the mint response, so existing clients pick the longer lifetime up without this change; this PR reduces mid-run deaths for turns starting on part-used sessions.

Mid-run rotation (per-step deadline check + re-resolving the page through the runtime) remains the durable fix and should ride with the #255-#257 recovery work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
