### PR TITLE
fix(agent): preserve message order across compaction

### DIFF
--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -206,6 +206,8 @@ pub async fn run_agent_with_events(
 
     let mut messages: Vec<Message> = options.seed_messages.clone();
     messages.push(Message::user(task.to_string()));
+    let mut anchor_user_index = options.seed_messages.len();
+    let is_follow_up = !options.seed_messages.is_empty();
     // Everything before this index is already in the trace: seed messages were
     // uploaded by the earlier turns that share this conversation's trace id,
     // and within the run the marker advances so each `chat` span carries only
@@ -252,7 +254,8 @@ pub async fn run_agent_with_events(
             &mut messages,
             options.compact_after_messages,
             options.keep_recent_messages,
-            options.seed_messages.len(),
+            &mut anchor_user_index,
+            is_follow_up,
         ) {
             // The trace is an append-only diagnostic record. The rewritten
             // transcript is local context management, so restart its cursor
@@ -560,7 +563,8 @@ pub async fn run_agent_with_events(
             &mut messages,
             options.compact_after_messages,
             options.keep_recent_messages,
-            options.seed_messages.len(),
+            &mut anchor_user_index,
+            is_follow_up,
         ) {
             traced_len = messages.len();
         }

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -24,7 +24,7 @@ const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 /// verbatim at the front; the last `keep_recent` messages remain verbatim
 /// (widened backward when the window would open on a tool_result message, so
 /// tool_use/tool_result pairs never split); older tool outputs become artifact
-/// locators. Follow-up runs (`anchor_user_index > 0`) also get a short task
+/// locators. Follow-up runs (`is_follow_up`) also get a short task
 /// reminder adjacent to the recent tail. `anchor_user_index` is updated to the
 /// anchor's new position after a rewrite so a later compaction in the same run
 /// cannot accidentally pin a tool message; `is_follow_up` remains stable so

--- a/core/src/agent/memory.rs
+++ b/core/src/agent/memory.rs
@@ -25,15 +25,19 @@ const LEGACY_EVIDENCE_HEADING: &str = "# Earlier tool evidence";
 /// (widened backward when the window would open on a tool_result message, so
 /// tool_use/tool_result pairs never split); older tool outputs become artifact
 /// locators. Follow-up runs (`anchor_user_index > 0`) also get a short task
-/// reminder immediately before the recent tail. Mutating the transcript, rather
-/// than rebuilding a summary for every request, leaves the request prefix
-/// stable until the next sawtooth compaction point and therefore friendly to
-/// provider prompt caches.
+/// reminder adjacent to the recent tail. `anchor_user_index` is updated to the
+/// anchor's new position after a rewrite so a later compaction in the same run
+/// cannot accidentally pin a tool message; `is_follow_up` remains stable so
+/// every later rewrite can recreate the reminder. Mutating the transcript,
+/// rather than rebuilding a summary for every request, leaves the request
+/// prefix stable until the next sawtooth compaction point and therefore
+/// friendly to provider prompt caches.
 pub fn compact_messages_for_context(
     messages: &mut Vec<Message>,
     compact_after: usize,
     keep_recent: usize,
-    anchor_user_index: usize,
+    anchor_user_index: &mut usize,
+    is_follow_up: bool,
 ) -> bool {
     if compact_after == 0
         || keep_recent == 0
@@ -55,7 +59,7 @@ pub fn compact_messages_for_context(
     while recent_start > 1 && contains_tool_result(&messages[recent_start]) {
         recent_start -= 1;
     }
-    let anchor_idx = anchor_user_index.min(messages.len().saturating_sub(1));
+    let anchor_idx = (*anchor_user_index).min(messages.len().saturating_sub(1));
     let anchor = messages[anchor_idx].clone();
     let older: Vec<Message> = (0..recent_start)
         .filter(|&index| index != anchor_idx)
@@ -69,18 +73,28 @@ pub fn compact_messages_for_context(
         .collect();
     let evidence = compact_older_messages(&older);
 
+    let task_reminder = is_follow_up
+        .then(|| user_text(&anchor))
+        .flatten()
+        .map(|task| current_task_reminder(&task));
+    let recent_ends_with_assistant = recent
+        .last()
+        .is_some_and(|message| matches!(message.role, MessageRole::Assistant));
+
     let mut compacted = Vec::with_capacity(3 + recent.len());
     compacted.push(anchor);
     if !evidence.is_empty() {
         compacted.push(Message::user(evidence));
     }
-    if anchor_user_index > 0 {
-        if let Some(task) = user_text(&compacted[0]) {
-            compacted.push(current_task_reminder(&task));
-        }
+    if !recent_ends_with_assistant {
+        compacted.extend(task_reminder.clone());
     }
     compacted.extend(recent);
+    if recent_ends_with_assistant {
+        compacted.extend(task_reminder);
+    }
     *messages = compacted;
+    *anchor_user_index = 0;
     true
 }
 


### PR DESCRIPTION
## Summary

Fix two context-compaction ordering regressions observed in production trace `0c797d181473ff6d7c236eb8a1d8a220` on v0.5.4 with Claude Sonnet 5.

- Keep the current-task anchor index synchronized after each transcript rewrite, so a second compaction cannot pin and relocate a tool message.
- Track follow-up state separately from the mutable anchor position, so every compaction recreates the current-task reminder.
- When the retained tail ends in an assistant message, append the reminder after it so Anthropic receives a user-ended conversation.
- Preserve the existing reminder position for tool-result and max-steps tails.

## Production evidence

The trace produced two deterministic 400 signatures:

```text
tool_use ids were found without tool_result blocks immediately after
```

```text
This model does not support assistant message prefill. The conversation must end with a user message.
```

The first signature occurred after repeated in-run compaction at seed message counts 12 and 18. Once a failed run was persisted, the second signature repeated five times at seed message counts 20 through 28, all at step 1 with zero provider usage.

## Validation

- `cargo check -p socai-core`
- `cargo test -p socai-core`: 91 passed, 2 ignored
- Focused temporary reproduction: repeated compaction preserves every tool_use/tool_result pair
- Focused temporary reproduction: assistant-ended seed history compacts to a user-ended request
- Codex CLI review cycle 1: one follow-up-state coupling issue found and fixed
- Codex CLI review cycle 2: no remaining actionable correctness findings

No new Rust tests were added, following the repository engineering rule.
