### PR TITLE
fix(agent): harden task execution reliability

### DIFF
--- a/app/src-tauri/src/artifact_tool.rs
+++ b/app/src-tauri/src/artifact_tool.rs
@@ -1,9 +1,24 @@
 use async_trait::async_trait;
+use calamine::{Reader, Xlsx};
 use cap_std::{ambient_authority, fs::Dir};
+use quick_xml::{events::Event as XmlEvent, Reader as XmlReader};
 use serde_json::{json, Value};
 use socai_core::agent::{Tool, ToolContext, ToolResult};
-use std::io::Write;
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+
+const MAX_OOXML_ARCHIVE_ENTRIES: usize = 4_096;
+const MAX_OOXML_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
+const DOCX_MAIN_CONTENT_TYPE: &str =
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+const DOCM_MAIN_CONTENT_TYPE: &str = "application/vnd.ms-word.document.macroEnabled.main+xml";
+const PPTX_MAIN_CONTENT_TYPE: &str =
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
+const PPTM_MAIN_CONTENT_TYPE: &str =
+    "application/vnd.ms-powerpoint.presentation.macroEnabled.main+xml";
+const XLSX_MAIN_CONTENT_TYPE: &str =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+const XLSM_MAIN_CONTENT_TYPE: &str = "application/vnd.ms-excel.sheet.macroEnabled.main+xml";
 
 /// Publish a completed file from this conversation as a desktop download card.
 /// The source stays in place; the user-facing copy lives in this turn's
@@ -131,6 +146,8 @@ impl Tool for PublishArtifactTool {
                 requested.display()
             );
         }
+
+        validate_artifact_format(&source, &mut source_file)?;
 
         let (run_dir, outputs, outputs_dir) = prepare_outputs_directory(&run_root)?;
         let (published, published_file) = if source.starts_with(&outputs) {
@@ -282,6 +299,442 @@ fn resolve_source_path(raw_path: &str, run_dir: &Path) -> PathBuf {
     } else {
         run_dir.join(path)
     }
+}
+
+fn validate_artifact_format(path: &Path, file: &mut std::fs::File) -> anyhow::Result<()> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let validation = match extension.as_str() {
+        "xlsx" => validate_spreadsheet(file, XLSX_MAIN_CONTENT_TYPE),
+        "xlsm" => validate_spreadsheet(file, XLSM_MAIN_CONTENT_TYPE),
+        "docx" => validate_ooxml_archive(
+            file,
+            "Word document",
+            "word/document.xml",
+            "document",
+            DOCX_MAIN_CONTENT_TYPE,
+        ),
+        "docm" => validate_ooxml_archive(
+            file,
+            "Word document",
+            "word/document.xml",
+            "document",
+            DOCM_MAIN_CONTENT_TYPE,
+        ),
+        "pptx" => validate_ooxml_archive(
+            file,
+            "PowerPoint presentation",
+            "ppt/presentation.xml",
+            "presentation",
+            PPTX_MAIN_CONTENT_TYPE,
+        ),
+        "pptm" => validate_ooxml_archive(
+            file,
+            "PowerPoint presentation",
+            "ppt/presentation.xml",
+            "presentation",
+            PPTM_MAIN_CONTENT_TYPE,
+        ),
+        "pdf" => validate_pdf(file),
+        _ => Ok(()),
+    };
+    file.seek(SeekFrom::Start(0))?;
+    validation
+}
+
+fn validate_spreadsheet(file: &mut std::fs::File, main_content_type: &str) -> anyhow::Result<()> {
+    crate::commands::validate_spreadsheet_archive(file)
+        .map_err(|error| anyhow::anyhow!("artifact extension/content mismatch: {error}"))?;
+    file.seek(SeekFrom::Start(0))?;
+    {
+        let mut archive = zip::ZipArchive::new(&mut *file).map_err(|error| {
+            anyhow::anyhow!("artifact extension/content mismatch: invalid Excel workbook: {error}")
+        })?;
+        validate_ooxml_content_type(
+            &mut archive,
+            "Excel workbook",
+            "xl/workbook.xml",
+            main_content_type,
+        )?;
+    }
+    file.seek(SeekFrom::Start(0))?;
+    let mut workbook = Xlsx::new(&mut *file).map_err(|error| {
+        anyhow::anyhow!(
+            "artifact extension/content mismatch: could not open Excel workbook: {error}"
+        )
+    })?;
+    if workbook.sheet_names().is_empty() {
+        anyhow::bail!("artifact extension/content mismatch: Excel workbook has no worksheets");
+    }
+    workbook
+        .worksheet_range_at(0)
+        .ok_or_else(|| anyhow::anyhow!("Excel workbook has no readable worksheet"))?
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "artifact extension/content mismatch: could not read Excel worksheet: {error}"
+            )
+        })?;
+    Ok(())
+}
+
+fn validate_ooxml_archive(
+    file: &mut std::fs::File,
+    kind: &str,
+    main_entry: &str,
+    main_root: &str,
+    main_content_type: &str,
+) -> anyhow::Result<()> {
+    let mut archive = zip::ZipArchive::new(&mut *file).map_err(|error| {
+        anyhow::anyhow!("artifact extension/content mismatch: invalid {kind}: {error}")
+    })?;
+    if archive.len() > MAX_OOXML_ARCHIVE_ENTRIES {
+        anyhow::bail!(
+            "artifact extension/content mismatch: {kind} exceeds the {MAX_OOXML_ARCHIVE_ENTRIES} entry limit"
+        );
+    }
+
+    let mut expanded_bytes = 0_u64;
+    let mut has_content_types = false;
+    let mut has_package_relationships = false;
+    let mut has_main_entry = false;
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index(index)
+            .map_err(|error| anyhow::anyhow!("could not inspect {kind}: {error}"))?;
+        has_content_types |= entry.name() == "[Content_Types].xml";
+        has_package_relationships |= entry.name() == "_rels/.rels";
+        has_main_entry |= entry.name() == main_entry;
+        expanded_bytes = expanded_bytes
+            .checked_add(entry.size())
+            .ok_or_else(|| anyhow::anyhow!("{kind} expanded size overflowed"))?;
+        if expanded_bytes > MAX_OOXML_UNCOMPRESSED_BYTES {
+            anyhow::bail!(
+                "artifact extension/content mismatch: {kind} exceeds the {} MB expanded size limit",
+                MAX_OOXML_UNCOMPRESSED_BYTES / (1024 * 1024)
+            );
+        }
+    }
+    if !has_content_types || !has_package_relationships || !has_main_entry {
+        anyhow::bail!(
+            "artifact extension/content mismatch: {kind} is missing required OOXML entries"
+        );
+    }
+    validate_ooxml_content_type(&mut archive, kind, main_entry, main_content_type)?;
+    validate_ooxml_relationship(&mut archive, kind, main_entry)?;
+    validate_ooxml_main_document(&mut archive, kind, main_entry, main_root)?;
+    Ok(())
+}
+
+fn validate_ooxml_content_type<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    kind: &str,
+    main_entry: &str,
+    main_content_type: &str,
+) -> anyhow::Result<()> {
+    let entry = archive
+        .by_name("[Content_Types].xml")
+        .map_err(|error| anyhow::anyhow!("could not open {kind} content types: {error}"))?;
+    let mut xml = XmlReader::from_reader(BufReader::new(entry));
+    let mut buffer = Vec::new();
+    let expected_part = format!("/{main_entry}");
+    let mut found = false;
+    let mut depth = 0_usize;
+    let mut root_seen = false;
+    loop {
+        buffer.clear();
+        match xml.read_event_into(&mut buffer) {
+            Ok(XmlEvent::Start(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "content types",
+                    b"Types",
+                    depth,
+                    &mut root_seen,
+                )?;
+                found |= ooxml_element_has_attributes(
+                    &event,
+                    b"Override",
+                    &[
+                        (b"PartName", expected_part.as_str()),
+                        (b"ContentType", main_content_type),
+                    ],
+                    kind,
+                )?;
+                depth = depth.checked_add(1).ok_or_else(|| {
+                    anyhow::anyhow!("{kind} content types XML is too deeply nested")
+                })?;
+            }
+            Ok(XmlEvent::Empty(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "content types",
+                    b"Types",
+                    depth,
+                    &mut root_seen,
+                )?;
+                found |= ooxml_element_has_attributes(
+                    &event,
+                    b"Override",
+                    &[
+                        (b"PartName", expected_part.as_str()),
+                        (b"ContentType", main_content_type),
+                    ],
+                    kind,
+                )?;
+            }
+            Ok(XmlEvent::End(_)) => {
+                depth = depth.checked_sub(1).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "artifact extension/content mismatch: invalid {kind} content types XML"
+                    )
+                })?;
+            }
+            Ok(XmlEvent::Eof) => {
+                if !root_seen || depth != 0 {
+                    anyhow::bail!(
+                        "artifact extension/content mismatch: incomplete {kind} content types XML"
+                    );
+                }
+                break;
+            }
+            Ok(_) => {}
+            Err(error) => anyhow::bail!(
+                "artifact extension/content mismatch: invalid {kind} content types XML: {error}"
+            ),
+        }
+    }
+    if !found {
+        anyhow::bail!(
+            "artifact extension/content mismatch: {kind} main content type is missing or invalid"
+        );
+    }
+    Ok(())
+}
+
+fn validate_ooxml_relationship<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    kind: &str,
+    main_entry: &str,
+) -> anyhow::Result<()> {
+    let entry = archive
+        .by_name("_rels/.rels")
+        .map_err(|error| anyhow::anyhow!("could not open {kind} relationships: {error}"))?;
+    let mut xml = XmlReader::from_reader(BufReader::new(entry));
+    let mut buffer = Vec::new();
+    let mut found = false;
+    let mut depth = 0_usize;
+    let mut root_seen = false;
+    loop {
+        buffer.clear();
+        match xml.read_event_into(&mut buffer) {
+            Ok(XmlEvent::Start(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "relationships",
+                    b"Relationships",
+                    depth,
+                    &mut root_seen,
+                )?;
+                found |= ooxml_relationship_targets(&event, main_entry, kind)?;
+                depth = depth.checked_add(1).ok_or_else(|| {
+                    anyhow::anyhow!("{kind} relationships XML is too deeply nested")
+                })?;
+            }
+            Ok(XmlEvent::Empty(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "relationships",
+                    b"Relationships",
+                    depth,
+                    &mut root_seen,
+                )?;
+                found |= ooxml_relationship_targets(&event, main_entry, kind)?;
+            }
+            Ok(XmlEvent::End(_)) => {
+                depth = depth.checked_sub(1).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "artifact extension/content mismatch: invalid {kind} relationships XML"
+                    )
+                })?;
+            }
+            Ok(XmlEvent::Eof) => {
+                if !root_seen || depth != 0 {
+                    anyhow::bail!(
+                        "artifact extension/content mismatch: incomplete {kind} relationships XML"
+                    );
+                }
+                break;
+            }
+            Ok(_) => {}
+            Err(error) => anyhow::bail!(
+                "artifact extension/content mismatch: invalid {kind} relationships XML: {error}"
+            ),
+        }
+    }
+    if !found {
+        anyhow::bail!(
+            "artifact extension/content mismatch: {kind} package does not target its main document"
+        );
+    }
+    Ok(())
+}
+
+fn validate_ooxml_main_document<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    kind: &str,
+    main_entry: &str,
+    main_root: &str,
+) -> anyhow::Result<()> {
+    let entry = archive
+        .by_name(main_entry)
+        .map_err(|error| anyhow::anyhow!("could not open {kind} main document: {error}"))?;
+    let mut xml = XmlReader::from_reader(BufReader::new(entry));
+    let mut buffer = Vec::new();
+    let mut depth = 0_usize;
+    let mut root_seen = false;
+    loop {
+        buffer.clear();
+        match xml.read_event_into(&mut buffer) {
+            Ok(XmlEvent::Start(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "main document",
+                    main_root.as_bytes(),
+                    depth,
+                    &mut root_seen,
+                )?;
+                depth = depth.checked_add(1).ok_or_else(|| {
+                    anyhow::anyhow!("{kind} main document XML is too deeply nested")
+                })?;
+            }
+            Ok(XmlEvent::Empty(event)) => {
+                validate_ooxml_root(
+                    &event,
+                    kind,
+                    "main document",
+                    main_root.as_bytes(),
+                    depth,
+                    &mut root_seen,
+                )?;
+            }
+            Ok(XmlEvent::End(_)) => {
+                depth = depth.checked_sub(1).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "artifact extension/content mismatch: invalid {kind} main document XML"
+                    )
+                })?;
+            }
+            Ok(XmlEvent::Eof) => {
+                if !root_seen || depth != 0 {
+                    anyhow::bail!(
+                        "artifact extension/content mismatch: incomplete {kind} main document XML"
+                    );
+                }
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(error) => anyhow::bail!(
+                "artifact extension/content mismatch: invalid {kind} main document XML: {error}"
+            ),
+        }
+    }
+}
+
+fn validate_ooxml_root(
+    event: &quick_xml::events::BytesStart<'_>,
+    kind: &str,
+    section: &str,
+    expected_root: &[u8],
+    depth: usize,
+    root_seen: &mut bool,
+) -> anyhow::Result<()> {
+    if depth != 0 {
+        return Ok(());
+    }
+    if *root_seen || event.local_name().as_ref() != expected_root {
+        anyhow::bail!("artifact extension/content mismatch: invalid {kind} {section} root");
+    }
+    *root_seen = true;
+    Ok(())
+}
+
+fn ooxml_element_has_attributes(
+    event: &quick_xml::events::BytesStart<'_>,
+    element: &[u8],
+    expected: &[(&[u8], &str)],
+    kind: &str,
+) -> anyhow::Result<bool> {
+    if event.local_name().as_ref() != element {
+        return Ok(false);
+    }
+    let mut matches = vec![false; expected.len()];
+    for attribute in event.attributes().with_checks(false) {
+        let attribute =
+            attribute.map_err(|error| anyhow::anyhow!("invalid {kind} XML attributes: {error}"))?;
+        for (index, (name, value)) in expected.iter().enumerate() {
+            if attribute.key.local_name().as_ref() == *name
+                && attribute.value.as_ref() == value.as_bytes()
+            {
+                matches[index] = true;
+            }
+        }
+    }
+    Ok(matches.into_iter().all(|matched| matched))
+}
+
+fn ooxml_relationship_targets(
+    event: &quick_xml::events::BytesStart<'_>,
+    main_entry: &str,
+    kind: &str,
+) -> anyhow::Result<bool> {
+    if event.local_name().as_ref() != b"Relationship" {
+        return Ok(false);
+    }
+    let mut relationship_type = None;
+    let mut target = None;
+    for attribute in event.attributes().with_checks(false) {
+        let attribute = attribute
+            .map_err(|error| anyhow::anyhow!("invalid {kind} relationship attributes: {error}"))?;
+        match attribute.key.local_name().as_ref() {
+            b"Type" => relationship_type = Some(attribute.value.into_owned()),
+            b"Target" => target = Some(attribute.value.into_owned()),
+            _ => {}
+        }
+    }
+    Ok(relationship_type
+        .as_deref()
+        .is_some_and(|value| value.ends_with(b"/officeDocument"))
+        && target.as_deref().is_some_and(|value| {
+            value.strip_prefix(b"/").unwrap_or(value) == main_entry.as_bytes()
+        }))
+}
+
+fn validate_pdf(file: &mut std::fs::File) -> anyhow::Result<()> {
+    let len = file.metadata()?.len();
+    if len < 8 {
+        anyhow::bail!("artifact extension/content mismatch: invalid PDF header");
+    }
+    let mut header = [0_u8; 5];
+    file.read_exact(&mut header)?;
+    if &header != b"%PDF-" {
+        anyhow::bail!("artifact extension/content mismatch: invalid PDF header");
+    }
+    let tail_len = len.min(1_024) as usize;
+    file.seek(SeekFrom::End(-(tail_len as i64)))?;
+    let mut tail = vec![0_u8; tail_len];
+    file.read_exact(&mut tail)?;
+    if !tail.windows(5).any(|window| window == b"%%EOF") {
+        anyhow::bail!("artifact extension/content mismatch: PDF end marker is missing");
+    }
+    Ok(())
 }
 
 fn prepare_outputs_directory(run_root: &Path) -> anyhow::Result<(Dir, PathBuf, Dir)> {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -21,7 +21,9 @@ use socai_core::runtime::{
 use socai_core::sites::xhs::{XhsHistoryStore, XhsPageRuntime};
 use socai_core::sites::{find_site, SiteSpec};
 use socai_core::telemetry::query_text_enabled;
-use socai_core::telemetry::tool_call::{summarize_tool_args, summarize_tool_result};
+use socai_core::telemetry::tool_call::{
+    is_site_tool_result, summarize_site_tool_result, summarize_tool_args,
+};
 use socai_core::telemetry::trace::mark_run_trace_status;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -1563,7 +1565,7 @@ fn spreadsheet_preview_response(file: std::fs::File) -> Result<tauri::ipc::Respo
         .map_err(|error| format!("could not encode Excel preview: {error}"))
 }
 
-fn validate_spreadsheet_archive(file: &mut Cursor<Vec<u8>>) -> Result<(), String> {
+pub(crate) fn validate_spreadsheet_archive<R: Read + Seek>(file: &mut R) -> Result<(), String> {
     let mut archive = zip::ZipArchive::new(&mut *file)
         .map_err(|error| format!("invalid Excel workbook: {error}"))?;
     if archive.len() > ARTIFACT_SPREADSHEET_MAX_ARCHIVE_ENTRIES {
@@ -1573,10 +1575,21 @@ fn validate_spreadsheet_archive(file: &mut Cursor<Vec<u8>>) -> Result<(), String
         ));
     }
     let mut uncompressed_bytes = 0_u64;
+    let mut has_content_types = false;
+    let mut has_workbook = false;
+    let mut has_worksheet = false;
     for index in 0..archive.len() {
         let entry = archive
             .by_index(index)
             .map_err(|error| format!("could not inspect Excel workbook: {error}"))?;
+        match entry.name() {
+            "[Content_Types].xml" => has_content_types = true,
+            "xl/workbook.xml" => has_workbook = true,
+            name if name.starts_with("xl/worksheets/") && name.ends_with(".xml") => {
+                has_worksheet = true;
+            }
+            _ => {}
+        }
         uncompressed_bytes = uncompressed_bytes
             .checked_add(entry.size())
             .ok_or_else(|| "Excel workbook uncompressed size overflowed".to_string())?;
@@ -1586,6 +1599,11 @@ fn validate_spreadsheet_archive(file: &mut Cursor<Vec<u8>>) -> Result<(), String
                 ARTIFACT_SPREADSHEET_MAX_UNCOMPRESSED_BYTES / (1024 * 1024)
             ));
         }
+    }
+    if !has_content_types || !has_workbook || !has_worksheet {
+        return Err(
+            "invalid Excel workbook: required OOXML workbook entries are missing".to_string(),
+        );
     }
     for index in 0..archive.len() {
         let entry = archive
@@ -2861,14 +2879,17 @@ fn pump_agent_task_events(
                     props.insert("duration_ms".into(), json!(tool_duration_ms));
                     props.insert("ok".into(), json!(error.is_none()));
                     props.insert("error".into(), json!(error.as_deref().map(short_error)));
-                    // Same shared summarizer the CLI daemon uses: the search
-                    // query is lifted into query_text/query_len (gated by
-                    // query_text_enabled) and every other arg folds into
-                    // metadata; result counts and bounded unexpected-page OCR
-                    // diagnostics are extracted from the output. Note bodies
-                    // and comments are never included.
+                    if is_site_tool_result(name) {
+                        props.insert("site".into(), json!(APP_SITE_ID));
+                    }
+                    // The search query is lifted into query_text/query_len
+                    // (gated by query_text_enabled), and every other arg folds
+                    // into metadata. Trusted site results are decoded from the
+                    // desktop content blocks before the shared summarizer
+                    // extracts counts and bounded diagnostics. Local tool
+                    // output, note bodies, and comments are never included.
                     props.extend(summarize_tool_args(input, query_text_enabled()));
-                    props.extend(summarize_tool_result(content));
+                    props.extend(summarize_site_tool_result(name, content));
                     telemetry.capture("socai_tool_call", Value::Object(props));
                 }
                 _ => {}

--- a/core/src/agent/conversation.rs
+++ b/core/src/agent/conversation.rs
@@ -142,9 +142,12 @@ impl Conversation {
             } else {
                 report
             };
-            messages.push(Message::assistant_blocks(vec![Block::Text {
-                text: report,
-            }]));
+            let mut blocks = Vec::new();
+            if let Some(reasoning) = final_reasoning_content(Path::new(&run.run_dir)) {
+                blocks.push(Block::ReasoningContent { text: reasoning });
+            }
+            blocks.push(Block::Text { text: report });
+            messages.push(Message::assistant_blocks(blocks));
         }
         messages
     }
@@ -196,6 +199,25 @@ impl Conversation {
             }
         }
     }
+}
+
+fn final_reasoning_content(run_dir: &Path) -> Option<String> {
+    let llm_dir = run_dir.join("llm");
+    let mut responses = std::fs::read_dir(llm_dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".response.json"))
+        })
+        .collect::<Vec<_>>();
+    responses.sort();
+    let response = responses.pop()?;
+    let response = std::fs::read_to_string(response).ok()?;
+    let response = serde_json::from_str::<LLMResponse>(&response).ok()?;
+    (!response.reasoning_content.trim().is_empty()).then_some(response.reasoning_content)
 }
 
 /// Reconstruct the normalized transcript that the agent had already seen

--- a/core/src/agent/llm.rs
+++ b/core/src/agent/llm.rs
@@ -189,7 +189,6 @@ impl LLMResponse {
         if self.thinking_blocks.is_empty()
             && self.reasoning_items.is_empty()
             && !self.reasoning_content.trim().is_empty()
-            && !self.tool_calls.is_empty()
         {
             blocks.push(Block::ReasoningContent {
                 text: self.reasoning_content.clone(),

--- a/core/src/agent/llm/openai.rs
+++ b/core/src/agent/llm/openai.rs
@@ -184,6 +184,7 @@ impl OpenAICompatBackend {
                 messages,
                 self.preserve_reasoning_content(),
                 self.provider == Provider::DeepSeek,
+                self.provider == Provider::DeepSeek,
             ),
             max_tokens,
             tools: chat_tools,
@@ -246,8 +247,16 @@ fn validate_deepseek_tool_context(messages: &[Message]) -> anyhow::Result<()> {
                         "DeepSeek API error | status=400 | code=invalid_tool_context | message=assistant turn started before every prior tool call had a matching result"
                     );
                 }
+                let has_reasoning = message.content.as_blocks().iter().any(|block| {
+                    matches!(block, Block::ReasoningContent { text } if !text.trim().is_empty())
+                });
                 for block in message.content.as_blocks() {
                     if let Block::ToolUse { id, .. } = block {
+                        if !has_reasoning {
+                            anyhow::bail!(
+                                "DeepSeek API error | status=400 | code=invalid_reasoning_context | message=assistant tool call is missing its reasoning_content"
+                            );
+                        }
                         if id.trim().is_empty() || !pending.insert(id) {
                             anyhow::bail!(
                                 "DeepSeek API error | status=400 | code=invalid_tool_context | message=assistant history contains an empty or duplicate tool call id"
@@ -399,6 +408,30 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output
         assert_eq!(payload["tool_choice"], "auto");
         assert!(payload["messages"][2]["content"].is_null());
 
+        let text_only_reasoning = [Message::assistant_blocks(vec![
+            Block::ReasoningContent {
+                text: "final answer reasoning".into(),
+            },
+            Block::Text {
+                text: "prior answer".into(),
+            },
+        ])];
+        let payload = serde_json::to_value(deepseek.build_chat_request(
+            "system",
+            &text_only_reasoning,
+            &[ToolSchema {
+                name: "lookup".into(),
+                description: "lookup a value".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            1024,
+        ))
+        .expect("request should serialize");
+        assert_eq!(
+            payload["messages"][1]["reasoning_content"],
+            "final answer reasoning"
+        );
+
         let invalid = [Message {
             role: MessageRole::User,
             content: MessageContent::Blocks(vec![Block::ToolResult {
@@ -454,6 +487,7 @@ fn build_chat_messages(
     messages: &[Message],
     preserve_reasoning: bool,
     require_assistant_content: bool,
+    preserve_all_reasoning: bool,
 ) -> Vec<Value> {
     let mut out = vec![json!({"role": "system", "content": system})];
 
@@ -499,11 +533,10 @@ fn build_chat_messages(
                 if !tool_calls.is_empty() {
                     assistant_msg.insert("tool_calls".into(), Value::Array(tool_calls.clone()));
                 }
-                if preserve_reasoning && !tool_calls.is_empty() {
-                    assistant_msg.insert(
-                        "reasoning_content".into(),
-                        json!(reasoning.unwrap_or_default()),
-                    );
+                if preserve_reasoning && (preserve_all_reasoning || !tool_calls.is_empty()) {
+                    if let Some(reasoning) = reasoning.filter(|text| !text.trim().is_empty()) {
+                        assistant_msg.insert("reasoning_content".into(), json!(reasoning));
+                    }
                 }
                 out.push(Value::Object(assistant_msg));
             }

--- a/core/src/agent/loop.rs
+++ b/core/src/agent/loop.rs
@@ -595,15 +595,35 @@ pub async fn run_agent_with_events(
                 );
                 usage += &response.usage;
                 let (visible_texts, _) = split_thinking(&response.text_blocks);
-                for text in &visible_texts {
+                let visible_text = visible_texts.join("\n\n");
+                if let Some(message) = forced_summary_failure(
+                    task,
+                    &response,
+                    &visible_text,
+                    run_state.as_ref(),
+                    tools.iter().any(|tool| tool.name() == "publish_artifact"),
+                ) {
+                    warn!(step = step + 1, "forced summary did not finish the task");
+                    final_text = message.clone();
                     emit(
                         &events,
-                        AgentEvent::AssistantText {
+                        AgentEvent::ApiError {
                             step: step + 1,
-                            text: text.clone(),
+                            message: message.clone(),
                         },
                     );
-                    final_text = text.clone();
+                    terminal_error = Some(message);
+                } else {
+                    for text in &visible_texts {
+                        emit(
+                            &events,
+                            AgentEvent::AssistantText {
+                                step: step + 1,
+                                text: text.clone(),
+                            },
+                        );
+                        final_text = text.clone();
+                    }
                 }
             }
             Err(e) => {
@@ -902,6 +922,316 @@ fn split_thinking(text_blocks: &[String]) -> (Vec<String>, Vec<String>) {
     (visible, thinking)
 }
 
+fn forced_summary_failure(
+    task: &str,
+    response: &LLMResponse,
+    visible_text: &str,
+    run_state: &RunState,
+    publish_required: bool,
+) -> Option<String> {
+    let tried_unavailable_tool =
+        !response.tool_calls.is_empty() || contains_pseudo_tool_call(visible_text);
+    let published = run_state
+        .artifact_records()
+        .into_iter()
+        .filter(|artifact| {
+            artifact.source_tool == "publish_artifact"
+                && artifact.metadata.get("category").and_then(Value::as_str) == Some("deliverable")
+        })
+        .collect::<Vec<_>>();
+    let mut required_kinds = requested_artifact_kinds(task);
+    for kind in claimed_artifact_kinds(visible_text) {
+        if !required_kinds.contains(&kind) {
+            required_kinds.push(kind);
+        }
+    }
+    required_kinds.sort_by_key(|kind| *kind == "generic");
+    let mut matched_artifacts = vec![false; published.len()];
+    let missing_required_deliverable = publish_required
+        && required_kinds.iter().any(|kind| {
+            if *kind == "generic" {
+                return published.is_empty();
+            }
+            let matching_index = published.iter().enumerate().position(|(index, artifact)| {
+                !matched_artifacts[index] && artifact_matches_kind(&artifact.path, kind)
+            });
+            if let Some(index) = matching_index {
+                matched_artifacts[index] = true;
+                false
+            } else {
+                true
+            }
+        });
+    if !tried_unavailable_tool && !missing_required_deliverable {
+        return None;
+    }
+
+    let chinese = task
+        .chars()
+        .any(|ch| ('\u{4e00}'..='\u{9fff}').contains(&ch));
+    Some(if chinese {
+        if missing_required_deliverable {
+            "任务在达到最大执行步数时仍未完成，且没有经过验证并成功发布的交付文件。已有过程记录已保留，请重试或缩小任务范围。".to_string()
+        } else {
+            "任务在达到最大执行步数后仍试图调用工具，但该操作没有实际执行。已有过程记录已保留，请重试。".to_string()
+        }
+    } else if missing_required_deliverable {
+        "The task reached its execution limit without a verified, published deliverable. Progress was preserved; retry or narrow the task scope.".to_string()
+    } else {
+        "The task reached its execution limit while still attempting a tool call, so that operation was not executed. Progress was preserved; please retry.".to_string()
+    })
+}
+
+fn contains_pseudo_tool_call(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    [
+        "<tool_calls",
+        "<function_calls",
+        "<invoke",
+        "<function name=",
+        "&lt;tool_calls",
+        "&lt;function_calls",
+        "&lt;invoke",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
+}
+
+fn requested_artifact_kinds(task: &str) -> Vec<&'static str> {
+    let lower = task.to_ascii_lowercase();
+    let creation_markers = [
+        "create",
+        "generate",
+        "export",
+        "produce",
+        "write",
+        "save",
+        "build",
+        "make",
+        "downloadable",
+        "生成",
+        "创建",
+        "制作",
+        "导出",
+        "保存",
+        "写入",
+        "做成",
+        "整理成",
+        "放到",
+    ];
+    let source_markers = [
+        " from ",
+        " using ",
+        " based on ",
+        " source ",
+        " input ",
+        " after ",
+        " for ",
+        " of ",
+        " about ",
+        "根据",
+        "基于",
+        "关于",
+        "输入",
+        "从",
+    ];
+    let mut kinds = Vec::new();
+    for creation_marker in &creation_markers {
+        for (offset, _) in lower.match_indices(*creation_marker) {
+            let target_start = offset + creation_marker.len();
+            let remaining = &lower[target_start..];
+            let target_end = source_markers
+                .iter()
+                .chain(creation_markers.iter())
+                .filter_map(|marker| remaining.find(marker))
+                .min()
+                .unwrap_or(remaining.len());
+            let target = &remaining[..target_end];
+            let target_kinds = artifact_kinds(target);
+            let has_typed_artifact = !target_kinds.is_empty();
+            for kind in target_kinds {
+                kinds.push(kind);
+            }
+            if !has_typed_artifact
+                && ["file", "document", "文件", "文档"]
+                    .iter()
+                    .any(|marker| target.contains(marker))
+                && !kinds.contains(&"generic")
+            {
+                kinds.push("generic");
+            }
+        }
+    }
+    kinds
+}
+
+fn claimed_artifact_kinds(text: &str) -> Vec<&'static str> {
+    let lower = text.to_ascii_lowercase();
+    let completion_markers = [
+        "generated",
+        "created",
+        "exported",
+        "saved",
+        "published",
+        "ready for download",
+        "已生成",
+        "已创建",
+        "已导出",
+        "已保存",
+        "已发布",
+        "可下载",
+    ];
+    let claim_boundaries = [
+        " source ",
+        " input ",
+        " based on ",
+        " from ",
+        ". ",
+        "; ",
+        "\n",
+        "来源",
+        "输入",
+        "基于",
+        "根据",
+        "。",
+        "；",
+    ];
+    let mut kinds = Vec::new();
+    for completion_marker in &completion_markers {
+        for (offset, _) in lower.match_indices(*completion_marker) {
+            let target_start = offset + completion_marker.len();
+            let remaining = &lower[target_start..];
+            let target_end = claim_boundaries
+                .iter()
+                .chain(completion_markers.iter())
+                .filter_map(|marker| remaining.find(marker))
+                .min()
+                .unwrap_or(remaining.len());
+            let target = &remaining[..target_end];
+            for kind in artifact_kinds(target) {
+                if !kinds.contains(&kind) {
+                    kinds.push(kind);
+                }
+            }
+            if kinds.is_empty()
+                && ["file", "document", "文件", "文档", "下载"]
+                    .iter()
+                    .any(|marker| target.contains(marker))
+            {
+                kinds.push("generic");
+            }
+        }
+    }
+    kinds
+}
+
+fn artifact_kinds(text: &str) -> Vec<&'static str> {
+    let groups: [(&str, &[&str]); 8] = [
+        (
+            "excel",
+            &[
+                ".xlsx",
+                ".xlsm",
+                "excel",
+                "excel file",
+                "excel report",
+                "excel workbook",
+                "excel spreadsheet",
+                "excel 文件",
+                "excel 报告",
+                "excel 表格",
+                "电子表格",
+            ],
+        ),
+        ("csv", &[".csv", "csv", "csv 文件", "csv file", "csv 格式"]),
+        (
+            "spreadsheet",
+            &[
+                "spreadsheet",
+                "spreadsheet file",
+                "spreadsheet document",
+                "表格文件",
+            ],
+        ),
+        (
+            "word",
+            &[
+                ".docx",
+                ".docm",
+                "word document",
+                "word file",
+                "word 文档",
+                "word 文件",
+            ],
+        ),
+        (
+            "powerpoint",
+            &[
+                ".pptx",
+                ".pptm",
+                "powerpoint",
+                "ppt",
+                "powerpoint presentation",
+                "powerpoint file",
+                "ppt 文件",
+                "ppt 文档",
+                "幻灯片文件",
+            ],
+        ),
+        (
+            "pdf",
+            &[
+                ".pdf",
+                "pdf",
+                "pdf 文件",
+                "pdf file",
+                "pdf 文档",
+                "pdf document",
+                "pdf 报告",
+                "pdf report",
+            ],
+        ),
+        ("archive", &[".zip", "zip", "zip 文件", "zip file"]),
+        (
+            "subtitle",
+            &[".srt", ".vtt", "srt", "vtt", "字幕文件", "subtitle file"],
+        ),
+    ];
+    let mut kinds = Vec::new();
+    for (kind, markers) in groups {
+        let occurrences = markers
+            .iter()
+            .map(|marker| text.match_indices(marker).count())
+            .max()
+            .unwrap_or_default();
+        kinds.extend(std::iter::repeat_n(kind, occurrences));
+    }
+    if kinds.contains(&"excel") {
+        kinds.retain(|kind| *kind != "spreadsheet");
+    }
+    kinds
+}
+
+fn artifact_matches_kind(path: &str, kind: &str) -> bool {
+    let extension = Path::new(path)
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match kind {
+        "excel" => matches!(extension.as_str(), "xlsx" | "xlsm"),
+        "csv" => extension == "csv",
+        "spreadsheet" => matches!(extension.as_str(), "xlsx" | "xlsm" | "csv"),
+        "word" => matches!(extension.as_str(), "docx" | "docm"),
+        "powerpoint" => matches!(extension.as_str(), "pptx" | "pptm"),
+        "pdf" => extension == "pdf",
+        "archive" => extension == "zip",
+        "subtitle" => matches!(extension.as_str(), "srt" | "vtt"),
+        "generic" => true,
+        _ => false,
+    }
+}
+
 /// Build the assistant message blocks for history. Truncates visible text to
 /// `ASSISTANT_TEXT_MAX_CHARS` to keep history bounded over many steps. Drops
 /// `[Thinking]`-prefixed text since that's already surfaced as a Reasoning
@@ -922,12 +1252,12 @@ fn build_assistant_blocks(response: &LLMResponse, visible_texts: &[String]) -> V
             signature: tb.signature.clone(),
         });
     }
-    // Preserve reasoning_content alongside tool_calls so providers that
-    // require it round-tripped (Kimi/Qwen) get it on the next step.
+    // Preserve every reasoning_content response, including text-only turns.
+    // DeepSeek thinking mode requires all prior reasoning to be replayed when
+    // a later request carries tools, not only turns that called a tool.
     if response.thinking_blocks.is_empty()
         && response.reasoning_items.is_empty()
         && !response.reasoning_content.trim().is_empty()
-        && !response.tool_calls.is_empty()
     {
         blocks.push(Block::ReasoningContent {
             text: response.reasoning_content.clone(),

--- a/core/src/sites/xhs/page.rs
+++ b/core/src/sites/xhs/page.rs
@@ -415,9 +415,57 @@ impl<'a> XhsPageRuntime<'a> {
             }
         }
 
+        // The current homepage composer can accept the requested keyword but
+        // ignore both Enter and its visible submit button (most often on
+        // Windows). At that point the input state is already verified, so use
+        // Xiaohongshu's own search-results route as a final in-site recovery.
+        // Still validate the resulting page and keyword before reporting
+        // success: navigation alone is not proof that search worked.
+        let manual_state = state.clone();
+        let direct_url = xhs_search_result_url(query);
+        let direct_navigation = if manual_state
+            .get("login_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            json!({ "ok": false, "skipped": "login_required" })
+        } else {
+            match self.page.navigate(&direct_url).await {
+                Ok(()) => {
+                    state = self
+                        .wait_for_search_transition(
+                            query,
+                            wait_seconds.max(SEARCH_TRANSITION_TIMEOUT_S),
+                        )
+                        .await?;
+                    if search_transition_ok(&state, query) {
+                        return Ok(json!({
+                            "ok": true,
+                            "strategy": "direct_search_result_navigation",
+                            "recovered_from": "manual_submit_failed",
+                            "manual_state": manual_state,
+                            "state": state,
+                            "url": self.current_url().await?,
+                        }));
+                    }
+                    json!({
+                        "ok": false,
+                        "url": self.current_url().await?,
+                        "state": state.clone(),
+                    })
+                }
+                Err(error) => json!({
+                    "ok": false,
+                    "error": format!("{error:#}"),
+                }),
+            }
+        };
+
         let mut result = json!({
             "ok": false,
-            "strategy": "manual_submit_failed",
+            "strategy": "all_search_submit_strategies_failed",
+            "manual_state": manual_state,
+            "direct_navigation": direct_navigation,
             "state": state,
             "url": self.current_url().await?,
             "error": if state.get("login_required").and_then(Value::as_bool).unwrap_or(false) {
@@ -2103,6 +2151,22 @@ fn normalize_keyword(value: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase()
+}
+
+fn xhs_search_result_url(query: &str) -> String {
+    let mut encoded = String::with_capacity(query.len());
+    for byte in query.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(char::from(*byte));
+            }
+            _ => {
+                use std::fmt::Write as _;
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    format!("https://www.xiaohongshu.com/search_result?keyword={encoded}&source=web_explore_feed")
 }
 
 fn normalize_image_url(value: &str) -> String {

--- a/core/src/telemetry/tool_call.rs
+++ b/core/src/telemetry/tool_call.rs
@@ -93,6 +93,12 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
     if let Some(cards) = data.get("selected_cards").and_then(Value::as_array) {
         props.insert("selected_cards_count".into(), json!(cards.len()));
     }
+    if let Some(strategy) = find_string(data, "strategy") {
+        props.insert(
+            "result_strategy".into(),
+            json!(strategy.chars().take(120).collect::<String>()),
+        );
+    }
     if let Some(notes) = data.get("notes").and_then(Value::as_array) {
         props.insert("notes_count".into(), json!(notes.len()));
         let skipped = notes
@@ -174,6 +180,45 @@ pub fn summarize_tool_result(value: &Value) -> Map<String, Value> {
         }
     }
     props
+}
+
+/// Summarize the model-visible content blocks emitted by a trusted site tool.
+/// Local tools such as `read_file` and `shell` may return arbitrary user JSON,
+/// so their text blocks must remain opaque to telemetry.
+pub fn summarize_site_tool_result(tool_name: &str, value: &Value) -> Map<String, Value> {
+    if !is_site_tool_result(tool_name) {
+        return Map::new();
+    }
+    result_json_from_content_blocks(value)
+        .as_ref()
+        .map(summarize_tool_result)
+        .unwrap_or_default()
+}
+
+pub fn is_site_tool_result(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "search" | "get_notes" | "author_scan" | "page_state"
+    )
+}
+
+/// Desktop and trace events serialize a tool result as model-visible content:
+/// `[{"type":"text","text":"<tool JSON>"}, ...]`. Parse only a complete
+/// JSON text block after the caller has established that the tool is a site
+/// tool. Non-JSON prose and image blocks stay opaque.
+fn result_json_from_content_blocks(value: &Value) -> Option<Value> {
+    let blocks = value.as_array()?;
+    blocks.iter().find_map(|block| {
+        let block = block.as_object()?;
+        if block.get("type").and_then(Value::as_str) != Some("text") {
+            return None;
+        }
+        let text = block.get("text").and_then(Value::as_str)?.trim();
+        if !(text.starts_with('{') || text.starts_with('[')) {
+            return None;
+        }
+        serde_json::from_str(text).ok()
+    })
 }
 
 fn find_string<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
@@ -295,10 +340,11 @@ mod tests {
     #[test]
     fn result_summary_extracts_safe_counts_without_copying_text() {
         let page_ocr = "限".repeat(PAGE_OCR_MAX_CHARS + 1);
-        let props = summarize_tool_result(&json!({
+        let result = json!({
             "run_dir": "/tmp/socai-run",
             "data": {
                 "ok": false,
+                "strategy": "direct_search_result_navigation",
                 "reason": "not_profile_page",
                 "page_error": "not_profile_page",
                 "page_url": "https://www.xiaohongshu.com/explore/abc?xsec_token=secret",
@@ -319,8 +365,13 @@ mod tests {
                     { "skipped": true, "comments": ["must not be copied"] }
                 ]
             }
-        }));
+        });
+        let props = summarize_tool_result(&result);
         assert_eq!(props.get("result_ok"), Some(&json!(false)));
+        assert_eq!(
+            props.get("result_strategy"),
+            Some(&json!("direct_search_result_navigation"))
+        );
         assert_eq!(props.get("cards_count"), Some(&json!(2)));
         assert_eq!(props.get("search_cards_count"), Some(&json!(3)));
         assert_eq!(props.get("selected_cards_count"), Some(&json!(1)));
@@ -364,5 +415,32 @@ mod tests {
         );
         assert!(!props.contains_key("body"));
         assert!(!props.contains_key("comments"));
+
+        let content = json!([
+            { "type": "text", "text": serde_json::to_string_pretty(&result).unwrap() },
+            { "type": "image", "media_type": "image/png" }
+        ]);
+        assert_eq!(summarize_site_tool_result("search", &content), props);
+
+        let hostile_local_json = json!([
+            {
+                "type": "text",
+                "text": r#"{"ok":false,"reason":"private user value","page_ocr_text":"private file contents","recovery_tool":"private command"}"#
+            }
+        ]);
+        assert!(summarize_site_tool_result("read_file", &hostile_local_json).is_empty());
+        assert!(summarize_site_tool_result("shell", &hostile_local_json).is_empty());
+        assert!(!is_site_tool_result("read_file"));
+        assert!(!is_site_tool_result("shell"));
+        assert!(summarize_site_tool_result(
+            "search",
+            &json!([{ "type": "image", "media_type": "image/png" }])
+        )
+        .is_empty());
+        assert!(summarize_site_tool_result(
+            "search",
+            &json!([{ "type": "text", "text": "ordinary non-JSON output" }])
+        )
+        .is_empty());
     }
 }

--- a/core/src/telemetry/trace.rs
+++ b/core/src/telemetry/trace.rs
@@ -16,8 +16,8 @@
 //! (`gen_ai.*`) — Axiom promotes those to first-class trace columns — with
 //! socai-specific context under `socai.*`. Tool args go through
 //! `summarize_tool_args` (query text gated by `SOCAI_TELEMETRY_QUERY_TEXT`)
-//! and tool output through `summarize_tool_result` (counts plus bounded
-//! unexpected-page OCR diagnostics).
+//! and trusted site-tool output through `summarize_site_tool_result` (counts
+//! plus bounded unexpected-page OCR diagnostics).
 //!
 //! Chat content rides on the `chat` spans (gated by
 //! `SOCAI_TELEMETRY_CHAT_TEXT`): `gen_ai.input.messages` carries only the
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-use super::tool_call::{summarize_tool_args, summarize_tool_result};
+use super::tool_call::{is_site_tool_result, summarize_site_tool_result, summarize_tool_args};
 use super::{chat_text_enabled, query_text_enabled};
 use crate::agent::llm::{
     Block, LLMResponse, Message, MessageContent, MessageRole, TokenUsage, ToolResultContent,
@@ -278,9 +278,9 @@ impl RunTraceBuilder {
             attr_bool("socai.ok", error.is_none()),
         ];
         extend_prefixed(&mut attrs, summarize_tool_args(input, query_text_enabled()));
-        extend_prefixed(&mut attrs, summarize_tool_result(output));
+        extend_prefixed(&mut attrs, summarize_site_tool_result(name, output));
         if chat_text_enabled() {
-            let notes = note_summaries(output);
+            let notes = note_summaries(name, output);
             if !notes.is_empty() {
                 let mut rendered = Value::Array(notes).to_string();
                 // Field caps bound this far below CHAT_ATTR_MAX_BYTES; the
@@ -709,9 +709,12 @@ fn chat_text(text: &str, part_cap: usize) -> String {
 /// replaying the run. Matches the opened-note shape (`notes[].entity`) and the
 /// preview/profile card arrays — the same paths `summarize_tool_result`
 /// counts. Stats stay the raw displayed strings ("1.2万", "评论").
-fn note_summaries(output: &Value) -> Vec<Value> {
+fn note_summaries(tool_name: &str, output: &Value) -> Vec<Value> {
     let mut notes: Vec<Value> = Vec::new();
     let mut seen_ids: Vec<String> = Vec::new();
+    if !is_site_tool_result(tool_name) {
+        return notes;
+    }
     let Some(blocks) = output.as_array() else {
         return notes;
     };


### PR DESCRIPTION
## Summary

- recover Xiaohongshu searches with a validated in-site result-route fallback when both Enter and the refreshed submit control leave the browser on the homepage
- reject mislabeled or structurally invalid Excel, Word, PowerPoint, and PDF deliverables before publishing a download card
- fail max-step summaries that still contain tool calls or claim required files that were not verified and published
- preserve DeepSeek `reasoning_content` across text-only turns and completed conversation replay
- restore bounded result metrics for trusted desktop site-tool content blocks while keeping local-tool output opaque

## Production evidence

The reviewed trace set contained a Xiaohongshu search where the requested keyword was present in the homepage input, 32 homepage feed cards were visible, no search cards were returned, and the task failed with `Search did not transition to a valid Xiaohongshu result page`.

Other traces showed files carrying Office extensions without a valid Office package, max-step summaries presenting unfinished tool work as success, DeepSeek follow-up context losing text-only reasoning, and desktop site-tool results reaching telemetry as content-block envelopes instead of direct JSON.

## Root cause

The Xiaohongshu guard correctly rejected homepage cards, but the submission sequence had no final recovery after both UI submission paths failed. Artifact publication trusted filenames without validating the represented format. Forced summaries were accepted without checking remaining tool calls or requested deliverables. DeepSeek replay retained reasoning only beside tool calls, while completed turns were reconstructed from report text alone. Desktop telemetry passed the content-block envelope directly to a summarizer that expected structured site JSON.

## Implementation

- build an RFC 3986-encoded Xiaohongshu result URL, navigate within the site as the last submission strategy, and require the normal result-page/query/card validation before success
- validate spreadsheet package structure and readability, distinguish `.xlsx` from `.xlsm` content types, validate Word/PowerPoint content types, package relationships, main XML roots, archive limits, and PDF markers
- scope artifact intent and completion checks to output clauses, match every requested format to a distinct published artifact, and let a typed artifact satisfy a generic document requirement
- serialize every non-empty DeepSeek reasoning turn, validate tool-call reasoning locally, and seed completed conversations with their final recorded reasoning
- decode complete JSON only for allowlisted site tools and expose bounded strategy/count/diagnostic metrics without copying note bodies or comments

## Validation

- `cargo check --workspace` — passed
- `cargo test -p socai-core` — 99 passed, 0 failed, 2 ignored
- `cargo test -p socai_app` — 3 passed, 0 failed
- `cargo test --workspace` — passed during the final independent review
- `git diff --check` — passed
- real logged-in Xiaohongshu search for `露营装备` entered a valid result page and returned 3 requested result cards
- two Codex CLI review cycles exercised the full diff; all reported correctness and validation boundaries were addressed

No new Rust test function was added, following the repository engineering rule; existing tests were extended where applicable, and live browser behavior was verified against the logged-in Xiaohongshu page.
