### PR TITLE
feat(agent): preserve XHS evidence during compaction

### DIFF
--- a/core/src/agent/compaction.rs
+++ b/core/src/agent/compaction.rs
@@ -37,6 +37,38 @@ const STRIPPED_ENRICHMENT_KEY: &str = "top_comments";
 /// What a stripped enrichment value is replaced with.
 const ENRICHMENT_OMITTED_MARKER: &str = "[omitted to fit context; full data in the run artifact]";
 
+const XHS_NOTE_METADATA_FIELDS: &[&str] = &[
+    "note_id",
+    "url",
+    "title",
+    "author",
+    "author_id",
+    "date",
+    "date_edited",
+    "type",
+    "likes",
+    "favorites",
+    "comments_count",
+    "location",
+    "ip_location",
+    "hashtags",
+];
+
+const XHS_PROFILE_FIELDS: &[&str] = &[
+    "display_name",
+    "nickname",
+    "name",
+    "xhs_id",
+    "url",
+    "bio",
+    "ip_location",
+    "verified",
+    "verification",
+    "followers",
+    "following",
+    "likes_and_collections",
+];
+
 /// Trim a string to at most `max_chars` characters, suffixing
 /// `... [truncated]` when the original was longer. Char-based, not byte-based,
 /// to keep UTF-8 safe.
@@ -58,8 +90,13 @@ pub fn truncate_result(text: &str, max_chars: usize) -> String {
     if count <= max_chars {
         return text.to_string();
     }
-    let mut out: String = text.chars().take(max_chars).collect();
-    out.push_str("\n... [truncated]");
+    const MARKER: &str = "\n... [truncated]";
+    let marker_chars = MARKER.chars().count();
+    if max_chars <= marker_chars {
+        return MARKER.chars().take(max_chars).collect();
+    }
+    let mut out: String = text.chars().take(max_chars - marker_chars).collect();
+    out.push_str(MARKER);
     out
 }
 
@@ -153,6 +190,30 @@ pub fn compress_text_maybe_json(text: &str, max_chars: usize) -> String {
         return text.to_string();
     }
     if let Ok(mut value) = serde_json::from_str::<Value>(text) {
+        // XHS search/author results carry a durable artifact pointer and a
+        // potentially large note list. Compact every note into a metadata-first
+        // record before the generic array limiter can reduce the list to five.
+        // A small comment/reply sample keeps common question-answer evidence;
+        // OCR and media remain in the artifact.
+        let xhs_result = is_xhs_artifact_result(&value);
+        for (level, body_cap, comment_limit) in [
+            (XhsMetadataLevel::Full, 700, 3),
+            (XhsMetadataLevel::Full, 320, 1),
+            (XhsMetadataLevel::Full, 0, 0),
+            (XhsMetadataLevel::Identity, 0, 0),
+            (XhsMetadataLevel::IdOnly, 0, 0),
+        ] {
+            if let Some(compact) = compact_xhs_tool_result(&value, level, body_cap, comment_limit) {
+                if let Ok(rendered) = serde_json::to_string(&compact) {
+                    if rendered.chars().count() <= max_chars {
+                        return rendered;
+                    }
+                }
+            }
+        }
+        if xhs_result {
+            return compact_xhs_id_index_to_budget(&value, max_chars);
+        }
         if cap_string_key_deep(&mut value, "ocr_text", OCR_TEXT_MAX_CHARS) {
             if let Ok(rendered) = serde_json::to_string(&value) {
                 if rendered.chars().count() <= max_chars {
@@ -179,6 +240,299 @@ pub fn compress_text_maybe_json(text: &str, max_chars: usize) -> String {
         }
     }
     truncate_result(text, max_chars)
+}
+
+#[derive(Clone, Copy)]
+enum XhsMetadataLevel {
+    Full,
+    Identity,
+    IdOnly,
+}
+
+fn is_xhs_artifact_result(value: &Value) -> bool {
+    value
+        .pointer("/artifact/path")
+        .and_then(Value::as_str)
+        .is_some_and(|path| !path.trim().is_empty())
+        && value.as_object().is_some_and(|source| {
+            source.get("notes").is_some_and(Value::is_array)
+                || source.get("cards").is_some_and(Value::is_array)
+        })
+}
+
+fn compact_xhs_tool_result(
+    value: &Value,
+    level: XhsMetadataLevel,
+    body_cap: usize,
+    comment_limit: usize,
+) -> Option<Value> {
+    let source = value.as_object()?;
+    let artifact_path = value.pointer("/artifact/path")?.as_str()?.trim();
+    if !is_xhs_artifact_result(value) {
+        return None;
+    }
+
+    let mut compact = Map::new();
+    for key in [
+        "ok",
+        "reason",
+        "error",
+        "query",
+        "author_id",
+        "search_feedback",
+    ] {
+        if let Some(field) = source.get(key) {
+            compact.insert(key.to_string(), compact_xhs_field(field, 320));
+        }
+    }
+    compact.insert(
+        "artifact".into(),
+        json_object([("path", Value::String(artifact_path.to_string()))]),
+    );
+    if let Some(profile) = source.get("profile").and_then(Value::as_object) {
+        compact.insert(
+            "profile".into(),
+            Value::Object(compact_selected_fields(profile, XHS_PROFILE_FIELDS)),
+        );
+    }
+    for key in ["notes", "cards"] {
+        let Some(items) = source.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        compact.insert(
+            key.to_string(),
+            Value::Array(
+                items
+                    .iter()
+                    .filter_map(|item| compact_xhs_note(item, level, body_cap, comment_limit))
+                    .collect(),
+            ),
+        );
+    }
+    compact.insert(
+        "context_compaction".into(),
+        json_object([
+            (
+                "note",
+                Value::String(
+                    "Post bodies and comment threads were compacted; full note data, OCR, and media metadata remain in the artifact."
+                        .to_string(),
+                ),
+            ),
+            ("artifact_path", Value::String(artifact_path.to_string())),
+        ]),
+    );
+    Some(Value::Object(compact))
+}
+
+fn compact_xhs_note(
+    item: &Value,
+    level: XhsMetadataLevel,
+    body_cap: usize,
+    comment_limit: usize,
+) -> Option<Value> {
+    let wrapped = item.get("entity").is_some();
+    let entity = item.get("entity").unwrap_or(item).as_object()?;
+    let fields = match level {
+        XhsMetadataLevel::Full => XHS_NOTE_METADATA_FIELDS,
+        XhsMetadataLevel::Identity => &[
+            "note_id",
+            "url",
+            "title",
+            "author",
+            "author_id",
+            "date",
+            "type",
+        ],
+        XhsMetadataLevel::IdOnly => &["note_id"],
+    };
+    let mut compact = compact_selected_fields(entity, fields);
+    if matches!(level, XhsMetadataLevel::Full) && body_cap > 0 {
+        if let Some(content) = entity
+            .get("content")
+            .and_then(Value::as_str)
+            .filter(|content| !content.is_empty())
+        {
+            compact.insert("content".into(), Value::String(truncate(content, body_cap)));
+        }
+    }
+    if matches!(level, XhsMetadataLevel::Full) && comment_limit > 0 {
+        if let Some(comments) = entity.get("top_comments").and_then(Value::as_array) {
+            let comments = comments
+                .iter()
+                .take(comment_limit)
+                .filter_map(compact_xhs_comment)
+                .collect::<Vec<_>>();
+            if !comments.is_empty() {
+                compact.insert("top_comments".into(), Value::Array(comments));
+            }
+        }
+    }
+    if compact.is_empty() {
+        return None;
+    }
+    let compact = Value::Object(compact);
+    if wrapped {
+        Some(json_object([("entity", compact)]))
+    } else {
+        Some(compact)
+    }
+}
+
+fn compact_xhs_comment(comment: &Value) -> Option<Value> {
+    if let Some(text) = comment.as_str() {
+        return Some(Value::String(truncate(text, 240)));
+    }
+    let source = comment.as_object()?;
+    let mut compact = Map::new();
+    for key in ["text", "author", "is_author", "likes", "time"] {
+        let Some(value) = source.get(key) else {
+            continue;
+        };
+        compact.insert(
+            key.to_string(),
+            match value {
+                Value::String(text) => Value::String(truncate(text, 240)),
+                other => other.clone(),
+            },
+        );
+    }
+    for key in ["sub_comments", "replies"] {
+        let Some(replies) = source.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        let replies = replies
+            .iter()
+            .take(2)
+            .filter_map(compact_xhs_comment)
+            .collect::<Vec<_>>();
+        if !replies.is_empty() {
+            compact.insert(key.to_string(), Value::Array(replies));
+        }
+    }
+    (!compact.is_empty()).then_some(Value::Object(compact))
+}
+
+fn compact_selected_fields(source: &Map<String, Value>, fields: &[&str]) -> Map<String, Value> {
+    let mut compact = Map::new();
+    for key in fields {
+        if let Some(value) = source.get(*key) {
+            compact.insert((*key).to_string(), compact_xhs_field(value, 320));
+        }
+    }
+    compact
+}
+
+fn compact_xhs_field(value: &Value, string_cap: usize) -> Value {
+    match value {
+        Value::String(text) => Value::String(truncate_exact(text, string_cap)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .take(12)
+                .map(|item| compact_xhs_field(item, 80))
+                .collect(),
+        ),
+        Value::Object(_) => compact_json_value_with_body_cap(value, string_cap),
+        other => other.clone(),
+    }
+}
+
+fn truncate_exact(text: &str, max_chars: usize) -> String {
+    let text = text.trim();
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+    let mut compact: String = text.chars().take(max_chars.saturating_sub(1)).collect();
+    compact.push('…');
+    compact
+}
+
+fn compact_xhs_id_index_to_budget(value: &Value, max_chars: usize) -> String {
+    let artifact_path = value
+        .pointer("/artifact/path")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut compact = Map::new();
+    compact.insert(
+        "artifact".into(),
+        json_object([("path", Value::String(truncate_exact(artifact_path, 1_000)))]),
+    );
+    let total = ["notes", "cards"]
+        .into_iter()
+        .filter_map(|key| value.get(key).and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    compact.insert("total_items".into(), Value::from(total));
+    compact.insert("retained_items".into(), Value::from(0));
+    compact.insert("omitted_items".into(), Value::from(total));
+    compact.insert(
+        "context_compaction".into(),
+        Value::String(
+            "Metadata is indexed by note_id; full records remain in the artifact.".into(),
+        ),
+    );
+
+    let mut retained = 0usize;
+    for key in ["notes", "cards"] {
+        let Some(items) = value.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        let mut ids = Vec::new();
+        for item in items {
+            let entity = item.get("entity").unwrap_or(item);
+            let Some(note_id) = entity
+                .get("note_id")
+                .or_else(|| entity.get("id"))
+                .and_then(Value::as_str)
+                .filter(|id| !id.trim().is_empty())
+            else {
+                continue;
+            };
+            ids.push(Value::String(truncate_exact(note_id, 96)));
+            compact.insert(key.into(), Value::Array(ids.clone()));
+            compact.insert("retained_items".into(), Value::from(retained + 1));
+            compact.insert(
+                "omitted_items".into(),
+                Value::from(total.saturating_sub(retained + 1)),
+            );
+            let fits = serde_json::to_string(&compact)
+                .is_ok_and(|rendered| rendered.chars().count() <= max_chars);
+            if !fits {
+                ids.pop();
+                compact.insert(key.into(), Value::Array(ids));
+                break;
+            }
+            retained += 1;
+        }
+    }
+    compact.insert("retained_items".into(), Value::from(retained));
+    compact.insert(
+        "omitted_items".into(),
+        Value::from(total.saturating_sub(retained)),
+    );
+    serde_json::to_string(&compact)
+        .ok()
+        .filter(|rendered| rendered.chars().count() <= max_chars)
+        .unwrap_or_else(|| {
+            if max_chars >= 2 {
+                "{}".to_string()
+            } else {
+                String::new()
+            }
+        })
+}
+
+fn json_object<const N: usize>(fields: [(&str, Value); N]) -> Value {
+    Value::Object(
+        fields
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect(),
+    )
 }
 
 /// Cap every occurrence of `key` (at any depth) to `max_chars` total. A
@@ -394,5 +748,82 @@ mod tests {
     fn compress_text_falls_through_when_short() {
         let s = "small payload";
         assert_eq!(compress_text_maybe_json(s, 100), s);
+
+        let notes: Vec<Value> = (0..12)
+            .map(|index| {
+                json!({
+                    "entity": {
+                        "note_id": format!("note-{index}"),
+                        "url": format!("https://www.xiaohongshu.com/explore/note-{index}"),
+                        "title": format!("title {index}"),
+                        "author": format!("author {index}"),
+                        "author_id": format!("author-{index}"),
+                        "date": "2026-08-21",
+                        "type": "normal",
+                        "likes": "1.2万",
+                        "favorites": "880",
+                        "comments_count": "61",
+                        "content": "body ".repeat(300),
+                        "top_comments": [{
+                            "text": "这个型号值得买吗？".repeat(30),
+                            "author": "reader",
+                            "sub_comments": [{"text": "长期使用后值得", "author": "author", "is_author": true}]
+                        }],
+                        "ocr_text": ["ocr".repeat(2000)]
+                    }
+                })
+            })
+            .collect();
+        let oversized = json!({
+            "query": "扫地机器人",
+            "notes": notes,
+            "artifact": {"path": "artifacts/search/robot.json"}
+        })
+        .to_string();
+        let compacted = compress_text_maybe_json(&oversized, 30_000);
+        let value: Value = serde_json::from_str(&compacted).unwrap();
+        let compacted_notes = value["notes"].as_array().unwrap();
+
+        assert_eq!(compacted_notes.len(), 12);
+        assert_eq!(
+            compacted_notes[11]["entity"]["author_id"],
+            json!("author-11")
+        );
+        assert_eq!(compacted_notes[11]["entity"]["comments_count"], json!("61"));
+        assert_eq!(
+            compacted_notes[0]["entity"]["top_comments"][0]["sub_comments"][0]["is_author"],
+            json!(true)
+        );
+        assert!(compacted.chars().count() <= 30_000);
+
+        let dense_notes: Vec<Value> = (0..60)
+            .map(|index| {
+                json!({
+                    "entity": {
+                        "note_id": format!("dense-note-{index}"),
+                        "title": "title".repeat(500),
+                        "author": "author".repeat(500),
+                        "url": format!("https://example.test/{}/{}", index, "path".repeat(500)),
+                        "content": "body".repeat(1000)
+                    }
+                })
+            })
+            .collect();
+        let dense = json!({
+            "notes": dense_notes,
+            "artifact": {"path": "artifacts/search/dense.json"}
+        })
+        .to_string();
+        let dense_compacted = compress_text_maybe_json(&dense, 10_000);
+        let dense_value: Value = serde_json::from_str(&dense_compacted).unwrap();
+        assert_eq!(dense_value["notes"].as_array().unwrap().len(), 60);
+        assert_eq!(
+            dense_value["notes"][59]["entity"]["note_id"],
+            "dense-note-59"
+        );
+        assert!(dense_compacted.chars().count() <= 10_000);
+
+        let bounded = truncate_result(&"x".repeat(100), 20);
+        assert_eq!(bounded.chars().count(), 20);
     }
 }

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -13,8 +13,10 @@ use crate::agent::llm::{Block, Message, MessageContent, MessageRole, ToolResultC
 
 pub const DEFAULT_COMPACT_AFTER_MESSAGES: usize = 20;
 pub const DEFAULT_KEEP_RECENT_MESSAGES: usize = 10;
-const TURN_MARKDOWN_MAX_CHARS: usize = 2_000;
-const USER_REQUEST_MAX_CHARS: usize = 500;
+const TURN_MARKDOWN_MAX_CHARS: usize = 3_000;
+const USER_REQUEST_MAX_CHARS: usize = 1_000;
+const COMPACT_CONTEXT_MAX_CHARS: usize = 48_000;
+const COMPACT_TURNS_MAX_CHARS: usize = 24_000;
 const COMPACT_CONTEXT_HEADING: &str = "# Earlier compacted context";
 const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 
@@ -113,8 +115,9 @@ fn contains_tool_result(message: &Message) -> bool {
 }
 
 fn compact_older_messages(messages: &[Message]) -> String {
-    let mut inherited = Vec::new();
-    let mut artifacts: BTreeMap<String, BTreeSet<(String, String)>> = BTreeMap::new();
+    let mut inherited_artifacts: BTreeMap<String, BTreeMap<String, CompactEntityEvidence>> =
+        BTreeMap::new();
+    let mut artifacts: BTreeMap<String, BTreeMap<String, CompactEntityEvidence>> = BTreeMap::new();
     let mut turns = Vec::new();
     let mut pending_user: Option<String> = None;
 
@@ -124,7 +127,7 @@ fn compact_older_messages(messages: &[Message]) -> String {
                 if text.starts_with(COMPACT_CONTEXT_HEADING)
                     || text.starts_with(LEGACY_EVIDENCE_HEADING)
                 {
-                    inherited.push(text.trim().to_string());
+                    collect_inherited_context(text, &mut turns, &mut inherited_artifacts);
                 } else {
                     pending_user = Some(text.trim().to_string());
                 }
@@ -168,28 +171,151 @@ fn compact_older_messages(messages: &[Message]) -> String {
         ));
     }
 
-    let mut rendered = if inherited.is_empty() {
-        COMPACT_CONTEXT_HEADING.to_string()
-    } else {
-        inherited.join("\n\n")
+    for (path, entities) in artifacts {
+        let inherited = inherited_artifacts.entry(path).or_default();
+        for entity in entities.values() {
+            inherited
+                .entry(entity.key())
+                .and_modify(|existing| existing.merge_from(entity))
+                .or_insert_with(|| entity.clone());
+        }
+    }
+    render_bounded_context(&turns, &inherited_artifacts)
+}
+
+fn collect_inherited_context(
+    text: &str,
+    turns: &mut Vec<String>,
+    artifacts: &mut BTreeMap<String, BTreeMap<String, CompactEntityEvidence>>,
+) {
+    enum Section {
+        None,
+        Turns,
+        Evidence,
+    }
+    let mut section = Section::None;
+    let mut current_turn = String::new();
+    let mut current_artifact: Option<String> = None;
+    let mut inside_pre = false;
+    let flush_turn = |turns: &mut Vec<String>, current: &mut String| {
+        let turn = current.trim();
+        if !turn.is_empty() && !turns.iter().any(|existing| existing == turn) {
+            turns.push(turn.to_string());
+        }
+        current.clear();
     };
+
+    for line in text.lines() {
+        let structural = !inside_pre;
+        if structural && line == "## Earlier conversation turns" {
+            flush_turn(turns, &mut current_turn);
+            section = Section::Turns;
+            current_artifact = None;
+            continue;
+        }
+        if structural && (line == "## Earlier tool evidence" || line == LEGACY_EVIDENCE_HEADING) {
+            flush_turn(turns, &mut current_turn);
+            section = Section::Evidence;
+            current_artifact = None;
+            continue;
+        }
+        if structural && matches!(section, Section::Turns) && line.starts_with("### Turn ") {
+            flush_turn(turns, &mut current_turn);
+            continue;
+        }
+        if structural && matches!(section, Section::Evidence) {
+            if let Some(path) = line.strip_prefix("## Artifact: ") {
+                current_artifact = Some(path.trim().to_string());
+                artifacts.entry(path.trim().to_string()).or_default();
+                continue;
+            }
+            if let (Some(path), Some(evidence)) =
+                (current_artifact.as_ref(), line.strip_prefix("- "))
+            {
+                let candidate = CompactEntityEvidence::parse(evidence.trim());
+                artifacts
+                    .entry(path.clone())
+                    .or_default()
+                    .entry(candidate.key())
+                    .and_modify(|existing| existing.merge_from(&candidate))
+                    .or_insert(candidate);
+            }
+            continue;
+        }
+        if matches!(section, Section::Turns) {
+            current_turn.push_str(line);
+            current_turn.push('\n');
+        }
+        if line.contains("<pre>") && !line.contains("</pre>") {
+            inside_pre = true;
+        }
+        if line.contains("</pre>") {
+            inside_pre = false;
+        }
+    }
+    flush_turn(turns, &mut current_turn);
+}
+
+fn render_bounded_context(
+    turns: &[String],
+    artifacts: &BTreeMap<String, BTreeMap<String, CompactEntityEvidence>>,
+) -> String {
+    let mut rendered = COMPACT_CONTEXT_HEADING.to_string();
     if !turns.is_empty() {
+        let mut selected = Vec::new();
+        let mut used = 0usize;
+        for turn in turns.iter().rev() {
+            let block_chars = turn.chars().count() + 32;
+            if used + block_chars <= COMPACT_TURNS_MAX_CHARS {
+                selected.push(turn);
+                used += block_chars;
+            }
+        }
+        selected.reverse();
         rendered.push_str("\n\n## Earlier conversation turns\n");
-        for (index, turn) in turns.iter().enumerate() {
-            rendered.push_str(&format!("\n### Turn {}\n{}", index + 1, turn));
+        let omitted = turns.len().saturating_sub(selected.len());
+        if omitted > 0 {
+            rendered.push_str(&format!("\n[{omitted} older compacted turns omitted]\n"));
+        }
+        for (index, turn) in selected.into_iter().enumerate() {
+            let block = format!("\n### Turn {}\n{}", index + 1, turn);
+            if rendered.chars().count() + block.chars().count() > COMPACT_CONTEXT_MAX_CHARS {
+                break;
+            }
+            rendered.push_str(&block);
         }
     }
     if !artifacts.is_empty() {
-        rendered.push_str("\n\n## Earlier tool evidence\n");
-        rendered.push_str("Full data is available in the listed artifacts.\n");
+        let heading =
+            "\n\n## Earlier tool evidence\nFull data is available in the listed artifacts.\n";
+        if rendered.chars().count() + heading.chars().count() <= COMPACT_CONTEXT_MAX_CHARS {
+            rendered.push_str(heading);
+        }
+        let mut omitted_entities = 0usize;
         for (path, entities) in artifacts {
-            rendered.push_str(&format!("\n## Artifact: {path}\n"));
-            for (id, title) in entities {
-                if title.is_empty() {
-                    rendered.push_str(&format!("- {id}\n"));
+            let artifact_heading = format!("\n## Artifact: {path}\n");
+            if rendered.chars().count() + artifact_heading.chars().count()
+                > COMPACT_CONTEXT_MAX_CHARS
+            {
+                omitted_entities += entities.len();
+                continue;
+            }
+            rendered.push_str(&artifact_heading);
+            for entity in entities.values() {
+                let line = format!("- {}\n", entity.render());
+                if rendered.chars().count() + line.chars().count() > COMPACT_CONTEXT_MAX_CHARS {
+                    omitted_entities += 1;
                 } else {
-                    rendered.push_str(&format!("- {id} — {title}\n"));
+                    rendered.push_str(&line);
                 }
+            }
+        }
+        if omitted_entities > 0 {
+            let marker = format!(
+                "\n[{omitted_entities} evidence entries omitted; use the artifact paths above]\n"
+            );
+            if rendered.chars().count() + marker.chars().count() <= COMPACT_CONTEXT_MAX_CHARS {
+                rendered.push_str(&marker);
             }
         }
     }
@@ -227,11 +353,24 @@ fn compact_turn_markdown(user: Option<&str>, markdown: &str) -> String {
     let mut rendered = String::new();
     if let Some(user) = user.filter(|text| !text.trim().is_empty()) {
         rendered.push_str("User request:\n");
-        rendered.push_str(&truncate_chars(user, USER_REQUEST_MAX_CHARS));
-        rendered.push_str("\n\n");
+        rendered.push_str("<pre>");
+        rendered.push_str(&escape_html_text(&compact_head_tail(
+            user,
+            USER_REQUEST_MAX_CHARS,
+            700,
+            "[middle omitted; full request remains in the conversation record]",
+        )));
+        rendered.push_str("</pre>\n\n");
     }
     rendered.push_str("Assistant report excerpt:\n");
-    rendered.push_str(&truncate_chars(markdown, TURN_MARKDOWN_MAX_CHARS));
+    rendered.push_str("<pre>");
+    rendered.push_str(&escape_html_text(&compact_head_tail(
+        markdown,
+        TURN_MARKDOWN_MAX_CHARS,
+        2_000,
+        "[middle omitted; full report remains in the run artifact]",
+    )));
+    rendered.push_str("</pre>");
 
     let (notes, artifacts) = extract_markdown_evidence(markdown);
     if !notes.is_empty() || !artifacts.is_empty() {
@@ -250,14 +389,35 @@ fn compact_turn_markdown(user: Option<&str>, markdown: &str) -> String {
     rendered
 }
 
-fn truncate_chars(text: &str, max_chars: usize) -> String {
+fn compact_head_tail(text: &str, max_chars: usize, head_chars: usize, marker: &str) -> String {
     let trimmed = text.trim();
     if trimmed.chars().count() <= max_chars {
         return trimmed.to_string();
     }
-    let mut out: String = trimmed.chars().take(max_chars).collect();
-    out.push_str("\n\n[truncated; full report remains in the run artifact]");
-    out
+    let separator = format!("\n\n{marker}\n\n");
+    let separator_chars = separator.chars().count();
+    if max_chars <= separator_chars {
+        return separator.chars().take(max_chars).collect();
+    }
+    let content_chars = max_chars - separator_chars;
+    let head_chars = head_chars.min(content_chars);
+    let tail_chars = content_chars.saturating_sub(head_chars);
+    let head: String = trimmed.chars().take(head_chars).collect();
+    let tail: String = trimmed
+        .chars()
+        .rev()
+        .take(tail_chars)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{head}{separator}{tail}")
+}
+
+fn escape_html_text(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 fn extract_markdown_evidence(markdown: &str) -> (BTreeSet<(String, String)>, BTreeSet<String>) {
@@ -312,7 +472,7 @@ fn is_artifact_link(target: &str) -> bool {
 
 fn collect_artifact_evidence(
     value: &Value,
-    artifacts: &mut BTreeMap<String, BTreeSet<(String, String)>>,
+    artifacts: &mut BTreeMap<String, BTreeMap<String, CompactEntityEvidence>>,
 ) {
     let Some(path) = value
         .pointer("/artifact/path")
@@ -330,7 +490,16 @@ fn collect_artifact_evidence(
             .or_else(|| value.pointer("/profile/name"))
             .and_then(Value::as_str)
             .unwrap_or("");
-        entities.insert((format!("author:{author_id}"), title.to_string()));
+        let id = format!("author:{author_id}");
+        let candidate = CompactEntityEvidence {
+            id,
+            title: title.to_string(),
+            ..CompactEntityEvidence::default()
+        };
+        entities
+            .entry(candidate.id.clone())
+            .and_modify(|existing| existing.merge_from(&candidate))
+            .or_insert(candidate);
     }
 
     for key in ["notes", "cards"] {
@@ -346,8 +515,160 @@ fn collect_artifact_evidence(
                 .unwrap_or("");
             let title = entity.get("title").and_then(Value::as_str).unwrap_or("");
             if !id.is_empty() || !title.is_empty() {
-                entities.insert((id.to_string(), title.to_string()));
+                let key = if id.is_empty() {
+                    format!("title:{title}")
+                } else {
+                    id.to_string()
+                };
+                let candidate = CompactEntityEvidence {
+                    id: id.to_string(),
+                    title: title.to_string(),
+                    author: string_field(entity, "author"),
+                    author_id: string_field(entity, "author_id"),
+                    url: string_field(entity, "url"),
+                    date: string_field(entity, "date"),
+                    note_type: string_field(entity, "type"),
+                    likes: scalar_field(entity, "likes"),
+                    favorites: scalar_field(entity, "favorites"),
+                    comments_count: scalar_field(entity, "comments_count"),
+                };
+                entities
+                    .entry(key)
+                    .and_modify(|existing| existing.merge_from(&candidate))
+                    .or_insert(candidate);
             }
         }
     }
+}
+
+#[derive(Clone, Default)]
+struct CompactEntityEvidence {
+    id: String,
+    title: String,
+    author: String,
+    author_id: String,
+    url: String,
+    date: String,
+    note_type: String,
+    likes: String,
+    favorites: String,
+    comments_count: String,
+}
+
+impl CompactEntityEvidence {
+    fn parse(rendered: &str) -> Self {
+        let (main, metadata) = rendered
+            .split_once(" | ")
+            .map_or((rendered, ""), |(main, metadata)| (main, metadata));
+        let (id, title) = main
+            .split_once(" — ")
+            .map_or((main.trim(), ""), |(id, title)| (id.trim(), title.trim()));
+        let mut parsed = Self {
+            id: id.to_string(),
+            title: title.to_string(),
+            ..Self::default()
+        };
+        for field in metadata.split("; ") {
+            let Some((label, value)) = field.split_once(": ") else {
+                continue;
+            };
+            match label {
+                "author" => parsed.author = value.to_string(),
+                "author_id" => parsed.author_id = value.to_string(),
+                "date" => parsed.date = value.to_string(),
+                "type" => parsed.note_type = value.to_string(),
+                "likes" => parsed.likes = value.to_string(),
+                "favorites" => parsed.favorites = value.to_string(),
+                "comments" => parsed.comments_count = value.to_string(),
+                "url" => parsed.url = value.to_string(),
+                _ => {}
+            }
+        }
+        parsed
+    }
+
+    fn key(&self) -> String {
+        if self.id.trim().is_empty() {
+            format!("title:{}", self.title.trim())
+        } else {
+            self.id.trim().to_string()
+        }
+    }
+
+    fn merge_from(&mut self, other: &Self) {
+        merge_field(&mut self.id, &other.id);
+        merge_field(&mut self.title, &other.title);
+        merge_field(&mut self.author, &other.author);
+        merge_field(&mut self.author_id, &other.author_id);
+        merge_field(&mut self.url, &other.url);
+        merge_field(&mut self.date, &other.date);
+        merge_field(&mut self.note_type, &other.note_type);
+        merge_field(&mut self.likes, &other.likes);
+        merge_field(&mut self.favorites, &other.favorites);
+        merge_field(&mut self.comments_count, &other.comments_count);
+    }
+
+    fn render(&self) -> String {
+        let mut main = match (self.id.is_empty(), self.title.is_empty()) {
+            (false, false) => format!("{} — {}", self.id, compact_field(&self.title, 120)),
+            (false, true) => self.id.clone(),
+            (true, false) => compact_field(&self.title, 120),
+            (true, true) => "unknown note".to_string(),
+        };
+        let mut metadata = Vec::new();
+        push_metadata(&mut metadata, "author", &self.author, 80);
+        push_metadata(&mut metadata, "author_id", &self.author_id, 80);
+        push_metadata(&mut metadata, "date", &self.date, 40);
+        push_metadata(&mut metadata, "type", &self.note_type, 30);
+        push_metadata(&mut metadata, "likes", &self.likes, 30);
+        push_metadata(&mut metadata, "favorites", &self.favorites, 30);
+        push_metadata(&mut metadata, "comments", &self.comments_count, 30);
+        push_metadata(&mut metadata, "url", &self.url, 220);
+        if !metadata.is_empty() {
+            main.push_str(" | ");
+            main.push_str(&metadata.join("; "));
+        }
+        main
+    }
+}
+
+fn merge_field(current: &mut String, candidate: &str) {
+    if candidate.trim().is_empty() {
+        return;
+    }
+    if current.trim().is_empty() || candidate.chars().count() > current.chars().count() {
+        *current = candidate.to_string();
+    }
+}
+
+fn string_field(entity: &Value, key: &str) -> String {
+    entity
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn scalar_field(entity: &Value, key: &str) -> String {
+    match entity.get(key) {
+        Some(Value::String(value)) => value.clone(),
+        Some(Value::Number(value)) => value.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn push_metadata(metadata: &mut Vec<String>, label: &str, value: &str, max_chars: usize) {
+    if !value.trim().is_empty() {
+        metadata.push(format!("{label}: {}", compact_field(value, max_chars)));
+    }
+}
+
+fn compact_field(value: &str, max_chars: usize) -> String {
+    let value = value.trim();
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut compact: String = value.chars().take(max_chars).collect();
+    compact.push('…');
+    compact
 }

--- a/docs/context-window-management.md
+++ b/docs/context-window-management.md
@@ -69,7 +69,7 @@ The request context has four relevant layers:
 | System | Rules, date, tool names, site instructions | No |
 | Earlier turns | User requests and final Markdown reports | Yes, after they enter the old region |
 | Recent in-run history | Assistant tool calls and tool results | No; the newest 10 messages stay verbatim |
-| Older in-run history | Earlier tool calls and structured results | Yes, to IDs, titles, and artifact paths |
+| Older in-run history | Earlier tool calls and structured results | Yes, to post metadata and artifact paths |
 | Run artifacts | Full JSON, OCR, media, requests, responses | No |
 
 Run artifacts are the durable evidence store. Context compaction changes only
@@ -82,14 +82,23 @@ Every raw tool result is written to its tool-call directory before the result is
 bounded for model history. The LLM-facing text has a 30,000-character ceiling.
 If an oversized result is JSON, degradation happens in this order:
 
-1. Cap each `ocr_text` value to 1,000 characters in total. For string arrays,
+1. For XHS search/author results with an artifact pointer, keep every returned
+   post as a metadata-first record using all fields available in the lean tool
+   result: note ID, title, author, author ID, URL, date, type, engagement
+   counts, a bounded body excerpt, and a small comment/reply sample. Full OCR,
+   media, bodies, comment threads, location, and hashtags remain in the
+   artifact when those fields were removed by the artifact-first tool shape.
+   If the full metadata view still exceeds the ceiling, reduce it through
+   identity-only and ID-only valid JSON forms. An extreme result that cannot
+   fit every ID keeps a valid artifact index with retained and omitted counts.
+2. Cap each `ocr_text` value to 1,000 characters in total. For string arrays,
    keep complete leading entries until the budget is exhausted and mark the
    truncation.
-2. Replace `top_comments` with an artifact pointer marker if the result is still
+3. Replace `top_comments` with an artifact pointer marker if the result is still
    too large.
-3. Compact JSON objects, arrays, and string leaves while keeping note body text
+4. Compact JSON objects, arrays, and string leaves while keeping note body text
    longer than generic strings.
-4. Apply a final character truncation only as a last resort.
+5. Apply a final character truncation only as a last resort.
 
 Xiaohongshu search and author-scan results are already artifact-first before
 this generic limit runs. Their full artifacts retain per-image OCR. The lean
@@ -102,7 +111,7 @@ Example for a three-image note:
 | --- | --- |
 | `artifacts/search/*.json` | Images 1, 2, and 3, including their complete per-image OCR fields |
 | LLM-facing `search` result | OCR summaries for images 1 and 2 only, each capped at 1,200 characters |
-| Later compacted context | Note ID, title, and artifact path; OCR text is removed |
+| Later compacted context | Available note metadata and artifact path; OCR text is removed |
 
 ## Sawtooth message window
 
@@ -154,17 +163,22 @@ Prior turns are seeded as user text followed by an assistant Markdown report.
 When those messages move into the compacted region, socai emits compact Markdown
 for each recognized report containing:
 
-- up to 500 characters of its associated user request, when available;
-- the first 2,000 characters of the assistant report;
+- up to 1,000 characters of its associated user request, preserving the start
+  and end when the middle must be removed;
+- up to 3,000 characters of the assistant report, preserving the opening
+  analysis and closing conclusions;
 - every note citation found in the full report using the canonical
   `[title](note:NOTE_ID)` form;
 - artifact links found in the full report when their targets point into known
   run artifact locations such as `artifacts/`, `tools/`, `snapshots/`,
   `site_media/`, or an absolute `.socai/runs/` path.
 
-Evidence extraction scans the complete Markdown report, not only its
-2,000-character excerpt. Earlier compacted Markdown is carried forward when the
-next sawtooth compaction occurs.
+Evidence extraction scans the complete Markdown report, including content
+outside the 3,000-character compact view. Request and report excerpts are HTML-
+escaped inside `<pre>` blocks so a cut cannot leave an open Markdown construct.
+At the next sawtooth point, prior turns and artifact entries are parsed back
+into structured blocks, deduplicated, and rendered within a 48,000-character
+aggregate ceiling.
 
 For example, suppose an older turn ends with a 3,000-character report whose
 last section contains these links:
@@ -179,19 +193,29 @@ Its compact representation is shaped like this:
 ```markdown
 ### Turn 1
 User request:
-<first 500 characters>
+<pre>
+<opening request text>
+
+[middle omitted; full request remains in the conversation record]
+
+<closing request text>
+</pre>
 
 Assistant report excerpt:
-<first 2,000 characters>
+<pre>
+<opening report text>
 
-[truncated; full report remains in the run artifact]
+[middle omitted; full report remains in the run artifact]
+
+<closing conclusions>
+</pre>
 
 Extracted evidence:
 - note_id: note-123; title: A useful note
 - artifact: artifacts/search/coffee.json
 ```
 
-The links are retained even though they appeared after character 2,000 because
+The links are retained even when they appear outside the compact view because
 evidence extraction scans the complete report. Ordinary Markdown such as a task
 checkbox (`[x]`) is ignored and cannot consume a later link's title.
 
@@ -207,14 +231,15 @@ Older `tool_result` text is parsed as JSON. When the result contains an
 `artifact.path`, the compacted context retains:
 
 - the artifact path;
-- note IDs and titles from `notes` or `cards`, accepting either direct entities
+- note IDs, titles, authors, author IDs, URLs, dates, note types, and available
+  engagement counts from `notes` or `cards`, accepting either direct entities
   or `{ "entity": ... }` wrappers;
 - an author ID and available profile name for author-scan results.
 
-Body text, OCR, comments, timing details, engagement metadata, and other large
-fields are omitted from this compact representation because the artifact path
-is the durable lookup key. Duplicate entity entries are removed
-deterministically.
+Body text, OCR, comments, timing details, and other large fields are omitted
+from this later sawtooth representation. The artifact path remains the durable
+lookup key. Duplicate entity entries merge non-empty fields so a later sparse
+card cannot replace richer metadata.
 
 For example, this older tool result:
 
@@ -222,7 +247,15 @@ For example, this older tool result:
 {
   "artifact": { "path": "artifacts/search/coffee.json" },
   "notes": [
-    { "note_id": "note-123", "title": "A useful note", "ocr_text": ["..."] }
+    {
+      "note_id": "note-123",
+      "title": "A useful note",
+      "author": "Lin",
+      "date": "2026-08-21",
+      "likes": 1200,
+      "url": "https://www.xiaohongshu.com/explore/note-123",
+      "ocr_text": ["..."]
+    }
   ]
 }
 ```
@@ -231,7 +264,7 @@ becomes approximately:
 
 ```markdown
 ## Artifact: artifacts/search/coffee.json
-- note-123 — A useful note
+- note-123 — A useful note | author: Lin; date: 2026-08-21; likes: 1200; url: https://www.xiaohongshu.com/explore/note-123
 ```
 
 The model can reopen the artifact if it needs the omitted body, comments, or


### PR DESCRIPTION
# Summary
- Preserve XHS post metadata and bounded question-answer samples in compact tool results.
- Keep oversized XHS payloads valid and artifact-addressable through progressive JSON compaction.
- Bound repeated sawtooth summaries and merge duplicate evidence field by field.
- Preserve opening and closing turn context and document the context lifecycle.