### PR TITLE
fix(telemetry): summarize desktop site tool results

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -21,7 +21,7 @@ use socai_core::runtime::{
 use socai_core::sites::xhs::{XhsHistoryStore, XhsPageRuntime};
 use socai_core::sites::{find_site, SiteSpec};
 use socai_core::telemetry::query_text_enabled;
-use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_result};
+use socai_core::telemetry::tool_call::{summarize_site_tool_result, summarize_tool_args};
 use socai_core::telemetry::trace::mark_run_trace_status;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -2861,14 +2861,14 @@ fn pump_agent_task_events(
                     props.insert("duration_ms".into(), json!(tool_duration_ms));
                     props.insert("ok".into(), json!(error.is_none()));
                     props.insert("error".into(), json!(error.as_deref().map(short_error)));
-                    // Same shared summarizer the CLI daemon uses: the search
-                    // query is lifted into query_text/query_len (gated by
-                    // query_text_enabled) and every other arg folds into
-                    // metadata; result counts and bounded unexpected-page OCR
-                    // diagnostics are extracted from the output. Note bodies
-                    // and comments are never included.
+                    // The search query is lifted into query_text/query_len
+                    // (gated by query_text_enabled), and every other arg folds
+                    // into metadata. Trusted site results are decoded from the
+                    // desktop content blocks before the shared summarizer
+                    // extracts counts and bounded diagnostics. Local tool
+                    // output, note bodies, and comments are never included.
                     props.extend(summarize_tool_args(input, query_text_enabled()));
-                    props.extend(summarize_tool_result(content));
+                    props.extend(summarize_site_tool_result(name, content));
                     telemetry.capture("socai_tool_call", Value::Object(props));
                 }
                 _ => {}

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -176,6 +176,45 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     props
 }
 
+/// Summarize the model-visible content blocks emitted by a trusted site tool.
+/// Local tools such as `read_file` and `shell` may return arbitrary user JSON,
+/// so their text blocks must remain opaque to telemetry.
+pub fn summarize_site_tool_result(tool_name: &str, value: &Value) -> Map<String, Value> {
+    if !is_site_tool_result(tool_name) {
+        return Map::new();
+    }
+    result_json_from_content_blocks(value)
+        .as_ref()
+        .map(summarize_tool_result)
+        .unwrap_or_default()
+}
+
+pub(crate) fn is_site_tool_result(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "search" | "get_notes" | "author_scan" | "page_state"
+    )
+}
+
+/// Desktop and trace events serialize a tool result as model-visible content:
+/// `[{"type":"text","text":"<tool JSON>"}, ...]`. Parse only a complete
+/// JSON text block after the caller has established that the tool is a site
+/// tool. Non-JSON prose and image blocks stay opaque.
+fn result_json_from_content_blocks(value: &Value) -> Option<Value> {
+    let blocks = value.as_array()?;
+    blocks.iter().find_map(|block| {
+        let block = block.as_object()?;
+        if block.get("type").and_then(Value::as_str) != Some("text") {
+            return None;
+        }
+        let text = block.get("text").and_then(Value::as_str)?.trim();
+        if !(text.starts_with('{') || text.starts_with('[')) {
+            return None;
+        }
+        serde_json::from_str(text).ok()
+    })
+}
+
 fn find_string<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
     match value {
         Value::Object(map) => map
@@ -295,7 +334,7 @@ mod tests {
     #[test]
     fn result_summary_extracts_safe_counts_without_copying_text() {
         let page_ocr = "限".repeat(PAGE_OCR_MAX_CHARS + 1);
-        let props = summarize_tool_result(&json!({
+        let result = json!({
             "run_dir": "/tmp/socai-run",
             "data": {
                 "ok": false,
@@ -319,7 +358,8 @@ mod tests {
                     { "skipped": true, "comments": ["must not be copied"] }
                 ]
             }
-        }));
+        });
+        let props = summarize_tool_result(&result);
         assert_eq!(props.get("result_ok"), Some(&json!(false)));
         assert_eq!(props.get("cards_count"), Some(&json!(2)));
         assert_eq!(props.get("search_cards_count"), Some(&json!(3)));
@@ -364,5 +404,32 @@ mod tests {
         );
         assert!(!props.contains_key("body"));
         assert!(!props.contains_key("comments"));
+
+        let content = json!([
+            { "type": "text", "text": serde_json::to_string_pretty(&result).unwrap() },
+            { "type": "image", "media_type": "image/png" }
+        ]);
+        assert_eq!(summarize_site_tool_result("search", &content), props);
+
+        let hostile_local_json = json!([
+            {
+                "type": "text",
+                "text": r#"{"ok":false,"reason":"private user value","page_ocr_text":"private file contents","recovery_tool":"private command"}"#
+            }
+        ]);
+        assert!(summarize_site_tool_result("read_file", &hostile_local_json).is_empty());
+        assert!(summarize_site_tool_result("shell", &hostile_local_json).is_empty());
+        assert!(!is_site_tool_result("read_file"));
+        assert!(!is_site_tool_result("shell"));
+        assert!(summarize_site_tool_result(
+            "search",
+            &json!([{ "type": "image", "media_type": "image/png" }])
+        )
+        .is_empty());
+        assert!(summarize_site_tool_result(
+            "search",
+            &json!([{ "type": "text", "text": "ordinary non-JSON output" }])
+        )
+        .is_empty());
     }
 }

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -16,8 +16,8 @@
 //! (`gen_ai.*`) — Axiom promotes those to first-class trace columns — with
 //! socai-specific context under `socai.*`. Tool args go through
 //! `summarize_tool_args` (query text gated by `SOCAI_TELEMETRY_QUERY_TEXT`)
-//! and tool output through `summarize_tool_result` (counts plus bounded
-//! unexpected-page OCR diagnostics).
+//! and trusted site-tool output through `summarize_site_tool_result` (counts
+//! plus bounded unexpected-page OCR diagnostics).
 //!
 //! Chat content rides on the `chat` spans (gated by
 //! `SOCAI_TELEMETRY_CHAT_TEXT`): `gen_ai.input.messages` carries only the
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-use super::tool_call::{summarize_tool_args, summarize_tool_result};
+use super::tool_call::{is_site_tool_result, summarize_site_tool_result, summarize_tool_args};
 use super::{chat_text_enabled, query_text_enabled};
 use crate::agent::llm::{
     Block, LLMResponse, Message, MessageContent, MessageRole, TokenUsage, ToolResultContent,
@@ -278,9 +278,9 @@ impl RunTraceBuilder {
             attr_bool("socai.ok", error.is_none()),
         ];
         extend_prefixed(&mut attrs, summarize_tool_args(input, query_text_enabled()));
-        extend_prefixed(&mut attrs, summarize_tool_result(output));
+        extend_prefixed(&mut attrs, summarize_site_tool_result(name, output));
         if chat_text_enabled() {
-            let notes = note_summaries(output);
+            let notes = note_summaries(name, output);
             if !notes.is_empty() {
                 let mut rendered = Value::Array(notes).to_string();
                 // Field caps bound this far below CHAT_ATTR_MAX_BYTES; the
@@ -709,9 +709,12 @@ fn chat_text(text: &str, part_cap: usize) -> String {
 /// replaying the run. Matches the opened-note shape (`notes[].entity`) and the
 /// preview/profile card arrays — the same paths `summarize_tool_result`
 /// counts. Stats stay the raw displayed strings ("1.2万", "评论").
-fn note_summaries(output: &Value) -> Vec<Value> {
+fn note_summaries(tool_name: &str, output: &Value) -> Vec<Value> {
     let mut notes: Vec<Value> = Vec::new();
     let mut seen_ids: Vec<String> = Vec::new();
+    if !is_site_tool_result(tool_name) {
+        return notes;
+    }
     let Some(blocks) = output.as_array() else {
         return notes;
     };


### PR DESCRIPTION
## Summary

- Decode trusted site-tool JSON from the desktop agent content-block envelope before building `socai_tool_call` metrics.
- Restore `result_ok`, card counts, selected-card counts, note counts, and bounded page diagnostics for desktop events and OTLP tool spans.
- Keep CLI daemon behavior unchanged because it already summarizes direct structured JSON.
- Keep `read_file`, `shell`, `publish_artifact`, and other local-tool content opaque to result telemetry.
- Apply the same trusted-tool boundary to `socai.notes` trace summaries.

## Production evidence

The fixed seven-day Axiom window contains 188 desktop `search` calls on v0.5.5. Every call has `result_unreported`, while `notes` and `selected_cards` remain zero. The root trace contains 201 `execute_tool search` spans with the same missing result metrics.

Desktop events and run traces receive `AgentEvent::ToolResult.content` in this shape:

```json
[{"type":"text","text":"{\"ok\":true,\"cards\":[...]}"}]
```

The shared summarizer previously expected direct JSON or the CLI daemon `data` envelope, so it inspected the content-block array and never reached the site result.

## Implementation

- Parse only complete JSON text blocks for `search`, `get_notes`, `author_scan`, and `page_state`.
- Feed parsed site results through the existing bounded result summarizer.
- Leave non-JSON text and image-only blocks opaque.
- Reject local tools before parsing, including hostile JSON shaped like known telemetry fields.
- Reuse the same trusted-tool check for note summaries carried by OTLP traces.

## Validation

- `cargo test -p socai-core telemetry::tool_call::tests` — 7 passed.
- `cargo check -p socai-core` — passed.
- `cargo check -p socai-cli` — passed.
- `TAURI_CONFIG=... cargo check -p socai_app` with `bundle.externalBin` cleared — passed. The override excludes the local worktree sidecar packaging dependency while compiling the modified desktop call site.
- `rustfmt --edition 2021 --check core/src/telemetry/tool_call.rs core/src/telemetry/trace.rs` — passed.
- `git diff --check` — passed.
- Codex CLI review identified the arbitrary local-JSON path and the separate note-summary path; both are now restricted to trusted site tools.

No new Rust test function was added, following the repository engineering rule; the existing result-summary test now covers desktop content blocks, hostile local JSON, image-only blocks, and non-JSON text.