### PR TITLE
fix(cdp): open Chrome settings directly on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5250,6 +5250,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "winreg",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,9 @@ symphonia = { version = "0.5", default-features = false, features = ["isomp4"] }
 [target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]
 oar-ocr = "0.7"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.55"
+
 [dev-dependencies]
 tracing-subscriber.workspace = true
 tempfile = "3"

--- a/core/src/cdp/endpoint.rs
+++ b/core/src/cdp/endpoint.rs
@@ -123,7 +123,7 @@ pub async fn wait_for_existing_chrome_endpoint(
     }
 }
 
-/// Open the chrome://inspect remote-debugging page in the user's default
+/// Open the chrome://inspect remote-debugging page in the user's installed
 /// chrome for the existing-browser attach flow.
 pub fn open_remote_debugging_page() -> anyhow::Result<()> {
     #[cfg(target_os = "macos")]
@@ -135,11 +135,26 @@ pub fn open_remote_debugging_page() -> anyhow::Result<()> {
         .arg(INSPECT_URL)
         .status()?;
     #[cfg(target_os = "windows")]
-    let status = std::process::Command::new("cmd")
-        .args(["/C", "start", "", INSPECT_URL])
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("chrome could not open the remote debugging page");
+    {
+        use anyhow::Context;
+
+        let executable = super::launch::find_chrome_executable().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no chrome/chromium executable found. install Google Chrome, or set \
+                 SOCAI_CHROME_EXECUTABLE / CHROME to its path."
+            )
+        })?;
+        std::process::Command::new(&executable)
+            .arg(INSPECT_URL)
+            .spawn()
+            .with_context(|| format!("failed to launch chrome at {}", executable.display()))?;
+        return Ok(());
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if !status.success() {
+            anyhow::bail!("chrome could not open the remote debugging page");
+        }
     }
     Ok(())
 }

--- a/core/src/cdp/launch.rs
+++ b/core/src/cdp/launch.rs
@@ -242,11 +242,18 @@ fn process_alive(pid: i32) -> bool {
 }
 
 /// Resolve the chrome/chromium executable: explicit env override first
-/// (`SOCAI_CHROME_EXECUTABLE`, then `CHROME`), then well-known per-OS install
-/// locations.
+/// (`SOCAI_CHROME_EXECUTABLE`, then `CHROME`), then Windows App Paths, then
+/// well-known per-OS install locations.
 pub(crate) fn find_chrome_executable() -> Option<PathBuf> {
     if let Some(path) = chrome_executable_override() {
         return Some(path);
+    }
+    #[cfg(target_os = "windows")]
+    if let Some(found) = registered_chrome_executables()
+        .into_iter()
+        .find(|path| path.exists())
+    {
+        return Some(found);
     }
     if let Some(found) = default_chrome_executables()
         .into_iter()
@@ -296,11 +303,55 @@ fn default_chrome_executables() -> Vec<PathBuf> {
         "microsoft-edge",
         "brave-browser",
     ];
-    let roots = ["/usr/bin", "/usr/local/bin", "/snap/bin", "/opt/google/chrome"];
+    let roots = [
+        "/usr/bin",
+        "/usr/local/bin",
+        "/snap/bin",
+        "/opt/google/chrome",
+    ];
     let mut out = Vec::new();
     for root in roots {
         for name in names {
             out.push(PathBuf::from(root).join(name));
+        }
+    }
+    out
+}
+
+#[cfg(target_os = "windows")]
+fn registered_chrome_executables() -> Vec<PathBuf> {
+    use winreg::enums::{
+        HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
+    };
+    use winreg::RegKey;
+
+    let roots = [
+        RegKey::predef(HKEY_CURRENT_USER),
+        RegKey::predef(HKEY_LOCAL_MACHINE),
+    ];
+    let views = [KEY_READ | KEY_WOW64_64KEY, KEY_READ | KEY_WOW64_32KEY];
+    let executable_names = ["chrome.exe", "chromium.exe", "msedge.exe", "brave.exe"];
+    let mut out = Vec::new();
+
+    for executable_name in executable_names {
+        let subkey =
+            format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{executable_name}");
+        for root in &roots {
+            for flags in views {
+                let Ok(key) = root.open_subkey_with_flags(&subkey, flags) else {
+                    continue;
+                };
+                let Ok(value) = key.get_value::<String, _>("") else {
+                    continue;
+                };
+                let value = value.trim().trim_matches('"');
+                if !value.is_empty() {
+                    let path = PathBuf::from(value);
+                    if !out.contains(&path) {
+                        out.push(path);
+                    }
+                }
+            }
         }
     }
     out


### PR DESCRIPTION
## Summary

- Resolve Chromium-family executables through explicit environment overrides, Windows App Paths, and existing well-known install locations.
- Open `chrome://inspect/#remote-debugging` by spawning the resolved browser executable on Windows.
- Stop routing the custom `chrome:` URI through `cmd /C start`, which can send users to Microsoft Store when no protocol handler is registered.
- Keep `winreg` scoped to Windows builds and reuse the same executable resolver for managed Chrome and the existing-browser setup flow.

## Reproduction

On an affected Windows installation with Chrome already installed, run:

```text
cmd /C start "" "chrome://inspect/#remote-debugging"
```

Windows resolves `chrome:` as a custom URI scheme. When that scheme has no registered handler, the shell offers a Microsoft Store search even though `chrome.exe` exists and Chrome handles ordinary `http` and `https` URLs.

Launching the installed executable directly opens the expected settings page:

```powershell
Start-Process -FilePath "$env:ProgramFiles\Google\Chrome\Application\chrome.exe" -ArgumentList "chrome://inspect/#remote-debugging"
```

## Implementation

- Check `SOCAI_CHROME_EXECUTABLE` and `CHROME` first.
- Read HKCU and HKLM App Paths through both 64-bit and 32-bit registry views.
- Fall back to the existing `Program Files`, `Program Files (x86)`, and `LocalAppData` locations.
- Spawn the resolved browser without waiting for the long-lived Chrome process to exit.
- Return an actionable missing-browser or spawn error instead of opening Microsoft Store.

## Validation

- `cargo test -p socai-core --lib` — 99 passed, 0 failed, 2 ignored.
- `cargo check -p socai_app` — passed.
- `rustfmt --edition 2021 --check core/src/cdp/endpoint.rs core/src/cdp/launch.rs` — passed.
- `git diff --check` — passed.
- Isolated `x86_64-pc-windows-msvc` compile probe covering the same winreg hive/view reads and browser spawn — passed.
- Codex CLI review — no actionable findings.

## Remaining platform coverage

- A real Windows 10/11 desktop click should confirm that Microsoft Store stays closed, Chrome opens the remote-debugging page, and Socai detects `DevToolsActivePort` after the user enables debugging and clicks Allow.
- A full Windows cross-build from macOS is blocked before project compilation by the existing `onig_sys` C dependency requiring MSVC headers; the repository release workflow remains the complete Windows packaging check.

No Rust tests were added, following the repository engineering rule.