### PR TITLE
fix(xhs): recover homepage search submission

### DIFF
--- a/core/src/sites/xhs/knowledge.md
+++ b/core/src/sites/xhs/knowledge.md
@@ -86,6 +86,11 @@ artifacts, and return a compact bundle. They differ only in where they enter:
 Both flows keep opening notes by clicking their cards. Their card/note URLs
 carry the xsec token needed for a later `get_notes` call.
 
+On the homepage, the visible AI-search submit button may not be mounted until
+after text is entered. Homepage feed cards are not proof that a search ran: a
+successful search must transition to a `/search_result*` page with the requested
+keyword. The runtime re-locates the post-typing submit control if Enter is ignored.
+
 While reading any result set, keep track of what each author is: the subject's
 own official account (the gym/brand/venue/organizer itself), semi-official
 voices (its staff or coaches), aggregator/curator accounts, or ordinary users.

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -374,7 +374,7 @@ impl<'a> XhsPageRuntime<'a> {
 
         sleep_ms(150).await;
         self.page.press_key("Enter").await?;
-        let state = self
+        let mut state = self
             .wait_for_search_transition(query, wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S))
             .await?;
         if search_transition_ok(&state, query) {
@@ -386,12 +386,19 @@ impl<'a> XhsPageRuntime<'a> {
             }));
         }
 
-        if let Some(submit) = loc.get("submit") {
+        // Typing opens the homepage suggestion panel and can re-render (or
+        // only then mount) the submit affordance. Do not reuse `loc.submit`,
+        // which was measured while the input was still empty: the stale/null
+        // coordinate was the cause of intermittent searches that visibly had
+        // the requested keyword but stayed on /explore. Re-read the live DOM
+        // after Enter has failed, then click the current control.
+        let current_loc = self.expect_object("searchInput", None).await?;
+        if let Some(submit) = current_loc.get("submit") {
             let x = number(submit, "x");
             let y = number(submit, "y");
             if x > 0.0 && y > 0.0 {
                 self.page.click(x, y).await?;
-                let state = self
+                state = self
                     .wait_for_search_transition(
                         query,
                         wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
@@ -400,7 +407,7 @@ impl<'a> XhsPageRuntime<'a> {
                 if search_transition_ok(&state, query) {
                     return Ok(json!({
                         "ok": true,
-                        "strategy": "click_search_button",
+                        "strategy": "click_refreshed_search_button",
                         "state": state,
                         "url": self.current_url().await?,
                     }));

--- a/core/src/sites/xhs/page_scripts.js
+++ b/core/src/sites/xhs/page_scripts.js
@@ -177,11 +177,11 @@ const SocaiXhsPageScripts = (() => {
   }
 
   // Selectors for the search-submit affordance, tried in priority order.
-  // The 2026-05 chat composer has explicit class names; legacy UIs used a
-  // <form> with type=submit or an .icon-search SVG sibling. We don't try
-  // to score arbitrary clickable elements anymore — if none of these
-  // match, Rust falls back to pressing Enter, which works in practice.
+  // The current single-line composer mounts `.single-line-search-btn` only
+  // after text is entered. Older chat-composer and legacy controls stay as
+  // fallbacks. We don't try to score arbitrary clickable elements anymore.
   const SEARCH_SUBMIT_SELECTORS = [
+    '.single-line-search-btn',
     '.bottom-box-right-submit-button',
     '.submit-button-wrapper',
     'button[type="submit"]',
@@ -194,7 +194,7 @@ const SocaiXhsPageScripts = (() => {
     const input = findSearchInput();
     if (!input) return { ok: false, error: 'search_input_not_found' };
     const root = input.closest(
-      'form, header, .search-input, .search-container, .search-bar, .search-box, .wendian-wrapper'
+      'form, header, .textarea-container, .search-input, .search-container, .search-bar, .search-box, .wendian-wrapper'
     ) || document;
 
     let submit = null;


### PR DESCRIPTION
## Summary

- recover Xiaohongshu homepage searches when typing succeeds but Enter does not trigger navigation
- re-locate the submit affordance after the query is entered instead of reusing the pre-input coordinate
- recognize the current `.single-line-search-btn` inside its `.textarea-container`
- keep the strict result-page guard so homepage feed cards cannot be reported as search results
- document the homepage composer lifecycle and result-route invariant in the XHS knowledge file

## Production evidence

An Axiom failure on v0.5.5 showed the requested query present in the input while the browser remained on `/explore`. The run observed 32 homepage feed cards, returned zero search cards, and reported `Search did not transition to a valid Xiaohongshu result page`.

A second historical failure had the same shape: the requested query and suggestion panel were visible, but unrelated homepage cards remained underneath and no result route was entered.

## Root cause

The homepage AI composer mounts or re-renders its visible submit button only after text is entered. `submit_search` measured the button before typing, so its fallback reused a missing or stale coordinate. When Xiaohongshu also ignored the synthetic Enter event, the query remained in the homepage input until the strict transition check correctly rejected the page.

## Implementation

- add `.single-line-search-btn` to the explicit submit selector list
- scope submit lookup to the closest `.textarea-container` to avoid the hidden duplicate composer
- refresh `searchInput` after an unsuccessful Enter and click the live post-typing submit control
- preserve the latest post-click transition state for failure diagnostics

## Validation

- `cargo test -p socai-core --lib` — 99 passed, 0 failed, 2 ignored
- `cargo test -p socai-cli` — 6 passed, 0 failed
- `node --check core/src/sites/xhs/page_scripts.js`
- `git diff --check`
- real logged-in homepage search for `内容策划 招聘 上海` entered `/search_result_ai`, preserved the exact query, and returned 10 requested cards
- four additional normal searches entered valid result pages
- deterministic fault injection blocked the first Enter: before the fix the page stayed on `/explore` with 30 homepage cards and zero results; after the fix `click_refreshed_search_button` entered the result page and returned 8 requested cards

No new Rust test function was added, following the repository engineering rule; the dynamic browser behavior was validated against the live logged-in Xiaohongshu DOM and with the controlled Enter-failure path.