### PR TITLE
fix(agent): replay DeepSeek reasoning context

### DIFF
--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -7,6 +7,8 @@
 //! their own `base_url` via `ProviderConfig`; their quirks (the
 //! `reasoning_content` field, thinking toggles) live here too.
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -126,9 +128,9 @@ impl OpenAICompatBackend {
         extra
     }
 
-    /// Some providers (Kimi, Qwen, Doubao) want `reasoning_content` round-tripped
-    /// in the assistant message when tool_calls are present. Others
-    /// (OpenAI proper) ignore it. Toggle is per-provider.
+    /// Some OpenAI-compatible providers require `reasoning_content` to be
+    /// round-tripped in the assistant message whenever tool calls are replayed.
+    /// Others (OpenAI proper) ignore it. Toggle is per-provider.
     fn preserve_reasoning_content(&self) -> bool {
         matches!(
             self.provider,
@@ -137,6 +139,7 @@ impl OpenAICompatBackend {
                 | Provider::Qwen
                 | Provider::QwenIntl
                 | Provider::Doubao
+                | Provider::DeepSeek
         )
     }
 
@@ -151,10 +154,20 @@ impl OpenAICompatBackend {
         let has_tools = !chat_tools.is_empty();
         OutgoingRequest {
             model: self.model.clone(),
-            messages: build_chat_messages(system, messages, self.preserve_reasoning_content()),
+            messages: build_chat_messages(
+                system,
+                messages,
+                self.preserve_reasoning_content(),
+                self.provider == Provider::DeepSeek,
+            ),
             max_tokens,
             tools: chat_tools,
-            tool_choice: if has_tools { Some("auto") } else { None },
+            // DeepSeek thinking mode supports tools but rejects tool_choice.
+            tool_choice: if has_tools && self.provider != Provider::DeepSeek {
+                Some("auto")
+            } else {
+                None
+            },
             extra: self.extra_body(),
         }
     }
@@ -196,6 +209,47 @@ impl OpenAICompatBackend {
             include,
         }
     }
+}
+
+fn validate_deepseek_tool_context(messages: &[Message]) -> anyhow::Result<()> {
+    let mut pending = HashSet::new();
+    for message in messages {
+        match message.role {
+            crate::agent::llm::MessageRole::Assistant => {
+                if !pending.is_empty() {
+                    anyhow::bail!(
+                        "DeepSeek API error | status=400 | code=invalid_tool_context | message=assistant turn started before every prior tool call had a matching result"
+                    );
+                }
+                for block in message.content.as_blocks() {
+                    if let Block::ToolUse { id, .. } = block {
+                        if id.trim().is_empty() || !pending.insert(id) {
+                            anyhow::bail!(
+                                "DeepSeek API error | status=400 | code=invalid_tool_context | message=assistant history contains an empty or duplicate tool call id"
+                            );
+                        }
+                    }
+                }
+            }
+            crate::agent::llm::MessageRole::User => {
+                for block in message.content.as_blocks() {
+                    if let Block::ToolResult { tool_use_id, .. } = block {
+                        if !pending.remove(&tool_use_id) {
+                            anyhow::bail!(
+                                "DeepSeek API error | status=400 | code=invalid_tool_context | message=tool result has no matching assistant tool call"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if !pending.is_empty() {
+        anyhow::bail!(
+            "DeepSeek API error | status=400 | code=invalid_tool_context | message=assistant tool call has no matching tool result"
+        );
+    }
+    Ok(())
 }
 
 /// OpenAI models that accept the Responses API `reasoning` parameter.
@@ -242,13 +296,18 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output
 
     #[test]
     fn responses_input_preserves_function_call_outputs() {
-        let input = build_responses_input(&[
+        let messages = [
             Message::user("lookup abc"),
-            Message::assistant_blocks(vec![Block::ToolUse {
-                id: "call_1".into(),
-                name: "lookup".into(),
-                input: json!({"key": "abc"}),
-            }]),
+            Message::assistant_blocks(vec![
+                Block::ReasoningContent {
+                    text: "need the lookup result".into(),
+                },
+                Block::ToolUse {
+                    id: "call_1".into(),
+                    name: "lookup".into(),
+                    input: json!({"key": "abc"}),
+                },
+            ]),
             Message {
                 role: MessageRole::User,
                 content: MessageContent::Blocks(vec![Block::ToolResult {
@@ -256,12 +315,76 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output
                     content: vec![ToolResultContent::Text { text: "42".into() }],
                 }]),
             },
-        ]);
+        ];
+        let input = build_responses_input(&messages);
 
         assert_eq!(input[1]["type"], "function_call");
         assert_eq!(input[1]["call_id"], "call_1");
         assert_eq!(input[2]["type"], "function_call_output");
         assert_eq!(input[2]["output"], "42");
+
+        let deepseek = OpenAICompatBackend {
+            provider: Provider::DeepSeek,
+            model: "deepseek-v4-pro".into(),
+            credential: Credential::ApiKey("test-key".into()),
+            base_url: "https://example.invalid/v1".into(),
+            client: reqwest::Client::new(),
+            task_id: None,
+        };
+        let request = deepseek.build_chat_request(
+            "system",
+            &messages,
+            &[ToolSchema {
+                name: "lookup".into(),
+                description: "lookup a value".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            1024,
+        );
+        let payload = serde_json::to_value(request).expect("request should serialize");
+        let chat = payload["messages"]
+            .as_array()
+            .expect("messages should be an array");
+        assert_eq!(chat[2]["reasoning_content"], "need the lookup result");
+        assert_eq!(chat[2]["content"], "");
+        assert_eq!(chat[2]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(chat[3]["role"], "tool");
+        assert_eq!(chat[3]["tool_call_id"], "call_1");
+        assert!(payload.get("tool_choice").is_none());
+
+        let kimi = OpenAICompatBackend {
+            provider: Provider::Kimi,
+            model: "kimi-k2.6".into(),
+            credential: Credential::ApiKey("test-key".into()),
+            base_url: "https://example.invalid/v1".into(),
+            client: reqwest::Client::new(),
+            task_id: None,
+        };
+        let payload = serde_json::to_value(kimi.build_chat_request(
+            "system",
+            &messages,
+            &[ToolSchema {
+                name: "lookup".into(),
+                description: "lookup a value".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            1024,
+        ))
+        .expect("request should serialize");
+        assert_eq!(payload["tool_choice"], "auto");
+        assert!(payload["messages"][2]["content"].is_null());
+
+        let invalid = [Message {
+            role: MessageRole::User,
+            content: MessageContent::Blocks(vec![Block::ToolResult {
+                tool_use_id: "missing_call".into(),
+                content: vec![ToolResultContent::Text { text: "42".into() }],
+            }]),
+        }];
+        let error = deepseek
+            .request_payload("system", &invalid, &[], 1024)
+            .expect_err("orphaned tool result should fail locally");
+        assert!(error.to_string().contains("code=invalid_tool_context"));
     }
 }
 
@@ -301,7 +424,12 @@ fn flatten_tool_result_content(blocks: &[ToolResultContent]) -> Value {
 }
 
 /// Translate Anthropic-shaped history into chat-completion messages.
-fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: bool) -> Vec<Value> {
+fn build_chat_messages(
+    system: &str,
+    messages: &[Message],
+    preserve_reasoning: bool,
+    require_assistant_content: bool,
+) -> Vec<Value> {
     let mut out = vec![json!({"role": "system", "content": system})];
 
     for msg in messages {
@@ -336,7 +464,9 @@ fn build_chat_messages(system: &str, messages: &[Message], preserve_reasoning: b
                 let content_str = text_parts.join("\n").trim().to_string();
                 let mut assistant_msg = Map::new();
                 assistant_msg.insert("role".into(), json!("assistant"));
-                if content_str.is_empty() {
+                if content_str.is_empty() && require_assistant_content && !tool_calls.is_empty() {
+                    assistant_msg.insert("content".into(), json!(""));
+                } else if content_str.is_empty() {
                     assistant_msg.insert("content".into(), Value::Null);
                 } else {
                     assistant_msg.insert("content".into(), json!(content_str));
@@ -742,6 +872,9 @@ impl Backend for OpenAICompatBackend {
         tools: &[ToolSchema],
         max_tokens: u32,
     ) -> anyhow::Result<Value> {
+        if self.provider == Provider::DeepSeek {
+            validate_deepseek_tool_context(messages)?;
+        }
         if self.provider == Provider::OpenAI {
             serde_json::to_value(self.build_responses_request(system, messages, tools, max_tokens))
                 .map_err(Into::into)
@@ -762,6 +895,10 @@ impl Backend for OpenAICompatBackend {
             return self
                 .send_responses(system, messages, tools, max_tokens)
                 .await;
+        }
+
+        if self.provider == Provider::DeepSeek {
+            validate_deepseek_tool_context(messages)?;
         }
 
         let body = self.build_chat_request(system, messages, tools, max_tokens);


### PR DESCRIPTION
# Summary
- Preserve DeepSeek `reasoning_content` when replaying assistant tool calls.
- Omit unsupported `tool_choice` and send empty assistant content for tool-call-only turns.
- Reject malformed DeepSeek tool-call history locally before sending the request.

# Validation
- `cargo test -p socai-core`: 91 passed, 2 ignored.
- Covered DeepSeek reasoning, tool call/result IDs, assistant content, missing `tool_choice`, malformed history, and a Kimi compatibility case.