### PR TITLE
fix(agent): pin follow-up compaction to the current user task

### DIFF
--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -252,6 +252,7 @@ pub async fn run_agent_with_events(
             &mut messages,
             options.compact_after_messages,
             options.keep_recent_messages,
+            options.seed_messages.len(),
         ) {
             // The trace is an append-only diagnostic record. The rewritten
             // transcript is local context management, so restart its cursor
@@ -559,6 +560,7 @@ pub async fn run_agent_with_events(
             &mut messages,
             options.compact_after_messages,
             options.keep_recent_messages,
+            options.seed_messages.len(),
         ) {
             traced_len = messages.len();
         }

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -19,17 +19,21 @@ const COMPACT_CONTEXT_HEADING: &str = "# Earlier compacted context";
 const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 
 /// Rewrite the transcript only when it has grown beyond `compact_after` full
-/// messages. The original first message remains, the last `keep_recent`
-/// messages remain verbatim (widened backward when the window would open on
-/// a tool_result message, so tool_use/tool_result pairs never split), and
-/// the older tool outputs become artifact locators. Mutating the transcript,
-/// rather than rebuilding a summary for every request, leaves the request
-/// prefix stable until the next sawtooth compaction point and therefore
-/// friendly to provider prompt caches.
+/// messages. The message at `anchor_user_index` — the current run's user task,
+/// index `0` for a fresh run and `seed_messages.len()` for a follow-up — stays
+/// verbatim at the front; the last `keep_recent` messages remain verbatim
+/// (widened backward when the window would open on a tool_result message, so
+/// tool_use/tool_result pairs never split); older tool outputs become artifact
+/// locators. Follow-up runs (`anchor_user_index > 0`) also get a short task
+/// reminder immediately before the recent tail. Mutating the transcript, rather
+/// than rebuilding a summary for every request, leaves the request prefix
+/// stable until the next sawtooth compaction point and therefore friendly to
+/// provider prompt caches.
 pub fn compact_messages_for_context(
     messages: &mut Vec<Message>,
     compact_after: usize,
     keep_recent: usize,
+    anchor_user_index: usize,
 ) -> bool {
     if compact_after == 0
         || keep_recent == 0
@@ -51,19 +55,52 @@ pub fn compact_messages_for_context(
     while recent_start > 1 && contains_tool_result(&messages[recent_start]) {
         recent_start -= 1;
     }
-    let original = messages[0].clone();
-    let older = &messages[1..recent_start];
-    let recent = messages[recent_start..].to_vec();
-    let evidence = compact_older_messages(older);
+    let anchor_idx = anchor_user_index.min(messages.len().saturating_sub(1));
+    let anchor = messages[anchor_idx].clone();
+    let older: Vec<Message> = (0..recent_start)
+        .filter(|&index| index != anchor_idx)
+        .map(|index| messages[index].clone())
+        .collect();
+    let recent: Vec<Message> = messages[recent_start..]
+        .iter()
+        .enumerate()
+        .filter(|(offset, _)| recent_start + offset != anchor_idx)
+        .map(|(_, message)| message.clone())
+        .collect();
+    let evidence = compact_older_messages(&older);
 
-    let mut compacted = Vec::with_capacity(2 + recent.len());
-    compacted.push(original);
+    let mut compacted = Vec::with_capacity(3 + recent.len());
+    compacted.push(anchor);
     if !evidence.is_empty() {
         compacted.push(Message::user(evidence));
+    }
+    if anchor_user_index > 0 {
+        if let Some(task) = user_text(&compacted[0]) {
+            compacted.push(current_task_reminder(&task));
+        }
     }
     compacted.extend(recent);
     *messages = compacted;
     true
+}
+
+fn user_text(message: &Message) -> Option<String> {
+    if !matches!(message.role, MessageRole::User) {
+        return None;
+    }
+    match &message.content {
+        MessageContent::Text(text) => {
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        MessageContent::Blocks(_) => None,
+    }
+}
+
+fn current_task_reminder(task: &str) -> Message {
+    Message::user(format!(
+        "Current task (do not confuse with earlier turns): {task}"
+    ))
 }
 
 fn contains_tool_result(message: &Message) -> bool {
@@ -122,6 +159,13 @@ fn compact_older_messages(messages: &[Message]) -> String {
                 collect_artifact_evidence(&value, &mut artifacts);
             }
         }
+    }
+
+    if let Some(user) = pending_user.take().filter(|text| !text.trim().is_empty()) {
+        turns.push(compact_turn_markdown(
+            Some(user.as_str()),
+            "(no assistant report was recorded before compaction)",
+        ));
     }
 
     let mut rendered = if inherited.is_empty() {


### PR DESCRIPTION
## Summary

Follow-up agent runs seed prior conversation turns (`user` + assistant `report.md` pairs) and then append the new user task. Sawtooth context compaction always pinned `messages[0]`, which on a follow-up is the **first turn's** user message — not the current run's task. After compaction the model therefore saw the wrong instruction at the prefix, while the real task could be dropped from the compacted summary entirely.

This PR:
- Pins compaction to `messages[seed_messages.len()]` (index `0` for fresh runs, unchanged).
- Excludes the anchor from the compacted older region and deduplicates it from the recent tail.
- Flushes orphan `pending_user` text into compact summaries (current task mid tool loop).
- Adds a follow-up-only reminder immediately before the recent tail: `Current task (do not confuse with earlier turns): …`

**Repro trace:** `096e9ac5f75953672519149eccccab28` (desktop, session `20260820_093659_xhs_…`).

Turn 5 task: *「帮我找出小红书10篇吐槽盲盒酒局/盲盒饭局活动的帖子 并帮我总结下大家吐槽的点有哪些」*. The model answered with the turn-4 KOL shortlist instead. Step 14 reasoning explicitly treated `messages[0]` as a repeat of the original KOL request.

## Before / after (turn 5, after first compaction at step 7)

Shared setup: `seed_messages = 8`, current task at index `8`, 21 messages before compact (`compact_after = 20`, `keep_recent = 10`). Indices 0–7 are four prior turns; 9–20 are steps 1–6 tool traces.

### Before

```
messages[0]  user: turn-1 KOL request (wrong pinned prefix)
messages[1]  user: # Earlier compacted context
               - Turn 1–4 report excerpts + artifact locators from step-1 search
               - current turn-5 task often missing (pending_user not flushed)
messages[2..] recent verbatim tail (steps 2–6 search/shell tool results)
```

At step 14 the model saw the KOL text at `[0]`, a thick compact blob still dominated by KOL/report evidence, and recent shell/grep output — but **no clear, top-level turn-5 task**.

### After

```
messages[0]  user: turn-5 task (anchor)
messages[1]  user: # Earlier compacted context (prior turns + early in-run evidence)
messages[2]  user: Current task (do not confuse with earlier turns): …
messages[3..] recent verbatim tail
```

## Files

- `core/src/agent/memory.rs` — anchor index, reminder, orphan user flush
- `core/src/agent/loop.rs` — pass `options.seed_messages.len()` into compaction

## Test plan

- [ ] Start a multi-turn desktop conversation; on a follow-up run that exceeds 20 messages, confirm compacted requests keep the **current** user task at `[0]` and include the reminder before the recent tail.
- [ ] Fresh single-turn runs behave as before (`anchor_user_index = 0`, no reminder).
- [ ] Re-run or inspect a trace similar to `096e9ac5f75953672519149eccccab28` turn 5: after compaction, step-14 reasoning should reference the complaint-post task, not the KOL brief.


Made with [Cursor](https://cursor.com)