### PR TITLE
feat(agent): add anonymous trial and error diagnosis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,6 +5240,7 @@ dependencies = [
  "image",
  "libc",
  "oar-ocr",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -351,7 +351,18 @@ pub async fn agent_save_api_key(provider: String, api_key: String) -> Result<(),
 #[tauri::command]
 pub async fn agent_list_models() -> Result<Vec<Value>, String> {
     use socai_core::agent::PROVIDERS;
-    let _ = socai_core::cloud::take_hosted_llm_default().map_err(|err| format!("{err:#}"))?;
+    if !socai_core::cloud::auth_session()
+        .map_err(|err| format!("{err:#}"))?
+        .logged_in
+    {
+        if let Err(error) = socai_core::cloud::ensure_trial_device().await {
+            eprintln!("anonymous trial registration failed: {error:#}");
+        }
+    }
+    if !provider_env_override_present() && configured_default_provider().is_none() {
+        let _ = socai_core::cloud::take_hosted_llm_default()
+            .map_err(|err| format!("{err:#}"))?;
+    }
     // The provider/model that would be used right now. Environment overrides
     // win when present; otherwise the desktop restores persisted defaults even
     // if the selected provider still needs a key. The frontend uses
@@ -591,7 +602,9 @@ pub async fn agent_task_start(
     if task_text.is_empty() {
         return Err("task is empty".into());
     }
-    run_task_preflight(provider.as_deref(), model.as_deref()).await?;
+    let (anonymous_trial, resolved_provider) =
+        run_task_preflight(provider.as_deref(), model.as_deref()).await?;
+    let provider = Some(resolved_provider.as_str().to_string());
 
     // One conversation = one folder under the runs root, named after the
     // first task; each turn's run dir nests inside it (turn-01_…, turn-02_…).
@@ -610,8 +623,10 @@ pub async fn agent_task_start(
             model.clone(),
             run_dir.display().to_string(),
             session_dir,
+            anonymous_trial,
         )
-        .await;
+        .await
+        .map_err(|detail| task_preflight_error("preflight_trial_running", detail))?;
     let task_id = snapshot.task_id.clone();
     let background_media_generation = socai_core::media::begin_background_media_generation();
     let runtime = runtime.inner().clone();
@@ -684,9 +699,17 @@ pub async fn agent_task_reply(
     let Some(session_dir) = existing.session_dir.as_deref() else {
         return Err("task has no conversation to continue".into());
     };
-    let provider = existing.provider.clone();
+    let requested_provider = existing.provider.clone();
     let model = existing.model.clone();
-    run_task_preflight(provider.as_deref(), model.as_deref()).await?;
+    let (_, resolved_provider) =
+        run_task_preflight(requested_provider.as_deref(), model.as_deref()).await?;
+    let provider = Some(resolved_provider.as_str().to_string());
+    if resolved_provider == Provider::Socai {
+        // A conversation can cross the anonymous-to-signed-in boundary
+        // between turns. Pin identity during a turn, then rebind to the
+        // current account at the next reply boundary.
+        socai_core::cloud::reset_llm_gateway_for_task(&task_id);
+    }
     if let Some(previous_run_dir) = existing.run_dir.as_deref() {
         socai_core::media::cancel_background_media_for_run(previous_run_dir);
     }
@@ -718,6 +741,8 @@ pub async fn agent_task_reply(
             snapshot.cost_currency = None;
             snapshot.points_used = None;
             snapshot.current_message = Some(message_text.clone());
+            snapshot.provider = provider.clone();
+            snapshot.model = model.clone();
         })
         .await
         .ok_or_else(|| format!("unknown task: {task_id}"))?;
@@ -764,23 +789,37 @@ pub async fn agent_task_reply(
     Ok(snapshot)
 }
 
-async fn run_task_preflight(provider: Option<&str>, model: Option<&str>) -> Result<(), String> {
+async fn run_task_preflight(
+    provider: Option<&str>,
+    model: Option<&str>,
+) -> Result<(bool, Provider), String> {
     let resolved_provider = ensure_llm_provider_configured_for(provider, model)
         .map_err(|error| task_preflight_error("preflight_model_config", format!("{error:#}")))?;
+    let mut anonymous_trial = false;
     if resolved_provider == Provider::Socai {
-        if !socai_core::cloud::pro_activated() {
+        let session = socai_core::cloud::auth_session()
+            .map_err(|error| task_preflight_error("preflight_auth", format!("{error:#}")))?;
+        if !session.logged_in && !session.trial_available {
+            let code = if matches!(session.trial_status.as_str(), "completed" | "converted") {
+                "preflight_trial_used"
+            } else {
+                "preflight_trial_unavailable"
+            };
             return Err(task_preflight_error(
-                "preflight_auth",
-                "sign in before using Socai Agent",
+                code,
+                "anonymous trial unavailable; sign in or configure an API key",
             ));
         }
-        let wallet = socai_core::cloud::wallet_balance().await.map_err(|error| {
-            task_preflight_error("preflight_region_or_account", format!("{error:#}"))
-        })?;
-        validate_preflight_balance(wallet.balance_points)?;
+        anonymous_trial = !session.logged_in;
+        if session.logged_in {
+            let wallet = socai_core::cloud::wallet_balance().await.map_err(|error| {
+                task_preflight_error("preflight_region_or_account", format!("{error:#}"))
+            })?;
+            validate_preflight_balance(wallet.balance_points)?;
+        }
     }
 
-    Ok(())
+    Ok((anonymous_trial, resolved_provider))
 }
 
 async fn run_session_login_preflight(page: &RuntimePageSession) -> Result<(), String> {
@@ -999,9 +1038,8 @@ pub async fn agent_task_list(
     let snapshots = tasks.list().await;
     recover_run_points_from_local_telemetry(&snapshots);
     let snapshots = tasks.list().await;
-    let has_cloud_session = socai_core::cloud::pro_activated();
     for snapshot in snapshots {
-        if !has_cloud_session
+        if snapshot.provider.as_deref() != Some(Provider::Socai.as_str())
             || snapshot.points_used.is_some()
             || !matches!(
                 snapshot.status.as_str(),
@@ -2099,7 +2137,7 @@ pub async fn agent_task_cancel(
         let _ = runtime.close_target(&target_id).await;
     }
     if changed {
-        if socai_core::cloud::pro_activated() {
+        if snapshot.provider.as_deref() == Some(Provider::Socai.as_str()) {
             if let Some(settlement) = settle_hosted_task_with_retry(&task_id, "cancelled").await {
                 if let Some(updated) = tasks
                     .update(&task_id, |task| {
@@ -2455,16 +2493,17 @@ async fn run_agent_task_background(
     )
     .await;
 
-    let settlement = if socai_core::cloud::pro_activated() {
-        let final_status = if result.is_ok() {
-            "completed"
+    let settlement =
+        if resolve_provider(provider.as_deref(), model.as_deref()).ok() == Some(Provider::Socai) {
+            let final_status = if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            };
+            settle_hosted_task_with_retry(&task_id, final_status).await
         } else {
-            "failed"
+            None
         };
-        settle_hosted_task_with_retry(&task_id, final_status).await
-    } else {
-        None
-    };
 
     let _ = registry.remove_abort_handle(&task_id).await;
 
@@ -2724,29 +2763,8 @@ async fn run_agent_task_on_session_page(
     let site = app_site()?;
     let session_id =
         session_id.ok_or_else(|| anyhow::anyhow!("task has no conversation session"))?;
-    // The tab was opened and bound to this task during admission. The browser
-    // lease and activity guard that keep it alive are held by the caller.
-    // Login is checked in the conversation's own tab rather than in a shared
-    // site tab, so a run never opens a second target just to look at the gate.
-    // Both outcomes carry a code the UI translates — a hosted browser's shared
-    // login is socai-operated, so its message differs from the local one.
-    let login_error_code = if page.is_remote_browser() {
-        "preflight_xhs_session"
-    } else {
-        "preflight_xhs_login"
-    };
-    let login = XhsPageRuntime::new(&page)
-        .login_gate(true)
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!(task_preflight_error(login_error_code, format!("{error:#}")))
-        })?;
-    if login == socai_core::sites::xhs::page::LoginGate::Required {
-        anyhow::bail!(task_preflight_error(
-            login_error_code,
-            "Xiaohongshu login is required in this conversation's Chrome tab",
-        ));
-    }
+    // Admission already validated login on this exact conversation page while
+    // holding its browser lease; do not poll the same gate a second time here.
     let outcome = async {
         let agent_tools = site.default_agent_tools.unwrap_or(site.agent_tools);
         let mut tools = agent_tools(page.clone(), llm_provider.clone()).await?;
@@ -2981,6 +2999,16 @@ pub async fn pro_activate(
 #[tauri::command]
 pub async fn auth_session() -> Result<socai_core::cloud::AuthSession, String> {
     socai_core::cloud::auth_session().map_err(|err| format!("{err:#}"))
+}
+
+#[tauri::command]
+pub async fn diagnose_error(
+    error: String,
+    language: String,
+) -> Result<socai_core::cloud::ErrorDiagnosis, String> {
+    socai_core::cloud::diagnose_error(&error, &language)
+        .await
+        .map_err(|err| format!("{err:#}"))
 }
 
 #[tauri::command]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -32,7 +32,7 @@ async fn interrupt_missing_browser_targets(
         .await
     {
         let task_id = snapshot.task_id.clone();
-        if snapshot.provider.as_deref() == Some("socai") && socai_core::cloud::pro_activated() {
+        if snapshot.provider.as_deref() == Some("socai") {
             if let Some(settlement) =
                 commands::settle_hosted_task_with_retry(&task_id, "interrupted").await
             {
@@ -354,6 +354,7 @@ pub fn run() {
             commands::config_unset,
             commands::pro_activate,
             commands::auth_session,
+            commands::diagnose_error,
             commands::auth_sms_send,
             commands::auth_sms_verify,
             commands::auth_logout,

--- a/app/src-tauri/src/tasks.rs
+++ b/app/src-tauri/src/tasks.rs
@@ -56,6 +56,10 @@ pub struct AgentTaskSnapshot {
     pub(crate) cost_currency: Option<String>,
     /// Server-authoritative LLM + paid cloud-tool charge for the latest turn.
     pub(crate) points_used: Option<i64>,
+    /// This conversation started with the one-device anonymous hosted trial.
+    /// Persisting the bit keeps admission checks scoped to the trial itself.
+    #[serde(default)]
+    pub(crate) anonymous_trial: bool,
     // The text driving the in-flight/most recent run — distinct from `task`,
     // which stays the thread's original title across replies. It is process-
     // local; interrupted startup recovery reads the canonical run.json task.
@@ -134,8 +138,17 @@ impl AgentTaskRegistry {
         model: Option<String>,
         run_dir: String,
         session_dir: String,
-    ) -> AgentTaskSnapshot {
+        reject_if_active: bool,
+    ) -> Result<AgentTaskSnapshot, String> {
         let mut guard = self.inner.lock().await;
+        if reject_if_active
+            && guard.tasks.iter().any(|task| {
+                task.anonymous_trial
+                    && matches!(task.status.as_str(), "queued" | "running")
+            })
+        {
+            return Err("anonymous trial task is already queued or running".into());
+        }
         guard.next_seq += 1;
         let task_id = format!("task-{}-{}", now_ms(), guard.next_seq);
         let snapshot = AgentTaskSnapshot {
@@ -164,10 +177,11 @@ impl AgentTaskRegistry {
             estimated_cost: None,
             cost_currency: None,
             points_used: None,
+            anonymous_trial: reject_if_active,
         };
         guard.tasks.push(snapshot.clone());
         persist_task_index(&guard.tasks);
-        snapshot
+        Ok(snapshot)
     }
 
     pub(crate) async fn acquire_run_permit(&self) -> Option<OwnedSemaphorePermit> {
@@ -521,6 +535,15 @@ fn hydrate_task_snapshot(mut snapshot: AgentTaskSnapshot) -> AgentTaskSnapshot {
         snapshot.final_text = final_text_from_run_dir(run_dir);
         if let Ok(text) = std::fs::read_to_string(PathBuf::from(run_dir).join("run.json")) {
             if let Ok(run) = serde_json::from_str::<Value>(&text) {
+                if snapshot.provider.is_none() {
+                    snapshot.provider = run
+                        .get("provider")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                }
+                if snapshot.model.is_none() {
+                    snapshot.model = run.get("model").and_then(Value::as_str).map(str::to_string);
+                }
                 snapshot.run_id = run.get("id").and_then(Value::as_str).map(str::to_string);
                 snapshot.error = run.get("error").and_then(Value::as_str).map(str::to_string);
                 // Pre-rename runs (< #190) recorded the step count as "turns".
@@ -588,6 +611,9 @@ fn load_task_index() -> Vec<AgentTaskSnapshot> {
     };
     let mut tasks = serde_json::from_str::<Vec<AgentTaskSnapshot>>(&text).unwrap_or_default();
     for task in &mut tasks {
+        let hydrated = hydrate_task_snapshot(task.clone());
+        task.provider = hydrated.provider;
+        task.model = hydrated.model;
         task.final_text = None;
     }
     tasks

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -133,6 +133,18 @@ const messages = {
     en: "sign in to get {points} points of agent credit",
     zh: "登录后获赠{points}点 agent额度",
   },
+  "auth.trialHint": {
+    en: "Complete one task free. Then sign in for {points} points or add your API key.",
+    zh: "可先免费完成 1 个任务。之后登录领取 {points} 点，或添加自己的 API Key。",
+  },
+  "auth.trialCompleteHint": {
+    en: "Your free task is complete. Sign in for {points} points or add your API key to continue.",
+    zh: "免费体验已完成。登录领取 {points} 点，或添加自己的 API Key 继续使用。",
+  },
+  "auth.trialUnavailableHint": {
+    en: "The free task status is unavailable. Sign in or add your API key to continue.",
+    zh: "暂时无法确认免费体验状态。请登录，或添加自己的 API Key 继续使用。",
+  },
   "auth.useOwnApiKey": {
     en: "or use your own API key, no sign-in required",
     zh: "或自己输入API key，无需登录",
@@ -413,6 +425,18 @@ const messages = {
     en: "your socai account is signed out. sign in, then send the task again.",
     zh: "当前 socai 账号尚未登录。请先登录账号，然后重新发送任务。",
   },
+  "task.preflightTrialUsed": {
+    en: "Your free task is complete. Sign in for {points} points or choose a model with your API key.",
+    zh: "免费体验已完成。请登录领取 {points} 点，或选择已配置 API Key 的模型。",
+  },
+  "task.preflightTrialUnavailable": {
+    en: "The free task status is unavailable. Check the network, sign in, or choose a model with your API key.",
+    zh: "暂时无法确认免费体验状态。请检查网络、登录账号，或选择已配置 API Key 的模型。",
+  },
+  "task.preflightTrialRunning": {
+    en: "The free task is already running. Wait for it to finish or cancel it first.",
+    zh: "免费任务正在运行。请等待完成，或先取消当前任务。",
+  },
   "task.preflightBalance": {
     en: "your socai account does not have enough points. recharge or switch to another configured model, then try again.",
     zh: "当前 socai 账号点数不足。请充值点数或切换到其他已配置的模型，然后重试。",
@@ -456,6 +480,12 @@ const messages = {
   "task.preflightFailedTitle": {
     en: "task cannot start yet",
     zh: "任务暂时无法开始",
+  },
+  "task.diagnosingError": { en: "checking the error…", zh: "正在诊断错误…" },
+  "task.diagnoseError": { en: "check this error", zh: "诊断这个错误" },
+  "task.diagnosisUnavailable": {
+    en: "Error guidance is unavailable. Try again later.",
+    zh: "暂时无法获取错误说明，请稍后重试。",
   },
   "task.errorCode": { en: "error code: {code}", zh: "错误码：{code}" },
   "task.apiErrorAuthTitle": { en: "model authentication failed", zh: "模型认证失败" },
@@ -730,6 +760,9 @@ export function t(
 const taskPreflightMessages = {
   preflight_model_config: "task.preflightModelConfig",
   preflight_auth: "task.preflightAuth",
+  preflight_trial_used: "task.preflightTrialUsed",
+  preflight_trial_unavailable: "task.preflightTrialUnavailable",
+  preflight_trial_running: "task.preflightTrialRunning",
   preflight_balance: "task.preflightBalance",
   preflight_region_or_account: "task.preflightAccount",
   preflight_site: "task.preflightSite",
@@ -757,7 +790,7 @@ export function formatTaskCommandErrorPresentation(
   const nudge = messageKey === "task.preflightModelConfig" ? managedModelNudge() : "";
   return {
     title: t("task.preflightFailedTitle"),
-    message: joinSentences(t(messageKey), nudge),
+    message: joinSentences(t(messageKey, { points: SIGNUP_BONUS_POINTS }), nudge),
     meta: t("task.errorCode", { code: payload.code }),
     fingerprint: `${payload.code}:${payload.detail}`,
   };
@@ -801,6 +834,27 @@ export interface TaskApiErrorPresentation {
   message: string;
   meta: string;
   fingerprint: string;
+}
+
+export interface ErrorDiagnosis {
+  title: string;
+  message: string;
+  action: string;
+}
+
+const errorDiagnoses = new Map<string, ErrorDiagnosis>();
+
+function diagnosisKey(error: string): string {
+  return `${currentLanguage}:${error.trim()}`;
+}
+
+export function setTaskApiErrorDiagnosis(error: string, diagnosis: ErrorDiagnosis): void {
+  errorDiagnoses.set(diagnosisKey(error), diagnosis);
+}
+
+export function taskApiErrorNeedsDiagnosis(error: string): boolean {
+  if (errorDiagnoses.has(diagnosisKey(error))) return false;
+  return formatTaskApiError(error).title === t("task.apiErrorGenericTitle");
 }
 
 export function formatTaskApiError(error: string): TaskApiErrorPresentation {
@@ -878,6 +932,15 @@ export function formatTaskApiError(error: string): TaskApiErrorPresentation {
     status !== null ? `HTTP ${status}` : "",
     parsed.requestId ? t("task.apiErrorRequestId", { id: parsed.requestId }) : "",
   ].filter(Boolean).join(" · ");
+  const diagnosis = fallbackCode === "api_error" ? errorDiagnoses.get(diagnosisKey(error)) : null;
+  if (diagnosis) {
+    return {
+      title: diagnosis.title,
+      message: joinSentences(diagnosis.message, diagnosis.action),
+      meta,
+      fingerprint: parsed.requestId || `${provider}:${parsed.statusText}:${errorCode}:${parsed.detail}`,
+    };
+  }
   return {
     title: t(titleKey),
     message: taskApiErrorMessage(messageKey, credential, provider),

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -76,6 +76,7 @@ export interface AgentTaskSnapshot {
   estimated_cost: number | null;
   cost_currency: string | null;
   points_used: number | null;
+  anonymous_trial: boolean;
 }
 
 export interface AgentArtifact {
@@ -755,7 +756,7 @@ async function main(): Promise<void> {
       void agentPanel.loadTaskNotes(event.payload.task_id, shell());
       void agentPanel.loadTaskArtifacts(event.payload.task_id, shell());
       maybeRelaunchReadyUpdate();
-      void authMenu.refreshWallet().then(render);
+      void Promise.all([authMenu.loadSession(), agentPanel.refreshModels()]).then(() => render());
     }
   });
   await listen<BackgroundMediaEvent>("agent_task:notes_updated", (event) => {

--- a/app/src/panels/auth.ts
+++ b/app/src/panels/auth.ts
@@ -13,6 +13,8 @@ interface AuthSession {
   phone: string;
   device_id: string;
   status: string;
+  trial_available: boolean;
+  trial_status: string;
 }
 
 interface SmsChallenge {
@@ -36,6 +38,8 @@ const EMPTY_SESSION: AuthSession = {
   phone: "",
   device_id: "",
   status: "",
+  trial_available: false,
+  trial_status: "unknown",
 };
 
 export namespace authMenu {
@@ -160,10 +164,18 @@ export namespace authMenu {
   }
 
   function renderSignedOut(modelConfigContent: string): string {
+    const trialMessage = session.trial_available
+      ? "auth.trialHint"
+      : session.trial_status === "completed" || session.trial_status === "converted"
+        ? "auth.trialCompleteHint"
+        : "auth.trialUnavailableHint";
     return `
       <section class="auth-choice">
         <div class="auth-choice-copy">
-          <p class="t-small subtle">${esc(t("auth.loginAgentHint", { points: SIGNUP_BONUS_POINTS }))}</p>
+          <p class="t-small auth-trial-copy">${esc(t(
+            trialMessage,
+            { points: SIGNUP_BONUS_POINTS },
+          ))}</p>
         </div>
         <button id="auth-start-login" type="button" class="btn-primary btn-compact" aria-expanded="${loginExpanded || challenge ? "true" : "false"}">${esc(t("auth.login"))}</button>
       </section>
@@ -437,7 +449,12 @@ export namespace authMenu {
       console.error("auth_logout failed:", err);
       error = friendlyError(err);
     } finally {
-      setSession(EMPTY_SESSION);
+      try {
+        setSession(await invoke<AuthSession>("auth_session"));
+      } catch (sessionError) {
+        console.error("auth_session failed after logout:", sessionError);
+        setSession(EMPTY_SESSION);
+      }
       wallet = null;
       walletUnavailable = false;
       loginExpanded = false;

--- a/app/src/panels/conversation.ts
+++ b/app/src/panels/conversation.ts
@@ -27,6 +27,7 @@ import {
   formatTokenUsage,
   isTaskApiError,
   t,
+  taskApiErrorNeedsDiagnosis,
   taskStatusLabel,
 } from "../lib/i18n";
 import { sendShortcutLabel } from "../lib/shortcuts";
@@ -298,7 +299,7 @@ function renderTurn(
       answer = renderTaskCommandErrorCard(commandError);
       if (finishedAt) metaBits.push(finishedAt);
     } else if (apiError) {
-      answer = renderTaskApiErrorCard(apiError);
+      answer = renderTaskApiErrorCard(apiError, task.task_id);
       if (finishedAt) metaBits.push(finishedAt);
     } else if (task.final_text) {
       exportText = task.final_text;
@@ -564,8 +565,14 @@ function renderTaskApiErrorEvent(ev: AgentTaskEventPayload): string {
   </div>`;
 }
 
-function renderTaskApiErrorCard(error: string): string {
+function renderTaskApiErrorCard(error: string, taskId: string): string {
   const presentation = formatTaskApiError(error);
+  const diagnose = taskApiErrorNeedsDiagnosis(error)
+    ? `<div class="task-api-error-card__actions">
+        <button type="button" class="btn-ghost btn-compact" data-diagnose-task-error="${esc(taskId)}">${esc(t("task.diagnoseError"))}</button>
+        <span class="t-small result-error" data-diagnosis-error="${esc(taskId)}" hidden></span>
+      </div>`
+    : "";
   return `<div class="task-api-error-card" role="alert">
     <div class="task-api-error-card__heading">
       <i class="runtime-error-notice__dot" aria-hidden="true"></i>
@@ -573,6 +580,7 @@ function renderTaskApiErrorCard(error: string): string {
     </div>
     <p class="task-api-error-card__message">${esc(presentation.message)}</p>
     <p class="task-api-error-card__meta">${esc(presentation.meta)}</p>
+    ${diagnose}
   </div>`;
 }
 

--- a/app/src/panels/tasks.ts
+++ b/app/src/panels/tasks.ts
@@ -14,7 +14,13 @@ import type {
   ShellState,
 } from "../main";
 import { esc } from "../lib/html";
-import { t } from "../lib/i18n";
+import {
+  getLanguage,
+  isTaskApiError,
+  setTaskApiErrorDiagnosis,
+  t,
+  type ErrorDiagnosis,
+} from "../lib/i18n";
 import { isSendShortcut } from "../lib/shortcuts";
 import { settingsMenu } from "./settings";
 import { renderConfirmDeleteDialog, renderSidebar as renderSidebarMarkup } from "./task_history";
@@ -973,6 +979,7 @@ export namespace agentPanel {
     });
 
     bindComposer(shell);
+    bindErrorDiagnosis(shell);
 
     // Fold/unfold a turn's activity detail. The explicit choice is remembered
     // per task+turn until the run's terminal transition clears it.
@@ -1466,6 +1473,47 @@ export namespace agentPanel {
     });
   }
 
+  function bindErrorDiagnosis(shell: ShellState): void {
+    document.querySelectorAll<HTMLButtonElement>("[data-diagnose-task-error]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const taskId = button.dataset.diagnoseTaskError;
+        const task = tasks.find((item) => item.task_id === taskId);
+        const error = task ? taskApiErrorText(task) : null;
+        if (!taskId || !error) return;
+        button.disabled = true;
+        button.textContent = t("task.diagnosingError");
+        try {
+          const diagnosis = await invoke<ErrorDiagnosis>("diagnose_error", {
+            error,
+            language: getLanguage(),
+          });
+          setTaskApiErrorDiagnosis(error, diagnosis);
+          shell.rerender();
+        } catch (diagnosisError) {
+          console.error("diagnose_error failed:", diagnosisError);
+          button.disabled = false;
+          button.textContent = t("task.diagnoseError");
+          const message = document.querySelector<HTMLElement>(
+            `[data-diagnosis-error="${CSS.escape(taskId)}"]`,
+          );
+          if (message) {
+            message.hidden = false;
+            message.textContent = t("task.diagnosisUnavailable");
+          }
+        }
+      });
+    });
+  }
+
+  function taskApiErrorText(task: AgentTaskView): string | null {
+    const error = task.error?.trim();
+    if (error && isTaskApiError(error)) return error;
+    const finalText = task.final_text?.trim();
+    return finalText && /^API error:\s*/i.test(finalText)
+      ? finalText.replace(/^API error:\s*/i, "")
+      : null;
+  }
+
   function syncChromeSetupDetection(shell: ShellState): void {
     chromeSetupStatus = shell.status;
 
@@ -1549,7 +1597,11 @@ export namespace agentPanel {
       draft = "";
     } catch (err) {
       console.error("agent_task_start failed:", err);
-      submitError = shell.notifyTaskCommandError(err) ? "" : `${err}`;
+      if (shell.notifyTaskCommandError(err)) {
+        submitError = "";
+      } else {
+        submitError = t("task.preflightUnknown");
+      }
     } finally {
       submittingTask = false;
       shell.rerender();
@@ -1581,7 +1633,11 @@ export namespace agentPanel {
       replyDraft = "";
     } catch (err) {
       console.error("agent_task_reply failed:", err);
-      replyError = shell.notifyTaskCommandError(err) ? "" : `${err}`;
+      if (shell.notifyTaskCommandError(err)) {
+        replyError = "";
+      } else {
+        replyError = t("task.preflightUnknown");
+      }
     } finally {
       submittingReply = false;
       shell.rerender();

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -368,7 +368,7 @@ body.has-paper > * { position: relative; z-index: 1; }
 }
 .task-api-error-card__message {
   margin: 5px 0 0;
-  color: var(--fg-muted);
+  color: var(--fg);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -383,7 +383,9 @@ body.has-paper > * { position: relative; z-index: 1; }
 .task-api-error-card__meta { margin: var(--sp-2) 0 0; }
 .task-api-error-copy { display: flex; flex-direction: column; gap: 3px; }
 .task-api-error-copy__title { color: var(--fg); font-weight: 500; }
-.task-api-error-copy__message { color: var(--fg-muted); line-height: 1.5; }
+.task-api-error-copy__message { color: var(--fg); line-height: 1.5; }
+
+.auth-trial-copy { color: var(--fg); }
 @keyframes runtime-error-enter {
   from { opacity: 0; transform: translateY(-6px); }
   to { opacity: 1; transform: translateY(0); }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ dirs = "5"
 libc.workspace = true
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+regex = "1"
 # Image compositing/resizing for batching note images into 2x2 vision grids.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 # Pure-Rust mp4 demux for transcription: the AAC track is repacked as ADTS and

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -71,7 +71,7 @@ impl OpenAICompatBackend {
     ) -> anyhow::Result<Self> {
         let cfg: &'static ProviderConfig = config_for(provider);
         let gateway = if provider == Provider::Socai {
-            Some(crate::cloud::llm_gateway_config()?)
+            Some(crate::cloud::llm_gateway_config_for_task(task_id)?)
         } else {
             None
         };

--- a/core/src/cloud/auth.rs
+++ b/core/src/cloud/auth.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -9,6 +10,7 @@ use serde_json::{json, Map, Value};
 use crate::config;
 
 const AUTH_KEY: &str = "socai_pro";
+const LEGACY_DEVICE_AUTH_KEY: &str = "socai_device";
 const LEGACY_AUTH_KEY: &str = "socai_cloud";
 const LEGACY_PRO_BASE_URL: &str = "http://47.94.86.171";
 const PRODUCTION_BASE_URL: &str = "https://api.socai.work";
@@ -21,6 +23,8 @@ pub struct AuthSession {
     pub phone: String,
     pub device_id: String,
     pub status: String,
+    pub trial_available: bool,
+    pub trial_status: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +70,18 @@ pub struct CloudCredentials {
     pub active_until: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DeviceCredentials {
+    device_id: String,
+    device_token: String,
+    status: String,
+    available: bool,
+    #[serde(default)]
+    hosted_llm_default_applied: bool,
+    #[serde(default)]
+    hosted_llm_selected: bool,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct AccountTelemetrySnapshot {
     pub phone: String,
@@ -94,6 +110,15 @@ struct ActivateResponse {
     device_token: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct TrialResponse {
+    device_id: String,
+    #[serde(default)]
+    device_token: Option<String>,
+    status: String,
+    available: bool,
+}
+
 /// Locally saved user session. Invite-code activations intentionally return a
 /// logged-out session because they have a device token but no user identity.
 pub fn auth_session() -> Result<AuthSession> {
@@ -113,7 +138,20 @@ pub fn auth_session() -> Result<AuthSession> {
         } else {
             creds.status
         },
+        trial_available: trial_available(),
+        trial_status: trial_status(),
     })
+}
+
+pub fn trial_available() -> bool {
+    load_device_credentials().is_some_and(|credentials| credentials.available)
+}
+
+pub fn trial_status() -> String {
+    load_device_credentials()
+        .map(|credentials| credentials.status)
+        .filter(|status| !status.trim().is_empty())
+        .unwrap_or_else(|| "unknown".into())
 }
 
 /// Whether socai pro is activated on this device. Local check only (reads
@@ -132,6 +170,70 @@ pub fn status() -> Result<CloudStatus> {
             .is_some_and(|c| !c.device_token.trim().is_empty()),
         device_id: creds.map(|c| c.device_id).unwrap_or_default(),
     })
+}
+
+pub async fn ensure_trial_device() -> Result<bool> {
+    if auth_session()?.logged_in {
+        return Ok(false);
+    }
+    let base_url = configured_base_url()
+        .ok_or_else(|| anyhow::anyhow!("socai service URL is not configured"))?;
+
+    if let Some(credentials) = load_device_credentials() {
+        let response = bearer(
+            http_client()?.get(format!("{base_url}/v1/auth/trial")),
+            &credentials.device_token,
+        )
+        .send()
+        .await
+        .context("failed to load anonymous trial status")?;
+        let body: TrialResponse = require_success(response, "anonymous trial status")
+            .await?
+            .json()
+            .await?;
+        let server_device_id = body.device_id;
+        let server_status = body.status;
+        let server_available = body.available;
+        let merged = update_device_credentials(|current| {
+            if current.device_id == server_device_id {
+                current.status = server_status;
+                current.available = server_available;
+            }
+        })?;
+        return Ok(merged.is_some_and(|current| current.available));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
+    let install_id = crate::identity::load_or_create_install_id(&home.join(".socai"));
+    let response = http_client()?
+        .post(format!("{base_url}/v1/auth/trial"))
+        .json(&json!({
+            "install_id": install_id,
+            "app_version": env!("CARGO_PKG_VERSION"),
+            "label": "desktop",
+        }))
+        .send()
+        .await
+        .context("failed to register anonymous trial")?;
+    let body: TrialResponse = require_success(response, "anonymous trial registration")
+        .await?
+        .json()
+        .await?;
+    let device_token = body
+        .device_token
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!("anonymous trial response did not include a device token")
+        })?;
+    save_device_credentials(&DeviceCredentials {
+        device_id: body.device_id,
+        device_token,
+        status: body.status,
+        available: body.available,
+        hosted_llm_default_applied: false,
+        hosted_llm_selected: false,
+    })?;
+    Ok(body.available)
 }
 
 pub async fn activate(invite_code: &str, label: &str) -> Result<CloudStatus> {
@@ -228,6 +330,9 @@ pub async fn verify_sms_code(
     let canonical_phone = normalize_mainland_phone(phone)?;
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
     let install_id = crate::identity::load_or_create_install_id(&home.join(".socai"));
+    let trial_device_token = load_device_credentials()
+        .map(|credentials| credentials.device_token)
+        .unwrap_or_default();
     let response = http_client()?
         .post(format!("{base_url}/v1/auth/sms/verify"))
         .json(&json!({
@@ -237,6 +342,7 @@ pub async fn verify_sms_code(
             "install_id": install_id,
             "app_version": env!("CARGO_PKG_VERSION"),
             "label": label.trim(),
+            "trial_device_token": trial_device_token,
         }))
         .send()
         .await
@@ -262,6 +368,9 @@ fn save_login_credentials(
         balance_points: None,
         active_until: None,
     })?;
+    if let Err(err) = mark_trial_converted() {
+        tracing::warn!(error = %err, "failed to persist local anonymous trial conversion marker");
+    }
     // Keep the CLI and future app builds pointed at the same accepted service,
     // even when this build received the URL through SOCAI_PRO_BASE_URL. The
     // authenticated session is still usable in this build if config persistence
@@ -302,45 +411,139 @@ pub async fn logout() -> Result<()> {
 pub fn llm_gateway_config() -> Result<LlmGatewayConfig> {
     let base_url = configured_base_url()
         .ok_or_else(|| anyhow::anyhow!("socai service URL is not configured"))?;
-    let credentials = load_credentials()
-        .filter(|creds| !creds.user_id.trim().is_empty() && !creds.device_token.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("sign in to use Socai Agent"))?;
+    if let Some(credentials) =
+        load_credentials().filter(|creds| !creds.device_token.trim().is_empty())
+    {
+        return Ok(LlmGatewayConfig {
+            base_url,
+            device_token: credentials.device_token,
+        });
+    }
+    let credentials = load_device_credentials()
+        .filter(|credentials| credentials.available && !credentials.device_token.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("sign in or configure an API key to continue"))?;
     Ok(LlmGatewayConfig {
         base_url,
         device_token: credentials.device_token,
     })
 }
 
+pub(crate) fn llm_gateway_config_for_task(task_id: Option<&str>) -> Result<LlmGatewayConfig> {
+    let gateway = llm_gateway_config()?;
+    let Some(task_id) = task_id.filter(|value| !value.trim().is_empty()) else {
+        return Ok(gateway);
+    };
+    let mut gateways = task_gateways()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("hosted LLM task state is unavailable"))?;
+    Ok(gateways
+        .entry(task_id.to_string())
+        .or_insert(gateway)
+        .clone())
+}
+
+pub(super) fn llm_gateway_config_for_settlement(task_id: &str) -> Result<LlmGatewayConfig> {
+    if let Ok(gateways) = task_gateways().lock() {
+        if let Some(gateway) = gateways.get(task_id) {
+            return Ok(gateway.clone());
+        }
+    }
+    if let Ok(gateway) = llm_gateway_config() {
+        return Ok(gateway);
+    }
+    // A consumed anonymous token is no longer eligible for a new model call,
+    // but it remains the identity for idempotently recovering that task's
+    // settlement after an app restart.
+    let base_url = configured_base_url()
+        .ok_or_else(|| anyhow::anyhow!("socai service URL is not configured"))?;
+    let credentials = load_device_credentials()
+        .filter(|credentials| !credentials.device_token.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("device registration is required"))?;
+    Ok(LlmGatewayConfig {
+        base_url,
+        device_token: credentials.device_token,
+    })
+}
+
+pub fn reset_llm_gateway_for_task(task_id: &str) {
+    if let Ok(mut gateways) = task_gateways().lock() {
+        gateways.remove(task_id);
+    }
+}
+
+fn task_gateways() -> &'static Mutex<HashMap<String, LlmGatewayConfig>> {
+    static TASK_GATEWAYS: OnceLock<Mutex<HashMap<String, LlmGatewayConfig>>> = OnceLock::new();
+    TASK_GATEWAYS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Returns true once per saved account, allowing the desktop to select the
 /// hosted model by default without overriding a later explicit BYOK choice.
 pub fn take_hosted_llm_default() -> Result<bool> {
-    let Some(mut credentials) = load_credentials() else {
-        return Ok(false);
-    };
-    if credentials.user_id.trim().is_empty() || credentials.hosted_llm_default_applied {
-        return Ok(false);
+    if let Some(mut credentials) = load_credentials() {
+        if !credentials.user_id.trim().is_empty() && !credentials.hosted_llm_default_applied {
+            credentials.hosted_llm_default_applied = true;
+            credentials.hosted_llm_selected = true;
+            save_credentials(&credentials)?;
+            return Ok(true);
+        }
     }
-    credentials.hosted_llm_default_applied = true;
-    credentials.hosted_llm_selected = true;
-    save_credentials(&credentials)?;
-    Ok(true)
+    let mut applied = false;
+    update_device_credentials(|credentials| {
+        if credentials.available && !credentials.hosted_llm_default_applied {
+            credentials.hosted_llm_default_applied = true;
+            credentials.hosted_llm_selected = true;
+            applied = true;
+        }
+    })?;
+    Ok(applied)
 }
 
 pub fn hosted_llm_selected() -> bool {
     load_credentials().is_some_and(|credentials| {
         !credentials.user_id.trim().is_empty() && credentials.hosted_llm_selected
-    })
+    }) || load_device_credentials()
+        .is_some_and(|credentials| credentials.available && credentials.hosted_llm_selected)
 }
 
 pub fn set_hosted_llm_selected(selected: bool) -> Result<()> {
-    let Some(mut credentials) = load_credentials() else {
-        return Ok(());
-    };
-    if credentials.user_id.trim().is_empty() {
-        return Ok(());
+    if let Some(mut credentials) = load_credentials() {
+        if !credentials.user_id.trim().is_empty() {
+            credentials.hosted_llm_selected = selected;
+            return save_credentials(&credentials).map(|_| ());
+        }
     }
-    credentials.hosted_llm_selected = selected;
-    save_credentials(&credentials).map(|_| ())
+    update_device_credentials(|credentials| {
+        credentials.hosted_llm_selected = selected;
+    })
+    .map(|_| ())
+}
+
+pub(super) fn mark_trial_completed() {
+    let _ = update_device_credentials(|credentials| {
+        credentials.status = "completed".into();
+        credentials.available = false;
+        credentials.hosted_llm_selected = false;
+    });
+}
+
+fn mark_trial_converted() -> Result<()> {
+    update_device_credentials(|credentials| {
+        credentials.status = "converted".into();
+        credentials.available = false;
+        credentials.hosted_llm_selected = false;
+    })
+    .map(|_| ())
+}
+
+pub(super) fn diagnostic_device_token() -> Option<String> {
+    load_credentials()
+        .filter(|credentials| !credentials.device_token.trim().is_empty())
+        .map(|credentials| credentials.device_token)
+        .or_else(|| {
+            load_device_credentials()
+                .filter(|credentials| !credentials.device_token.trim().is_empty())
+                .map(|credentials| credentials.device_token)
+        })
 }
 
 pub(crate) fn telemetry_account_snapshot() -> Option<AccountTelemetrySnapshot> {
@@ -394,6 +597,8 @@ fn logged_out_session() -> AuthSession {
         phone: String::new(),
         device_id: String::new(),
         status: String::new(),
+        trial_available: trial_available(),
+        trial_status: trial_status(),
     }
 }
 
@@ -517,6 +722,20 @@ pub(super) fn load_credentials() -> Option<CloudCredentials> {
     serde_json::from_value(block.clone()).ok()
 }
 
+fn load_device_credentials() -> Option<DeviceCredentials> {
+    let _guard = device_file_lock().lock().ok()?;
+    load_device_credentials_unlocked()
+}
+
+fn load_device_credentials_unlocked() -> Option<DeviceCredentials> {
+    if let Ok(bytes) = std::fs::read(device_auth_path().ok()?) {
+        return serde_json::from_slice(&bytes).ok();
+    }
+    let bytes = std::fs::read(auth_path().ok()?).ok()?;
+    let value: Value = serde_json::from_slice(&bytes).ok()?;
+    serde_json::from_value(value.get(LEGACY_DEVICE_AUTH_KEY)?.clone()).ok()
+}
+
 fn save_credentials(credentials: &CloudCredentials) -> Result<PathBuf> {
     let path = auth_path()?;
     if let Some(parent) = path.parent() {
@@ -533,6 +752,37 @@ fn save_credentials(credentials: &CloudCredentials) -> Result<PathBuf> {
     data.remove(LEGACY_AUTH_KEY);
     write_auth_file(&path, data)?;
     Ok(path)
+}
+
+fn save_device_credentials(credentials: &DeviceCredentials) -> Result<PathBuf> {
+    let _guard = device_file_lock()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("device credentials are unavailable"))?;
+    write_device_credentials_unlocked(credentials)
+}
+
+fn write_device_credentials_unlocked(credentials: &DeviceCredentials) -> Result<PathBuf> {
+    let path = device_auth_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(credentials)?)?;
+    set_private_permissions(&path);
+    Ok(path)
+}
+
+fn update_device_credentials(
+    update: impl FnOnce(&mut DeviceCredentials),
+) -> Result<Option<DeviceCredentials>> {
+    let _guard = device_file_lock()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("device credentials are unavailable"))?;
+    let Some(mut credentials) = load_device_credentials_unlocked() else {
+        return Ok(None);
+    };
+    update(&mut credentials);
+    write_device_credentials_unlocked(&credentials)?;
+    Ok(Some(credentials))
 }
 
 fn clear_credentials() -> Result<()> {
@@ -556,13 +806,27 @@ fn auth_path() -> Result<PathBuf> {
     Ok(home.join(".socai/auth.json"))
 }
 
+fn device_auth_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
+    Ok(home.join(".socai/device.json"))
+}
+
+fn device_file_lock() -> &'static Mutex<()> {
+    static DEVICE_FILE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    DEVICE_FILE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn write_auth_file(path: &Path, data: Map<String, Value>) -> Result<()> {
     let rendered = serde_json::to_string_pretty(&Value::Object(data))?;
     std::fs::write(path, rendered)?;
+    set_private_permissions(path);
+    Ok(())
+}
+
+fn set_private_permissions(path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
     }
-    Ok(())
 }

--- a/core/src/cloud/billing.rs
+++ b/core/src/cloud/billing.rs
@@ -4,7 +4,8 @@ use serde_json::json;
 
 use super::auth::{
     cache_active_until, cache_balance_points, cache_wallet_snapshot, configured_base_url,
-    http_client, load_credentials, require_success,
+    http_client, llm_gateway_config, llm_gateway_config_for_settlement, load_credentials,
+    mark_trial_completed, require_success, reset_llm_gateway_for_task,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +60,10 @@ pub struct LlmSettlement {
     pub balance_points: i64,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(default)]
+    pub trial_completed: bool,
+    #[serde(default)]
+    pub trial: bool,
 }
 
 fn authenticated_request(method: reqwest::Method, path: &str) -> Result<reqwest::RequestBuilder> {
@@ -170,14 +175,44 @@ pub async fn settle_llm_task(task_id: &str, final_status: &str) -> Result<LlmSet
         anyhow::bail!("invalid hosted LLM final status");
     }
     let path = format!("/v1/llm/tasks/{task_id}/settle?final_status={final_status}");
-    let response = authenticated_request(reqwest::Method::POST, &path)?
+    let gateway = llm_gateway_config_for_settlement(task_id)?;
+    let request = |gateway: &super::auth::LlmGatewayConfig| -> Result<reqwest::RequestBuilder> {
+        Ok(http_client()?
+            .post(format!(
+                "{}{}",
+                gateway.base_url.trim_end_matches('/'),
+                path
+            ))
+            .bearer_auth(&gateway.device_token))
+    };
+    let mut response = request(&gateway)?
         .send()
         .await
         .context("failed to settle hosted LLM task")?;
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        let current = llm_gateway_config()?;
+        if current.device_token != gateway.device_token {
+            response = request(&current)?
+                .send()
+                .await
+                .context("failed to settle hosted LLM task")?;
+        }
+    }
     let settlement: LlmSettlement = require_success(response, "hosted LLM settlement")
         .await?
         .json()
         .await?;
-    cache_balance_points(settlement.balance_points);
+    if settlement.trial_completed {
+        mark_trial_completed();
+    }
+    if !settlement.trial {
+        cache_balance_points(settlement.balance_points);
+    }
+    if settlement.status != "settlement_pending" {
+        reset_llm_gateway_for_task(task_id);
+    }
     Ok(settlement)
 }

--- a/core/src/cloud/mod.rs
+++ b/core/src/cloud/mod.rs
@@ -4,13 +4,15 @@ mod asr;
 mod auth;
 mod billing;
 mod browser;
+mod support;
 
 pub use asr::{transcribe_audio_file, CloudAsrResult};
 pub use auth::{
-    activate, activate_with_base_url, auth_session, hosted_llm_selected, llm_gateway_config,
-    logout, pro_activated, redeem_invite, send_sms_code, set_hosted_llm_selected, status,
-    take_hosted_llm_default, verify_sms_code, AuthSession, CloudCredentials, CloudStatus,
-    InviteRedemption, LlmGatewayConfig, SmsChallengeResponse,
+    activate, activate_with_base_url, auth_session, ensure_trial_device, hosted_llm_selected,
+    llm_gateway_config, logout, pro_activated, redeem_invite, reset_llm_gateway_for_task,
+    send_sms_code, set_hosted_llm_selected, status, take_hosted_llm_default, trial_available,
+    verify_sms_code, AuthSession, CloudCredentials, CloudStatus, InviteRedemption,
+    LlmGatewayConfig, SmsChallengeResponse,
 };
 pub use billing::{
     create_alipay_order, create_wechat_order, mock_recharge, payment_order, payment_plan,
@@ -18,5 +20,7 @@ pub use billing::{
     WalletBalance,
 };
 pub use browser::{create_browser_session, release_browser_session, BrowserSessionInfo};
+pub use support::{diagnose_error, ErrorDiagnosis};
 
+pub(crate) use auth::llm_gateway_config_for_task;
 pub(crate) use auth::telemetry_account_snapshot;

--- a/core/src/cloud/support.rs
+++ b/core/src/cloud/support.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use super::auth::{configured_base_url, diagnostic_device_token, require_success};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorDiagnosis {
+    pub title: String,
+    pub message: String,
+    pub action: String,
+}
+
+pub async fn diagnose_error(error: &str, language: &str) -> Result<ErrorDiagnosis> {
+    let base_url = configured_base_url()
+        .ok_or_else(|| anyhow::anyhow!("socai service URL is not configured"))?;
+    let device_token = diagnostic_device_token()
+        .ok_or_else(|| anyhow::anyhow!("device registration is required"))?;
+    let response = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(35))
+        .build()?
+        .post(format!("{base_url}/v1/support/diagnose-error"))
+        .bearer_auth(device_token)
+        .json(&json!({
+            "error": sanitize_error(error),
+            "language": if language == "en" { "en" } else { "zh" },
+        }))
+        .send()
+        .await
+        .context("failed to diagnose error")?;
+    Ok(require_success(response, "error diagnosis")
+        .await?
+        .json()
+        .await?)
+}
+
+fn sanitize_error(error: &str) -> String {
+    static JSON_SECRET: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?i)([\"'](?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|secret|client[_ -]?(?:id|secret)|credential|authorization|cookie|x-api-key|session|password|passwd)[\"']\s*:\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;}\]]+)"#,
+        )
+        .expect("valid error sanitizer")
+    });
+    static LINE_SECRET: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?im)(\b(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|session|password|passwd|credential|client[_ -]?id)\s*[:=]\s*).+$",
+        )
+        .expect("valid error sanitizer")
+    });
+    static INLINE_SECRET: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?i)(\b(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|secret|client[_ -]?(?:id|secret)|credential|authorization|cookie|x-api-key|session)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)"#,
+        )
+        .expect("valid error sanitizer")
+    });
+    static WINDOWS_PATH: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[A-Za-z]:[\\/][^\s,;]+").expect("valid error sanitizer"));
+    static UNIX_PATH: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?m)(^|[\s(=:'"])(/(?:[^/\s,;]+/)+[^/\s,;]+)"#)
+            .expect("valid error sanitizer")
+    });
+    static URL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s,;]+").expect("valid error sanitizer")
+    });
+    static AWS_ACCESS_KEY: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b").expect("valid error sanitizer")
+    });
+    static EMAIL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b").expect("valid error sanitizer")
+    });
+    static PHONE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?:\+?86[- ]?)?1[3-9]\d{9}").expect("valid error sanitizer"));
+
+    let text = crate::telemetry::redact_secrets(error);
+    let text = JSON_SECRET.replace_all(&text, "${1}\"[redacted]\"");
+    let text = LINE_SECRET.replace_all(&text, "${1}[redacted]");
+    let text = INLINE_SECRET.replace_all(&text, "${1}[redacted]");
+    let text = AWS_ACCESS_KEY.replace_all(&text, "[redacted]");
+    let text = URL.replace_all(&text, "[url]");
+    let text = WINDOWS_PATH.replace_all(&text, "[local-path]");
+    let text = UNIX_PATH.replace_all(&text, "${1}[local-path]");
+    let text = EMAIL.replace_all(&text, "[email]");
+    let text = PHONE.replace_all(&text, "[phone]");
+    text.chars().take(2000).collect()
+}


### PR DESCRIPTION
## Summary

- allow one anonymous hosted-model task per device, then guide the user to sign in for credits or configure an API key
- keep the trial credential separate from account credentials and pin the correct identity for each task turn and settlement
- keep the managed-task limit local: up to three authenticated tasks, while only one anonymous trial task may be active
- preserve the per-session Xiaohongshu login gate and avoid opening or checking a second shared page
- add client-side sanitized diagnosis and localized rendering for otherwise unknown errors
- rebase onto the current `main` managed-background-task implementation

## Server

- https://github.com/socai-io/socai-server/pull/28

## Contract notes

- no `/v1/llm/tasks/{task_id}/acquire` endpoint is introduced
- a login during an in-flight trial does not break that task; the next reply rebinds to the current signed-in identity
- restart recovery may settle the original anonymous task idempotently, but cannot start another anonymous model call

## Validation

- `npm_config_registry=https://registry.npmjs.org pnpm run build`
- `cargo test -p socai-core --lib` — 99 passed, 0 failed, 2 ignored
- `cargo check -p socai_app -p socai-cli`
- `git diff --check`
- final automated review: no blocking findings

